### PR TITLE
Fix makefile to not re-download bins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,18 +7,18 @@ ARCH = amd64
 
 all: build
 
-bin:
-	mkdir -p bin/
-
 bin/runc:
+	mkdir -p $(dir $@)
 	curl -L -o bin/runc https://github.com/opencontainers/runc/releases/download/v$(RUNC_VERSION)/runc.$(ARCH)
 
-bin/containerd: bin
+bin/containerd:
+	mkdir -p $(dir $@)
 	curl -L https://github.com/containerd/containerd/releases/download/v$(CONTAINERD_VERSION)/containerd-$(CONTAINERD_VERSION).linux-$(ARCH).tar.gz | tar zxvf -
 	rm bin/containerd-stress
 	rm bin/ctr
 
-bin/kubelet: bin
+bin/kubelet:
+	mkdir -p $(dir $@)
 	curl -L -o bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v$(KUBLET_VERSION)/bin/linux/$(ARCH)/kubelet
 
 pkg/assets/zz_generated_bindata.go: bin/kubelet bin/containerd bin/runc


### PR DESCRIPTION
Do not use the directory as dependency for downloaded files, as the
timestamp of directory will be updated, causing a "rebuild" of
previously downloaded files (eg. re-download) each run.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>