### PR TITLE
Re-use previously extracted binaries (#11)

### DIFF
--- a/pkg/assets/stage.go
+++ b/pkg/assets/stage.go
@@ -9,20 +9,43 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// return true if currently running executable is older than given filepath
+func ExecutableIsOlder(filepath string) bool {
+	ex, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	exinfo, err := os.Stat(ex)
+	if err != nil {
+		return false
+	}
+	pathinfo, err := os.Stat(filepath)
+	if err != nil {
+		return false
+	}
+	return exinfo.ModTime().Unix() < pathinfo.ModTime().Unix()
+}
+
 // Stage ...
 func Stage(dataDir string) error {
 	for _, name := range AssetNames() {
+		p := filepath.Join(dataDir, name)
+
+		if ExecutableIsOlder(p) {
+			logrus.Debug("Re-use existing file:", p)
+			continue
+		}
+
 		content, err := Asset(name)
 		if err != nil {
 			return err
 		}
-		p := filepath.Join(dataDir, name)
 		logrus.Debug("Writing static file: ", p)
 		err = os.MkdirAll(filepath.Dir(p), 0700)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create dir %s", filepath.Dir(p))
 		}
-		os.Remove(p);
+		os.Remove(p)
 		if err := ioutil.WriteFile(p, content, 0600); err != nil {
 			return errors.Wrapf(err, "failed to write to %s", name)
 		}


### PR DESCRIPTION
Only extract the bundled binaries if mke itself is newer than the
extracted binaries or if they don't exist.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>