### PR TITLE
Add basic config structures and storage (kine) configs

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -10,6 +10,8 @@ import (
 	"github.com/Mirantis/mke/pkg/component"
 	"github.com/Mirantis/mke/pkg/constant"
 	"github.com/urfave/cli/v2"
+
+	config "github.com/Mirantis/mke/pkg/apis/v1beta1"
 )
 
 // ServerCommand ...
@@ -28,6 +30,8 @@ func startServer(ctx *cli.Context) error {
 		return err
 	}
 
+	spec := config.DefaultClusterSpec()
+
 	components := make(map[string]component.Component)
 
 	certs := component.Certificates{}
@@ -40,7 +44,9 @@ func startServer(ctx *cli.Context) error {
 	c := make(chan os.Signal)
 	signal.Notify(c, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
-	components["kine"] = &component.Kine{}
+	components["kine"] = &component.Kine{
+		Config: spec.Storage.Kine,
+	}
 	components["kine"].Run()
 
 	components["kube-apiserver"] = &component.ApiServer{}

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -39,8 +39,6 @@ func startWorker(ctx *cli.Context) error {
 		return err
 	}
 
-	//logrus.Infof("args: %s", ctx.Args().Slice())
-
 	serverAddress := ctx.String("server")
 	if serverAddress == "" {
 		return fmt.Errorf("mke worker needs the controller address as --server option")

--- a/pkg/apis/v1beta1/cluster.go
+++ b/pkg/apis/v1beta1/cluster.go
@@ -1,0 +1,39 @@
+package v1beta1
+
+type ClusterConfig struct {
+	APIVersion string       `yaml:"apiVersion" validate:"eq=mke.mirantis.com/v1beta1"`
+	Kind       string       `yaml:"kind" validate:"eq=Cluster"`
+	Metadata   *ClusterMeta `yaml:"metadata"`
+	Spec       *ClusterSpec `yaml:"spec"`
+}
+
+type ClusterMeta struct {
+	Name string `yaml:"name" validate:"required"`
+}
+
+type ClusterSpec struct {
+	Storage *StorageSpec
+}
+
+// UnmarshalYAML sets in some sane defaults when unmarshaling the data from yaml
+func (c *ClusterConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	c.Metadata = &ClusterMeta{
+		Name: "mke",
+	}
+	c.Spec = &ClusterSpec{}
+
+	type yclusterconfig ClusterConfig
+	yc := (*yclusterconfig)(c)
+
+	if err := unmarshal(yc); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func DefaultClusterSpec() ClusterSpec {
+	return ClusterSpec{
+		Storage: DefaultStorageSpec(),
+	}
+}

--- a/pkg/apis/v1beta1/storage.go
+++ b/pkg/apis/v1beta1/storage.go
@@ -1,0 +1,19 @@
+package v1beta1
+
+type StorageSpec struct {
+	Type string      `yaml:"type" validate:"oneof=kine"`
+	Kine *KineConfig `yaml:"kine"`
+}
+
+type KineConfig struct {
+	DataSource string `yaml:"dataSource"`
+}
+
+func DefaultStorageSpec() *StorageSpec {
+	return &StorageSpec{
+		Type: "kine",
+		Kine: &KineConfig{
+			DataSource: "/var/lib/mke/db/state.db?more=rwc&_journal=WAL&cache=shared",
+		},
+	}
+}

--- a/pkg/component/kine.go
+++ b/pkg/component/kine.go
@@ -1,26 +1,36 @@
 package component
 
 import (
+	"fmt"
 	"path"
 
 	"github.com/Mirantis/mke/pkg/constant"
 	"github.com/Mirantis/mke/pkg/supervisor"
 	"github.com/sirupsen/logrus"
+
+	config "github.com/Mirantis/mke/pkg/apis/v1beta1"
 )
 
 // Kine implement the component interface to run kine
 type Kine struct {
+	Config     *config.KineConfig
 	supervisor supervisor.Supervisor
 }
 
 // Run runs kine
 func (k *Kine) Run() error {
 	logrus.Info("Starting kine")
+	logrus.Debugf("datasource: %s", k.Config.DataSource)
 	k.supervisor = supervisor.Supervisor{
 		Name:    "kine",
 		BinPath: path.Join(constant.DataDir, "bin", "kine"),
+		Dir:     constant.DataDir, // makes kine sqlite db to be created on /var/lib/mke/db
+		Args: []string{
+			// Does not work yet because of https://github.com/rancher/kine/blob/26bd5085f45f9c0c687d1ac652fa4526b07d2653/pkg/endpoint/endpoint.go#L145
+			// kine will only always default to /.db ... :()
+			fmt.Sprintf("--endpoint=%s", k.Config.DataSource),
+		},
 	}
-	// TODO We need to dump the config file suited for mke use
 
 	k.supervisor.Supervise()
 

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -18,10 +18,11 @@ type Supervisor struct {
 	Name    string
 	BinPath string
 	Args    []string
+	Dir     string
 
-	cmd     *exec.Cmd
-	quit	chan bool
-	done	chan bool
+	cmd  *exec.Cmd
+	quit chan bool
+	done chan bool
 }
 
 // Supervise Starts supervising the given process
@@ -36,14 +37,15 @@ func (s *Supervisor) Supervise() {
 		}()
 		for {
 			s.cmd = exec.Command(s.BinPath, s.Args...)
+			s.cmd.Dir = s.Dir
 
 			s.cmd.Env = getEnv()
 
 			// detach from the process group so children don't
 			// get signals sent directly to parent.
-			s.cmd.SysProcAttr = &syscall.SysProcAttr {
+			s.cmd.SysProcAttr = &syscall.SysProcAttr{
 				Setpgid: true,
-				Pgid: 0,
+				Pgid:    0,
 			}
 
 			// TODO Wire up the stdout&stderr to somehow through logger to be able to distinguis the components.


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

The kine endpoint config does not (yet) actually work as kine just ignores it: https://github.com/rancher/kine/blob/26bd5085f45f9c0c687d1ac652fa4526b07d2653/pkg/endpoint/endpoint.go#L145

@ncopa is looking to make a fix PR on kine side for this.