### PR TITLE
Create pid files for supervised processes

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -9,4 +9,7 @@ const (
 
 	// KubeletBootstrapConfigPath defines the default path for kubelet bootstrap auth config
 	KubeletBootstrapConfigPath = "/var/lib/mke/kubelet-bootstrap.conf"
+
+	// PidDir defines the location of supervised pid files
+	PidDir = "/run/mke"
 )


### PR DESCRIPTION
It makes it easier to clean up the started processes after mke
unexpectedly died without cleaning up after itself.

Manual cleanup can be done with: kill $(cat /run/mke/*.pid)

Signed-off-by: Natanael Copa <ncopa@mirantis.com>