### PR TITLE
Only extract the needed binaries (#35)

### DIFF
--- a/pkg/assets/stage.go
+++ b/pkg/assets/stage.go
@@ -27,31 +27,29 @@ func ExecutableIsOlder(filepath string) bool {
 }
 
 // Stage ...
-func Stage(dataDir string) error {
-	for _, name := range AssetNames() {
-		p := filepath.Join(dataDir, name)
+func Stage(dataDir, name string) error {
+	p := filepath.Join(dataDir, name)
 
-		if ExecutableIsOlder(p) {
-			logrus.Debug("Re-use existing file:", p)
-			continue
-		}
+	if ExecutableIsOlder(p) {
+		logrus.Debug("Re-use existing file:", p)
+		return nil
+	}
 
-		content, err := Asset(name)
-		if err != nil {
-			return err
-		}
-		logrus.Debug("Writing static file: ", p)
-		err = os.MkdirAll(filepath.Dir(p), 0700)
-		if err != nil {
-			return errors.Wrapf(err, "failed to create dir %s", filepath.Dir(p))
-		}
-		os.Remove(p)
-		if err := ioutil.WriteFile(p, content, 0600); err != nil {
-			return errors.Wrapf(err, "failed to write to %s", name)
-		}
-		if err := os.Chmod(p, 0500); err != nil {
-			return errors.Wrapf(err, "failed to chmod %s", name)
-		}
+	content, err := Asset(name)
+	if err != nil {
+		return err
+	}
+	logrus.Debug("Writing static file: ", p)
+	err = os.MkdirAll(filepath.Dir(p), 0700)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create dir %s", filepath.Dir(p))
+	}
+	os.Remove(p)
+	if err := ioutil.WriteFile(p, content, 0600); err != nil {
+		return errors.Wrapf(err, "failed to write to %s", name)
+	}
+	if err := os.Chmod(p, 0500); err != nil {
+		return errors.Wrapf(err, "failed to chmod %s", name)
 	}
 
 	return nil

--- a/pkg/component/apiserver.go
+++ b/pkg/component/apiserver.go
@@ -3,14 +3,20 @@ package component
 import (
 	"path"
 
+	"github.com/Mirantis/mke/pkg/assets"
 	"github.com/Mirantis/mke/pkg/constant"
 	"github.com/Mirantis/mke/pkg/supervisor"
 	"github.com/sirupsen/logrus"
 )
 
-// Kine implement the component interface to run kube api
+// ApiServer implement the component interface to run kube api
 type ApiServer struct {
 	supervisor supervisor.Supervisor
+}
+
+// Init extracts needed binaries
+func (a *ApiServer) Init() error {
+	return assets.Stage(constant.DataDir, path.Join("bin","kube-apiserver"))
 }
 
 // Run runs kube api

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -1,6 +1,7 @@
 package component
 
 type Component interface {
+	Init() error
 	Run() error
 	Stop() error
 }

--- a/pkg/component/containerd.go
+++ b/pkg/component/containerd.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/Mirantis/mke/pkg/assets"
 	"github.com/Mirantis/mke/pkg/constant"
 	"github.com/Mirantis/mke/pkg/supervisor"
 )
@@ -12,6 +13,11 @@ import (
 // ContainerD implement the component interface to manage containerd as mke component
 type ContainerD struct {
 	supervisor supervisor.Supervisor
+}
+
+// Init extracts the needed binaries
+func (c *ContainerD) Init() error {
+	return assets.Stage(constant.DataDir, path.Join("bin","containerd"))
 }
 
 // Run runs containerD

--- a/pkg/component/controllermanager.go
+++ b/pkg/component/controllermanager.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/Mirantis/mke/pkg/assets"
 	"github.com/Mirantis/mke/pkg/constant"
 	"github.com/Mirantis/mke/pkg/supervisor"
 	"github.com/sirupsen/logrus"
@@ -13,6 +14,11 @@ import (
 // ControllerManager implement the component interface to run kube scheduler
 type ControllerManager struct {
 	supervisor supervisor.Supervisor
+}
+
+// Init extracts the needed binaries
+func (a *ControllerManager) Init() error {
+	return assets.Stage(constant.DataDir, path.Join("bin","kube-controller-manager"))
 }
 
 // Run runs kube ControllerManager

--- a/pkg/component/kine.go
+++ b/pkg/component/kine.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/Mirantis/mke/pkg/assets"
 	"github.com/Mirantis/mke/pkg/constant"
 	"github.com/Mirantis/mke/pkg/supervisor"
 	"github.com/sirupsen/logrus"
@@ -15,6 +16,11 @@ import (
 type Kine struct {
 	Config     *config.KineConfig
 	supervisor supervisor.Supervisor
+}
+
+// Init extracts the needed binaries
+func (k *Kine) Init() error {
+	return assets.Stage(constant.DataDir, path.Join("bin","kine"))
 }
 
 // Run runs kine

--- a/pkg/component/kubelet.go
+++ b/pkg/component/kubelet.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/Mirantis/mke/pkg/assets"
 	"github.com/Mirantis/mke/pkg/constant"
 	"github.com/Mirantis/mke/pkg/supervisor"
 	"github.com/pkg/errors"
@@ -32,6 +33,11 @@ type Kubelet struct {
 }
 
 type KubeletConfig struct {
+}
+
+// Init extracts the needed binaries
+func (k *Kubelet) Init() error {
+	return assets.Stage(constant.DataDir, path.Join("bin", "kubelet"))
 }
 
 // Run runs kubelet

--- a/pkg/component/scheduler.go
+++ b/pkg/component/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/Mirantis/mke/pkg/assets"
 	"github.com/Mirantis/mke/pkg/constant"
 	"github.com/Mirantis/mke/pkg/supervisor"
 	"github.com/sirupsen/logrus"
@@ -13,6 +14,11 @@ import (
 // Scheduler implement the component interface to run kube scheduler
 type Scheduler struct {
 	supervisor supervisor.Supervisor
+}
+
+// Init extracts the needed binaries
+func (a *Scheduler) Init() error {
+	return assets.Stage(constant.DataDir, path.Join("bin", "kube-scheduler"))
 }
 
 // Run runs kube scheduler


### PR DESCRIPTION
Extract only the binaries that each component is actually using instead
of dumping all of them.

Fixes #35

Signed-off-by: Natanael Copa <ncopa@mirantis.com>