### PR TITLE
Configure kernel for worker (#32)

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Mirantis/mke/pkg/component"
 	"github.com/Mirantis/mke/pkg/constant"
 	"github.com/Mirantis/mke/pkg/util"
+	"github.com/Mirantis/mke/pkg/worker"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -35,6 +36,8 @@ func startWorker(ctx *cli.Context) error {
 	if serverAddress == "" {
 		return fmt.Errorf("mke worker needs the controller address as --server option")
 	}
+
+	worker.KernelSetup()
 
 	logrus.Debugf("using server address %s", serverAddress)
 	token := ctx.Args().First()

--- a/pkg/worker/kernelsetup_linux.go
+++ b/pkg/worker/kernelsetup_linux.go
@@ -1,0 +1,61 @@
+// +build linux
+
+package worker
+
+import (
+	"io/ioutil"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/Mirantis/mke/pkg/util"
+	"github.com/sirupsen/logrus"
+)
+
+// check if kernel has overlay fs
+func hasFilesystem(filesystem string) bool {
+	data, err := ioutil.ReadFile("/proc/filesystems")
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[1] == filesystem {
+			return true
+		}
+	}
+	return false
+}
+
+func modprobe(module string) {
+	err := exec.Command("modprobe", module)
+	if err != nil {
+		logrus.Warnf("failed to load %s kernel module: %s", module, err)
+	}
+}
+
+func enableSysCtl(entry string) {
+	file := path.Join("/proc", "sys", entry)
+	err := ioutil.WriteFile(file, []byte("1"), 0644)
+	if err != nil {
+		logrus.Warnf("Failed to enable %s:", file, err)
+	}
+}
+
+func KernelSetup() {
+	if !hasFilesystem("overlay") {
+		modprobe("overlay")
+	}
+	if !util.FileExists("/proc/net/nf_conntrack") {
+		modprobe("nf_conntrack")
+	}
+	if !util.FileExists("/proc/sys/net/bridge/bridge-nf-call-iptables") {
+		modprobe("br_netfilter")
+	}
+	enableSysCtl("net/ipv4/conf/all/forwarding")
+	enableSysCtl("net/ipv4/conf/default/forwarding")
+	enableSysCtl("net/ipv6/conf/all/forwarding")
+	enableSysCtl("net/ipv6/conf/default/forwarding")
+	enableSysCtl("net/bridge/bridge-nf-call-iptables")
+	enableSysCtl("net/bridge/bridge-nf-call-ip6tables")
+}


### PR DESCRIPTION
Check relevant /proc entries to test for overlay fs, nf_conntrack and
br_netfilter. Try load kernel module if something is missing.

Enable ip forwarding for ipv4 and ipv6 and bridge-nf-call-arptables.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>