### PR TITLE
Add --config command line option (#57)

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -19,12 +19,17 @@ func ServerCommand() *cli.Command {
 		Name:            "server",
 		Usage:           "Run server",
 		Action:          startServer,
-		SkipFlagParsing: true,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name: "config",
+				Value: "mke.yaml",
+			},
+		},
 	}
 }
 
 func startServer(ctx *cli.Context) error {
-	clusterConfig, err := config.FromYaml("mke.yaml")
+	clusterConfig, err := config.FromYaml(ctx.String("config"))
 	if err != nil {
 		logrus.Errorf("Failed to read cluster config: %s", err.Error())
 		logrus.Error("THINGS MIGHT NOT WORK PROPERLY AS WE'RE GONNA USE DEFAULTS")

--- a/mke.yaml
+++ b/mke.yaml
@@ -9,6 +9,6 @@ spec:
   #   kine:
   #     dataSource: sqlite:///var/lib/mke/db/state.db?more=rwc&_journal=WAL&cache=shared
   api:
-    address: 172.17.0.2 # Address where the k8s API is accessed at (nodes public IP or LB)
+    address: 172.17.0.3 # Address where the k8s API is accessed at (nodes public IP or LB)
     sans: # If you want to incorporate multiple addresses into the generates api server certs
       - 13.48.10.8


### PR DESCRIPTION
So we can override the default mke.yaml

Fixes #57

Signed-off-by: Natanael Copa <ncopa@mirantis.com>