### PR TITLE
bump containerd version to 1.3.6 and kube to 1.18.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 RUNC_VERSION = 1.0.0-rc90
-CONTAINERD_VERSION = 1.3.4
-KUBE_VERSION = 1.18.4
+CONTAINERD_VERSION = 1.3.6
+KUBE_VERSION = 1.18.5
 KINE_VERSION = 0.4.0
 
 GO_SRCS := $(shell find -name '*.go')
@@ -17,7 +17,7 @@ bin/runc:
 
 bin/containerd:
 	mkdir -p $(dir $@)
-	curl --silent -L https://github.com/containerd/containerd/releases/download/v$(CONTAINERD_VERSION)/containerd-$(CONTAINERD_VERSION).linux-$(ARCH).tar.gz \
+	curl --silent -L https://github.com/containerd/containerd/releases/download/v$(CONTAINERD_VERSION)/containerd-$(CONTAINERD_VERSION)-linux-$(ARCH).tar.gz \
 		| tar zxv bin/containerd bin/containerd-shim bin/containerd-shim-runc-v1 bin/containerd-shim-runc-v2
 
 bin/kubelet:


### PR DESCRIPTION
Signed-off-by: Natanael Copa <ncopa@mirantis.com>