### PR TITLE
Allow build without any embedded binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,26 @@ GO_SRCS := $(shell find -name '*.go')
 # EMBEDDED_BINS_BUILDMODE can be either 'docker' or 'fetch'
 EMBEDDED_BINS_BUILDMODE=docker
 
+
 .PHONY: all
 all: build
 
+ifeq ($(EMBEDDED_BINS_BUILDMODE),none)
+pkg/assets/zz_generated_bindata.go:
+	printf "%s\n\n%s" \
+		"package assets" \
+		"func Asset(name string) ([]byte, error) { return nil, nil }" \
+		> $@
+else
+
 pkg/assets/zz_generated_bindata.go: .bins.stamp
-	go-bindata -o pkg/assets/zz_generated_bindata.go \
+	go-bindata -o $@ \
 		-pkg assets \
 		-prefix embedded-bins/staging/linux/ \
-		embedded-bins/staging/linux/bin \
+		embedded-bins/staging/linux/bin
+
+endif
+
 
 mke: pkg/assets/zz_generated_bindata.go $(GO_SRCS)
 	go build -o mke main.go

--- a/pkg/assets/stage.go
+++ b/pkg/assets/stage.go
@@ -27,6 +27,15 @@ func ExecutableIsOlder(filepath string) bool {
 	return exinfo.ModTime().Unix() < pathinfo.ModTime().Unix()
 }
 
+// StagedBinPath returns the path of the staged bin or the name without path if it does not exist
+func StagedBinPath(dataDir, name string) string {
+	p := filepath.Join(dataDir, "bin", name)
+	if util.FileExists(p) {
+		return p
+	}
+	return name
+}
+
 // Stage ...
 func Stage(dataDir, name, group string) error {
 	p := filepath.Join(dataDir, name)
@@ -37,7 +46,7 @@ func Stage(dataDir, name, group string) error {
 	}
 
 	content, err := Asset(name)
-	if err != nil {
+	if err != nil || content == nil {
 		return err
 	}
 	logrus.Debug("Writing static file: ", p)

--- a/pkg/component/server/apiserver.go
+++ b/pkg/component/server/apiserver.go
@@ -39,7 +39,7 @@ func (a *ApiServer) Run() error {
 	logrus.Info("Starting kube-apiserver")
 	a.supervisor = supervisor.Supervisor{
 		Name:    "kube-apiserver",
-		BinPath: path.Join(constant.DataDir, "bin", "kube-apiserver"),
+		BinPath: assets.StagedBinPath(constant.DataDir, "kube-apiserver"),
 		Args: []string{
 			"--allow-privileged=true",
 			"--authorization-mode=Node,RBAC",

--- a/pkg/component/server/controllermanager.go
+++ b/pkg/component/server/controllermanager.go
@@ -45,7 +45,7 @@ func (a *ControllerManager) Run() error {
 	ccmAuthConf := filepath.Join(constant.CertRoot, "ccm.conf")
 	a.supervisor = supervisor.Supervisor{
 		Name:    "kube-ccm",
-		BinPath: path.Join(constant.DataDir, "bin", "kube-controller-manager"),
+		BinPath: assets.StagedBinPath(constant.DataDir, "kube-controller-manager"),
 		Args: []string{
 			"--allocate-node-cidrs=true",
 			fmt.Sprintf("--authentication-kubeconfig=%s", ccmAuthConf),

--- a/pkg/component/server/etcd.go
+++ b/pkg/component/server/etcd.go
@@ -59,7 +59,7 @@ func (e *Etcd) Run() error {
 
 	e.supervisor = supervisor.Supervisor{
 		Name:    "etcd",
-		BinPath: path.Join(constant.DataDir, "bin", "etcd"),
+		BinPath: assets.StagedBinPath(constant.DataDir, "etcd"),
 		Dir:     constant.DataDir,
 		Args: []string{
 			fmt.Sprintf("--data-dir=%s", e.etcdDataDir),

--- a/pkg/component/server/kine.go
+++ b/pkg/component/server/kine.go
@@ -61,7 +61,7 @@ func (k *Kine) Run() error {
 
 	k.supervisor = supervisor.Supervisor{
 		Name:    "kine",
-		BinPath: path.Join(constant.DataDir, "bin", "kine"),
+		BinPath: assets.StagedBinPath(constant.DataDir, "kine"),
 		Dir:     constant.DataDir,
 		Args: []string{
 			fmt.Sprintf("--endpoint=%s", k.Config.DataSource),

--- a/pkg/component/server/scheduler.go
+++ b/pkg/component/server/scheduler.go
@@ -38,7 +38,7 @@ func (a *Scheduler) Run() error {
 	schedulerAuthConf := filepath.Join(constant.CertRoot, "scheduler.conf")
 	a.supervisor = supervisor.Supervisor{
 		Name:    "kube-scheduler",
-		BinPath: path.Join(constant.DataDir, "bin", "kube-scheduler"),
+		BinPath: assets.StagedBinPath(constant.DataDir, "kube-scheduler"),
 		Args: []string{
 			fmt.Sprintf("--authentication-kubeconfig=%s", schedulerAuthConf),
 			fmt.Sprintf("--authorization-kubeconfig=%s", schedulerAuthConf),

--- a/pkg/component/worker/containerd.go
+++ b/pkg/component/worker/containerd.go
@@ -31,7 +31,7 @@ func (c *ContainerD) Run() error {
 	logrus.Info("Starting containerD")
 	c.supervisor = supervisor.Supervisor{
 		Name:    "containerd",
-		BinPath: path.Join(constant.DataDir, "bin", "containerd"),
+		BinPath: assets.StagedBinPath(constant.DataDir, "containerd"),
 	}
 	// TODO We need to dump the config file suited for mke use
 

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -50,7 +50,7 @@ func (k *Kubelet) Run() error {
 	logrus.Info("Starting containerD")
 	k.supervisor = supervisor.Supervisor{
 		Name:    "kubelet",
-		BinPath: path.Join(constant.DataDir, "bin", "kubelet"),
+		BinPath: assets.StagedBinPath(constant.DataDir, "kubelet"),
 		Args: []string{
 			"--container-runtime=remote",
 			"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",


### PR DESCRIPTION
Make it possible to build mke without embedding any binaries at all, and
only use the system binaries found in PATH.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>