### PR TITLE
Ignore staging from docker builds

### DIFF
--- a/embedded-bins/.dockerignore
+++ b/embedded-bins/.dockerignore
@@ -1,0 +1,1 @@
+staging/


### PR DESCRIPTION
Faster builds because docker context does not grow after each binary.