### PR TITLE
Respect EMBEDDED_BINS_BUILDMODE from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 
 GO_SRCS := $(shell find -name '*.go')
 
-# EMBEDDED_BINS_BUILDMODE can be either 'docker' or 'fetch'
-EMBEDDED_BINS_BUILDMODE=docker
+# EMBEDDED_BINS_BUILDMODE can be either:
+#   docker	builds the binaries in docker
+#   fetch	fetch precompiled binaries from internet (except kine)
+#   none	does not embed any binaries
+
+EMBEDDED_BINS_BUILDMODE ?= fetch
 
 
 .PHONY: all


### PR DESCRIPTION
Let environment variable EMBEDDED_BINS_BUILDMODE override default.

Also improve comment about the different build modes and use fetch as
the default for now.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>