### PR TITLE
Add initial test using bats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ bins: .bins.stamp
 	$(MAKE) -C embedded-bins buildmode=$(EMBEDDED_BINS_BUILDMODE)
 	touch $@
 
+.PHONY: check
+check: mke
+	$(MAKE) -C tests check
+
 .PHONY: clean
 clean:
 	rm -f pkg/assets/zz_generated_bindata.go mke .bins.stamp

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,4 @@
+.test-*
+bin/
+footloose-*.yaml
+id_ed25519_mke*

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,35 @@
+
+footloose_version = 0.6.3
+kubectl_version = 1.18.6
+
+footloose_url = https://github.com/weaveworks/footloose/releases/download/$(footloose_version)/footloose-$(footloose_version)-linux-x86_64
+kubectl_url = https://storage.googleapis.com/kubernetes-release/release/v$(kubectl_version)/bin/linux/amd64/kubectl
+
+curl = curl -L --silent
+
+bins = bin/footloose bin/kubectl
+
+.PHONY: all
+all: $(bins) id_ed25519_mke
+
+bin:
+	mkdir -p $@
+
+bin/footloose bin/kubectl: | bin
+	$(curl) -o $@.tmp $($(notdir $@)_url)
+	chmod +x $@.tmp && mv $@.tmp $@
+
+id_ed25519_mke:
+	ssh-keygen -t ed25519 -N "" -f $@
+
+
+.test-%: %.bats footloose-%.yaml.tpl $(bins) id_ed25519_mke ../mke
+	bats $<
+	touch $@
+
+.PHONY: check
+check: $(bins) .test-single
+
+.PHONY: clean
+clean:
+	rm -rf bin id_ed25519_mke* footloose-*.yaml

--- a/tests/footloose-single.yaml.tpl
+++ b/tests/footloose-single.yaml.tpl
@@ -1,0 +1,24 @@
+cluster:
+  name: $CLUSTER_NAME
+  privateKey: id_ed25519_mke
+machines:
+- count: 1
+  backend: docker
+  spec:
+    image: $LINUX_IMAGE
+    name: node%d
+    privileged: true
+    volumes:
+    - type: bind
+      source: $MKE_BINARY
+      destination: /usr/bin/mke
+    - type: volume
+      destination: /var/lib/containerd
+    - type: volume
+      destination: /var/lib/kubelet
+    networks:
+    - $NETWORK_NAME
+    portMappings:
+    - containerPort: 22
+      hostPort: 9022
+

--- a/tests/shared.bash
+++ b/tests/shared.bash
@@ -1,0 +1,26 @@
+setup_file() {
+	export name=$(basename ${BATS_TEST_FILENAME%.bats})
+	export netname=mke-test-$name
+	export footlooseconfig=footloose-$name.yaml
+
+	docker network inspect $netname 2>/dev/null \
+		|| docker network create $netname
+
+	CLUSTER_NAME=$name \
+		LINUX_IMAGE=quay.io/footloose/ubuntu18.04 \
+		NETWORK_NAME=$netname \
+		MKE_BINARY=${MKE_BINARY:-$(readlink -f ../mke)} \
+		envsubst < ${footlooseconfig}.tpl > $footlooseconfig
+
+	footloose create --config $footlooseconfig
+	export node0=$(printf "$(footloose --config $footlooseconfig show -o json \
+		| jq --raw-output '.machines[0].spec.name')\n" 0)
+
+	footloose ssh --config $footlooseconfig root@$node0 "addgroup --system mke"
+}
+
+teardown_file() {
+	footloose delete --config $footlooseconfig
+	docker network rm $netname
+}
+

--- a/tests/single.bats
+++ b/tests/single.bats
@@ -1,0 +1,8 @@
+#!/usr/bin/env bats
+
+load shared.bash
+
+@test "mke single --test" {
+	run footloose ssh --config $footlooseconfig root@$node0 "mke single --test"
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Create a simple test for default config (without mke.yaml). It will
simply create a footloose cluster with a single node and run `mke
single --test`.

Can be invoked with `make check`

Depends on bats and jq.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>