### PR TITLE
Make missing mke group non-fatal for server

### DIFF
--- a/pkg/component/server/certificates.go
+++ b/pkg/component/server/certificates.go
@@ -301,9 +301,11 @@ func (c *Certificates) loadOrGenerateCA(name, commonName string) error {
 				logrus.Warning(err)
 			}
 		}
+	} else {
+		logrus.Warning(err)
 	}
 
-	return err
+	return nil
 }
 
 type certReq struct {


### PR DESCRIPTION
Do not abort with error when mke group is missing on the system

Signed-off-by: Natanael Copa <ncopa@mirantis.com>