### PR TITLE
Use /run/mke for kine unix socket

### DIFF
--- a/pkg/component/server/apiserver.go
+++ b/pkg/component/server/apiserver.go
@@ -87,7 +87,8 @@ func (a *ApiServer) Run() error {
 	}
 	switch a.ClusterConfig.Spec.Storage.Type {
 	case "kine":
-		a.supervisor.Args = append(a.supervisor.Args, "--etcd-servers=unix:///run/kine.sock:2379") // kine endpoint
+		a.supervisor.Args = append(a.supervisor.Args,
+			fmt.Sprintf("--etcd-servers=unix://%s", path.Join(constant.RunDir, "kine.sock:2379"))) // kine endpoint
 	case "etcd":
 		a.supervisor.Args = append(a.supervisor.Args,
 			"--etcd-servers=https://127.0.0.1:2379",

--- a/pkg/component/server/kine.go
+++ b/pkg/component/server/kine.go
@@ -28,7 +28,7 @@ type Kine struct {
 // Init extracts the needed binaries
 func (k *Kine) Init() error {
 	var err error
-	k.uid, err = util.GetUid("kine")
+	k.uid, err = util.GetUid(constant.KineUser)
 	if err != nil {
 		logrus.Warning(errors.Wrap(err, "Running kine as root"))
 	}
@@ -65,7 +65,7 @@ func (k *Kine) Run() error {
 		Dir:     constant.DataDir,
 		Args: []string{
 			fmt.Sprintf("--endpoint=%s", k.Config.DataSource),
-			"--listen-address=unix:///run/kine.sock:2379",
+			fmt.Sprintf("--listen-address=unix://%s", path.Join(constant.RunDir, "kine.sock:2379")),
 		},
 		Uid: k.uid,
 		Gid: k.gid,

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -13,14 +13,15 @@ const (
 	// AdminKubeconfigConfigPath defines the cluster admin kubeconfig location
 	AdminKubeconfigConfigPath = "/var/lib/mke/pki/admin.conf"
 
-	// PidDir defines the location of supervised pid files
-	PidDir = "/run/mke"
+	// RunDir defines the location of supervised pid files and sockets
+	RunDir = "/run/mke"
 
 	// Group defines group name for shared directories
 	Group = "mke"
 
 	// User accounts for services
 	EtcdUser              = "etcd"
+	KineUser              = "kine"
 	ApiserverUser         = "kube-apiserver"
 	ControllerManagerUser = "kube-controller-manager"
 	SchedulerUser         = "kube-scheduler"

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -67,8 +67,8 @@ func (s *Supervisor) processWaitQuit() bool {
 func (s *Supervisor) Supervise() {
 	s.quit = make(chan bool)
 	s.done = make(chan bool)
-	s.PidFile = path.Join(constant.PidDir, s.Name) + ".pid"
-	os.MkdirAll(constant.PidDir, 0755) // ignore errors in case directory exists
+	s.PidFile = path.Join(constant.RunDir, s.Name) + ".pid"
+	os.MkdirAll(constant.RunDir, 0755) // ignore errors in case directory exists
 	go func() {
 		log := logrus.WithField("component", s.Name)
 		log.Info("Starting to supervise")


### PR DESCRIPTION
kine needs write permissions in directory for socket. Use /run/mke since
kine may not run as root. Rename constant.PidDir to RunDir and use this
for /run/mke.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>