### PR TITLE
Create footloose config with make

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,6 +10,8 @@ curl = curl -L --silent
 
 bins = bin/footloose bin/kubectl bin/sonobuoy
 
+mke = $(shell readlink -f ../mke)
+
 .PHONY: all
 all: $(bins) id_ed25519_mke
 
@@ -27,7 +29,14 @@ id_ed25519_mke:
 	ssh-keygen -t ed25519 -N "" -f $@
 
 
-.test-%: %.bash footloose-%.yaml.tpl $(bins) id_ed25519_mke ../mke
+footloose-%.yaml: footloose-%.yaml.tpl
+	CLUSTER_NAME=$(@:footloose-%.yaml=%) \
+	LINUX_IMAGE=quay.io/footloose/ubuntu18.04 \
+	MKE_BINARY=$(mke) \
+	envsubst < $< > $@.tmp
+	mv $@.tmp $@
+
+.test-%: %.bash footloose-%.yaml $(bins) id_ed25519_mke $(mke)
 	bash $<
 	touch $@
 

--- a/tests/shared.bash
+++ b/tests/shared.bash
@@ -11,12 +11,9 @@ _setup() {
   export footlooseconfig=footloose-$name.yaml
 
   echo "==> SETUP"
-  logline "creating footloose config ..."
-  CLUSTER_NAME=$name \
-    LINUX_IMAGE=quay.io/footloose/ubuntu18.04 \
-    MKE_BINARY=${MKE_BINARY:-$(readlink -f ../mke)} \
-    envsubst < ${footlooseconfig}.tpl > $footlooseconfig
-
+  if ! [ -f "$footlooseconfig" ]; then
+    >/dev/null 2>&1 make $footlooseconfig
+  fi
   logline "starting to create footloose nodes ..."
   >/dev/null 2>&1 ./bin/footloose create --config $footlooseconfig
 
@@ -45,6 +42,6 @@ _collect_logs() {
   nodes=("node0" "node1" "node2")
   for node in "${nodes[@]}";
   do
-    >$node.log ./bin/footloose ssh --config $footlooseconfig root@$node "cat /tmp/mke-*.log"  
+    >$node.log ./bin/footloose ssh --config $footlooseconfig root@$node "cat /tmp/mke-*.log"
   done
 }


### PR DESCRIPTION
This makes it posible to run `make footloose-sig-network.yaml` to
generate the footloose config for manual testing.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>