### PR TITLE
Run all builds on self-hosted runner

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted,linux]
     steps:
 
     - name: Set up Go 1.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted,linux]
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

The GH provided runners are super slow which cause too much flakyness on the smoke runs.