### PR TITLE
Fix Makefile to work on OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ mke
 mke.code
 bindata
 .*.stamp
+.tmp

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-GO_SRCS := $(shell find -name '*.go')
+GO_SRCS := $(shell find . -type f -name '*.go')
 
 # EMBEDDED_BINS_BUILDMODE can be either:
 #   docker	builds the binaries in docker

--- a/pkg/component/worker/kernelsetup.go
+++ b/pkg/component/worker/kernelsetup.go
@@ -1,6 +1,6 @@
 // +build !linux
 
 package worker
-
+// KernelSetup comment
 func KernelSetup() {}
 


### PR DESCRIPTION
on osx `find -name` isn't a valid option. this PR changes that to `find . -type f -name '*.go'`
++ fix linting error
++ add .tmp to .gitignore