### PR TITLE
Enable join API conditionally

### DIFF
--- a/pkg/apis/v1beta1/joinclient.go
+++ b/pkg/apis/v1beta1/joinclient.go
@@ -113,7 +113,7 @@ func (j *JoinClient) JoinEtcd(peerAddress string) (EtcdResponse, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return etcdResponse, fmt.Errorf("unexpected response status: %s", resp.Status)
+		return etcdResponse, fmt.Errorf("unexpected response status when trying to join etcd cluster: %s", resp.Status)
 	}
 
 	b, err := ioutil.ReadAll(resp.Body)

--- a/pkg/apis/v1beta1/storage.go
+++ b/pkg/apis/v1beta1/storage.go
@@ -1,6 +1,8 @@
 package v1beta1
 
 import (
+	"strings"
+
 	"github.com/Mirantis/mke/pkg/util"
 	"github.com/sirupsen/logrus"
 )
@@ -26,6 +28,27 @@ func DefaultStorageSpec() *StorageSpec {
 		Type: "etcd",
 		Etcd: DefaultEtcdConfig(),
 	}
+}
+
+// IsJoinable returns true only if the storage config is such that another controller can join the cluster
+func (s *StorageSpec) IsJoinable() bool {
+	if s.Type == "etcd" {
+		return true
+	}
+
+	if strings.HasPrefix(s.Kine.DataSource, "sqlite://") {
+		return false
+	}
+
+	if strings.HasPrefix(s.Kine.DataSource, "mysql://") {
+		return true
+	}
+
+	if strings.HasPrefix(s.Kine.DataSource, "postgres://") {
+		return true
+	}
+
+	return false
 }
 
 // UnmarshalYAML sets in some sane defaults when unmarshaling the data from yaml

--- a/pkg/apis/v1beta1/storage_test.go
+++ b/pkg/apis/v1beta1/storage_test.go
@@ -1,0 +1,68 @@
+package v1beta1
+
+import (
+	"testing"
+)
+
+func TestStorageSpec_IsJoinable(t *testing.T) {
+	tests := []struct {
+		name    string
+		storage StorageSpec
+		want    bool
+	}{
+		{
+			name: "etcd",
+			storage: StorageSpec{
+				Type: "etcd",
+			},
+			want: true,
+		},
+		{
+			name: "kine-sqlite",
+			storage: StorageSpec{
+				Type: "kine",
+				Kine: &KineConfig{
+					DataSource: "sqlite://foobar",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "kine-mysql",
+			storage: StorageSpec{
+				Type: "kine",
+				Kine: &KineConfig{
+					DataSource: "mysql://foobar",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "kine-postgres",
+			storage: StorageSpec{
+				Type: "kine",
+				Kine: &KineConfig{
+					DataSource: "postgres://foobar",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "kine-unknown",
+			storage: StorageSpec{
+				Type: "kine",
+				Kine: &KineConfig{
+					DataSource: "unknown://foobar",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.storage.IsJoinable(); got != tt.want {
+				t.Errorf("StorageSpec.IsJoinable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/component/server/mkecontrolapi.go
+++ b/pkg/component/server/mkecontrolapi.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"os"
 
 	config "github.com/Mirantis/mke/pkg/apis/v1beta1"
@@ -9,6 +10,7 @@ import (
 
 // MkeControlAPI implements the mke control API component
 type MkeControlAPI struct {
+	ConfigPath    string
 	ClusterConfig *config.ClusterConfig
 
 	supervisor supervisor.Supervisor
@@ -28,6 +30,7 @@ func (m *MkeControlAPI) Run() error {
 		BinPath: os.Args[0],
 		Args: []string{
 			"api",
+			fmt.Sprintf("--config=%s", m.ConfigPath),
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

Fixes #98 

Essentially this means that if the conditions are not such that another controller could be joined, we do not enable the join APIs at all.