### PR TITLE
Fix make target mentioned in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ make -j$(nproc)
 
 To run a smoke test after build:
 ```
-make check
+make check-basic
 ```
 
 ## Cluster bootstrapping


### PR DESCRIPTION
Minor fix in the readme:
- actual name for the smoke tests target is `check-basic`