### PR TITLE
Minor fix: change name for the mkecontrolapi supervisor component

### DIFF
--- a/pkg/component/server/mkecontrolapi.go
+++ b/pkg/component/server/mkecontrolapi.go
@@ -26,7 +26,7 @@ func (m *MkeControlAPI) Init() error {
 func (m *MkeControlAPI) Run() error {
 	// TODO: Make the api process to use some other user
 	m.supervisor = supervisor.Supervisor{
-		Name:    "mke control api",
+		Name:    "mke-control-api",
 		BinPath: os.Args[0],
 		Args: []string{
 			"api",


### PR DESCRIPTION
Super minor change. Caught my eyes while experimenting with local cluster setup, that one of the pid-files in /var/run/mke has different naming:


```
root@controller1:/var/run/mke# ls -la
total 24
drwxr-xr-x  2 root root 180 Oct  5 03:48  .
drwxr-xr-x 10 root root 260 Oct  5 03:16  ..
-rw-r--r--  1 root root   4 Oct  5 03:15  etcd.pid
...
-rw-r--r--  1 root root   4 Oct  5 03:48  kube-scheduler.pid
-rw-r--r--  1 root root   4 Oct  5 03:15 'mke control api.pid'
```


By applying this patch the name for mke control api would be `mke-control-api.pid` instead of `'mke control api.pid'`