### PR TITLE
Use the kubernetes interface type whenever interacting with the client

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -39,7 +39,7 @@ func APICommand() *cli.Command {
 	}
 }
 
-var kubeClient *k8s.Clientset
+var kubeClient k8s.Interface
 
 func startAPI(ctx *cli.Context) error {
 	clusterConfig, err := configFromCmdFlag(ctx)

--- a/pkg/component/server/calico.go
+++ b/pkg/component/server/calico.go
@@ -15,7 +15,7 @@ import (
 
 // Calico is the Component interface implementation to manage Calico
 type Calico struct {
-	client      *kubernetes.Clientset
+	client      kubernetes.Interface
 	clusterSpec *config.ClusterSpec
 	tickerDone  chan struct{}
 	log         *logrus.Entry

--- a/pkg/component/server/coredns.go
+++ b/pkg/component/server/coredns.go
@@ -207,7 +207,7 @@ spec:
 
 // CoreDNS is the component implementation to manage CoreDNS
 type CoreDNS struct {
-	client        *kubernetes.Clientset
+	client        kubernetes.Interface
 	tickerDone    chan struct{}
 	log           *logrus.Entry
 	clusterConfig *config.ClusterSpec

--- a/pkg/component/worker/kubeletconfigclient.go
+++ b/pkg/component/worker/kubeletconfigclient.go
@@ -13,7 +13,7 @@ import (
 
 // KubeletConfigClient is the client used to fetch kubelet config from a common config map
 type KubeletConfigClient struct {
-	kubeClient *kubernetes.Clientset
+	kubeClient kubernetes.Interface
 }
 
 // NewKubeletConfigClient creates new KubeletConfigClient using the specified kubeconfig

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Client creates new k8s client based of the given kubeconfig
-func Client(kubeconfig string) (*kubernetes.Clientset, error) {
+func Client(kubeconfig string) (kubernetes.Interface, error) {
 	// use the current context in kubeconfig
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {

--- a/pkg/token/manager.go
+++ b/pkg/token/manager.go
@@ -27,7 +27,7 @@ func NewManager(kubeconfig string) (*Manager, error) {
 
 // Manager is responsible to manage the join tokens in kube API as secrets in kube-system namespace
 type Manager struct {
-	client *kubernetes.Clientset
+	client kubernetes.Interface
 }
 
 // Create creates a new bootstrap token


### PR DESCRIPTION
This makes everything more testable down the line as we can pass down the fake clientset that Kubernetes ships with.

Part of #229