### PR TITLE
[no-merge] use bash based sig-network to see if it's any less flaky

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ lint:
 
 .PHONY: check-network
 check-network: mke
-	$(MAKE) -C inttest check-network
+	$(MAKE) -C tests check
 
 .PHONY: check-basic
 check-basic: mke


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

Just to see if the "old" bash based sig-network is any less flaky