### PR TITLE
Do not run linters on main, until we fix all the warnings (issue #247)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -125,7 +125,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref != 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>
Related to 
https://github.com/Mirantis/mke/issues/247

TL;DR

current main branch code has lot of lint warning which makes linter job to fail on main branch.