### PR TITLE
Parallelise certificate generation

### DIFF
--- a/pkg/component/worker/containerd.go
+++ b/pkg/component/worker/containerd.go
@@ -19,11 +19,13 @@ type ContainerD struct {
 // Init extracts the needed binaries
 func (c *ContainerD) Init() error {
 	for _, bin := range []string{"containerd", "containerd-shim", "containerd-shim-runc-v1", "containerd-shim-runc-v2", "runc"} {
+		// unfortunately, this cannot be parallelized – it will result in a fork/exec error
 		err := assets.Stage(constant.BinDir, bin, constant.BinDirMode, constant.Group)
 		if err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Leo Sjöberg <lsjoberg@mirantis.com>

Introduced a performance timer as well, sample output:

```
DEBU[2020-10-09 07:30:19] checkpoint recorded                           checkpoint=starting-component-init component=performance-timer duration=3.6913ms target=server-start
DEBU[2020-10-09 07:30:19] checkpoint recorded                           checkpoint=finished-component-init component=performance-timer duration=2.7985201s target=server-start
DEBU[2020-10-09 07:30:19] checkpoint recorded                           checkpoint=starting-cert-run component=performance-timer duration=2.7985283s target=server-start
DEBU[2020-10-09 07:30:19] checkpoint recorded                           checkpoint=finished-cert-run component=performance-timer duration=3.8721981s target=server-start
DEBU[2020-10-09 07:30:19] checkpoint recorded                           checkpoint=starting-components component=performance-timer duration=3.8728552s target=server-start
DEBU[2020-10-09 07:30:19] checkpoint recorded                           checkpoint=finished-starting-components component=performance-timer duration=5.8761871s target=server-start
DEBU[2020-10-09 07:30:19] checkpoint recorded                           checkpoint=starting-reconcilers component=performance-timer duration=5.8761934s target=server-start
DEBU[2020-10-09 07:30:19] checkpoint recorded                           checkpoint=started-reconcilers component=performance-timer duration=5.8989783s target=server-start
```