### PR TITLE
fix stderr output when running mke token create

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
-	config "github.com/Mirantis/mke/pkg/apis/v1beta1"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
+
+	config "github.com/Mirantis/mke/pkg/apis/v1beta1"
 )
 
 // ConfigFromYaml returns given MKE config or default config

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"html/template"
 	"io/ioutil"
 	"path"
@@ -83,6 +84,9 @@ func CreateCommand() *cli.Command {
 			},
 		},
 		Action: func(c *cli.Context) error {
+			// Disable logrus for token commands
+			logrus.SetOutput(ioutil.Discard)
+
 			clusterConfig := ConfigFromYaml(c)
 			expiry, err := time.ParseDuration(c.String("expiry"))
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Karen Almog <kalmog@mirantis.com>

82ea1908ff34f327976e4c8c1c6f4e6888e1f159 introduced an issue where the command `mke token create` printed error messages to the token output:
```
root@controller-0:~# mke token create --role=worker
ERRO[2020-10-12 13:06:50] Failed to read cluster config: failed to read config file at mke.yaml: open mke.yaml: no such file or directory
ERRO[2020-10-12 13:06:50] THINGS MIGHT NOT WORK PROPERLY AS WE'RE GONNA USE DEFAULTS
H4sIAAAAAAAC/2xV0Y6jOhZ876/ID/Rc23RmpyPtC8QOIcFcG2yD3wAzTWJDaEISktX++6ozM9KutG/Hp0pVluVz6qUcDrIZz4dTv1pc4UvtLuepGc+rl9fF73r1slgsFudmvDbjatFO03Be/ etc etc
```
This pr removes the output logs for this subcommand only.