### PR TITLE
Fix build with EMBEDDED_BINS_BUILDMODE=fetch on MacOS (#289)

### DIFF
--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -11,6 +11,9 @@ bins = runc kubelet containerd containerd-shim containerd-shim-runc-v1 container
 
 buildmode = docker
 
+GOOS ?= linux
+export GOOS
+
 .PHONY: all
 all: $(addprefix $(bindir)/, $(bins))
 


### PR DESCRIPTION
The konnectivity-server and kine binaries needs to be compiled for linux
when building on MacOS.

Fixes #289

Signed-off-by: Natanael Copa <ncopa@mirantis.com>