### PR TITLE
Add -c short flag for mke server to pass config

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -50,8 +50,9 @@ func ServerCommand() *cli.Command {
 		Action: startServer,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:  "config",
-				Value: "mke.yaml",
+				Name:    "config",
+				Aliases: []string{"c"},
+				Value:   "mke.yaml",
 			},
 			&cli.BoolFlag{
 				Name:  "enable-worker",


### PR DESCRIPTION
It's even already mentioned in
https://github.com/Mirantis/mke/blob/main/docs/create-cluster.md#bootstrapping-controller-node