### PR TITLE
Trigger sig-network VM tests nightly too

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -6,6 +6,9 @@ on:
         description: PR against which to this workflow
         required: true
 
+  schedule:
+    - cron: "0 23 * * *"
+
 jobs:
   terraform:
     env:


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>


**Issue**
N/A

**What this PR Includes**

Adds nightly run to SIG-Network tests