### PR TITLE
Ignore controller join token if CA is already existing

### DIFF
--- a/inttest/hacontrolplane/hacontrolplane_test.go
+++ b/inttest/hacontrolplane/hacontrolplane_test.go
@@ -110,6 +110,15 @@ func (s *HAControlplaneSuite) TestDeregistration() {
 	s.Equal(membersFromMain, membersFromJoined,
 		"etcd cluster members list must be the same across all nodes")
 	s.Len(membersFromJoined, 2, "etcd cluster must have exactly 2 members")
+
+	// Restart the second controller with a token to see it comes up
+	// It should just ignore the token as there's CA etc already in place
+	sshC1, err := s.SSH("controller1")
+	s.Require().NoError(err)
+	_, _ = sshC1.ExecWithOutput("kill $(pidof mke)")
+
+	s.NoError(s.JoinController(1, token))
+
 	s.makeNodeLeave(1, membersFromJoined["controller1"])
 	refreshedMembers := s.getMembers(0)
 	s.Len(refreshedMembers, 1)


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>


**Issue**
Fixes #350 

**What this PR Includes**
IF we see that CA already exists we'll now ignore the given join token on `mke server`. In cases where mke controller restarts  and etcd has temporarily lost quorum the join call (even as being no-op in general) would fail and will make the mke restart fail.

Added also test for this as part of the HA controller suite.