### PR TITLE
Add EnsureSANHosts verification to certificates

### DIFF
--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -20,9 +20,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
-	"github.com/Mirantis/mke/pkg/constant"
-	"github.com/Mirantis/mke/pkg/util"
+	"github.com/cloudflare/cfssl/certinfo"
 	"github.com/cloudflare/cfssl/cli"
 	"github.com/cloudflare/cfssl/cli/genkey"
 	"github.com/cloudflare/cfssl/cli/sign"
@@ -31,6 +31,9 @@ import (
 	"github.com/cloudflare/cfssl/signer"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
+	"github.com/Mirantis/mke/pkg/constant"
+	"github.com/Mirantis/mke/pkg/util"
 )
 
 // Request defines the certificate request fields
@@ -59,7 +62,6 @@ func (m *Manager) EnsureCA(name, cn string) error {
 	certFile := filepath.Join(constant.CertRootDir, fmt.Sprintf("%s.crt", name))
 
 	if util.FileExists(keyFile) && util.FileExists(certFile) {
-
 		return nil
 	}
 
@@ -112,6 +114,11 @@ func (m *Manager) EnsureCertificate(certReq Request, ownerName string) (Certific
 	uid, _ := util.GetUID(ownerName)
 
 	if util.FileExists(keyFile) && util.FileExists(certFile) {
+		err := m.EnsureSANHosts(certReq, certFile)
+		if err != nil {
+			return Certificate{}, err
+		}
+
 		_ = os.Chown(keyFile, uid, gid)
 		_ = os.Chown(certFile, uid, gid)
 
@@ -190,4 +197,32 @@ func (m *Manager) EnsureCertificate(certReq Request, ownerName string) (Certific
 	}
 
 	return c, nil
+}
+
+// EnsureSANHosts verifies if the certificates contains the correct SANs
+// If not, it removes the certificate and forces generation of a new Cert
+func (m *Manager) EnsureSANHosts(certReq Request, certFile string) (err error) {
+	var cert *certinfo.Certificate
+
+	if cert, err = certinfo.ParseCertificateFile(certFile); err != nil {
+		return fmt.Errorf("unable to parse certificate file: %v", err)
+	}
+
+	// if existing SANs are different than configured, delete the certificate to re-generat it
+	if !util.IsStringArrayEqual(certReq.Hostnames, cert.SANs) {
+		logrus.Debug("found changes in SAN configuration. attempting to re-generate files")
+		// find and remove files to remove
+		filter := fmt.Sprintf("%s.*", strings.TrimSuffix(certFile, filepath.Ext(certFile))) // returns <cert_name>.*
+		files, err := filepath.Glob(filter)
+		if err != nil {
+			logrus.Errorf("unable to find files to clean up: %v", err)
+		}
+		for _, f := range files {
+			logrus.Debugf("deleting file %v for certificate re-generation", f)
+			if err := os.Remove(f); err != nil {
+				logrus.Errorf("failed to delete file: %v", f)
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/util/slice.go
+++ b/pkg/util/slice.go
@@ -15,6 +15,11 @@ limitations under the License.
 */
 package util
 
+import (
+	"reflect"
+	"sort"
+)
+
 // StringSliceContains check whether the given string slice contains the other string
 func StringSliceContains(strSlice []string, str string) bool {
 	for _, s := range strSlice {
@@ -23,5 +28,15 @@ func StringSliceContains(strSlice []string, str string) bool {
 		}
 	}
 
+	return false
+}
+
+// IsStringArrayEqual returns true if an array of strings is equal, regardless of order
+func IsStringArrayEqual(a1 []string, a2 []string) bool {
+	sort.Strings(a1)
+	sort.Strings(a2)
+	if len(a1) == len(a2) {
+		return reflect.DeepEqual(a1, a2)
+	}
 	return false
 }

--- a/pkg/util/slice_test.go
+++ b/pkg/util/slice_test.go
@@ -52,3 +52,39 @@ func TestStringSliceContains(t *testing.T) {
 		})
 	}
 }
+
+func TestArrayIsEqual(t *testing.T) {
+	type args struct {
+		arrayString     []string
+		arrayStringComp []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "unordered equal",
+			args: args{
+				arrayString:     []string{"a", "b", "c"},
+				arrayStringComp: []string{"b", "a", "c"},
+			},
+			want: true,
+		},
+		{
+			name: "ordered unequal",
+			args: args{
+				arrayString:     []string{"a", "b", "c"},
+				arrayStringComp: []string{"a", "b", "d"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsStringArrayEqual(tt.args.arrayString, tt.args.arrayStringComp); got != tt.want {
+				t.Errorf("IsStringArrayEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Karen Almog <kalmog@mirantis.com>

**Issue**
Fixes #345 

**What this PR Includes**
This PR scans the configured SANs from mke.yaml, and if they don't match, will remove the offending certificates for re-generation.