### PR TITLE
Add regenerateCert verification to certificates

### DIFF
--- a/pkg/util/slice.go
+++ b/pkg/util/slice.go
@@ -15,6 +15,11 @@ limitations under the License.
 */
 package util
 
+import (
+	"reflect"
+	"sort"
+)
+
 // StringSliceContains check whether the given string slice contains the other string
 func StringSliceContains(strSlice []string, str string) bool {
 	for _, s := range strSlice {
@@ -23,5 +28,15 @@ func StringSliceContains(strSlice []string, str string) bool {
 		}
 	}
 
+	return false
+}
+
+// IsStringArrayEqual returns true if an array of strings is equal, regardless of order
+func IsStringArrayEqual(a1 []string, a2 []string) bool {
+	sort.Strings(a1)
+	sort.Strings(a2)
+	if len(a1) == len(a2) {
+		return reflect.DeepEqual(a1, a2)
+	}
 	return false
 }

--- a/pkg/util/slice_test.go
+++ b/pkg/util/slice_test.go
@@ -52,3 +52,39 @@ func TestStringSliceContains(t *testing.T) {
 		})
 	}
 }
+
+func TestArrayIsEqual(t *testing.T) {
+	type args struct {
+		arrayString     []string
+		arrayStringComp []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "unordered equal",
+			args: args{
+				arrayString:     []string{"a", "b", "c"},
+				arrayStringComp: []string{"b", "a", "c"},
+			},
+			want: true,
+		},
+		{
+			name: "ordered unequal",
+			args: args{
+				arrayString:     []string{"a", "b", "c"},
+				arrayStringComp: []string{"a", "b", "d"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsStringArrayEqual(tt.args.arrayString, tt.args.arrayStringComp); got != tt.want {
+				t.Errorf("IsStringArrayEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Karen Almog <kalmog@mirantis.com>

**Issue**
Fixes #345
Re-opened from #352 after repo name change.

**What this PR Includes**
This PR adds an EnsureSANHosts to the certificate manager in order to detect changes in the configured SANs and re-generate the certificate.

**e2e Test Results**
https://github.com/k0sproject/k0s/actions/runs/347326449 ✅ 