### PR TITLE
Ignore controller join token if CA is already existing

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -85,6 +86,16 @@ func configFromCmdFlag(ctx *cli.Context) (*config.ClusterConfig, error) {
 	return clusterConfig, nil
 }
 
+// If we've got CA in place we assume the node has already joined previously
+func needToJoin() bool {
+	if util.FileExists(filepath.Join(constant.CertRootDir, "ca.key")) &&
+		util.FileExists(filepath.Join(constant.CertRootDir, "ca.crt")) {
+		return false
+	}
+
+	return true
+}
+
 func startServer(ctx *cli.Context) error {
 	perfTimer := performance.NewTimer("server-start").Buffer().Start()
 	clusterConfig, err := configFromCmdFlag(ctx)
@@ -106,7 +117,7 @@ func startServer(ctx *cli.Context) error {
 	var join = false
 	var joinClient *v1beta1.JoinClient
 	token := ctx.Args().First()
-	if token != "" {
+	if token != "" && needToJoin() {
 		join = true
 		joinClient, err = v1beta1.JoinClientFromToken(token)
 		if err != nil {

--- a/inttest/hacontrolplane/hacontrolplane_test.go
+++ b/inttest/hacontrolplane/hacontrolplane_test.go
@@ -110,6 +110,15 @@ func (s *HAControlplaneSuite) TestDeregistration() {
 	s.Equal(membersFromMain, membersFromJoined,
 		"etcd cluster members list must be the same across all nodes")
 	s.Len(membersFromJoined, 2, "etcd cluster must have exactly 2 members")
+
+	// Restart the second controller with a token to see it comes up
+	// It should just ignore the token as there's CA etc already in place
+	sshC1, err := s.SSH("controller1")
+	s.Require().NoError(err)
+	_, _ = sshC1.ExecWithOutput("kill $(pidof mke)")
+	s.NoError(s.JoinController(1, token))
+
+	// Make one member leave the etcd cluster
 	s.makeNodeLeave(1, membersFromJoined["controller1"])
 	refreshedMembers := s.getMembers(0)
 	s.Len(refreshedMembers, 1)


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

This PR replaces #351 as I managed to delete my previous forked repo and thus rebasing was not really doable. 🤦 

**Issue**
Fixes #350 

**What this PR Includes**
IF we see that CA already exists we'll now ignore the given join token on `mke server`. In cases where mke controller restarts  and etcd has temporarily lost quorum the join call (even as being no-op in general) would fail and will make the mke restart fail.

Added also test for this as part of the HA controller suite.