### PR TITLE
Fix running kube-apiserver as non-root (#363)

### DIFF
--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -18,7 +18,9 @@ RUN echo "#!/bin/sh" > /etc/local.d/machine-id.start \
        && echo "fi" >> /etc/local.d/machine-id.start \
        && chmod +x /etc/local.d/machine-id.start
 
-RUN adduser -H -S -s /sbin/nologin etcd
+RUN for i in etcd kube-apiserver; do \
+        adduser -H -S -s /sbin/nologin $i; \
+    done
 
 # Put kubectl into place to ease up debugging
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl \

--- a/pkg/component/server/konnectivity.go
+++ b/pkg/component/server/konnectivity.go
@@ -41,7 +41,7 @@ type Konnectivity struct {
 // Init ...
 func (k *Konnectivity) Init() error {
 	var err error
-	k.uid, err = util.GetUID(constant.ApiserverUser)
+	k.uid, err = util.GetUID(constant.KonnectivityServerUser)
 	if err != nil {
 		logrus.Warning(errors.Wrap(err, "Running konnectivity as root"))
 	}

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -31,7 +31,7 @@ const (
 	//EtcdCertDir contains etcd certificates
 	EtcdCertDir = "/var/lib/k0s/pki/etcd"
 	// EtcdCertDirMode is the expected directory permissions for EtcdCertDir
-	EtcdCertDirMode = 0700
+	EtcdCertDirMode = 0711
 	// CertMode is the expected permissions for certificates. see: https://docs.datadoghq.com/security_monitoring/default_rules/cis-kubernetes-1.5.1-1.1.20/
 	CertMode = 0644
 	// CertSecureMode is the expected file permissions for secure files. see: https://docs.datadoghq.com/security_monitoring/default_rules/cis-kubernetes-1.5.1-1.1.13/
@@ -79,6 +79,8 @@ const (
 	ControllerManagerUser = "kube-controller-manager"
 	// SchedulerUser defines the user to use for running k8s scheduler
 	SchedulerUser = "kube-scheduler"
+	// KonnectivityServerUser deinfes the user to use for konnectivity-server
+	KonnectivityServerUser = "konnectivity-server"
 
 	// KubernetesMajorMinorVersion defines the current embedded major.minor version info
 	KubernetesMajorMinorVersion = "1.19"


### PR DESCRIPTION
Use a separate user for konnectivity-server so kube-apiserver has a
dedicated user account.

Adjust permissions of etcd certificate dir so apiserver can read the
etcd CA cert.

---
name: Pull Request
about: Create a Pull Request
title: ''
labels: ''
assignees: ''

---

**Issue**
Fixes #363
**What this PR Includes**

Create user for kube-apiserver in footloose smoke tests

Use a separate user for konnectivity-server so kube-apiserver has a
dedicated user account.

Adjust permissions of etcd certificate dir so apiserver can read the
etcd CA cert.


