### PR TITLE
Enable cloud providers for k0s clusters

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -50,6 +50,11 @@ func WorkerCommand() *cli.Command {
 				Name:  "cri-socket",
 				Usage: "contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]",
 			},
+			&cli.BoolFlag{
+				Name:  "enable-cloud-provider",
+				Usage: "Whether or not to enable cloud provider support in kubelet",
+				Value: false,
+			},
 		},
 		ArgsUsage: "[join-token]",
 	}
@@ -84,6 +89,7 @@ func startWorker(ctx *cli.Context) error {
 		KubeletConfigClient: kubeletConfigClient,
 		Profile:             ctx.String("profile"),
 		CRISocket:           ctx.String("cri-socket"),
+		EnableCloudProvider: ctx.Bool("enable-cloud-provider"),
 	})
 
 	// extract needed components

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -1,0 +1,20 @@
+# Using cloud providers
+
+k0s builds Kubernetes components in "providerless" mode. This means that there is no cloud providers built into k0s managed Kubernetes components.
+
+This means the cloud providers have to be configured "externally". The following steps outline how to enable cloud providers support in your k0s cluster.
+
+For more information on running Kubernetes with cloud providers see the [official documentation](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/).
+
+## Enabling cloud provider support in kubelet
+
+Even when all components are built with "providerless" mode, we need to be able to enable cloud provider "mode" for kubelet. This is done by running the workers with `--enable-cloud-provider=true`. This enables `--cloud-provider=external` on kubelet process.
+
+## Deploying the actual cloud provider
+
+Fro Kubernetes point of view, it does not realy matter how and where the cloud providers controller(s) are running. Of course the easiest way is to deploy them on the cluster itself. 
+
+To deploy your cloud provider as k0s managed stack you can use the built-in [manifest deployer](manifests.md). Simply drop all the needed manifests under e.g. `/var/lib/k0s/manifests/aws/` directory and k0s will deploy everything.
+
+Some cloud providers do need some configuration files to be present on all the nodes or some other pre-requisites. Consult your cloud providers documentation for needed steps.
+

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -30,7 +30,7 @@ $ kubectl -n kube-system logs coredns-5c98d7d4d8-tfs4q
 plugin/loop: Loop (127.0.0.1:55953 -> :1053) detected for zone ".", see https://coredns.io/plugins/loop#troubleshooting. Query: "HINFO 4547991504243258144.3688648895315093531."
 ```
 
-This is most often cause by systemd-resolved stub (or something similar) running locally and CoreDNS detects a possible loop with DNS queries.
+This is most often caused by systemd-resolved stub (or something similar) running locally and CoreDNS detects a possible loop with DNS queries.
 
 The easiest but most crude way to workaround is to disable the systemd-resolved stub and revert the hosts `/etc/resolv.conf` to original
 
@@ -43,3 +43,10 @@ In the logs you probably see ETCD not starting up properly.
 Etcd is [not fully supported](https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/supported-platform.md#current-support) on ARM architecture, thus you need to run `k0s server` and thus also etcd process with env `ETCD_UNSUPPORTED_ARCH=arm64`.
 
 As Etcd is not fully supported on ARM architecture it also means that k0s controlplane with etcd itself is not fully supported on ARM either.
+
+
+## Pods pending when using cloud providers
+
+Once we enable [cloud provider support](cloud-providers.md) on kubelet on worker nodes, kubelet will automatically add a taint `node.cloudprovider.kubernetes.io/uninitialized` for the node. This tain will prevent normal workloads to be scheduled on the node untill the cloud provider controller actually runs second initialization on the node and removes the taint. This means that these nodes are not schedulable untill the cloud provider controller is actually succesfully running on the cluster.
+
+For troubleshooting your specific cloud provider see its documentation.

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -36,6 +36,7 @@ type Kubelet struct {
 	KubeletConfigClient *KubeletConfigClient
 	Profile             string
 	CRISocket           string
+	EnableCloudProvider bool
 	supervisor          supervisor.Supervisor
 	dataDir             string
 }
@@ -100,6 +101,11 @@ func (k *Kubelet) Run() error {
 	} else {
 		args = append(args, "--container-runtime=remote")
 		args = append(args, fmt.Sprintf("--container-runtime-endpoint=unix://%s", path.Join(constant.RunDir, "containerd.sock")))
+	}
+
+	// We only support external providers
+	if k.EnableCloudProvider {
+		args = append(args, "--cloud-provider=external")
 	}
 
 	k.supervisor = supervisor.Supervisor{


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
N/A

**What this PR Includes**

This PR adds flag for worker to enable cloud provider functionality on kubelets. This is needed to support any externally provided clour provider.

**Testing**

Currently pretty impossible to do any smoke tests for this as there's no simple "fake" cloud providers to test with. 

I've tested this manually in Hetzners cloud.

Ran controller with:
```
k0s server
```

Ran the worker with:
```
k0s worker --enable-cloud-provider=true <token>
```

As expected, some pods are still pending and for the node we only see the internal address kubelet picks up:
```
root@k0s-demo-controller-0:~# kubectl get node -o wide
NAME                STATUS   ROLES    AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
k0s-demo-worker-0   Ready    <none>   60s   v1.19.3   78.47.195.159   <none>        Ubuntu 18.04.5 LTS   4.15.0-122-generic   containerd://1.4.0
```

Then deployed the [Hetzner cloud provider](https://github.com/hetznercloud/hcloud-cloud-controller-manager) with:
```
$ kubectl -n kube-system create secret generic hcloud --from-literal=token=<htoken>
$ mkdir -p /var/lib/k0s/manifests/hcloud
$ curl -sSLf https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/ccm.yaml > var/lib/k0s/manifests/hcloud/hcloud.yaml
```

Once all the cloud controller components gets up, we see the node getting synced with Hetzner cloud side:
```
root@k0s-demo-controller-0:~# kubectl get node -o wide --show-labels
NAME                STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP     OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME    LABELS
k0s-demo-worker-0   Ready    <none>   55m   v1.19.3   <none>        78.47.195.159   Ubuntu 18.04.5 LTS   4.15.0-122-generic   containerd://1.4.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=cx21,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=fsn1,failure-domain.beta.kubernetes.io/zone=fsn1-dc14,kubernetes.io/arch=amd64,kubernetes.io/hostname=k0s-demo-worker-0,kubernetes.io/os=linux,node.kubernetes.io/instance-type=cx21,topology.kubernetes.io/region=fsn1,topology.kubernetes.io/zone=fsn1-dc14
```
