### PR TITLE
Add fallback for MachineID based on hostname

### DIFF
--- a/pkg/util/machineid.go
+++ b/pkg/util/machineid.go
@@ -1,8 +1,23 @@
 package util
 
-import "github.com/denisbrodbeck/machineid"
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"os"
+
+	"github.com/denisbrodbeck/machineid"
+)
 
 // MachineID returns protected id for the current machine
 func MachineID() (string, error) {
-	return machineid.ProtectedID("k0sproject-k0s")
+	id, err := machineid.ProtectedID("k0sproject-k0s")
+	if err != nil {
+		name, err := os.Hostname()
+		if err != nil {
+			return "", err
+		}
+		sum := md5.Sum([]byte(name))
+		id = hex.EncodeToString(sum[:])
+	}
+	return id, err
 }


### PR DESCRIPTION
Generate a machine id from md5sum of hostname in case /etc/machine-id is missing.

fixes #353

