### PR TITLE
Add kine smoke test

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -227,6 +227,37 @@ jobs:
           path: |
             /tmp/*.log
 
+  smoketest-kine:
+    name: Smoke test for kine backed
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR Reference and Set Cache Name
+        run: |
+          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Cache compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
+
+      - name: Run kine test
+        run: make -C inttest check-kine
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
 
   smoketest-network:
     name: Smoke test for network

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ check-addons: k0s
 check-singlenode: k0s
 	$(MAKE) -C inttest check-singlenode
 
+.PHONY: check-kine
+check-kine: k0s
+	$(MAKE) -C inttest check-kine
+
 .PHONY: check-unit
 check-unit: pkg/assets/zz_generated_offsets.go
 	go test -race ./pkg/...

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -43,6 +43,8 @@ check-addons: .footloose-alpine.stamp
 check-singlenode: .footloose-alpine.stamp
 	K0S_PATH=$(realpath ../k0s) go test -count=1 -v -timeout 3m github.com/k0sproject/k0s/inttest/singlenode
 
+check-kine: .footloose-alpine.stamp
+	K0S_PATH=$(realpath ../k0s) go test -count=1 -v -timeout 3m github.com/k0sproject/k0s/inttest/kine
 
 .PHONY: clean
 clean:

--- a/inttest/kine/kine_test.go
+++ b/inttest/kine/kine_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 Mirantis, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package kine
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type KineSuite struct {
+	common.FootlooseSuite
+}
+
+func (s *KineSuite) TestK0sGetsUp() {
+	s.putFile("controller0", "/tmp/k0s.yaml", k0sConfigWithKine)
+	s.NoError(s.InitMainController("/tmp/k0s.yaml"))
+	s.NoError(s.RunWorkers())
+
+	kc, err := s.KubeClient("controller0")
+	s.NoError(err)
+
+	err = s.WaitForNodeReady("worker0", kc)
+	s.NoError(err)
+
+	err = s.WaitForNodeReady("worker1", kc)
+	s.NoError(err)
+
+	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
+		Limit: 100,
+	})
+	s.NoError(err)
+
+	podCount := len(pods.Items)
+
+	s.T().Logf("found %d pods in kube-system", podCount)
+	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+
+	s.T().Log("waiting to see calico pods ready")
+	s.NoError(common.WaitForCalicoReady(kc), "calico did not start")
+}
+
+func TestKineSuite(t *testing.T) {
+	s := KineSuite{
+		common.FootlooseSuite{
+			ControllerCount: 1,
+			WorkerCount:     2,
+		},
+	}
+	suite.Run(t, &s)
+}
+
+func (s *KineSuite) putFile(node string, path string, content string) {
+	ssh, err := s.SSH(node)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+	_, err = ssh.ExecWithOutput(fmt.Sprintf("echo '%s' >%s", content, path))
+
+	s.Require().NoError(err)
+}
+
+const k0sConfigWithKine = `
+spec:
+  storage:
+    type: kine
+`

--- a/pkg/component/server/apiserver.go
+++ b/pkg/component/server/apiserver.go
@@ -138,7 +138,7 @@ func (a *APIServer) Run() error {
 		switch a.ClusterConfig.Spec.Storage.Type {
 		case config.KineStorageType:
 			a.supervisor.Args = append(a.supervisor.Args,
-				fmt.Sprintf("--etcd-servers=unix://%s", path.Join(constant.RunDir, "kine.sock:2379"))) // kine endpoint
+				fmt.Sprintf("--etcd-servers=unix://%s", constant.KineSocketPath)) // kine endpoint
 		case config.EtcdStorageType:
 			a.supervisor.Args = append(a.supervisor.Args,
 				"--etcd-servers=https://127.0.0.1:2379",

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -51,6 +51,8 @@ const (
 	ManifestsDir = "/var/lib/k0s/manifests"
 	// ManifestsDirMode is the expected directory permissions for ManifestsDir
 	ManifestsDirMode = 0644
+	// KineSocket is the unix socket path for kine
+	KineSocketPath = "/run/k0s/kine/kine.sock:2379"
 
 	// KubeletBootstrapConfigPath defines the default path for kubelet bootstrap auth config
 	KubeletBootstrapConfigPath = "/var/lib/k0s/kubelet-bootstrap.conf"
@@ -72,7 +74,7 @@ const (
 	// EtcdUser defines the user to use for running etcd process
 	EtcdUser = "etcd"
 	// KineUser defines the user to use for running kine process
-	KineUser = "kine"
+	KineUser = "kube-apiserver" // apiserver needs to be able to read the kine unix socket
 	// ApiserverUser defines the user to use for running k8s api-server process
 	ApiserverUser = "kube-apiserver"
 	// ControllerManagerUser defines the user to use for running k8s controller manager process


### PR DESCRIPTION
**What this PR Includes**
- add an option k0s config file to footloose smoke test via `K0S_CONFIG` env var
- adds a smoke test for kine
- fix so kine can run as non-root, as `kube-apiserver`
