### PR TITLE
Add log levels to kubelet and containerd when launched as part of server

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -194,6 +194,37 @@ jobs:
           path: |
             /tmp/*.log
 
+  smoketest-singlenode:
+    name: Smoke test for single node k0s
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR Reference and Set Cache Name
+        run: |
+          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Cache compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
+
+      - name: Run singlenode test
+        run: make -C inttest check-singlenode
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
 
   smoketest-network:
     name: Smoke test for network

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,10 @@ check-hacontrolplane: k0s
 check-addons: k0s
 	$(MAKE) -C inttest check-addons
 
+.PHONY:
+check-singlenode: k0s
+	$(MAKE) -C inttest check-singlenode
+
 .PHONY: check-unit
 check-unit: pkg/assets/zz_generated_offsets.go
 	go test -race ./pkg/...

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -356,10 +356,13 @@ func enableServerWorker(clusterConfig *config.ClusterConfig, componentManager *c
 		return err
 	}
 
-	containerd := &worker.ContainerD{}
+	containerd := &worker.ContainerD{
+		LogLevel: logging["containerd"],
+	}
 	kubelet := &worker.Kubelet{
 		KubeletConfigClient: kubeletConfigClient,
 		Profile:             profile,
+		LogLevel:            logging["kubelet"],
 	}
 
 	if err := containerd.Init(); err != nil {

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -40,6 +40,9 @@ check-hacontrolplane: .footloose-alpine.stamp
 check-addons: .footloose-alpine.stamp
 	K0S_PATH=$(realpath ../k0s) go test -count=1 -v -timeout 3m github.com/k0sproject/k0s/inttest/addons
 
+check-singlenode: .footloose-alpine.stamp
+	K0S_PATH=$(realpath ../k0s) go test -count=1 -v -timeout 3m github.com/k0sproject/k0s/inttest/singlenode
+
 
 .PHONY: clean
 clean:

--- a/inttest/singlenode/singlenode_test.go
+++ b/inttest/singlenode/singlenode_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 Mirantis, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package singlenode
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type SingleNodeSuite struct {
+	common.FootlooseSuite
+}
+
+func (s *SingleNodeSuite) TestK0sGetsUp() {
+	ssh, err := s.SSH("controller0")
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	_, err = ssh.ExecWithOutput("ETCD_UNSUPPORTED_ARCH=arm64 nohup k0s --debug server --enable-worker >/tmp/k0s-server.log 2>&1 &")
+	s.Require().NoError(err)
+	err = s.WaitForKubeAPI("controller0")
+	s.Require().NoError(err)
+
+	kc, err := s.KubeClient("controller0")
+	s.NoError(err)
+
+	err = s.WaitForNodeReady("controller0", kc)
+	s.NoError(err)
+
+	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
+		Limit: 100,
+	})
+	s.NoError(err)
+
+	podCount := len(pods.Items)
+
+	s.T().Logf("found %d pods in kube-system", podCount)
+	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+
+	s.T().Log("waiting to see calico pods ready")
+	s.NoError(common.WaitForCalicoReady(kc), "calico did not start")
+}
+
+func TestSingleNodeSuite(t *testing.T) {
+	s := SingleNodeSuite{
+		common.FootlooseSuite{
+			ControllerCount: 1,
+		},
+	}
+	suite.Run(t, &s)
+}


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Currently `k0s server --enable-worker` fails to get kubelet up. That's because we pass in an empty string for the `-v` flag as we do not set the log levels in this special case.

**What this PR Includes**
Fixes the log levels for kubelet and containerd when running with `k0s server --enable-worker`