### PR TITLE
Add "resolv-conf" flag to Kubelet for CoreDNS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cloudflare/cfssl v1.4.1
 	github.com/containerd/containerd v1.4.1 // indirect
 	github.com/denisbrodbeck/machineid v1.0.1
+	github.com/docker/libnetwork v0.5.6
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/ghodss/yaml v1.0.0
@@ -16,6 +17,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.8
+	github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07 // indirect
 	github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/magiconair/properties v1.8.1
@@ -57,4 +59,5 @@ replace go.etcd.io/etcd => github.com/etcd-io/etcd v0.5.0-alpha.5.0.202008241911
 replace (
 	github.com/docker/distribution => github.com/docker/distribution v0.0.0-20191216044856-a8371794149d
 	github.com/docker/docker => github.com/moby/moby v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible
+	github.com/docker/libnetwork => github.com/moby/libnetwork v0.8.0-dev.2.0.20201031180254-535ef365dc1d
 )

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916/go.mod h1:/u0gXw
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/libnetwork v0.5.6 h1:hnGiypBsZR6PW1I8lqaBHh06U6LCJbI3IhOvfsZiymY=
+github.com/docker/libnetwork v0.5.6/go.mod h1:93m0aTqz6z+g32wla4l4WxTrdtvBRmVzYRkYvasA5Z8=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 h1:ZClxb8laGDf5arXfYcAtECDFgAgHklGI8CxgjHnXKJ4=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
@@ -456,6 +458,8 @@ github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07 h1:rw3IAne6CDuVFlZbPOkA7bhxlqawFh7RJJ+CejfMaxE=
+github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -564,6 +568,8 @@ github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f h1:2+myh5ml7lgEU/5
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/moby/libnetwork v0.8.0-dev.2.0.20201031180254-535ef365dc1d h1:328tNjlGcQcWHD8NMPNWq/2aQSc6EJtE5NRU3nHJUv8=
+github.com/moby/libnetwork v0.8.0-dev.2.0.20201031180254-535ef365dc1d/go.mod h1:RQTqDxGZChsPHosY8R3ZL2THYWUuW8X5SRhiBNoTY5I=
 github.com/moby/moby v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible h1:NT0cwArZg/wGdvY8pzej4tPr+9WGmDdkF8Suj+mkz2g=
 github.com/moby/moby v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd h1:aY7OQNf2XqY/JQ6qREWamhI/81os/agb2BAGpcx5yWI=

--- a/inttest/terraform/test-cluster/controller.tf
+++ b/inttest/terraform/test-cluster/controller.tf
@@ -26,16 +26,6 @@ resource "aws_instance" "cluster-controller" {
     inline = [<<EOF
       sudo hostnamectl set-hostname controller-${count.index}
       sudo sh -c 'echo 127.0.0.1 controller-${count.index} >> /etc/hosts'
-
-      echo "checking systemd resolv.conf..."
-      if grep -q "127.0.0.53" /etc/resolv.conf; then
-        echo "resolv.conf still points to localhost. Attempting to fix..."
-        sudo rm /etc/resolv.conf
-        sudo systemctl disable systemd-resolved.service
-        sudo systemctl stop systemd-resolved
-        sudo sh -c 'echo nameserver 10.0.0.2 >> /etc/resolv.conf'
-        sudo sh -c 'echo search eu-west-1.compute.internal >> /etc/resolv.conf'
-      fi
     EOF
     ]
   }

--- a/inttest/terraform/test-cluster/worker.tf
+++ b/inttest/terraform/test-cluster/worker.tf
@@ -27,15 +27,6 @@ resource "aws_instance" "cluster-workers" {
     inline = [<<EOF
       sudo hostnamectl set-hostname worker-${count.index}
       sudo sh -c 'echo 127.0.0.1 worker-${count.index} >> /etc/hosts'
-      echo "checking systemd resolv.conf..."
-      if grep -q "127.0.0.53" /etc/resolv.conf; then
-        echo "resolv.conf still points to localhost. Attempting to fix..."
-        sudo rm /etc/resolv.conf
-        sudo systemctl disable systemd-resolved.service
-        sudo systemctl stop systemd-resolved
-        sudo sh -c 'echo nameserver 10.0.0.2 >> /etc/resolv.conf'
-        sudo sh -c 'echo search eu-west-1.compute.internal >> /etc/resolv.conf'
-      fi
     EOF
     ]
   }


### PR DESCRIPTION
**Issue**
Fixes  #390

**What this PR Includes**
This PR removes the need for "hacking" the `resolv.conf` file in systemd-resolvd systems, by finding out the "real" resolv.conf file and passing it as the value for the `--resolv-conf` flag in kubelet.

**e2e**
https://github.com/k0sproject/k0s/actions/runs/361469902 ✅ 