### PR TITLE
Add unit tests for machine-id fallback

### DIFF
--- a/pkg/util/machineid.go
+++ b/pkg/util/machineid.go
@@ -12,12 +12,17 @@ import (
 func MachineID() (string, error) {
 	id, err := machineid.ProtectedID("k0sproject-k0s")
 	if err != nil {
-		name, err := os.Hostname()
-		if err != nil {
-			return "", err
-		}
-		sum := md5.Sum([]byte(name))
-		id = hex.EncodeToString(sum[:])
+		return MachineIDFromHostname()
 	}
 	return id, err
+}
+
+// MachineIDFromHostname generates a machine id hash from hostname
+func MachineIDFromHostname() (string, error) {
+	name, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+	sum := md5.Sum([]byte(name))
+	return hex.EncodeToString(sum[:]), nil
 }

--- a/pkg/util/machineid_test.go
+++ b/pkg/util/machineid_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 Mirantis, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import "testing"
+
+func TestMachineIDFromHostname(t *testing.T) {
+	id, err := MachineIDFromHostname()
+	if err != nil {
+		t.Errorf("machineIDFromHostname() unexpctedly returned error")
+	} else if len(id) != 32 {
+		t.Errorf("len(machineIDFromHostname()) = %d, want %d", len(id), 32)
+	}
+
+	// test that id does not change
+	id2, err := MachineIDFromHostname()
+	if err != nil {
+		t.Errorf("machineIDFromHostname() unexpectedly returned error")
+	} else if id != id2 {
+		t.Errorf("machineIDFromHostname() = %s, want %s", id2, id)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Natanael Copa <ncopa@mirantis.com>

**What this PR Includes**
Add unit tests for machine-id fallback introduced in commit 1629769fd3bdca2a0a6c1b78753f01db25913f08