### PR TITLE
Fix control plane as non root (#392)

### DIFF
--- a/pkg/assets/stage.go
+++ b/pkg/assets/stage.go
@@ -83,7 +83,7 @@ func Stage(dataDir string, name string, filemode os.FileMode, group string) erro
 		for _, path := range []string{dataDir, filepath.Dir(p)} {
 			logrus.Debugf("setting group ownership for %s to %d", path, gid)
 			err := os.Chown(path, -1, gid)
-			if err != nil {
+			if err != nil && os.Geteuid() == 0 {
 				return err
 			}
 		}

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -93,7 +93,7 @@ func (m *Manager) EnsureCA(name, cn string) error {
 		paths := []string{filepath.Dir(keyFile), keyFile, certFile}
 		for _, path := range paths {
 			err = os.Chown(path, -1, gid)
-			if err != nil {
+			if err != nil && os.Geteuid() == 0 {
 				logrus.Warning(err)
 			}
 		}
@@ -167,11 +167,11 @@ func (m *Manager) EnsureCertificate(certReq Request, ownerName string) (Certific
 		}
 
 		err = os.Chown(keyFile, uid, gid)
-		if err != nil {
+		if err != nil && os.Geteuid() == 0 {
 			return Certificate{}, err
 		}
 		err = os.Chown(certFile, uid, gid)
-		if err != nil {
+		if err != nil && os.Geteuid() == 0 {
 			return Certificate{}, err
 		}
 

--- a/pkg/component/server/controllermanager.go
+++ b/pkg/component/server/controllermanager.go
@@ -61,7 +61,7 @@ func (a *ControllerManager) Init() error {
 
 	// controller manager should be the only component that needs access to
 	// ca.key so let it own it.
-	if err := os.Chown(path.Join(constant.CertRootDir, "ca.key"), a.uid, -1); err != nil {
+	if err := os.Chown(path.Join(constant.CertRootDir, "ca.key"), a.uid, -1); err != nil && os.Geteuid() == 0 {
 		logrus.Warning(errors.Wrap(err, "Can't change permissions for the ca.key"))
 	}
 

--- a/pkg/component/server/etcd.go
+++ b/pkg/component/server/etcd.go
@@ -80,7 +80,7 @@ func (e *Etcd) Init() error {
 
 	for _, f := range []string{constant.EtcdDataDir, constant.EtcdCertDir} {
 		err = os.Chown(f, e.uid, e.gid)
-		if err != nil {
+		if err != nil && os.Geteuid() == 0 {
 			return err
 		}
 	}
@@ -90,7 +90,7 @@ func (e *Etcd) Init() error {
 		"server.crt",
 		"server.key",
 	} {
-		if err := os.Chown(path.Join(constant.EtcdCertDir, f), e.uid, e.gid); err != nil {
+		if err := os.Chown(path.Join(constant.EtcdCertDir, f), e.uid, e.gid); err != nil && os.Geteuid() == 0 {
 			// TODO: directory may not yet exist. log it and wait for retry for now
 			logrus.Errorf("failed to chown %s: %s", f, err)
 		}
@@ -154,7 +154,7 @@ func (e *Etcd) Run() error {
 				return err
 			}
 			for _, f := range []string{filepath.Dir(etcdCaCertKey), etcdCaCertKey, etcdCaCert} {
-				if err := os.Chown(f, e.uid, e.gid); err != nil {
+				if err := os.Chown(f, e.uid, e.gid); err != nil && os.Geteuid() == 0 {
 					return err
 				}
 			}

--- a/pkg/component/server/kine.go
+++ b/pkg/component/server/kine.go
@@ -55,7 +55,7 @@ func (k *Kine) Init() error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to create %s", kineSocketDir)
 	}
-	if err := os.Chown(kineSocketDir, k.uid, k.gid); err != nil {
+	if err := os.Chown(kineSocketDir, k.uid, k.gid); err != nil && os.Geteuid() == 0 {
 		logrus.Warningf("failed to chown %s", kineSocketDir)
 	}
 
@@ -70,10 +70,10 @@ func (k *Kine) Init() error {
 			return errors.Wrapf(err, "failed to create dir %s", filepath.Dir(dsURL.Path))
 		}
 		err = os.Chown(filepath.Dir(dsURL.Path), k.uid, k.gid)
-		if err != nil {
+		if err != nil && os.Geteuid() == 0 {
 			return errors.Wrapf(err, "failed to chown dir %s", filepath.Dir(dsURL.Path))
 		}
-		if err := os.Chown(dsURL.Path, k.uid, k.gid); err != nil {
+		if err := os.Chown(dsURL.Path, k.uid, k.gid); err != nil && os.Geteuid() == 0 {
 			logrus.Warningf("datasource file %s does not exist", dsURL.Path)
 		}
 	}

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -50,7 +50,7 @@ const (
 	// ManifestsDir defines the location for all stack manifests
 	ManifestsDir = "/var/lib/k0s/manifests"
 	// ManifestsDirMode is the expected directory permissions for ManifestsDir
-	ManifestsDirMode = 0644
+	ManifestsDirMode = 0755
 	// KineSocket is the unix socket path for kine
 	KineSocketPath = "/run/k0s/kine/kine.sock:2379"
 

--- a/pkg/supervisor/detachattr.go
+++ b/pkg/supervisor/detachattr.go
@@ -18,16 +18,25 @@ limitations under the License.
 
 package supervisor
 
-import "syscall"
+import (
+	"os"
+	"syscall"
+)
 
 // DetachAttr creates the proper syscall attributes to run the managed processes
 func DetachAttr(uid, gid int) *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{
-		Setpgid: true,
-		Pgid:    0,
-		Credential: &syscall.Credential{
+	var creds *syscall.Credential
+
+	if os.Geteuid() == 0 {
+		creds = &syscall.Credential{
 			Uid: uint32(uid),
 			Gid: uint32(gid),
-		},
+		}
+	}
+
+	return &syscall.SysProcAttr{
+		Setpgid:    true,
+		Pgid:       0,
+		Credential: creds,
 	}
 }


### PR DESCRIPTION

**Issue**
Fixes #392 

**What this PR Includes**
Fix running the full control plane as non-root by:
- fix permissions of manifests dir
- don't try set credentials in supervisor when running as non-root
- ignore errors from chown when running as non-root
