### PR TITLE
Set smoke test default timeout to 4 min

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -29,7 +29,7 @@ check-network-vm: bin/sonobuoy
 	K0S_PATH=$(realpath ../k0s) SONOBUOY_PATH=$(realpath bin/sonobuoy) \
 		go test -count=1 -v -timeout 20m github.com/k0sproject/k0s/inttest/sonobuoy/ -run ^TestVMNetworkSuite$
 
-TIMEOUT ?= 3m
+TIMEOUT ?= 4m
 smoketests := check-addons check-basic check-byocri check-hacontrolplane check-kine check-singlenode
 
 check-byocri: TIMEOUT=5m


### PR DESCRIPTION
The CI needs a bit more time.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

**What this PR Includes**
Increase the timeout to 4 mins for the smoke tests