### PR TITLE
Code cleanup, drop use of separate k0s group

### DIFF
--- a/pkg/assets/stage.go
+++ b/pkg/assets/stage.go
@@ -65,28 +65,13 @@ func BinPath(name string) string {
 }
 
 // Stage ...
-func Stage(dataDir string, name string, filemode os.FileMode, group string) error {
+func Stage(dataDir string, name string, filemode os.FileMode) error {
 	p := filepath.Join(dataDir, name)
 	logrus.Infof("Staging %s", p)
 
 	err := util.InitDirectory(filepath.Dir(p), filemode)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create dir %s", filepath.Dir(p))
-	}
-
-	/* set group owner of the directories */
-	gid, err := util.GetGID(group)
-	if err != nil {
-		logrus.Error(err)
-	}
-	if gid != 0 {
-		for _, path := range []string{dataDir, filepath.Dir(p)} {
-			logrus.Debugf("setting group ownership for %s to %d", path, gid)
-			err := os.Chown(path, -1, gid)
-			if err != nil && os.Geteuid() == 0 {
-				return err
-			}
-		}
 	}
 
 	if ExecutableIsOlder(p) {

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -88,19 +88,6 @@ func (m *Manager) EnsureCA(name, cn string) error {
 		return err
 	}
 
-	gid, err := util.GetGID(constant.Group)
-	if err == nil {
-		paths := []string{filepath.Dir(keyFile), keyFile, certFile}
-		for _, path := range paths {
-			err = os.Chown(path, -1, gid)
-			if err != nil && os.Geteuid() == 0 {
-				logrus.Warning(err)
-			}
-		}
-	} else {
-		logrus.Warning(err)
-	}
-
 	return nil
 }
 
@@ -110,7 +97,6 @@ func (m *Manager) EnsureCertificate(certReq Request, ownerName string) (Certific
 	keyFile := filepath.Join(constant.CertRootDir, fmt.Sprintf("%s.key", certReq.Name))
 	certFile := filepath.Join(constant.CertRootDir, fmt.Sprintf("%s.crt", certReq.Name))
 
-	gid, _ := util.GetGID(constant.Group)
 	uid, _ := util.GetUID(ownerName)
 
 	// if regenerateCert returns true, it means we need to create the certs
@@ -166,11 +152,11 @@ func (m *Manager) EnsureCertificate(certReq Request, ownerName string) (Certific
 			return Certificate{}, err
 		}
 
-		err = os.Chown(keyFile, uid, gid)
+		err = os.Chown(keyFile, uid, -1)
 		if err != nil && os.Geteuid() == 0 {
 			return Certificate{}, err
 		}
-		err = os.Chown(certFile, uid, gid)
+		err = os.Chown(certFile, uid, -1)
 		if err != nil && os.Geteuid() == 0 {
 			return Certificate{}, err
 		}
@@ -179,8 +165,8 @@ func (m *Manager) EnsureCertificate(certReq Request, ownerName string) (Certific
 	}
 
 	// certs exist, let's just verify their permissions
-	_ = os.Chown(keyFile, uid, gid)
-	_ = os.Chown(certFile, uid, gid)
+	_ = os.Chown(keyFile, uid, -1)
+	_ = os.Chown(certFile, uid, -1)
 
 	cert, err := ioutil.ReadFile(certFile)
 	if err != nil {

--- a/pkg/component/server/apiserver.go
+++ b/pkg/component/server/apiserver.go
@@ -72,7 +72,6 @@ func (a *APIServer) Init() error {
 	if err != nil {
 		logrus.Warning(errors.Wrap(err, "Running kube-apiserver as root"))
 	}
-	a.gid, _ = util.GetGID(constant.Group)
 
 	return assets.Stage(constant.BinDir, "kube-apiserver", constant.BinDirMode)
 }

--- a/pkg/component/server/apiserver.go
+++ b/pkg/component/server/apiserver.go
@@ -74,7 +74,7 @@ func (a *APIServer) Init() error {
 	}
 	a.gid, _ = util.GetGID(constant.Group)
 
-	return assets.Stage(constant.BinDir, "kube-apiserver", constant.BinDirMode, constant.Group)
+	return assets.Stage(constant.BinDir, "kube-apiserver", constant.BinDirMode)
 }
 
 // Run runs kube api

--- a/pkg/component/server/controllermanager.go
+++ b/pkg/component/server/controllermanager.go
@@ -57,7 +57,6 @@ func (a *ControllerManager) Init() error {
 	if err != nil {
 		logrus.Warning(errors.Wrap(err, "Running kube-controller-manager as root"))
 	}
-	a.gid, _ = util.GetGID(constant.Group)
 
 	// controller manager should be the only component that needs access to
 	// ca.key so let it own it.

--- a/pkg/component/server/controllermanager.go
+++ b/pkg/component/server/controllermanager.go
@@ -65,7 +65,7 @@ func (a *ControllerManager) Init() error {
 		logrus.Warning(errors.Wrap(err, "Can't change permissions for the ca.key"))
 	}
 
-	return assets.Stage(constant.BinDir, "kube-controller-manager", constant.BinDirMode, constant.Group)
+	return assets.Stage(constant.BinDir, "kube-controller-manager", constant.BinDirMode)
 }
 
 // Run runs kube ControllerManager

--- a/pkg/component/server/etcd.go
+++ b/pkg/component/server/etcd.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -81,17 +80,6 @@ func (e *Etcd) Init() error {
 		err = os.Chown(f, e.uid, e.gid)
 		if err != nil && os.Geteuid() == 0 {
 			return err
-		}
-	}
-
-	for _, f := range []string{
-		"ca.crt",
-		"server.crt",
-		"server.key",
-	} {
-		if err := os.Chown(path.Join(constant.EtcdCertDir, f), e.uid, e.gid); err != nil && os.Geteuid() == 0 {
-			// TODO: directory may not yet exist. log it and wait for retry for now
-			logrus.Errorf("failed to chown %s: %s", f, err)
 		}
 	}
 

--- a/pkg/component/server/etcd.go
+++ b/pkg/component/server/etcd.go
@@ -96,7 +96,7 @@ func (e *Etcd) Init() error {
 		}
 	}
 
-	return assets.Stage(constant.BinDir, "etcd", constant.BinDirMode, constant.Group)
+	return assets.Stage(constant.BinDir, "etcd", constant.BinDirMode)
 }
 
 // Run runs etcd

--- a/pkg/component/server/etcd.go
+++ b/pkg/component/server/etcd.go
@@ -66,7 +66,6 @@ func (e *Etcd) Init() error {
 	if err != nil {
 		logrus.Warning(errors.Wrap(err, "Running etcd as root"))
 	}
-	e.gid, _ = util.GetGID(constant.Group)
 
 	err = util.InitDirectory(constant.EtcdDataDir, constant.EtcdDataDirMode) // https://docs.datadoghq.com/security_monitoring/default_rules/cis-kubernetes-1.5.1-1.1.11/
 	if err != nil {

--- a/pkg/component/server/kine.go
+++ b/pkg/component/server/kine.go
@@ -77,7 +77,7 @@ func (k *Kine) Init() error {
 			logrus.Warningf("datasource file %s does not exist", dsURL.Path)
 		}
 	}
-	return assets.Stage(constant.BinDir, "kine", constant.BinDirMode, constant.Group)
+	return assets.Stage(constant.BinDir, "kine", constant.BinDirMode)
 }
 
 // Run runs kine

--- a/pkg/component/server/kine.go
+++ b/pkg/component/server/kine.go
@@ -49,8 +49,6 @@ func (k *Kine) Init() error {
 		logrus.Warning(errors.Wrap(err, "Running kine as root"))
 	}
 
-	k.gid, _ = util.GetGID(constant.Group)
-
 	err = util.InitDirectory(kineSocketDir, 0755)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create %s", kineSocketDir)

--- a/pkg/component/server/konnectivity.go
+++ b/pkg/component/server/konnectivity.go
@@ -48,7 +48,6 @@ func (k *Konnectivity) Init() error {
 		logrus.Warning(fmt.Errorf("Running konnectivity as root: %v", err))
 	}
 
-	k.gid, _ = util.GetGID(constant.Group)
 	err = util.InitDirectory(konnectivitySocketDir, 0755)
 	if err != nil {
 		return fmt.Errorf("failed to initialize directory %s: %v", konnectivitySocketDir, err)

--- a/pkg/component/server/konnectivity.go
+++ b/pkg/component/server/konnectivity.go
@@ -49,7 +49,6 @@ func (k *Konnectivity) Init() error {
 	}
 
 	k.gid, _ = util.GetGID(constant.Group)
-
 	err = util.InitDirectory(konnectivitySocketDir, 0755)
 	if err != nil {
 		return fmt.Errorf("failed to initialize directory %s: %v", konnectivitySocketDir, err)
@@ -60,7 +59,7 @@ func (k *Konnectivity) Init() error {
 		return fmt.Errorf("failed to chown %s: %v", konnectivitySocketDir, err)
 	}
 
-	return assets.Stage(constant.BinDir, "konnectivity-server", constant.BinDirMode, constant.Group)
+	return assets.Stage(constant.BinDir, "konnectivity-server", constant.BinDirMode)
 }
 
 // Run ..

--- a/pkg/component/server/scheduler.go
+++ b/pkg/component/server/scheduler.go
@@ -46,7 +46,7 @@ func (a *Scheduler) Init() error {
 	}
 	a.gid, _ = util.GetGID(constant.Group)
 
-	return assets.Stage(constant.BinDir, "kube-scheduler", constant.BinDirMode, constant.Group)
+	return assets.Stage(constant.BinDir, "kube-scheduler", constant.BinDirMode)
 }
 
 // Run runs kube scheduler

--- a/pkg/component/server/scheduler.go
+++ b/pkg/component/server/scheduler.go
@@ -44,7 +44,6 @@ func (a *Scheduler) Init() error {
 	if err != nil {
 		logrus.Warning(errors.Wrap(err, "Running kube-scheduler as root"))
 	}
-	a.gid, _ = util.GetGID(constant.Group)
 
 	return assets.Stage(constant.BinDir, "kube-scheduler", constant.BinDirMode)
 }

--- a/pkg/component/worker/containerd.go
+++ b/pkg/component/worker/containerd.go
@@ -36,7 +36,7 @@ type ContainerD struct {
 func (c *ContainerD) Init() error {
 	for _, bin := range []string{"containerd", "containerd-shim", "containerd-shim-runc-v1", "containerd-shim-runc-v2", "runc"} {
 		// unfortunately, this cannot be parallelized – it will result in a fork/exec error
-		err := assets.Stage(constant.BinDir, bin, constant.BinDirMode, constant.Group)
+		err := assets.Stage(constant.BinDir, bin, constant.BinDirMode)
 		if err != nil {
 			return err
 		}

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -52,7 +52,7 @@ type KubeletConfig struct {
 
 // Init extracts the needed binaries
 func (k *Kubelet) Init() error {
-	err := assets.Stage(constant.BinDir, "kubelet", constant.BinDirMode, constant.Group)
+	err := assets.Stage(constant.BinDir, "kubelet", constant.BinDirMode)
 	if err != nil {
 		return err
 	}

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -66,9 +66,6 @@ const (
 	// AdminKubeconfigConfigPath defines the cluster admin kubeconfig location
 	AdminKubeconfigConfigPath = "/var/lib/k0s/pki/admin.conf"
 
-	// Group defines group name for shared directories
-	Group = "k0s"
-
 	// User accounts for services
 
 	// EtcdUser defines the user to use for running etcd process


### PR DESCRIPTION
**What this PR Includes**

Do not try set group owner to `k0s` group. We don't need it, so we can simplify things by removing it.

Also clean up a warning in the log about a chown of nonexisting etcd cert.