### PR TITLE
Replace os.MkdirAll with the more secure InitDirectory

### DIFF
--- a/pkg/component/server/coredns.go
+++ b/pkg/component/server/coredns.go
@@ -16,17 +16,17 @@ limitations under the License.
 package server
 
 import (
-	"os"
 	"path"
 	"path/filepath"
 	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
 
 	config "github.com/k0sproject/k0s/pkg/apis/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
 	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/pkg/util"
-	"github.com/sirupsen/logrus"
-	"k8s.io/client-go/kubernetes"
 )
 
 const coreDNSTemplate = `
@@ -261,7 +261,7 @@ func (c *CoreDNS) Init() error {
 // Run runs the CoreDNS reconciler component
 func (c *CoreDNS) Run() error {
 	corednsDir := path.Join(c.K0sVars.ManifestsDir, "coredns")
-	err := os.MkdirAll(corednsDir, constant.ManifestsDirMode)
+	err := util.InitDirectory(corednsDir, constant.ManifestsDirMode)
 	if err != nil {
 		return err
 	}

--- a/pkg/component/server/defaultpsp.go
+++ b/pkg/component/server/defaultpsp.go
@@ -16,7 +16,6 @@ limitations under the License.
 package server
 
 import (
-	"os"
 	"path"
 	"path/filepath"
 
@@ -53,7 +52,7 @@ func (d *DefaultPSP) Init() error {
 // Run reconciles the k0s default PSP rules
 func (d *DefaultPSP) Run() error {
 	pspDir := path.Join(d.k0sVars.ManifestsDir, "defaultpsp")
-	err := os.MkdirAll(pspDir, constant.ManifestsDirMode)
+	err := util.InitDirectory(pspDir, constant.ManifestsDirMode)
 	if err != nil {
 		return err
 	}

--- a/pkg/component/server/konnectivity.go
+++ b/pkg/component/server/konnectivity.go
@@ -103,7 +103,7 @@ type konnectivityAgentConfig struct {
 
 func (k *Konnectivity) writeKonnectivityAgent() error {
 	konnectivityDir := filepath.Join(k.K0sVars.ManifestsDir, "konnectivity")
-	err := os.MkdirAll(konnectivityDir, constant.ManifestsDirMode)
+	err := util.InitDirectory(konnectivityDir, constant.ManifestsDirMode)
 	if err != nil {
 		return err
 	}

--- a/pkg/component/server/kubeletconfig.go
+++ b/pkg/component/server/kubeletconfig.go
@@ -18,7 +18,6 @@ package server
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"path"
 	"path/filepath"
 
@@ -26,11 +25,12 @@ import (
 	"io/ioutil"
 
 	"github.com/imdario/mergo"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+
 	config "github.com/k0sproject/k0s/pkg/apis/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/util"
-	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 // KubeletConfig is the reconciler for generic kubelet configs
@@ -109,7 +109,7 @@ func (k *KubeletConfig) run(dnsAddress string) (*bytes.Buffer, error) {
 
 func (k *KubeletConfig) save(data []byte) error {
 	kubeletDir := path.Join(k.manifestDir, "kubelet")
-	err := os.MkdirAll(kubeletDir, constant.ManifestsDirMode)
+	err := util.InitDirectory(kubeletDir, constant.ManifestsDirMode)
 	if err != nil {
 		return err
 	}

--- a/pkg/component/server/kubeproxy.go
+++ b/pkg/component/server/kubeproxy.go
@@ -16,15 +16,15 @@ limitations under the License.
 package server
 
 import (
-	"os"
 	"path"
 	"path/filepath"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	config "github.com/k0sproject/k0s/pkg/apis/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/util"
-	"github.com/sirupsen/logrus"
 )
 
 // KubeProxy is the compoennt implementation to manage kube-proxy
@@ -58,7 +58,7 @@ func (k *KubeProxy) Run() error {
 	k.tickerDone = make(chan struct{})
 
 	proxyDir := path.Join(k.K0sVars.ManifestsDir, "kubeproxy")
-	err := os.MkdirAll(proxyDir, constant.ManifestsDirMode)
+	err := util.InitDirectory(proxyDir, constant.ManifestsDirMode)
 	if err != nil {
 		return err
 	}

--- a/pkg/component/server/manifests.go
+++ b/pkg/component/server/manifests.go
@@ -19,11 +19,11 @@ package server
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"path/filepath"
 
 	"github.com/k0sproject/k0s/pkg/constant"
+	"github.com/k0sproject/k0s/pkg/util"
 )
 
 // FsManifestsSaver saves all given manifests under the specified root dir
@@ -42,7 +42,7 @@ func (f FsManifestsSaver) Save(dst string, content []byte) error {
 // NewManifestsSaver builds new filesystem manifests saver
 func NewManifestsSaver(dir string, dataDir string) (*FsManifestsSaver, error) {
 	calicoDir := path.Join(dataDir, "manifests", dir)
-	err := os.MkdirAll(calicoDir, constant.ManifestsDirMode)
+	err := util.InitDirectory(calicoDir, constant.ManifestsDirMode)
 	if err != nil {
 		return nil, err
 	}

--- a/static/gen_manifests.go
+++ b/static/gen_manifests.go
@@ -38,6 +38,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/k0sproject/k0s/pkg/util"
 )
 
 func bindataRead(data []byte, name string) ([]byte, error) {
@@ -674,7 +676,7 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"gen_manifests.go":                                                                                   gen_manifestsGo,
+	"gen_manifests.go": gen_manifestsGo,
 	"manifests/calico/ClusterRole/calico-kube-controllers.yaml":                                          manifestsCalicoClusterroleCalicoKubeControllersYaml,
 	"manifests/calico/ClusterRole/calico-node.yaml":                                                      manifestsCalicoClusterroleCalicoNodeYaml,
 	"manifests/calico/ClusterRoleBinding/calico-kube-controllers.yaml":                                   manifestsCalicoClusterrolebindingCalicoKubeControllersYaml,
@@ -803,7 +805,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
+	err = util.InitDirectory(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Karen Almog <kalmog@mirantis.com>

**What this PR Includes**
`os.MkdirAll` has some inherent security issues (https://bugzilla.redhat.com/show_bug.cgi?id=1868870).
To resolve this, we created `util.InitDirectory`. This PR removes any instances of os.MkdirAll and replaces it with the more secure function.
