### PR TITLE
Add systemd k0s.service

### DIFF
--- a/init/k0s.service
+++ b/init/k0s.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=K0s Frictionless Kubernetes
+Documentation=https://k0sproject.io
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/sbin/k0s server -c /root/.k0s/k0s.yaml
+Type=notify
+Delegate=yes
+KillMode=process
+LimitNOFILE=infinity
+LimitNPROC=infinity
+LimitCORE=infinity
+TasksMax=infinity
+TimeoutStartSec=0
+Restart=always
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add systemd k0s.service. 

Building on [k0s-single-node.md](https://github.com/k0sproject/k0s/blob/main/docs/k0s-single-node.md), this systemd unit provides necessary functionality for educating users in persisting their k0s installation via systemd.

Supports #206 