### PR TITLE
Add example how to run gVisor with k0s

### DIFF
--- a/docs/containerd_config.md
+++ b/docs/containerd_config.md
@@ -38,6 +38,77 @@ Next if you want to change CRI look into this section
     runtime = "runc"
 ```
 
+## Using gVisor
+
+> [gVisor](https://gvisor.dev/docs/) is an application kernel, written in Go, that implements a substantial portion of the Linux system call interface. It provides an additional layer of isolation between running applications and the host operating system.
+
+First you must install the needed gVisor binaries into the host.
+```sh
+(
+  set -e
+  URL=https://storage.googleapis.com/gvisor/releases/release/latest
+  wget ${URL}/runsc ${URL}/runsc.sha512 \
+    ${URL}/gvisor-containerd-shim ${URL}/gvisor-containerd-shim.sha512 \
+    ${URL}/containerd-shim-runsc-v1 ${URL}/containerd-shim-runsc-v1.sha512
+  sha512sum -c runsc.sha512 \
+    -c gvisor-containerd-shim.sha512 \
+    -c containerd-shim-runsc-v1.sha512
+  rm -f *.sha512
+  chmod a+rx runsc gvisor-containerd-shim containerd-shim-runsc-v1
+  sudo mv runsc gvisor-containerd-shim containerd-shim-runsc-v1 /usr/local/bin
+)
+```
+
+See gVisor [install docs](https://gvisor.dev/docs/user_guide/install/)
+
+Next we need to prepare the config for `k0s` managed containerD to utilize gVisor as additional runtime:
+```sh
+cat <<EOF | sudo tee /etc/k0s/containerd.toml
+disabled_plugins = ["restart"]
+[plugins.linux]
+  shim_debug = true
+[plugins.cri.containerd.runtimes.runsc]
+  runtime_type = "io.containerd.runsc.v1"
+EOF
+```
+
+Then we can start and join the worker as normally into the cluster:
+```sh
+k0s worker $token
+```
+
+By default containerd uses nromal runc as the runtime. To make gVisor runtime usable for workloads we must register it to Kubernetes side:
+```sh
+cat <<EOF | kubectl apply -f -
+apiVersion: node.k8s.io/v1beta1
+kind: RuntimeClass
+metadata:
+  name: gvisor
+handler: runsc
+EOF
+```
+
+After this we can use it for our workloads:
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-gvisor
+spec:
+  runtimeClassName: gvisor
+  containers:
+  - name: nginx
+    image: nginx
+```
+
+We can verify the created nginx pod is actually running under gVisor runtime:
+```
+# kubectl exec nginx-gvisor -- dmesg | grep -i gvisor
+[    0.000000] Starting gVisor...
+```
+
+## Using custom `nvidia-container-runtime`
+
 By default CRI is set tu runC and if you want to configure Nvidia GPU support you will have to replace `runc` with `nvidia-container-runtime` as shown below:
 
 ```


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>


**Issue**
Fixes #55 

No need to bundle gVisor bins with k0s.

We can revisit that ⬆️  if there's enough interest in community to ship these with k0s. Currently the assumed usage would be quite low in normal cases thus not enough justification to add another ~70M "fat" for k0s bin.

**What this PR Includes**

Adds docs and example how to run gVisor with k0s managed containerd.