### PR TITLE
Fix fallback for embedded bins path

### DIFF
--- a/pkg/assets/stage.go
+++ b/pkg/assets/stage.go
@@ -61,7 +61,7 @@ func BinPath(name string, binDir string) string {
 		path, _ := filepath.Abs(path)
 		return path
 	}
-	return ""
+	return name
 }
 
 // Stage ...


### PR DESCRIPTION
Make the supervisor try to start the component without absolute path,
relying on $PATH, rather than try to start an emptystring "".

This fixes the error message when there are no embedded binaries
(EMBEDDED_BINS_BUILDMODE=none) by fallback the name if binary is not
found in our staging directory.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

