### PR TITLE
Fix initialize logging option

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,8 +42,6 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Debug logging (default: false)")
 	rootCmd.PersistentFlags().StringToStringVarP(&cmdLogLevels, "logging", "l", defaultLogLevels, "Logging Levels for the different components")
 
-	logging = setLogging(cmdLogLevels)
-
 	// initialize configuration
 	err := initConfig()
 	if err != nil {
@@ -79,6 +77,9 @@ var (
 			if viper.GetString("debug") != "" || debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
+
+			// Set logging
+			logging = setLogging(cmdLogLevels)
 
 			// Get relevant Vars from constant package
 			k0sVars = constant.GetConfig(dataDir)


### PR DESCRIPTION
Signed-off-by: makocchi-git <makocchi@gmail.com>

**What this PR Includes**
Now `--logging` flag doesn't work correctly.

```bash
# For example
$ k0s --logging containerd=panic server 

# But still log level is "info"
$ ps -ef | grep containerd
/var/lib/k0s/bin/containerd --root=/var/lib/k0s/containerd --state=/var/lib/k0s/run/containerd --address=/var/lib/k0s/run/containerd.sock --log-level=info --config=/etc/k0s/containerd.toml
```

I think the reason is that `cmdLogLevels` could not be set correctly in `init()` phase even if pass `--logging` flag.
`cmdLogLevels` is always set to default value in `init()`, so it should be configured outside of `init()`.

