### PR TITLE
Bump containerd to 1.4.2

### DIFF
--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -1,6 +1,6 @@
 
 runc_version = 1.0.0-rc92
-containerd_version = 1.4.1
+containerd_version = 1.4.2
 kubernetes_version = 1.19.4
 kine_version = 0.5.1
 etcd_version = 3.4.13

--- a/embedded-bins/containerd/Dockerfile
+++ b/embedded-bins/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine AS build
+FROM golang:1.15-alpine AS build
 
 ARG VERSION
 ENV GOPATH=/go


### PR DESCRIPTION
Use go 1.15 to build containerd since that is what upstream containerd
uses.

See https://github.com/containerd/containerd/releases/tag/v1.4.2

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

