### PR TITLE
Fix Helm values parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bindata
 *.tfstate*
 aws_private.pem
 out.json
+.vscode

--- a/pkg/apis/helm.k0sproject.io/v1beta1/chart_types.go
+++ b/pkg/apis/helm.k0sproject.io/v1beta1/chart_types.go
@@ -36,7 +36,9 @@ func (cs ChartSpec) YamlValues() map[string]interface{} {
 	if err := yaml.Unmarshal([]byte(cs.Values), &res); err != nil {
 		logrus.WithField("values", cs.Values).Warn("broken yaml values")
 	}
-	return res
+	// We need to clean the map to have nested maps as map[string]interface{} types
+	// otherwise Helm will fail to merge default values and create the release object
+	return CleanUpGenericMap(res)
 }
 
 // ChartStatus defines the observed state of Chart

--- a/pkg/apis/helm.k0sproject.io/v1beta1/generic_hash.go
+++ b/pkg/apis/helm.k0sproject.io/v1beta1/generic_hash.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 Mirantis, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1beta1
+
+import "fmt"
+
+// Cleans up a slice of interfaces into slice of actual values
+func cleanUpInterfaceArray(in []interface{}) []interface{} {
+	result := make([]interface{}, len(in))
+	for i, v := range in {
+		result[i] = cleanUpMapValue(v)
+	}
+	return result
+}
+
+// Cleans up the map keys to be strings
+func cleanUpInterfaceMap(in map[interface{}]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for k, v := range in {
+		result[fmt.Sprintf("%v", k)] = cleanUpMapValue(v)
+	}
+	return result
+}
+
+// Cleans up the value in the map, recurses in case of arrays and maps
+func cleanUpMapValue(v interface{}) interface{} {
+	switch v := v.(type) {
+	case []interface{}:
+		return cleanUpInterfaceArray(v)
+	case map[interface{}]interface{}:
+		return cleanUpInterfaceMap(v)
+	case string:
+		return v
+	case int:
+		return v
+	case bool:
+		return v
+	case float64:
+		return v
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// CleanUpGenericMap is a helper to "cleanup" generic yaml parsing where nested maps
+// are unmarshalled with type map[interface{}]interface{}
+func CleanUpGenericMap(in map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for k, v := range in {
+		result[fmt.Sprintf("%v", k)] = cleanUpMapValue(v)
+	}
+	return result
+}


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Fixes #447 

**What this PR Includes**
Intorduces a cleanup function to make all nested maps being converted into `map[string]interface{}` types. By default golang parses the nested maps into `map[interface{}]interface{}` types which makes Helm to actually ignore those keys when merging the chart default values into given values.

in the Helm code which merges the defaults in, there’s this:
```
if dest, ok := value.(map[string]interface{}); ok {
```
see: https://github.com/helm/helm/blob/6aefbdcf38e14998d0bcb24030061822b1e8888d/pkg/chartutil/coalesce.go#L156-L157

The cast is not successfull with `map[interface{}]interface{}` type and thus no merging actually happened

Adds also a verification into the related smoke case that we really see the given values being propagated into place.