### PR TITLE
Bump kube-proxy to 1.19.4

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -91,7 +91,7 @@ const (
 	MetricsImage               = "gcr.io/k8s-staging-metrics-server/metrics-server"
 	MetricsImageVersion        = "v0.3.7"
 	KubeProxyImage             = "k8s.gcr.io/kube-proxy"
-	KubeProxyImageVersion      = "v1.19.0"
+	KubeProxyImageVersion      = "v1.19.4"
 	CoreDNSImage               = "docker.io/coredns/coredns"
 	CoreDNSImageVersion        = "1.7.0"
 	CalicoImage                = "calico/cni"


### PR DESCRIPTION
Signed-off-by: makocchi-git <makocchi@gmail.com>

**What this PR Includes**
Use kube-proxy 1.19.4