### PR TITLE
Separate kubeconfig for konnectivity and tighter permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,9 @@ name: Go build
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - release-*
     paths-ignore:
       - 'docs/**'
       - 'examples/**'
@@ -10,7 +12,9 @@ on:
       - LICENSE
       - '**.svg'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - release-*
     paths-ignore:
       - 'docs/**'
       - 'examples/**'

--- a/pkg/component/server/certificates.go
+++ b/pkg/component/server/certificates.go
@@ -130,7 +130,7 @@ func (c *Certificates) Init() error {
 			return err
 		}
 
-		return generateKeyPair("sa", c.K0sVars)
+		return generateKeyPair("sa", c.K0sVars, constant.ApiserverUser)
 	})
 
 	eg.Go(func() error {
@@ -161,13 +161,13 @@ func (c *Certificates) Init() error {
 			CACert: caCertPath,
 			CAKey:  caCertKey,
 		}
-		ccmCert, err := c.CertManager.EnsureCertificate(ccmReq, constant.ControllerManagerUser)
+		ccmCert, err := c.CertManager.EnsureCertificate(ccmReq, constant.ApiserverUser)
 
 		if err != nil {
 			return err
 		}
 
-		return kubeConfig(filepath.Join(c.K0sVars.CertRootDir, "ccm.conf"), "https://localhost:6443", c.CACert, ccmCert.Cert, ccmCert.Key, constant.ControllerManagerUser)
+		return kubeConfig(filepath.Join(c.K0sVars.CertRootDir, "ccm.conf"), "https://localhost:6443", c.CACert, ccmCert.Cert, ccmCert.Key, constant.ApiserverUser)
 	})
 
 	eg.Go(func() error {
@@ -260,7 +260,7 @@ func (c *Certificates) Stop() error {
 
 func kubeConfig(dest, url, caCert, clientCert, clientKey, owner string) error {
 	if util.FileExists(dest) {
-		return nil
+		return chownFile(dest, owner, constant.CertSecureMode)
 	}
 	data := struct {
 		URL        string
@@ -284,9 +284,17 @@ func kubeConfig(dest, url, caCert, clientCert, clientKey, owner string) error {
 		return err
 	}
 
+	return chownFile(output.Name(), owner, constant.CertSecureMode)
+}
+
+func chownFile(file, owner string, permissions os.FileMode) error {
 	// Chown the file properly for the owner
 	uid, _ := util.GetUID(owner)
-	err = os.Chown(output.Name(), uid, -1)
+	err := os.Chown(file, uid, -1)
+	if err != nil && os.Geteuid() == 0 {
+		return err
+	}
+	err = os.Chmod(file, permissions)
 	if err != nil && os.Geteuid() == 0 {
 		return err
 	}
@@ -294,12 +302,12 @@ func kubeConfig(dest, url, caCert, clientCert, clientKey, owner string) error {
 	return nil
 }
 
-func generateKeyPair(name string, k0sVars constant.CfgVars) error {
+func generateKeyPair(name string, k0sVars constant.CfgVars, owner string) error {
 	keyFile := filepath.Join(k0sVars.CertRootDir, fmt.Sprintf("%s.key", name))
 	pubFile := filepath.Join(k0sVars.CertRootDir, fmt.Sprintf("%s.pub", name))
 
 	if util.FileExists(keyFile) && util.FileExists(pubFile) {
-		return nil
+		return chownFile(keyFile, owner, constant.CertSecureMode)
 	}
 
 	reader := rand.Reader
@@ -315,11 +323,16 @@ func generateKeyPair(name string, k0sVars constant.CfgVars) error {
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	}
 
-	outFile, err := os.Create(keyFile)
+	outFile, err := os.OpenFile(keyFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, constant.CertSecureMode)
 	if err != nil {
 		return err
 	}
 	defer outFile.Close()
+
+	err = chownFile(keyFile, owner, constant.CertSecureMode)
+	if err != nil {
+		return err
+	}
 
 	err = pem.Encode(outFile, privateKey)
 	if err != nil {

--- a/pkg/component/server/controllermanager.go
+++ b/pkg/component/server/controllermanager.go
@@ -55,7 +55,8 @@ var cmDefaultArgs = map[string]string{
 // Init extracts the needed binaries
 func (a *ControllerManager) Init() error {
 	var err error
-	a.uid, err = util.GetUID(constant.ControllerManagerUser)
+	// controller manager running as api-server user as they both need access to same sa.key
+	a.uid, err = util.GetUID(constant.ApiserverUser)
 	if err != nil {
 		logrus.Warning(errors.Wrap(err, "Running kube-controller-manager as root"))
 	}

--- a/pkg/component/server/konnectivity.go
+++ b/pkg/component/server/konnectivity.go
@@ -69,7 +69,7 @@ func (k *Konnectivity) Run() error {
 			fmt.Sprintf("--uds-name=%s", filepath.Join(k.K0sVars.KonnectivitySocketDir, "konnectivity-server.sock")),
 			fmt.Sprintf("--cluster-cert=%s", filepath.Join(k.K0sVars.CertRootDir, "server.crt")),
 			fmt.Sprintf("--cluster-key=%s", filepath.Join(k.K0sVars.CertRootDir, "server.key")),
-			fmt.Sprintf("--kubeconfig=%s", k.K0sVars.AdminKubeconfigConfigPath), // FIXME: should have user rights
+			fmt.Sprintf("--kubeconfig=%s", k.K0sVars.KonnectivityKubeconfigConfigPath),
 			"--mode=grpc",
 			"--server-port=0",
 			"--agent-port=8132",

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -75,8 +75,6 @@ const (
 	KineUser = "kube-apiserver" // apiserver needs to be able to read the kine unix socket
 	// ApiserverUser defines the user to use for running k8s api-server process
 	ApiserverUser = "kube-apiserver"
-	// ControllerManagerUser defines the user to use for running k8s controller manager process
-	ControllerManagerUser = "kube-controller-manager"
 	// SchedulerUser defines the user to use for running k8s scheduler
 	SchedulerUser = "kube-scheduler"
 	// KonnectivityServerUser deinfes the user to use for konnectivity-server

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -19,19 +19,20 @@ import "fmt"
 
 // CfgVars is a struct that holds all the config variables requried for K0s
 type CfgVars struct {
-	AdminKubeconfigConfigPath  string // The cluster admin kubeconfig location
-	BinDir                     string // location for all pki related binaries
-	CertRootDir                string // CertRootDir defines the root location for all pki related artifacts
-	DataDir                    string // Data directory containing k0s state
-	EtcdCertDir                string // EtcdCertDir contains etcd certificates
-	EtcdDataDir                string // EtcdDataDir contains etcd state
-	KineSocketPath             string // The unix socket path for kine
-	KonnectivitySocketDir      string // location of konnectivity's socket path
-	KubeletAuthConfigPath      string // KubeletAuthConfigPath defines the default kubelet auth config path
-	KubeletBootstrapConfigPath string // KubeletBootstrapConfigPath defines the default path for kubelet bootstrap auth config
-	KubeletVolumePluginDir     string // location for kubelet plugins volume executables
-	ManifestsDir               string // location for all stack manifests
-	RunDir                     string // location of supervised pid files and sockets
+	AdminKubeconfigConfigPath        string // The cluster admin kubeconfig location
+	BinDir                           string // location for all pki related binaries
+	CertRootDir                      string // CertRootDir defines the root location for all pki related artifacts
+	DataDir                          string // Data directory containing k0s state
+	EtcdCertDir                      string // EtcdCertDir contains etcd certificates
+	EtcdDataDir                      string // EtcdDataDir contains etcd state
+	KineSocketPath                   string // The unix socket path for kine
+	KonnectivitySocketDir            string // location of konnectivity's socket path
+	KubeletAuthConfigPath            string // KubeletAuthConfigPath defines the default kubelet auth config path
+	KubeletBootstrapConfigPath       string // KubeletBootstrapConfigPath defines the default path for kubelet bootstrap auth config
+	KubeletVolumePluginDir           string // location for kubelet plugins volume executables
+	ManifestsDir                     string // location for all stack manifests
+	RunDir                           string // location of supervised pid files and sockets
+	KonnectivityKubeconfigConfigPath string // location for konnectivity kubeconfig
 
 	// Helm config
 	HelmHome             string
@@ -115,19 +116,20 @@ func GetConfig(dataDir string) CfgVars {
 	helmHome := fmt.Sprintf("%s/helmhome", dataDir)
 
 	return CfgVars{
-		AdminKubeconfigConfigPath:  fmt.Sprintf("%s/admin.conf", certDir),
-		BinDir:                     fmt.Sprintf("%s/bin", dataDir),
-		CertRootDir:                certDir,
-		DataDir:                    dataDir,
-		EtcdCertDir:                fmt.Sprintf("%s/etcd", certDir),
-		EtcdDataDir:                fmt.Sprintf("%s/etcd", dataDir),
-		KineSocketPath:             fmt.Sprintf("%s/kine/kine.sock:2379", runDir),
-		KonnectivitySocketDir:      fmt.Sprintf("%s/konnectivity-server", runDir),
-		KubeletAuthConfigPath:      fmt.Sprintf("%s/kubelet.conf", dataDir),
-		KubeletBootstrapConfigPath: fmt.Sprintf("%s/kubelet-bootstrap.conf", dataDir),
-		KubeletVolumePluginDir:     "/usr/libexec/k0s/kubelet-plugins/volume/exec",
-		ManifestsDir:               fmt.Sprintf("%s/manifests", dataDir),
-		RunDir:                     runDir,
+		AdminKubeconfigConfigPath:        fmt.Sprintf("%s/admin.conf", certDir),
+		BinDir:                           fmt.Sprintf("%s/bin", dataDir),
+		CertRootDir:                      certDir,
+		DataDir:                          dataDir,
+		EtcdCertDir:                      fmt.Sprintf("%s/etcd", certDir),
+		EtcdDataDir:                      fmt.Sprintf("%s/etcd", dataDir),
+		KineSocketPath:                   fmt.Sprintf("%s/kine/kine.sock:2379", runDir),
+		KonnectivitySocketDir:            fmt.Sprintf("%s/konnectivity-server", runDir),
+		KubeletAuthConfigPath:            fmt.Sprintf("%s/kubelet.conf", dataDir),
+		KubeletBootstrapConfigPath:       fmt.Sprintf("%s/kubelet-bootstrap.conf", dataDir),
+		KubeletVolumePluginDir:           "/usr/libexec/k0s/kubelet-plugins/volume/exec",
+		ManifestsDir:                     fmt.Sprintf("%s/manifests", dataDir),
+		RunDir:                           runDir,
+		KonnectivityKubeconfigConfigPath: fmt.Sprintf("%s/konnectivity.conf", certDir),
 
 		// Helm Config
 		HelmHome:             helmHome,


### PR DESCRIPTION
**Issue**


**What this PR Includes**
Konnectivity was sharing the main `admin.conf`, this PR creates a separate kubeconfig for konnectivity so we can tighten up the file permissions.

This also adds permissions and chown changes for upgrades, so whenever k0s restarts and there's changes needed it'll run chown/chmod on the files if needed.

✅  network tests passing: https://github.com/k0sproject/k0s/actions/runs/396175839