### PR TITLE
feat: reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12
 
-RUN apk add bash coreutils findutils iptables curl
+RUN apk add --no-cache bash coreutils findutils iptables curl
 
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl \
        && chmod +x ./kubectl \


### PR DESCRIPTION
Signed-off-by: Liviu Costea <email.lcostea@gmail.com>


---

**What this PR Includes**
A small change not to use apk cache when installing dependencies. Reduces the image size by about 2 megs.