### PR TITLE
Get kine from official binaries & follow the upstream golang version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GO_SRCS := $(shell find . -type f -name '*.go')
 
 # EMBEDDED_BINS_BUILDMODE can be either:
 #   docker	builds the binaries in docker
-#   fetch	fetch precompiled binaries from internet (except kine)
+#   fetch	fetch precompiled binaries from internet
 #   none	does not embed any binaries
 
 EMBEDDED_BINS_BUILDMODE ?= docker

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Read more details at [running k0s in Docker](docs/k0s-in-docker.md).
 
 `k0s` can be built in 3 different ways:
 
-Fetch official binaries (except `kine` and `konnectivity-server`, which are built from source):
+Fetch official binaries (except `konnectivity-server`, which are built from source):
 ```
 make EMBEDDED_BINS_BUILDMODE=fetch
 ```

--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -71,6 +71,7 @@ kubelet_url = https://storage.googleapis.com/kubernetes-release/release/v$(kuber
 kube-apiserver_url = https://storage.googleapis.com/kubernetes-release/release/v$(kubernetes_version)/bin/linux/$(arch)/kube-apiserver
 kube-scheduler_url = https://storage.googleapis.com/kubernetes-release/release/v$(kubernetes_version)/bin/linux/$(arch)/kube-scheduler
 kube-controller-manager_url = https://storage.googleapis.com/kubernetes-release/release/v$(kubernetes_version)/bin/linux/$(arch)/kube-controller-manager
+kine_url = https://github.com/k3s-io/kine/releases/download/v$(kine_version)/kine-amd64
 
 containerd_url = https://github.com/containerd/containerd/releases/download/v$(containerd_version)/containerd-$(containerd_version)-linux-$(arch).tar.gz
 etcd_url = https://github.com/etcd-io/etcd/releases/download/v$(etcd_version)/etcd-v$(etcd_version)-linux-$(arch).tar.gz
@@ -82,20 +83,11 @@ tmpdir ?= .tmp
 arch = amd64
 
 
-$(addprefix $(bindir)/, runc kubelet kube-apiserver kube-scheduler kube-controller-manager): | $(bindir)
+$(addprefix $(bindir)/, runc kubelet kube-apiserver kube-scheduler kube-controller-manager kine): | $(bindir)
 	$(curl) -o $@ $($(notdir $@)_url)
 
 $(addprefix $(bindir)/, containerd etcd): | $(bindir)
 	$(curl) $($(notdir $@)_url) | tar -C $(bindir)/ -zxv --strip-components=1 $($(notdir $@)_extract)
-
-# kine does not ship precompiled binaries so lets build it from source
-$(bindir)/kine: | $(bindir)
-	if ! [ -d $(tmpdir)/kine ]; then \
-		mkdir -p $(tmpdir) \
-			&& cd $(tmpdir) \
-			&& git clone -b v$(kine_version) --depth=1 https://github.com/rancher/kine.git; \
-	fi
-	cd $(tmpdir)/kine && go build -o $(CURDIR)/$@
 
 # konnectivity does not ship precompiled binaries so lets build it from source
 $(bindir)/konnectivity-server: | $(bindir)

--- a/embedded-bins/kine/Dockerfile
+++ b/embedded-bins/kine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine AS build
+FROM golang:1.15-alpine AS build
 ARG VERSION
 
 RUN apk add build-base git


### PR DESCRIPTION
Signed-off-by: William Zhang <warmchang@outlook.com>

---
name: Pull Request
about: Create a Pull Request
title: ''
labels: ''
assignees: ''

---

**Issue**
Fixes #482

**What this PR Includes**
1. Get kine from official binaries, no need to build it from source.
2. Follow the upstream golang version (https://github.com/k3s-io/kine/blob/v0.6.0/Dockerfile#L1).