### PR TITLE
Setup kernel options right before starting components

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -82,8 +82,6 @@ var (
 )
 
 func startWorker(token string) error {
-	worker.KernelSetup()
-
 	if token == "" && !util.FileExists(k0sVars.KubeletAuthConfigPath) {
 		return fmt.Errorf("normal kubelet kubeconfig does not exist and no join-token given. dunno how to make kubelet auth to api")
 	}
@@ -121,6 +119,8 @@ func startWorker(token string) error {
 	if err := componentManager.Init(); err != nil {
 		return err
 	}
+
+	worker.KernelSetup()
 
 	// Set up signal handling. Use bufferend channel so we dont miss
 	// signals during startup


### PR DESCRIPTION
Don't set kernel options until we are ready to start the kubelet and
containerd.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

**What this PR Includes**

Minor cleanup.