### PR TITLE
Use mkdocs to deploy documentation to Github Pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,61 @@
+name: Publish docs via GitHub Pages
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  release:
+    types:
+      - published
+jobs:
+  build:
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Checkout deps
+        uses: actions/checkout@v2
+        with:
+          repository: lensapp/mkdocs-material-insiders
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip -v --log /tmp/pip.log install ./mkdocs-material-insiders
+          pip install mike
+      - name: Checkout K0s release
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: git config
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+      - name: Using Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: mkdocs deploy main
+        if: contains(github.ref, 'refs/heads/main')
+        run: |
+          mike deploy --push main
+      - name: Get the release version
+        if: contains(github.ref, 'refs/tags/v') # && !github.event.release.prerelease (generate pre-release docs until Lens 4.0.0 is GA, see #1408)
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - name: mkdocs deploy new release
+        if: contains(github.ref, 'refs/tags/v') # && !github.event.release.prerelease (generate pre-release docs until Lens 4.0.0 is GA, see #1408)
+        run: |
+          mike deploy --push --update-aliases ${{ steps.get_version.outputs.VERSION }} latest
+          mike set-default --push ${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
Signed-off-by: Karen Almog <kalmog@mirantis.com>

**Issue**
Fixes #481

**What this PR Includes**
This PR adds a workflow to deploy release docs to GitHub Pages using MKDocs