### PR TITLE
Config option for external api address

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,9 +66,9 @@ metadata:
   name: k0s
 spec:
   api:
+    externalAddress: my-lb-address.example.com
     address: 192.168.68.106
     sans:
-    - 192.168.68.106
     - 192.168.68.106
     extraArgs: {}
   controllerManager:
@@ -143,6 +143,7 @@ extensions:
 
 ### `spec.api`
 
+- `externalAddress`: If k0s controllers are running behind a loadbalancer provide the loadbalancer address here. This will configure all cluster components to connect to this address and also configures this address to be used when joining new nodes into the cluster.
 - `address`: The local address to bind API on. Also used as one of the addresses pushed on the k0s create service certificate on the API. Defaults to first non-local address found on the node.
 - `sans`: List of additional addresses to push to API servers serving certificate
 - `extraArgs`: Map of key-values (strings) for any extra arguments you wish to pass down to Kubernetes api-server process

--- a/internal/util/slice.go
+++ b/internal/util/slice.go
@@ -40,3 +40,16 @@ func IsStringArrayEqual(a1 []string, a2 []string) bool {
 	}
 	return false
 }
+
+// Unique returns only the unique items from given input slice
+func Unique(input []string) []string {
+	m := make(map[string]bool)
+	result := make([]string, 0, len(input))
+	for _, s := range input {
+		if _, ok := m[s]; !ok {
+			m[s] = true
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/internal/util/slice_test.go
+++ b/internal/util/slice_test.go
@@ -15,7 +15,11 @@ limitations under the License.
 */
 package util
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestStringSliceContains(t *testing.T) {
 	type args struct {
@@ -87,4 +91,32 @@ func TestArrayIsEqual(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUnique(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{
+			"all unique",
+			[]string{"a", "b", "c"},
+			[]string{"a", "b", "c"},
+		},
+		{
+			"some non unique",
+			[]string{"c", "a", "b", "b", "c"},
+			[]string{"c", "a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Unique(tt.input)
+			assert.Equal(t, tt.want, got)
+
+		})
+	}
+
 }

--- a/pkg/apis/v1beta1/cluster.go
+++ b/pkg/apis/v1beta1/cluster.go
@@ -55,9 +55,10 @@ type ClusterSpec struct {
 
 // APISpec ...
 type APISpec struct {
-	Address   string            `yaml:"address"`
-	SANs      []string          `yaml:"sans"`
-	ExtraArgs map[string]string `yaml:"extraArgs"`
+	Address         string            `yaml:"address"`
+	ExternalAddress string            `yaml:"externalAddress"`
+	SANs            []string          `yaml:"sans"`
+	ExtraArgs       map[string]string `yaml:"extraArgs"`
 }
 
 // ControllerManagerSpec ...
@@ -88,11 +89,17 @@ func (c *ClusterConfig) Validate() []error {
 
 // APIAddress ...
 func (a *APISpec) APIAddress() string {
+	if a.ExternalAddress != "" {
+		return fmt.Sprintf("https://%s:6443", a.ExternalAddress)
+	}
 	return fmt.Sprintf("https://%s:6443", a.Address)
 }
 
 // K0sControlPlaneAPIAddress returns the controller join APIs address
 func (a *APISpec) K0sControlPlaneAPIAddress() string {
+	if a.ExternalAddress != "" {
+		return fmt.Sprintf("https://%s:9443", a.ExternalAddress)
+	}
 	return fmt.Sprintf("https://%s:9443", a.Address)
 }
 

--- a/pkg/apis/v1beta1/cluster.go
+++ b/pkg/apis/v1beta1/cluster.go
@@ -103,6 +103,18 @@ func (a *APISpec) K0sControlPlaneAPIAddress() string {
 	return fmt.Sprintf("https://%s:9443", a.Address)
 }
 
+// Sans return the given SANS plus all local adresses and externalAddress if given
+func (a *APISpec) Sans() []string {
+	sans, _ := util.AllAddresses()
+	sans = append(sans, a.Address)
+	sans = append(sans, a.SANs...)
+	if a.ExternalAddress != "" {
+		sans = append(sans, a.ExternalAddress)
+	}
+
+	return util.Unique(sans)
+}
+
 // FromYaml ...
 func FromYaml(filename string) (*ClusterConfig, error) {
 	buf, err := ioutil.ReadFile(filename)

--- a/pkg/apis/v1beta1/cluster_test.go
+++ b/pkg/apis/v1beta1/cluster_test.go
@@ -150,7 +150,7 @@ spec:
 	c, err := fromYaml(t, yamlData)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://foo.bar.com:6443", c.Spec.API.APIAddress())
-	assert.Equal(t, "https://foo.bar.com:9443", c.Spec.API.ControllerJoinAddress())
+	assert.Equal(t, "https://foo.bar.com:9443", c.Spec.API.K0sControlPlaneAPIAddress())
 }
 
 func TestApiNoExternalAddress(t *testing.T) {
@@ -167,5 +167,5 @@ spec:
 	c, err := fromYaml(t, yamlData)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://1.2.3.4:6443", c.Spec.API.APIAddress())
-	assert.Equal(t, "https://1.2.3.4:9443", c.Spec.API.ControllerJoinAddress())
+	assert.Equal(t, "https://1.2.3.4:9443", c.Spec.API.K0sControlPlaneAPIAddress())
 }

--- a/pkg/apis/v1beta1/cluster_test.go
+++ b/pkg/apis/v1beta1/cluster_test.go
@@ -134,3 +134,38 @@ spec:
 	assert.Equal(t, 1, len(errors))
 	assert.Equal(t, "unsupported network provider: invalidProvider", errors[0].Error())
 }
+
+func TestApiExternalAddress(t *testing.T) {
+	yamlData := `
+apiVersion: k0s.k0sproject.io/v1beta1
+kind: Cluster
+metadata:
+  name: foobar
+spec:
+  api:
+    externalAddress: foo.bar.com
+    address: 1.2.3.4
+`
+
+	c, err := fromYaml(t, yamlData)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://foo.bar.com:6443", c.Spec.API.APIAddress())
+	assert.Equal(t, "https://foo.bar.com:9443", c.Spec.API.ControllerJoinAddress())
+}
+
+func TestApiNoExternalAddress(t *testing.T) {
+	yamlData := `
+apiVersion: k0s.k0sproject.io/v1beta1
+kind: Cluster
+metadata:
+  name: foobar
+spec:
+  api:
+    address: 1.2.3.4
+`
+
+	c, err := fromYaml(t, yamlData)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://1.2.3.4:6443", c.Spec.API.APIAddress())
+	assert.Equal(t, "https://1.2.3.4:9443", c.Spec.API.ControllerJoinAddress())
+}

--- a/pkg/component/server/apiendpointreconciler.go
+++ b/pkg/component/server/apiendpointreconciler.go
@@ -102,11 +102,13 @@ func (a *APIEndpointReconciler) Healthy() error { return nil }
 func (a *APIEndpointReconciler) reconcileEndpoints() error {
 	if !a.leaderElector.IsLeader() {
 		a.L.Debug("we're not the leader, not reconciling api endpoints")
+		return nil
 	}
 
 	ips, err := net.LookupIP(a.ClusterConfig.Spec.API.ExternalAddress)
 	if err != nil {
 		a.L.Errorf("cannot resolve api.externalAddress: %s", err.Error())
+		return err
 	}
 	// Sort the addresses so we can more easily tell if we need to update the endpoints or not
 	ipStrings := make([]string, len(ips))

--- a/pkg/component/server/apiendpointreconciler.go
+++ b/pkg/component/server/apiendpointreconciler.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2020 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package server
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"reflect"
+	"sort"
+	"sync/atomic"
+	"time"
+
+	config "github.com/k0sproject/k0s/pkg/apis/v1beta1"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/v1beta1"
+	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// APIEndpointReconciler is the component to reconcile in-cluster API address endpoint based from externalName
+type APIEndpointReconciler struct {
+	ClusterConfig *config.ClusterConfig
+
+	L *logrus.Entry
+
+	leaderElector     LeaderElector
+	stopCh            chan struct{}
+	kubeClientFactory k8sutil.ClientFactory
+}
+
+// NewEndpointReconciler creates new endpoint reconciler
+func NewEndpointReconciler(c *k0sv1beta1.ClusterConfig, leaderElector LeaderElector, kubeClientFactory k8sutil.ClientFactory) *APIEndpointReconciler {
+	d := atomic.Value{}
+	d.Store(true)
+	return &APIEndpointReconciler{
+		ClusterConfig:     c,
+		leaderElector:     leaderElector,
+		stopCh:            make(chan struct{}),
+		kubeClientFactory: kubeClientFactory,
+		L:                 logrus.WithFields(logrus.Fields{"component": "endpointreconciler"}),
+	}
+}
+
+// Init initializes the APIEndpointReconciler
+func (a *APIEndpointReconciler) Init() error {
+	_, err := net.LookupIP(a.ClusterConfig.Spec.API.ExternalAddress)
+	if err != nil {
+		return fmt.Errorf("cannot resolve api.externalAddress: %w", err)
+	}
+
+	return nil
+}
+
+// Run runs the main loop for reconciling the externalAddress
+func (a *APIEndpointReconciler) Run() error {
+
+	go func() {
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				err := a.reconcileEndpoints()
+				if err != nil {
+					a.L.Warnf("external API address reconciliation failed: %s", err.Error())
+				}
+			case <-a.stopCh:
+				a.L.Info("endpoint reconciler done")
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Stop stops the reconciler
+func (a *APIEndpointReconciler) Stop() error {
+	close(a.stopCh)
+	return nil
+}
+
+// Healthy dummy implementation
+func (a *APIEndpointReconciler) Healthy() error { return nil }
+
+func (a *APIEndpointReconciler) reconcileEndpoints() error {
+	if !a.leaderElector.IsLeader() {
+		a.L.Debug("we're not the leader, not reconciling api endpoints")
+	}
+
+	ips, err := net.LookupIP(a.ClusterConfig.Spec.API.ExternalAddress)
+	if err != nil {
+		a.L.Errorf("cannot resolve api.externalAddress: %s", err.Error())
+	}
+	// Sort the addresses so we can more easily tell if we need to update the endpoints or not
+	ipStrings := make([]string, len(ips))
+	for i, ip := range ips {
+		ipStrings[i] = ip.String()
+	}
+	sort.Strings(ipStrings)
+
+	c, err := a.kubeClientFactory.Create()
+	if err != nil {
+		return err
+	}
+
+	epClient := c.CoreV1().Endpoints("default")
+
+	ep, err := epClient.Get(context.TODO(), "kubernetes", v1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			err := a.createEndpoint(ipStrings)
+			return err
+		}
+
+		return err
+	}
+
+	if len(ep.Subsets) == 0 || needsUpdate(ipStrings, ep) {
+		ep.Subsets = []corev1.EndpointSubset{
+			corev1.EndpointSubset{
+				Addresses: stringsToEndpointAddresses(ipStrings),
+				Ports: []corev1.EndpointPort{
+					corev1.EndpointPort{
+						Name:     "https",
+						Protocol: "TCP",
+						Port:     6443,
+					},
+				},
+			},
+		}
+
+		_, err := epClient.Update(context.TODO(), ep, v1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}
+
+func (a *APIEndpointReconciler) createEndpoint(addresses []string) error {
+	ep := &corev1.Endpoints{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Endpoints",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "kubernetes",
+		},
+		Subsets: []corev1.EndpointSubset{
+			corev1.EndpointSubset{
+				Addresses: stringsToEndpointAddresses(addresses),
+				Ports: []corev1.EndpointPort{
+					corev1.EndpointPort{
+						Name:     "https",
+						Protocol: "TCP",
+						Port:     6443,
+					},
+				},
+			},
+		},
+	}
+
+	c, err := a.kubeClientFactory.Create()
+	if err != nil {
+		return err
+	}
+
+	_, err = c.CoreV1().Endpoints("default").Create(context.TODO(), ep, v1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func needsUpdate(newAddresses []string, ep *corev1.Endpoints) bool {
+	currentAddresses := endpointAddressesToStrings(ep.Subsets[0].Addresses)
+	sort.Strings(currentAddresses)
+	return reflect.DeepEqual(currentAddresses, newAddresses)
+}
+
+func endpointAddressesToStrings(eps []corev1.EndpointAddress) []string {
+	a := make([]string, len(eps))
+
+	for i, e := range eps {
+		a[i] = e.IP
+	}
+
+	return a
+}
+
+func stringsToEndpointAddresses(addresses []string) []corev1.EndpointAddress {
+	eps := make([]corev1.EndpointAddress, len(addresses))
+
+	for i, a := range addresses {
+		eps[i] = corev1.EndpointAddress{
+			IP: a,
+		}
+	}
+
+	return eps
+}

--- a/pkg/component/server/apiendpointreconciler_test.go
+++ b/pkg/component/server/apiendpointreconciler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/apis/v1beta1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -39,6 +40,18 @@ func (f *fakeAlwaysLeaderElector) IsLeader() bool {
 	return true
 }
 
+type fakeNeverLeaderElector struct {
+}
+
+func (f *fakeNeverLeaderElector) Run() error     { return nil }
+func (f *fakeNeverLeaderElector) Init() error    { return nil }
+func (f *fakeNeverLeaderElector) Stop() error    { return nil }
+func (f *fakeNeverLeaderElector) Healthy() error { return nil }
+
+func (f *fakeNeverLeaderElector) IsLeader() bool {
+	return false
+}
+
 var expectedAddresses = []string{
 	"185.199.108.153",
 	"185.199.109.153",
@@ -52,6 +65,33 @@ type fakeClientFactory struct {
 
 func (f *fakeClientFactory) Create() (kubernetes.Interface, error) {
 	return f.fakeClient, nil
+}
+
+func TestBasicReconcilerWithNoLeader(t *testing.T) {
+	var fakeFactory = &fakeClientFactory{
+		fakeClient: fake.NewSimpleClientset(),
+	}
+	config := &v1beta1.ClusterConfig{
+		Spec: &v1beta1.ClusterSpec{
+			API: &v1beta1.APISpec{
+				Address:         "1.2.3.4",
+				ExternalAddress: "get.k0s.sh",
+			},
+		},
+	}
+
+	r := NewEndpointReconciler(config, &fakeNeverLeaderElector{}, fakeFactory)
+
+	assert.NoError(t, r.Init())
+
+	assert.NoError(t, r.reconcileEndpoints())
+	client, err := fakeFactory.Create()
+	assert.NoError(t, err)
+	_, err = client.CoreV1().Endpoints("default").Get(context.TODO(), "kubernetes", v1.GetOptions{})
+	// The reconciler should not make any modification as we're not the leader so the endpoint should not get created
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+	//verifyEndpointAddresses(t, expectedAddresses, fakeFactory)
 }
 
 func TestBasicReconcilerWithNoExistingEndpoint(t *testing.T) {

--- a/pkg/component/server/apiendpointreconciler_test.go
+++ b/pkg/component/server/apiendpointreconciler_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2020 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/k0sproject/k0s/pkg/apis/v1beta1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type fakeAlwaysLeaderElector struct {
+}
+
+func (f *fakeAlwaysLeaderElector) Run() error     { return nil }
+func (f *fakeAlwaysLeaderElector) Init() error    { return nil }
+func (f *fakeAlwaysLeaderElector) Stop() error    { return nil }
+func (f *fakeAlwaysLeaderElector) Healthy() error { return nil }
+
+func (f *fakeAlwaysLeaderElector) IsLeader() bool {
+	return true
+}
+
+var expectedAddresses = []string{
+	"185.199.108.153",
+	"185.199.109.153",
+	"185.199.110.153",
+	"185.199.111.153",
+}
+
+type fakeClientFactory struct {
+	fakeClient kubernetes.Interface
+}
+
+func (f *fakeClientFactory) Create() (kubernetes.Interface, error) {
+	return f.fakeClient, nil
+}
+
+func TestBasicReconcilerWithNoExistingEndpoint(t *testing.T) {
+	var fakeFactory = &fakeClientFactory{
+		fakeClient: fake.NewSimpleClientset(),
+	}
+	config := &v1beta1.ClusterConfig{
+		Spec: &v1beta1.ClusterSpec{
+			API: &v1beta1.APISpec{
+				Address:         "1.2.3.4",
+				ExternalAddress: "get.k0s.sh",
+			},
+		},
+	}
+
+	r := NewEndpointReconciler(config, &fakeAlwaysLeaderElector{}, fakeFactory)
+
+	assert.NoError(t, r.Init())
+
+	assert.NoError(t, r.reconcileEndpoints())
+	verifyEndpointAddresses(t, expectedAddresses, fakeFactory)
+}
+
+func TestBasicReconcilerWithEmptyEndpointSubset(t *testing.T) {
+	var fakeFactory = &fakeClientFactory{
+		fakeClient: fake.NewSimpleClientset(),
+	}
+	existingEp := corev1.Endpoints{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Endpoints",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "kubernetes",
+		},
+		Subsets: []corev1.EndpointSubset{},
+	}
+	fakeClient, err := fakeFactory.Create()
+	assert.NoError(t, err)
+	_, err = fakeClient.CoreV1().Endpoints("default").Create(context.TODO(), &existingEp, v1.CreateOptions{})
+	assert.NoError(t, err)
+	config := &v1beta1.ClusterConfig{
+		Spec: &v1beta1.ClusterSpec{
+			API: &v1beta1.APISpec{
+				Address:         "1.2.3.4",
+				ExternalAddress: "get.k0s.sh",
+			},
+		},
+	}
+
+	r := NewEndpointReconciler(config, &fakeAlwaysLeaderElector{}, fakeFactory)
+
+	assert.NoError(t, r.Init())
+
+	assert.NoError(t, r.reconcileEndpoints())
+	verifyEndpointAddresses(t, expectedAddresses, fakeFactory)
+}
+
+func TestReconcilerWithNoNeedForUpdate(t *testing.T) {
+	var fakeFactory = &fakeClientFactory{
+		fakeClient: fake.NewSimpleClientset(),
+	}
+	existingEp := corev1.Endpoints{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Endpoints",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "kubernetes",
+			Annotations: map[string]string{
+				"foo": "bar",
+			},
+		},
+		Subsets: []corev1.EndpointSubset{
+			{
+				Addresses: stringsToEndpointAddresses(expectedAddresses),
+			},
+		},
+	}
+
+	fakeClient, _ := fakeFactory.Create()
+
+	_, err := fakeClient.CoreV1().Endpoints("default").Create(context.TODO(), &existingEp, v1.CreateOptions{})
+	assert.NoError(t, err)
+
+	config := &v1beta1.ClusterConfig{
+		Spec: &v1beta1.ClusterSpec{
+			API: &v1beta1.APISpec{
+				Address:         "1.2.3.4",
+				ExternalAddress: "get.k0s.sh",
+			},
+		},
+	}
+	r := NewEndpointReconciler(config, &fakeAlwaysLeaderElector{}, fakeFactory)
+
+	assert.NoError(t, r.Init())
+
+	assert.NoError(t, r.reconcileEndpoints())
+	e := verifyEndpointAddresses(t, expectedAddresses, fakeFactory)
+	assert.Equal(t, "bar", e.ObjectMeta.Annotations["foo"])
+}
+
+func verifyEndpointAddresses(t *testing.T, expectedAddresses []string, fakeFactory *fakeClientFactory) *corev1.Endpoints {
+
+	fakeClient, _ := fakeFactory.Create()
+	ep, err := fakeClient.CoreV1().Endpoints("default").Get(context.TODO(), "kubernetes", v1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, expectedAddresses, endpointAddressesToStrings(ep.Subsets[0].Addresses))
+
+	return ep
+}

--- a/pkg/component/server/apiserver.go
+++ b/pkg/component/server/apiserver.go
@@ -122,6 +122,9 @@ func (a *APIServer) Run() error {
 				args[name] = value
 			}
 		}
+		if a.ClusterConfig.Spec.API.ExternalAddress != "" {
+			args["endpoint-reconciler-type"] = "none"
+		}
 		apiServerArgs := []string{}
 		for name, value := range args {
 			apiServerArgs = append(apiServerArgs, fmt.Sprintf("--%s=%s", name, value))

--- a/pkg/component/server/certificates.go
+++ b/pkg/component/server/certificates.go
@@ -208,8 +208,7 @@ func (c *Certificates) Init() error {
 		"localhost",
 	}
 
-	hostnames = append(hostnames, c.ClusterSpec.API.Address)
-	hostnames = append(hostnames, c.ClusterSpec.API.SANs...)
+	hostnames = append(hostnames, c.ClusterSpec.API.Sans()...)
 
 	internalAPIAddress, err := c.ClusterSpec.Network.InternalAPIAddress()
 	if err != nil {

--- a/pkg/component/server/leaderelector.go
+++ b/pkg/component/server/leaderelector.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2020 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package server
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	config "github.com/k0sproject/k0s/pkg/apis/v1beta1"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component"
+	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/k0sproject/k0s/pkg/leaderelection"
+	"github.com/sirupsen/logrus"
+)
+
+// LeaderElector is the common leader elector component to manage each controller leader status
+type LeaderElector interface {
+	IsLeader() bool
+	component.Component
+}
+
+type leaderElector struct {
+	ClusterConfig *config.ClusterConfig
+
+	L *logrus.Entry
+
+	stopCh            chan struct{}
+	leaderStatus      atomic.Value
+	kubeClientFactory kubeutil.ClientFactory
+	leaseCancel       context.CancelFunc
+}
+
+// NewLeaderElector creates new leader elector
+func NewLeaderElector(c *k0sv1beta1.ClusterConfig, kubeClientFactory kubeutil.ClientFactory) LeaderElector {
+	d := atomic.Value{}
+	d.Store(false)
+	return &leaderElector{
+		ClusterConfig:     c,
+		stopCh:            make(chan struct{}),
+		kubeClientFactory: kubeClientFactory,
+		L:                 logrus.WithFields(logrus.Fields{"component": "endpointreconciler"}),
+		leaderStatus:      d,
+	}
+}
+
+func (l *leaderElector) Init() error {
+	return nil
+}
+
+func (l *leaderElector) Run() error {
+	client, err := l.kubeClientFactory.Create()
+	if err != nil {
+		return fmt.Errorf("can't create kubernetes rest client for lease pool: %v", err)
+	}
+	leasePool, err := leaderelection.NewLeasePool(client, "k0s-endpoint-reconciler", leaderelection.WithLogger(l.L))
+
+	if err != nil {
+		return err
+	}
+	events, cancel, err := leasePool.Watch()
+	if err != nil {
+		return err
+	}
+	l.leaseCancel = cancel
+
+	go func() {
+		for {
+			select {
+			case <-events.AcquiredLease:
+				l.L.Info("acquired leader lease")
+				l.leaderStatus.Store(true)
+			case <-events.LostLease:
+				l.L.Info("lost leader lease")
+				l.leaderStatus.Store(false)
+			}
+		}
+	}()
+	return nil
+}
+
+func (l *leaderElector) Stop() error {
+	if l.leaseCancel != nil {
+		l.leaseCancel()
+	}
+	return nil
+}
+
+func (l *leaderElector) IsLeader() bool {
+	return l.leaderStatus.Load().(bool)
+}
+
+func (l *leaderElector) Healthy() error { return nil }


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>


**Issue**
Fixes #455 

**What this PR Includes**

This PR introduces new options to configure external API address. This is needed in cases where there's a LB in front of the controller nodes.

So the `api.externalAddress` value is being now used in few cases:
- the server address in join tokens
- the API address when configuring cluster components that need to talk with the API (konnectivity agents, kube-proxy etc.)
- new reconciler that resolves the `externalAddress` into a IP addresses and pushes them into the `kubernetes` service endpoints.

### Example use case

So say I configure my cluster with AWS ELB in front of controllers. The ELB has address `my-k0s-lb.us-west-2.elb.amazonaws.com` and it resolves to addresses:
- `1.2.3.4`
- `5.6.7.8`

This would essentially mean the following:
- Join token has server address `https://my-k0s-lb.us-west-2.elb.amazonaws.com:6443`
- All components connecting DIRECTLY to API will connect to the same address as above
- automatic `endpoints/kubernetes` addresses will be disabled and k0s controller will resolve it to have `1.2.3.4:6443` and `5.6.7.8:6443` addresses. This essentially means all in-cluster components connecting through the `kunernetes` service will also connect through the LB

## TODO

- [x] add the external address to SANs list automatically

