### PR TITLE
docs: remove symlinked markdown files

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: mkdocs deploy main
-        #if: contains(github.ref, 'refs/heads/main')
+        if: contains(github.ref, 'refs/heads/main')
         run: |
           mike deploy --push main
       - name: Get the release version

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,3 @@
-docs/contributors/CODE_OF_CONDUCT.md
+# K0s Community Code Of Conduct
+
+Please refer to our [contributor code of conduct](docs/contributors/CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,2 @@
-docs/contributors/overview.md
+# K0s Contributor Guide
+Our contributor's guide can be found [here](docs/contributors/overview.md).


### PR DESCRIPTION
symlinked files don't look so great in Github's web UI, so I replaced
them with regular files with a proper link to the actual documentation.

Signed-off-by: Karen Almog <kalmog@mirantis.com>

