### PR TITLE
update k8s artifacts to 1.20.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.12
 
 RUN apk add --no-cache bash coreutils findutils iptables curl
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl \
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.20.0/bin/linux/amd64/kubectl \
        && chmod +x ./kubectl \
        && mv ./kubectl /usr/local/bin/kubectl
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ _We have seen Kubernetes with cumbersome lifecycle management, high minimum syst
 
 ## Other Features
 
-- Kubernetes 1.19
+- Kubernetes 1.20
 - Containerd 1.4
 - Control plane storage options:
   - sqlite (in-cluster)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,7 +102,7 @@ images:
     version: v0.3.7
   kubeproxy:
     image: k8s.gcr.io/kube-proxy
-    version: v1.19.0
+    version: v1.20.0
   coredns:
     image: docker.io/coredns/coredns
     version: 1.7.0

--- a/examples/footloose-ha-controllers/Dockerfile
+++ b/examples/footloose-ha-controllers/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/footloose/ubuntu18.04
 
 ADD k0s.service /etc/systemd/system/k0s.service
 
-RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl && \
+RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.20.0/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -2,7 +2,7 @@
 ARCH = $(shell go env GOARCH)
 OS = $(shell go env GOOS)
 
-sonobuoy_url = https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.19.0/sonobuoy_0.19.0_$(OS)_$(ARCH).tar.gz
+sonobuoy_url = https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.20.0/sonobuoy_0.20.0_$(OS)_$(ARCH).tar.gz
 
 curl = curl -L --silent
 

--- a/inttest/conformance/README.md
+++ b/inttest/conformance/README.md
@@ -1,4 +1,4 @@
-# Sonobuoy 
+# Conformance Testing 
 
 This is a TF configuration to easily setup a K0s cluster with AWS and start sonobuoy.
 Requirements:
@@ -25,21 +25,24 @@ controller_ip = [
   "54.73.141.241",
 ]
 ```
-  
-**NOTE:** Terraform will fetch K0s version **v0.7.0-beta2** and sonobuoy version **0.19.0**. If you want to test different version you can override this by running terraform apply with 
+## Test Variables
+In order to run the conformance test, you will need to set the tested k0s version and the tested Kubernetes version.
+This can be done in two ways.
+### 1. Create a var file
+In the same directory as your `main.tf` file, create an additional file `terraform.tfvars` with the following input:
 ```
-TF_VAR_k0s_version=v0.7.0-beta1 TF_VAR_sonobuoy_version=0.18.0 terraform apply
+k0s_version=v0.9.0
+k8s_version=v1.20.0
+onobuoy_version=0.20.0
+```  
+### 2. Environment variables
 ```
-Alternatively you create terraform.tfvars with content similar to this:
+TF_VAR_k0s_version=v0.7.0-beta1 TF_VAR_sonobuoy_version=0.18.0 TF_VAR_k8s_version=v1.20.0 terraform apply
 ```
-k0s_version=v0.7.0-beta1
-sonobuoy_version=0.18.0
-```
-And run `terraform apply`
+**NOTE:** By default, terraform will fetch sonobuoy version **0.20.0**. If you want to use a different version you can override this with one of the above methods. 
 
-
-Once provisioning of the cluster finishes you can get sonobuoy results you have to SSH into the controller:
-
+## Fetching Sonobuoy's results
+Once provisioning of the cluster finishes you can get the results by SSH'ing into the controller:
 ```
 $ ssh -i .terraform/modules/k0s-sonobuoy/inttest/terraform/test-cluster/aws_private.pem ubuntu@[controller_ip]
 

--- a/inttest/conformance/terraform/main.tf
+++ b/inttest/conformance/terraform/main.tf
@@ -9,7 +9,12 @@ variable "k0s_version" {
 
 variable "sonobuoy_version" {
   type    = string
-  default = "0.19.0"
+  default = "0.20.0"
+}
+
+variable "k8s_version" {
+  // format: v1.20.0
+  type = string
 }
 
 output "controller_ip" {
@@ -119,7 +124,7 @@ resource "null_resource" "sonobuoy" {
       "tar -xvf sonobuoy_${var.sonobuoy_version}_linux_amd64.tar.gz",
       "sudo mv sonobuoy /usr/local/bin",
       "sudo chmod +x /usr/local/bin/sonobuoy",
-      "KUBECONFIG=/var/lib/k0s/pki/admin.conf sonobuoy run --mode=certified-conformance"
+      "KUBECONFIG=/var/lib/k0s/pki/admin.conf sonobuoy run --mode=certified-conformance --kube-conformance-image-version=${var.k8s_version}"
     ]
   }
 }

--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -19,7 +19,7 @@ RUN echo "#!/bin/sh" > /etc/local.d/machine-id.start \
        && chmod +x /etc/local.d/machine-id.start
 
 # Put kubectl into place to ease up debugging
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl \
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.20.0/bin/linux/amd64/kubectl \
        && chmod +x ./kubectl \
        && mv ./kubectl /usr/local/bin/kubectl
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf

--- a/inttest/sonobuoy/signetwork_test.go
+++ b/inttest/sonobuoy/signetwork_test.go
@@ -64,6 +64,7 @@ func (s *NetworkSuite) TestSigNetwork() {
 		`--e2e-focus=\[sig-network\].*\[Conformance\]`,
 		`--e2e-skip=\[Serial\]`,
 		"--e2e-parallel=y",
+		"--kube-conformance-image-version=v1.20.0",
 	}
 	s.T().Log("running sonobuoy, this may take a while")
 	sonoFinished := make(chan bool)

--- a/pkg/component/server/kubeletconfig_test.go
+++ b/pkg/component/server/kubeletconfig_test.go
@@ -42,7 +42,7 @@ func Test_KubeletConfig(t *testing.T) {
 		manifestYamls := strings.Split(strings.TrimSuffix(buf.String(), "---"), "---")[1:]
 		t.Run("output_must_have_3_manifests", func(t *testing.T) {
 			assert.Len(t, manifestYamls, 3, "Must have exactly 3 generated manifests per profile")
-			assertConfigMap(t, manifestYamls[0], "kubelet-config-default-1.19")
+			assertConfigMap(t, manifestYamls[0], "kubelet-config-default-1.20")
 			assertRole(t, manifestYamls[1], []string{formatProfileName("default")})
 			assertRoleBinding(t, manifestYamls[2])
 		})
@@ -59,7 +59,7 @@ func Test_KubeletConfig(t *testing.T) {
 			// check that each profile has config map, role and role binding
 			resourceNamesForRole := []string{}
 			for idx, profileName := range []string{"default", "profile_XXX", "profile_YYY"} {
-				fullName := "kubelet-config-" + profileName + "-1.19"
+				fullName := "kubelet-config-" + profileName + "-1.20"
 				resourceNamesForRole = append(resourceNamesForRole, formatProfileName(profileName))
 				assertConfigMap(t, manifestYamls[idx], fullName)
 			}

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -80,7 +80,7 @@ const (
 	// KonnectivityServerUser deinfes the user to use for konnectivity-server
 	KonnectivityServerUser = "konnectivity-server"
 	// KubernetesMajorMinorVersion defines the current embedded major.minor version info
-	KubernetesMajorMinorVersion = "1.19"
+	KubernetesMajorMinorVersion = "1.20"
 	// DefaultPSP defines the system level default PSP to apply
 	DefaultPSP = "00-k0s-privileged"
 
@@ -90,7 +90,7 @@ const (
 	MetricsImage               = "gcr.io/k8s-staging-metrics-server/metrics-server"
 	MetricsImageVersion        = "v0.3.7"
 	KubeProxyImage             = "k8s.gcr.io/kube-proxy"
-	KubeProxyImageVersion      = "v1.19.4"
+	KubeProxyImageVersion      = "v1.20.0"
 	CoreDNSImage               = "docker.io/coredns/coredns"
 	CoreDNSImageVersion        = "1.7.0"
 	CalicoImage                = "calico/cni"


### PR DESCRIPTION
**Issue**
Fixes #542

**What this PR Includes**
Update a few more constants to k8s v1.20.0
This PR also:
* Updates sonobuoy to version 0.20
* Adds the `kube-conformance-image-version` flag to sonobuoy conformance and e2e testing
* Updates conformance test docs.