### PR TITLE
Always set calico to auto detect iptables backend mode

### DIFF
--- a/docs/internal/upgrading-calico.md
+++ b/docs/internal/upgrading-calico.md
@@ -44,7 +44,12 @@ not the calico originals.
   value: "{{ .VxlanVNI }}"
 {{- end }}
 ```
-
+- iptables auto detect:
+```helmyaml
+# Auto detect the iptables backend
+- name: FELIX_IPTABLESBACKEND
+  value: "auto"
+```
 - variable-based WireGuard support:
 ```helmyaml
 {{- if .EnableWireguard }}

--- a/static/manifests/calico/DaemonSet/calico-node.yaml
+++ b/static/manifests/calico/DaemonSet/calico-node.yaml
@@ -154,6 +154,9 @@ spec:
             # Auto-detect the BGP IP address.
             - name: IP
               value: "autodetect"
+            # Auto detect the iptables backend
+            - name: FELIX_IPTABLESBACKEND
+              value: "auto"
             {{- if eq .Mode "ipip" }}
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Might be a partial fix for #537 but even if not, making Calico autodetect the used mode is a good idea.

**What this PR Includes**
This PR sets Calico to always use auto-detect mode for iptables backend.


✅  SIG-Network tests succesful at https://github.com/k0sproject/k0s/actions/runs/435568064