### PR TITLE
Disable parallel jobs in release make targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Build
-        run: make -j$(nproc) EMBEDDED_BINS_BUILDMODE=docker
+        run: make EMBEDDED_BINS_BUILDMODE=docker
         env:
           VERSION: ${{ needs.release.outputs.tag_name }}
       - name: Clean Docker
@@ -118,7 +118,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Build
-        run: make -j$(nproc) EMBEDDED_BINS_BUILDMODE=docker k0s.exe
+        run: make EMBEDDED_BINS_BUILDMODE=docker k0s.exe
         env:
           VERSION: ${{ needs.release.outputs.tag_name }}
 
@@ -162,7 +162,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Build
-        run: make -j$(nproc) EMBEDDED_BINS_BUILDMODE=docker
+        run: make EMBEDDED_BINS_BUILDMODE=docker
         env:
           VERSION: ${{ needs.release.outputs.tag_name }}
       - name: Clean Docker


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Some of the make target changes in #508 seems to cause parallel builds with `-j` fail.

**What this PR Includes**
Short term mitigation by disabling the parallelization in release builds