### PR TITLE
Remove smoke test from win release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,15 +126,6 @@ jobs:
         run: |
           docker system prune --all --volumes --force
 
-      - name: Run basic smoke test
-        run: make check-basic
-
-      - name: Collect smoke test logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          name: logs
-          path: tests/*.log
       - name: Upload Release Assets
         id: upload-release-asset
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Win release job runs smokes but fails as the smokes are linux only currently

**What this PR Includes**
Removes the smokes from win release job as they cannot be really run.