### PR TITLE
Don't generate new docs for pre-releases

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,12 +50,12 @@ jobs:
         run: |
           mike deploy --push main
       - name: Get the release version
-        if: contains(github.ref, 'refs/tags/v') # && !github.event.release.prerelease (generate pre-release docs until Lens 4.0.0 is GA, see #1408)
+        if: contains(github.ref, 'refs/tags/v') && !github.event.release.prerelease # (don't generate for pre-releases)
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
       - name: mkdocs deploy new release
-        if: contains(github.ref, 'refs/tags/v') # && !github.event.release.prerelease (generate pre-release docs until Lens 4.0.0 is GA, see #1408)
+        if: contains(github.ref, 'refs/tags/v') && !github.event.release.prerelease # (don't generate for pre-releases)
         run: |
           mike deploy --push --update-aliases ${{ steps.get_version.outputs.VERSION }} latest
           mike set-default --push ${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,6 +24,9 @@ on:
       - '**.md'
       - LICENSE
       - '**.svg'
+      - '.github/workflows/docs.yml'
+      - '.github/workflows/mkdocs-set-default-version.yml'
+      - 'mkdocs.yml'
 jobs:
   build:
     name: Build

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ k0s is an all-inclusive Kubernetes distribution with all the required bells and 
 
 If you'd like to try k0s, please jump to our:
 
-- [Super QuickStart](https://docs.k0sproject.io/main/k0s-single-node/) - Create a k0s control plane and worker, and access it locally with kubectl.
-- [NanoDemo](https://docs.k0sproject.io/main/#demo) - Watch a .gif recording of how to create a k0s instance.
-- [Create a k0s cluster](https://docs.k0sproject.io/main/create-cluster/) - For when you're ready to build a multi-node cluster.
-- [Run k0s in Docker](https://docs.k0sproject.io/main/k0s-in-docker/) - Run k0s controllers and workers in containers.
-- [Run in Windows](https://docs.k0sproject.io/main/experimental-windows/) - For running k0s on a windows host (experimental!).
+- [Super QuickStart](https://docs.k0sproject.io/latest/k0s-single-node/) - Create a k0s control plane and worker, and access it locally with kubectl.
+- [NanoDemo](https://docs.k0sproject.io/latest/#demo) - Watch a .gif recording of how to create a k0s instance.
+- [Create a k0s cluster](https://docs.k0sproject.io/latest/create-cluster/) - For when you're ready to build a multi-node cluster.
+- [Run k0s in Docker](https://docs.k0sproject.io/latest/k0s-in-docker/) - Run k0s controllers and workers in containers.
+- [Run in Windows](https://docs.k0sproject.io/latest/experimental-windows/) - For running k0s on a windows host (experimental!).
 - You may also be interested in current version specifications. For docs, tutorials, and other k0s resources, see our Docs and Resources [main page](https://docs.k0sproject.io).
 
 ## Join the Community
-If you'd like to help build k0s, please check out our guide to [Contributing](https://docs.k0sproject.io/main/contributors/overview/) and our [Code of Conduct](https://docs.k0sproject.io/main/contributors/CODE_OF_CONDUCT/).
+If you'd like to help build k0s, please check out our guide to [Contributing](https://docs.k0sproject.io/latest/contributors/overview/) and our [Code of Conduct](https://docs.k0sproject.io/latest/contributors/CODE_OF_CONDUCT/).
 
 ## Motivation
 


### PR DESCRIPTION
Signed-off-by: Karen Almog <kalmog@mirantis.com>

**What this PR Includes**
This PR fixes the doc generation workflow, to not be triggered for pre-releases.
It also fixes the links in the main README to point to `latest` instead of `main`