### PR TITLE
Refactor makefile

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -61,7 +61,7 @@ jobs:
             .bins.stamp
             embedded-bins/staging/linux/bin/
             bindata_linux
-            pkg/assets/zz_generated_offsets.go
+            pkg/assets/zz_generated_offsets_linux.go
 
           key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}
           restore-keys: |
@@ -309,7 +309,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: codegen
-        run: make pkg/assets/zz_generated_offsets.go
+        run: make pkg/assets/zz_generated_offsets_linux.go
         env:
           EMBEDDED_BINS_BUILDMODE: none
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
-pkg/assets/zz_generated_offsets.go
+pkg/assets/zz_generated_offsets*.go
 k0s
 k0s.code
 k0s.exe
 k0s.exe.code
-bindata
+bindata*
 .*.stamp
 .tmp
 .terraform

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ smoketests := check-addons check-basic check-byocri check-hacontrolplane check-k
 $(smoketests): k0s
 	$(MAKE) -C inttest $@
 
+.PHONY: smoketests
+smoketests: $(smoketests)
+
 .PHONY: check-unit
 check-unit: pkg/assets/zz_generated_offsets_$(TARGET_OS).go
 	go test -race ./pkg/...

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,18 @@ ifeq ($(golint),)
 golint := go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.31.0 && "${GOPATH}/bin/golangci-lint"
 endif
 
+.PHONY: build
+ifeq ($(TARGET_OS),windows)
+build: k0s.exe
+else
+build: k0s
+endif
+
 .PHONY: all
-all: build
+all: k0s k0s.exe
 
 ifeq ($(EMBEDDED_BINS_BUILDMODE),none)
-pkg/assets/zz_generated_offsets.go:
+pkg/assets/zz_generated_offsets_linux.go pkg/assets/zz_generated_offsets_windows.go:
 	rm -f bindata && touch bindata
 	printf "%s\n\n%s\n%s\n" \
 		"package assets" \
@@ -32,43 +39,33 @@ pkg/assets/zz_generated_offsets.go:
 		"var BinDataSize int64 = 0" \
 		> $@
 else
-pkg/assets/zz_generated_offsets.go: # embedded-bins/staging/${TARGET_OS}/bin gen_bindata.go
-	# TODO: this dependencies moved here instead of being listed under the actual dependencies because it seems
-	# like variable interpolation doesn't work there
-	make embedded-bins/staging/${TARGET_OS}/bin gen_bindata.go
-	go generate
+zz_os = $(patsubst pkg/assets/zz_generated_offsets_%.go,%,$@)
+
+pkg/assets/zz_generated_offsets_linux.go: .bins.linux.stamp
+pkg/assets/zz_generated_offsets_windows.go: .bins.windows.stamp
+pkg/assets/zz_generated_offsets_linux.go pkg/assets/zz_generated_offsets_windows.go: gen_bindata.go
+	GOOS=${GOHOSTOS} go run gen_bindata.go -o bindata_$(zz_os) -pkg assets \
+	     -gofile pkg/assets/zz_generated_offsets_$(zz_os).go \
+	     -prefix embedded-bins/staging/$(zz_os)/ embedded-bins/staging/$(zz_os)/bin
 endif
 
+k0s: TARGET_OS = linux
+k0s: pkg/assets/zz_generated_offsets_linux.go .bins.linux.stamp
 
-k0s: export TARGET_OS := linux
-k0s: pkg/assets/zz_generated_offsets.go embedded-bins/staging/linux/bin $(GO_SRCS)
-	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags='-w -s -X github.com/k0sproject/k0s/pkg/build.Version=$(VERSION) -X "github.com/k0sproject/k0s/pkg/build.EulaNotice=$(EULA_NOTICE)" -X github.com/k0sproject/k0s/pkg/telemetry.segmentToken=$(SEGMENT_TOKEN)' -o k0s.code main.go
-	cat k0s.code bindata_${TARGET_OS} > $@.tmp && chmod +x $@.tmp && mv $@.tmp $@
+k0s.exe: TARGET_OS = windows
+k0s.exe: pkg/assets/zz_generated_offsets_windows.go .bins.windows.stamp
 
-k0s.exe: export TARGET_OS := windows
-k0s.exe: pkg/assets/zz_generated_offsets.go embedded-bins/staging/windows/bin $(GO_SRCS)
-	CGO_ENABLED=0 GOOS=windows GOARCH=$(GOARCH) go build -ldflags='-w -s -X github.com/k0sproject/k0s/pkg/build.Version=$(VERSION) -X "github.com/k0sproject/k0s/pkg/build.EulaNotice=$(EULA_NOTICE)" -X github.com/k0sproject/k0s/pkg/telemetry.segmentToken=$(SEGMENT_TOKEN)' -o k0s.exe.code main.go
-	cat k0s.exe.code bindata_${TARGET_OS} > $@.tmp && chmod +x $@.tmp && mv $@.tmp $@
+k0s.exe k0s: $(GO_SRCS)
+	CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(GOARCH) go build -ldflags='-w -s -X github.com/k0sproject/k0s/pkg/build.Version=$(VERSION) -X "github.com/k0sproject/k0s/pkg/build.EulaNotice=$(EULA_NOTICE)" -X github.com/k0sproject/k0s/pkg/telemetry.segmentToken=$(SEGMENT_TOKEN)' \
+		    -o $@.code main.go
+	cat $@.code bindata_$(TARGET_OS) > $@.tmp && chmod +x $@.tmp && mv $@.tmp $@
 
-.PHONY: build
-build: k0s
-
-.PHONY: bins
-bins: .bins.stamp
-
-embedded-bins/staging/linux/bin: .bins.linux.stamp
-embedded-bins/staging/windows/bin: .bins.windows.stamp
-
-.bins.windows.stamp:
-	$(MAKE) -C embedded-bins buildmode=$(EMBEDDED_BINS_BUILDMODE) TARGET_OS=windows
-	touch $@
-
-.bins.linux.stamp:
-	$(MAKE) -C embedded-bins buildmode=$(EMBEDDED_BINS_BUILDMODE) TARGET_OS=linux
+.bins.windows.stamp .bins.linux.stamp:
+	$(MAKE) -C embedded-bins buildmode=$(EMBEDDED_BINS_BUILDMODE) TARGET_OS=$(patsubst .bins.%.stamp,%,$@)
 	touch $@
 
 .PHONY: lint
-lint: pkg/assets/zz_generated_offsets.go
+lint: pkg/assets/zz_generated_offsets_$(TARGET_OS).go
 	$(golint) run ./...
 
 smoketests := check-addons check-basic check-byocri check-hacontrolplane check-kine check-network check-singlenode
@@ -77,12 +74,12 @@ $(smoketests): k0s
 	$(MAKE) -C inttest $@
 
 .PHONY: check-unit
-check-unit: pkg/assets/zz_generated_offsets.go
+check-unit: pkg/assets/zz_generated_offsets_$(TARGET_OS).go
 	go test -race ./pkg/...
 
 .PHONY: clean
 clean:
-	rm -f pkg/assets/zz_generated_offsets.go k0s .bins.*stamp bindata*
+	rm -f pkg/assets/zz_generated_offsets_*.go k0s k0s.exe .bins.*stamp bindata*
 	$(MAKE) -C embedded-bins clean
 
 .PHONY: manifests
@@ -94,5 +91,5 @@ bindata-manifests:
 	go-bindata -o static/gen_manifests.go -pkg static -prefix static static/...
 
 .PHONY: generate-bindata
-generate-bindata:
-	GOOS=${GOHOSTOS} go run gen_bindata.go -o bindata_${TARGET_OS} -pkg assets -gofile pkg/assets/zz_generated_offsets.go -prefix embedded-bins/staging/${TARGET_OS}/ embedded-bins/staging/${TARGET_OS}/bin
+generate-bindata: pkg/assets/zz_generated_offsets_$(TARGET_OS).go
+


### PR DESCRIPTION
**What this PR Includes**

Refactor Makefile:
- dedupe build rules for windows and linux
- fix race condition that caused arm64 build to fail
- add `make smoketests` target so we can run all tests in one go