### PR TITLE
Add separate GHA workflow with actions/stale to mark and close staled PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: "Close stale PRs"
+on:
+  schedule:
+    - cron: "0 23 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # Empty message to prevent issues from being closed or staled
+          stale-issue-message: ''
+          stale-pr-message: 'The PR is marked as stale since no activity has been recorded in 30 days'
+          days-before-stale: 30
+          close-pr-label: "stale"


### PR DESCRIPTION
Add `actions/stale@v3` to run daily and mark staled (no activity for more than 30 days) PRs. 
Staled PRs are closed in 7 days after being marked.

No issues are marked as staled.