### PR TITLE
Add KillMode=process to systemd unit

### DIFF
--- a/pkg/install/service.go
+++ b/pkg/install/service.go
@@ -58,7 +58,7 @@ func EnsureService(args []string) error {
 	case "linux-openrc":
 		deps = []string{"need net", "use dns", "after firewall"}
 	case "linux-systemd":
-		deps = []string{"After=network.target"}
+		deps = []string{"After=network.target", "KillMode=process"}
 	default:
 	}
 


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
The current default way for systemd is to kill ALL processes in the services group. In k0s case it means all the managed processes AND al the containers too.

**What this PR Includes**
This changes the systemd unit to send kill signals only to the main process (k0s itself) so it'll allow k0s to shutdown other components gracefully.