### PR TITLE
Use /run as rundir when running as root

### DIFF
--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -1,6 +1,7 @@
 package constant
 
 import (
+	"os"
 	"runtime"
 )
 
@@ -105,7 +106,12 @@ func GetConfig(dataDir string) CfgVars {
 		}
 	}
 
-	runDir := formatPath(dataDir, "run")
+	var runDir string
+	if os.Geteuid() == 0 {
+		runDir = "/run/k0s"
+	} else {
+		runDir = formatPath(dataDir, "run")
+	}
 	certDir := formatPath(dataDir, "pki")
 	winCertDir := WinDataDirDefault + "\\pki" // hacky but we need it to be windows style even on linux machine
 	helmHome := formatPath(dataDir, "helmhome")


### PR DESCRIPTION
/run is supposed to be on tmpfs and cleaned on reboots so it is where
the run state (unix sockets, pid files etc) should be. However, it
is only writable by root, so use it only when k0s runs as root and use
datadir when running as non-root.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

---
name: Pull Request
about: Create a Pull Request
title: ''
labels: ''
assignees: ''

---

**Issue**
Fixes #{ issue number }

**What this PR Includes**
A short description of what this PR does.