### PR TITLE
Install improvement

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -21,44 +21,28 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-
 	"github.com/k0sproject/k0s/pkg/apis/v1beta1"
 	"github.com/k0sproject/k0s/pkg/install"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 func init() {
-	installCmd.Flags().StringVar(&role, "role", "server", "node role (possible values: server or worker. In a single-node setup, a worker role should be used)")
-
-	// shell completion options
-	_ = installCmd.RegisterFlagCompletionFunc("role", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"server", "worker"}, cobra.ShellCompDirectiveDefault
-	})
+	installCmd.AddCommand(installServerCmd)
+	installCmd.AddCommand(installWorkerCmd)
 }
 
 var (
-	role string
-
 	installCmd = &cobra.Command{
 		Use:   "install",
 		Short: "Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			switch role {
-			case "server", "worker":
-				return setup()
-			default:
-				logrus.Errorf("invalid value %s for install role", role)
-				return cmd.Help()
-			}
-		},
 	}
 )
 
 // the setup functions:
 // * Ensures that the proper users are created
 // * sets up startup and logging for k0s
-func setup() error {
+func setup(role string, args []string) error {
 	if os.Geteuid() != 0 {
 		logrus.Fatal("this command must be run as root!")
 	}
@@ -68,9 +52,8 @@ func setup() error {
 			logrus.Errorf("failed to create server users: %v", err)
 		}
 	}
-	// set-up service and logging
-	serviceArgs := getCmdArgs(role)
-	err := install.EnsureService(serviceArgs)
+
+	err := install.EnsureService(args)
 	if err != nil {
 		logrus.Errorf("failed to install k0s service: %v", err)
 	}
@@ -82,6 +65,7 @@ func createServerUsers() error {
 	if err != nil {
 		return err
 	}
+
 	users := getUserList(*clusterConfig.Install.SystemUsers)
 
 	var messages []string
@@ -105,22 +89,4 @@ func getUserList(sysUsers v1beta1.SystemUser) []string {
 		values[i] = v.Field(i).String()
 	}
 	return values
-}
-
-func getCmdArgs(role string) []string {
-	var args []string
-
-	if role == "server" {
-		args = append(args, "server")
-		if cfgFile != "" {
-			args = append(args, "--config", cfgFile)
-		}
-	} else {
-		args = append(args, "worker", "--token-file", "REPLACEME")
-	}
-
-	if debug {
-		args = append(args, "--debug")
-	}
-	return args
 }

--- a/cmd/installServer.go
+++ b/cmd/installServer.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 Mirantis, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	installServerCmd = &cobra.Command{
+		Use:   "server",
+		Short: "Helper command for setting up k0s as server node on a brand-new system. Must be run as root (or with sudo)",
+		Example: `All default values of server command will be passed to the service stub unless overriden. 
+To get information about default values run "k0s install server --help"
+
+With server subcommand you can setup a single node cluster by running:
+
+	k0s install server --enable-worker
+	`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flagsAndVals := []string{"server"}
+			cmd.Flags().Visit(func(f *pflag.Flag) {
+				flagsAndVals = append(flagsAndVals, fmt.Sprintf("--%s", f.Name), f.Value.String())
+			})
+			return setup("server", flagsAndVals)
+		},
+	}
+)

--- a/cmd/installWorker.go
+++ b/cmd/installWorker.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2021 Mirantis, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	installWorkerCmd = &cobra.Command{
+		Use:   "worker",
+		Short: "Helper command for setting up k0s as a worker node on a brand-new system. Must be run as root (or with sudo)",
+		Example: `Worker subcommand allows you to pass in all available worker parameters. 
+All default values of worker command will be passed to the service stub unless overriden.
+To get information about default values run "k0s install worker --help"
+
+Windows flags like "--api-server", "--cidr-range" and "--cluster-dns" will be ignored since install command doesn't yet support Windows services`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flagsAndVals := []string{"worker"}
+			cmd.Flags().Visit(func(f *pflag.Flag) {
+				flagsAndVals = append(flagsAndVals, fmt.Sprintf("--%s", f.Name), f.Value.String())
+			})
+
+			return setup("worker", flagsAndVals)
+		},
+	}
+)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -52,6 +52,8 @@ func init() {
 	serverCmd.Flags().BoolVar(&enableWorker, "enable-worker", false, "enable worker (default false)")
 	serverCmd.Flags().StringVar(&tokenFile, "token-file", "", "Path to the file containing join-token.")
 	serverCmd.Flags().StringVar(&criSocket, "cri-socket", "", "contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]")
+	installServerCmd.Flags().AddFlagSet(serverCmd.Flags())
+
 }
 
 var (

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -45,6 +45,7 @@ func init() {
 	workerCmd.Flags().StringVar(&clusterDNS, "cluster-dns", "10.96.0.10", "HACK: cluster dns for the windows worker node")
 	workerCmd.Flags().BoolVar(&cloudProvider, "enable-cloud-provider", false, "Whether or not to enable cloud provider support in kubelet")
 	workerCmd.Flags().StringVar(&tokenFile, "token-file", "", "Path to the file containing token.")
+	installWorkerCmd.Flags().AddFlagSet(workerCmd.Flags())
 }
 
 var (

--- a/docs/cli/k0s.md
+++ b/docs/cli/k0s.md
@@ -12,8 +12,9 @@ k0s - The zero friction Kubernetes - https://k0sproject.io
   -c, --config string            config file (default: ./k0s.yaml)
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
+      --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
   -h, --help                     help for k0s
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_api.md
+++ b/docs/cli/k0s_api.md
@@ -18,7 +18,8 @@ k0s api [flags]
   -c, --config string            config file (default: ./k0s.yaml)
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+      --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
+  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_completion.md
+++ b/docs/cli/k0s_completion.md
@@ -49,7 +49,8 @@ k0s completion [bash|zsh|fish|powershell]
   -c, --config string            config file (default: ./k0s.yaml)
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+      --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
+  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_default-config.md
+++ b/docs/cli/k0s_default-config.md
@@ -18,7 +18,8 @@ k0s default-config [flags]
   -c, --config string            config file (default: ./k0s.yaml)
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+      --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
+  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_docs.md
+++ b/docs/cli/k0s_docs.md
@@ -18,7 +18,8 @@ k0s docs [flags]
   -c, --config string            config file (default: ./k0s.yaml)
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+      --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
+  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_etcd.md
+++ b/docs/cli/k0s_etcd.md
@@ -14,7 +14,8 @@ Manage etcd cluster
   -c, --config string            config file (default: ./k0s.yaml)
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+      --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
+  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_etcd_leave.md
+++ b/docs/cli/k0s_etcd_leave.md
@@ -19,7 +19,8 @@ k0s etcd leave [flags]
   -c, --config string            config file (default: ./k0s.yaml)
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+      --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
+  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_etcd_member-list.md
+++ b/docs/cli/k0s_etcd_member-list.md
@@ -18,7 +18,8 @@ k0s etcd member-list [flags]
   -c, --config string            config file (default: ./k0s.yaml)
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+      --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
+  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_install.md
+++ b/docs/cli/k0s_install.md
@@ -2,15 +2,10 @@
 
 Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)
 
-```
-k0s install [flags]
-```
-
 ### Options
 
 ```
-  -h, --help          help for install
-      --role string   node role (possible values: server or worker. In a single-node setup, a worker role should be used) (default "server")
+  -h, --help   help for install
 ```
 
 ### Options inherited from parent commands
@@ -19,10 +14,13 @@ k0s install [flags]
   -c, --config string            config file (default: ./k0s.yaml)
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+      --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
+  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
 ```
 
 ### SEE ALSO
 
 * [k0s](k0s.md)	 - k0s - Zero Friction Kubernetes
+* [k0s install server](k0s_install_server.md)	 - Helper command for setting up k0s as server node on a brand-new system. Must be run as root (or with sudo)
+* [k0s install worker](k0s_install_worker.md)	 - Helper command for setting up k0s as a worker node on a brand-new system. Must be run as root (or with sudo)
 

--- a/docs/cli/k0s_install_server.md
+++ b/docs/cli/k0s_install_server.md
@@ -1,21 +1,21 @@
-## k0s server
+## k0s install server
 
-Run server
+Helper command for setting up k0s as server node on a brand-new system. Must be run as root (or with sudo)
 
 ```
-k0s server [join-token] [flags]
+k0s install server [flags]
 ```
 
 ### Examples
 
 ```
-	Command to associate master nodes:
-	CLI argument:
-	$ k0s server [join-token]
+All default values of server command will be passed to the service stub unless overriden. 
+To get information about default values run "k0s install server --help"
 
-	or CLI flag:
-	$ k0s server --token-file [path_to_file]
-	Note: Token can be passed either as a CLI argument or as a flag
+With server subcommand you can setup a single node cluster by running:
+
+	k0s install server --enable-worker
+	
 ```
 
 ### Options
@@ -39,5 +39,5 @@ k0s server [join-token] [flags]
 
 ### SEE ALSO
 
-* [k0s](k0s.md)	 - k0s - Zero Friction Kubernetes
+* [k0s install](k0s_install.md)	 - Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)
 

--- a/docs/cli/k0s_install_worker.md
+++ b/docs/cli/k0s_install_worker.md
@@ -1,21 +1,19 @@
-## k0s worker
+## k0s install worker
 
-Run worker
+Helper command for setting up k0s as a worker node on a brand-new system. Must be run as root (or with sudo)
 
 ```
-k0s worker [join-token] [flags]
+k0s install worker [flags]
 ```
 
 ### Examples
 
 ```
-	Command to add worker node to the master node:
-	CLI argument:
-	$ k0s worker [token]
+Worker subcommand allows you to pass in all available worker parameters. 
+All default values of worker command will be passed to the service stub unless overriden.
+To get information about default values run "k0s install worker --help"
 
-	or CLI flag:
-	$ k0s worker --token-file [path_to_file]
-	Note: Token can be passed either as a CLI argument or as a flag
+Windows flags like "--api-server", "--cidr-range" and "--cluster-dns" will be ignored since install command doesn't yet support Windows services
 ```
 
 ### Options
@@ -43,5 +41,5 @@ k0s worker [join-token] [flags]
 
 ### SEE ALSO
 
-* [k0s](k0s.md)	 - k0s - Zero Friction Kubernetes
+* [k0s install](k0s_install.md)	 - Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)
 

--- a/docs/cli/k0s_kubeconfig.md
+++ b/docs/cli/k0s_kubeconfig.md
@@ -18,7 +18,8 @@ k0s kubeconfig [command] [flags]
   -c, --config string            config file (default: ./k0s.yaml)
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+      --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
+  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_kubeconfig_admin.md
+++ b/docs/cli/k0s_kubeconfig_admin.md
@@ -30,7 +30,8 @@ k0s kubeconfig admin [command] [flags]
   -c, --config string            config file (default: ./k0s.yaml)
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+      --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
+  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_kubeconfig_create.md
+++ b/docs/cli/k0s_kubeconfig_create.md
@@ -35,7 +35,8 @@ k0s kubeconfig create [username] [flags]
   -c, --config string            config file (default: ./k0s.yaml)
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+      --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
+  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_token.md
+++ b/docs/cli/k0s_token.md
@@ -19,7 +19,8 @@ k0s token [flags]
   -c, --config string            config file (default: ./k0s.yaml)
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+      --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
+  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_token_create.md
+++ b/docs/cli/k0s_token_create.md
@@ -21,7 +21,8 @@ k0s token create [flags]
   -c, --config string            config file (default: ./k0s.yaml)
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+      --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
+  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_version.md
+++ b/docs/cli/k0s_version.md
@@ -18,7 +18,8 @@ k0s version [flags]
   -c, --config string            config file (default: ./k0s.yaml)
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+      --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
+  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/avast/retry-go v2.6.0+incompatible
 	github.com/cloudflare/cfssl v1.4.1
 	github.com/containerd/containerd v1.4.1 // indirect
-	github.com/davecgh/go-spew v1.1.1
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/docker/libnetwork v0.5.6
 	github.com/evanphx/json-patch v4.9.0+incompatible
@@ -34,8 +33,11 @@ require (
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.1
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
+	github.com/vishvananda/netlink v1.1.0 // indirect
+	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f // indirect
 	github.com/weaveworks/footloose v0.0.0-20200609124411-8f3df89ea188
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
@@ -45,7 +47,6 @@ require (
 	golang.org/x/tools v0.0.0-20201013201025-64a9e34f3752 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/fsnotify.v1 v1.4.7
-	gopkg.in/ini.v1 v1.51.0
 	gopkg.in/segmentio/analytics-go.v3 v3.1.0
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,6 @@ github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916/go.mod h1:/u0gXw
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/docker/libnetwork v0.5.6 h1:hnGiypBsZR6PW1I8lqaBHh06U6LCJbI3IhOvfsZiymY=
-github.com/docker/libnetwork v0.5.6/go.mod h1:93m0aTqz6z+g32wla4l4WxTrdtvBRmVzYRkYvasA5Z8=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 h1:ZClxb8laGDf5arXfYcAtECDFgAgHklGI8CxgjHnXKJ4=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
@@ -483,10 +481,6 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/k0sproject/kardianos-service v1.2.1-0.20201210130727-fd641b530ae7 h1:0VzMJhj1mj9AVZ4EejKThuiigtrOprV5q4OcEbsHeEs=
-github.com/k0sproject/kardianos-service v1.2.1-0.20201210130727-fd641b530ae7/go.mod h1:5Q3jjY0dCC/LrFssMVPnB/r2g1Dt6RETQfPAvhhZ2so=
-github.com/kardianos/service v1.2.0 h1:bGuZ/epo3vrt8IPC7mnKQolqFeYJb7Cs8Rk4PSOBB/g=
-github.com/kardianos/service v1.2.0/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/kardianos/service v1.2.1-0.20201211143537-ef35c563203c h1:otL8yWHnEhB7k7CBJZy95ri364Z2ee+IE7CyfVxOcIA=
 github.com/kardianos/service v1.2.1-0.20201211143537-ef35c563203c/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -800,6 +794,11 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
+github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
+github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
+github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f h1:p4VB7kIXpOQvVn1ZaTIVp+3vuYAXFe3OJEvjbUYJLaA=
+github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/weaveworks/footloose v0.0.0-20200609124411-8f3df89ea188 h1:BuiVM+91YRjWUSMvF93A7Sm7s7IHrxjrPcc/5boO2V0=
 github.com/weaveworks/footloose v0.0.0-20200609124411-8f3df89ea188/go.mod h1:nxDdCjg1kb5+luh4mUCp+mtBZIWrhzoLIArrD99y+Sc=
 github.com/weppos/publicsuffix-go v0.4.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
@@ -970,6 +969,7 @@ golang.org/x/sys v0.0.0-20190514135907-3a4b5fb9f71f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190515120540-06a5c4944438/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -985,6 +985,7 @@ golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/install/service.go
+++ b/pkg/install/service.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
+var (
 	k0sServiceName = "k0s"
 	k0sDescription = "k0s - Zero Friction Kubernetes"
 )
@@ -30,14 +30,12 @@ func EnsureService(args []string) error {
 	var k0sDisplayName string
 
 	prg := &program{}
-
 	for _, v := range args {
-		if v == "server" {
-			k0sDisplayName = "k0s server"
-		} else {
-			k0sDisplayName = "k0s worker"
+		if v == "server" || v == "worker" {
+			k0sDisplayName = "k0s " + v
+			k0sServiceName = k0sServiceName + v
+			break
 		}
-
 	}
 
 	// initial svc config


### PR DESCRIPTION
This improvement allows to pass all possible k0s parameters to install command. 
Syntax is like this:

```
# ./k0s install --role server --enable-worker
INFO[2020-12-31 13:12:53] Installing k0s service                       
# cat /etc/systemd/system/k0s.service 
[Unit]
Description=k0s - Zero Friction Kubernetes
ConditionFileIsExecutable=/root/go/src/github.com/k0sproject/k0s/k0s

After=network.target 

[Service]
StartLimitInterval=5
StartLimitBurst=10
ExecStart=/root/go/src/github.com/k0sproject/k0s/k0s "server" "--config" "/root/go/src/github.com/k0sproject/k0s/k0s.yaml" "--enable-worker"
...
```

I believe this will clear up the questions related to #593  or similar

p.s. as @jnummelin mentioned maybe it would be worth considering adding separate install commands for server and worker so it would be easier to understand.