### PR TITLE
Add automatic per-node scaling to metrics server

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -240,7 +240,7 @@ func startServer(token string) error {
 	}
 
 	// in-cluster component reconcilers
-	reconcilers := createClusterReconcilers(clusterConfig, k0sVars)
+	reconcilers := createClusterReconcilers(clusterConfig, k0sVars, adminClientFactory)
 	if err == nil {
 		perfTimer.Checkpoint("starting-reconcilers")
 
@@ -286,7 +286,7 @@ func startServer(token string) error {
 	return nil
 }
 
-func createClusterReconcilers(clusterConf *config.ClusterConfig, k0sVars constant.CfgVars) map[string]component.Component {
+func createClusterReconcilers(clusterConf *config.ClusterConfig, k0sVars constant.CfgVars, kubeClientFactory kubernetes.ClientFactory) map[string]component.Component {
 	reconcilers := make(map[string]component.Component)
 	clusterSpec := clusterConf.Spec
 
@@ -320,7 +320,7 @@ func createClusterReconcilers(clusterConf *config.ClusterConfig, k0sVars constan
 	reconcilers["crd"] = server.NewCRD(manifestsSaver)
 	reconcilers["helmAddons"] = server.NewHelmAddons(clusterConf, manifestsSaver, k0sVars)
 
-	metricServer, err := server.NewMetricServer(clusterConf, k0sVars)
+	metricServer, err := server.NewMetricServer(clusterConf, k0sVars, kubeClientFactory)
 	if err != nil {
 		logrus.Warnf("failed to initialize metric server reconciler: %s", err.Error())
 	} else {

--- a/pkg/component/server/metricserver_test.go
+++ b/pkg/component/server/metricserver_test.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/k0sproject/k0s/pkg/apis/v1beta1"
+	"github.com/k0sproject/k0s/pkg/constant"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetConfigWithZeroNodes(t *testing.T) {
+	var fakeFactory = &fakeClientFactory{
+		fakeClient: fake.NewSimpleClientset(),
+	}
+	clusterCfg := v1beta1.DefaultClusterConfig()
+	metrics, err := NewMetricServer(clusterCfg, constant.GetConfig("/foo/bar"), fakeFactory)
+	require.NoError(t, err)
+	cfg, err := metrics.getConfig()
+	require.NoError(t, err)
+	require.Equal(t, "10m", cfg.CPURequest)
+	require.Equal(t, "30M", cfg.MEMRequest)
+}
+
+func TestGetConfigWithSomeNodes(t *testing.T) {
+	var fakeFactory = &fakeClientFactory{
+		fakeClient: fake.NewSimpleClientset(),
+	}
+
+	for i := 1; i <= 100; i++ {
+		n := &corev1.Node{
+			ObjectMeta: v1.ObjectMeta{
+				Name: fmt.Sprintf("node-%d", i),
+			},
+		}
+		_, err := fakeFactory.fakeClient.CoreV1().Nodes().Create(context.TODO(), n, v1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	clusterCfg := v1beta1.DefaultClusterConfig()
+	metrics, err := NewMetricServer(clusterCfg, constant.GetConfig("/foo/bar"), fakeFactory)
+	require.NoError(t, err)
+	cfg, err := metrics.getConfig()
+	require.NoError(t, err)
+	require.Equal(t, "100m", cfg.CPURequest)
+	require.Equal(t, "300M", cfg.MEMRequest)
+}


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Fixes #599 

**What this PR Includes**
Metric server is scaled per node count as documented in metric-server repo: https://github.com/kubernetes-sigs/metrics-server#scaling

This also fixes the constant re-applying of the manifests, now the manifests are only written if there is a change in the scaling config.