### PR TITLE
Use same kube clients everywhere

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -20,15 +20,16 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/k0sproject/k0s/internal/util"
 	"io/ioutil"
-	corev1 "k8s.io/api/core/v1"
 	"log"
 	"net/http"
 	"path"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/k0sproject/k0s/internal/util"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
@@ -60,8 +61,8 @@ func startAPI() error {
 	if err != nil {
 		return err
 	}
-
-	kubeClient, err = kubernetes.Client(k0sVars.AdminKubeConfigPath)
+	// Single kube client for whole lifetime of the API
+	kubeClient, err = kubernetes.NewClient(k0sVars.AdminKubeConfigPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -167,6 +167,9 @@ func startServer(token string) error {
 	logrus.Infof("Using storage backend %s", clusterConfig.Spec.Storage.Type)
 	componentManager.Add(storageBackend)
 
+	// common factory to get the admin kube client that's needed in many components
+	adminClientFactory := kubernetes.NewAdminClientFactory(k0sVars)
+
 	componentManager.Add(&server.APIServer{
 		ClusterConfig: clusterConfig,
 		K0sVars:       k0sVars,
@@ -188,7 +191,7 @@ func startServer(token string) error {
 		LogLevel:      logging["kube-controller-manager"],
 		K0sVars:       k0sVars,
 	})
-	componentManager.Add(&applier.Manager{K0sVars: k0sVars})
+	componentManager.Add(&applier.Manager{K0sVars: k0sVars, KubeClientFactory: adminClientFactory})
 	componentManager.Add(&server.K0SControlAPI{
 		ConfigPath: cfgFile,
 		K0sVars:    k0sVars,
@@ -196,15 +199,12 @@ func startServer(token string) error {
 
 	if clusterConfig.Telemetry.Enabled {
 		componentManager.Add(&telemetry.Component{
-			ClusterConfig: clusterConfig,
-			Version:       build.Version,
-			K0sVars:       k0sVars,
+			ClusterConfig:     clusterConfig,
+			Version:           build.Version,
+			K0sVars:           k0sVars,
+			KubeClientFactory: adminClientFactory,
 		})
 	}
-
-	// common factory to get the admin kube client that's needed in many components
-	// TODO: Refactor all needed components to use this factory
-	adminClientFactory := kubernetes.NewAdminClientFactory(k0sVars)
 
 	// One leader elector per controller
 	// TODO: Make all other needed components use this "global" leader elector
@@ -287,7 +287,7 @@ func startServer(token string) error {
 	return nil
 }
 
-func createClusterReconcilers(clusterConf *config.ClusterConfig, k0sVars constant.CfgVars, kubeClientFactory kubernetes.ClientFactory) map[string]component.Component {
+func createClusterReconcilers(clusterConf *config.ClusterConfig, k0sVars constant.CfgVars, cf kubernetes.ClientFactory) map[string]component.Component {
 	reconcilers := make(map[string]component.Component)
 	clusterSpec := clusterConf.Spec
 
@@ -305,7 +305,7 @@ func createClusterReconcilers(clusterConf *config.ClusterConfig, k0sVars constan
 		reconcilers["kube-proxy"] = proxy
 	}
 
-	coreDNS, err := server.NewCoreDNS(clusterConf, k0sVars)
+	coreDNS, err := server.NewCoreDNS(clusterConf, k0sVars, cf)
 	if err != nil {
 		logrus.Warnf("failed to initialize CoreDNS reconciler: %s", err.Error())
 	} else {
@@ -319,9 +319,9 @@ func createClusterReconcilers(clusterConf *config.ClusterConfig, k0sVars constan
 		logrus.Warnf("failed to initialize reconcilers manifests saver: %s", err.Error())
 	}
 	reconcilers["crd"] = server.NewCRD(manifestsSaver)
-	reconcilers["helmAddons"] = server.NewHelmAddons(clusterConf, manifestsSaver, k0sVars)
+	reconcilers["helmAddons"] = server.NewHelmAddons(clusterConf, manifestsSaver, k0sVars, cf)
 
-	metricServer, err := server.NewMetricServer(clusterConf, k0sVars, kubeClientFactory)
+	metricServer, err := server.NewMetricServer(clusterConf, k0sVars, cf)
 	if err != nil {
 		logrus.Warnf("failed to initialize metric server reconciler: %s", err.Error())
 	} else {

--- a/internal/testutil/kube_client.go
+++ b/internal/testutil/kube_client.go
@@ -1,0 +1,43 @@
+package testutil
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+func NewFakeClientFactory() FakeClientFactory {
+	rawDiscovery := &discoveryfake.FakeDiscovery{Fake: &kubetesting.Fake{}}
+
+	return FakeClientFactory{
+		Client:          fake.NewSimpleClientset(),
+		DynamicClient:   dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+		DiscoveryClient: memory.NewMemCacheClient(rawDiscovery),
+		RawDiscovery:    rawDiscovery,
+	}
+}
+
+type FakeClientFactory struct {
+	Client          kubernetes.Interface
+	DynamicClient   dynamic.Interface
+	DiscoveryClient discovery.CachedDiscoveryInterface
+	RawDiscovery    *discoveryfake.FakeDiscovery
+}
+
+func (f FakeClientFactory) GetClient() (kubernetes.Interface, error) {
+	return f.Client, nil
+}
+
+func (f FakeClientFactory) GetDynamicClient() (dynamic.Interface, error) {
+	return f.DynamicClient, nil
+}
+
+func (f FakeClientFactory) GetDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	return f.DiscoveryClient, nil
+}

--- a/pkg/applier/stackapplier.go
+++ b/pkg/applier/stackapplier.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	"github.com/k0sproject/k0s/pkg/debounce"
+	"github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/fsnotify.v1"
 )
@@ -36,7 +37,7 @@ type StackApplier struct {
 }
 
 // NewStackApplier crates new stack applier to manage a stack
-func NewStackApplier(path string, kubeConfig string) (*StackApplier, error) {
+func NewStackApplier(path string, kubeClientFactory kubernetes.ClientFactory) (*StackApplier, error) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
@@ -45,7 +46,7 @@ func NewStackApplier(path string, kubeConfig string) (*StackApplier, error) {
 	if err != nil {
 		return nil, err
 	}
-	applier := NewApplier(path, kubeConfig)
+	applier := NewApplier(path, kubeClientFactory)
 	log := logrus.WithField("component", "applier-"+applier.Name)
 	log.WithField("path", path).Debug("created stack applier")
 

--- a/pkg/component/server/apiendpointreconciler.go
+++ b/pkg/component/server/apiendpointreconciler.go
@@ -117,7 +117,7 @@ func (a *APIEndpointReconciler) reconcileEndpoints() error {
 	}
 	sort.Strings(ipStrings)
 
-	c, err := a.kubeClientFactory.Create()
+	c, err := a.kubeClientFactory.GetClient()
 	if err != nil {
 		return err
 	}
@@ -181,7 +181,7 @@ func (a *APIEndpointReconciler) createEndpoint(addresses []string) error {
 		},
 	}
 
-	c, err := a.kubeClientFactory.Create()
+	c, err := a.kubeClientFactory.GetClient()
 	if err != nil {
 		return err
 	}

--- a/pkg/component/server/coredns.go
+++ b/pkg/component/server/coredns.go
@@ -239,8 +239,8 @@ type coreDNSConfig struct {
 }
 
 // NewCoreDNS creates new instance of CoreDNS component
-func NewCoreDNS(clusterConfig *config.ClusterConfig, k0sVars constant.CfgVars) (*CoreDNS, error) {
-	client, err := k8sutil.Client(k0sVars.AdminKubeConfigPath)
+func NewCoreDNS(clusterConfig *config.ClusterConfig, k0sVars constant.CfgVars, clientFactory k8sutil.ClientFactory) (*CoreDNS, error) {
+	client, err := clientFactory.GetClient()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/server/leaderelector.go
+++ b/pkg/component/server/leaderelector.go
@@ -63,7 +63,7 @@ func (l *leaderElector) Init() error {
 }
 
 func (l *leaderElector) Run() error {
-	client, err := l.kubeClientFactory.Create()
+	client, err := l.kubeClientFactory.GetClient()
 	if err != nil {
 		return fmt.Errorf("can't create kubernetes rest client for lease pool: %v", err)
 	}

--- a/pkg/component/server/metricserver.go
+++ b/pkg/component/server/metricserver.go
@@ -298,7 +298,7 @@ func (m *MetricServer) getConfig() (metricsConfig, error) {
 		Image: m.clusterConfig.Images.MetricsServer.URI(),
 	}
 
-	kubeClient, err := m.kubeClientFactory.Create()
+	kubeClient, err := m.kubeClientFactory.GetClient()
 	if err != nil {
 		return cfg, err
 	}

--- a/pkg/component/server/metricserver_test.go
+++ b/pkg/component/server/metricserver_test.go
@@ -5,18 +5,17 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/k0sproject/k0s/internal/testutil"
 	"github.com/k0sproject/k0s/pkg/apis/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestGetConfigWithZeroNodes(t *testing.T) {
-	var fakeFactory = &fakeClientFactory{
-		fakeClient: fake.NewSimpleClientset(),
-	}
+	fakeFactory := testutil.NewFakeClientFactory()
+
 	clusterCfg := v1beta1.DefaultClusterConfig()
 	metrics, err := NewMetricServer(clusterCfg, constant.GetConfig("/foo/bar"), fakeFactory)
 	require.NoError(t, err)
@@ -27,9 +26,8 @@ func TestGetConfigWithZeroNodes(t *testing.T) {
 }
 
 func TestGetConfigWithSomeNodes(t *testing.T) {
-	var fakeFactory = &fakeClientFactory{
-		fakeClient: fake.NewSimpleClientset(),
-	}
+	fakeFactory := testutil.NewFakeClientFactory()
+	fakeClient, _ := fakeFactory.GetClient()
 
 	for i := 1; i <= 100; i++ {
 		n := &corev1.Node{
@@ -37,7 +35,7 @@ func TestGetConfigWithSomeNodes(t *testing.T) {
 				Name: fmt.Sprintf("node-%d", i),
 			},
 		}
-		_, err := fakeFactory.fakeClient.CoreV1().Nodes().Create(context.TODO(), n, v1.CreateOptions{})
+		_, err := fakeClient.CoreV1().Nodes().Create(context.TODO(), n, v1.CreateOptions{})
 		require.NoError(t, err)
 	}
 

--- a/pkg/component/worker/kubeletconfigclient.go
+++ b/pkg/component/worker/kubeletconfigclient.go
@@ -33,7 +33,7 @@ type KubeletConfigClient struct {
 
 // NewKubeletConfigClient creates new KubeletConfigClient using the specified kubeconfig
 func NewKubeletConfigClient(kubeconfigPath string) (*KubeletConfigClient, error) {
-	kubeClient, err := k8sutil.Client(kubeconfigPath)
+	kubeClient, err := k8sutil.NewClient(kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/telemetry/component.go
+++ b/pkg/telemetry/component.go
@@ -13,9 +13,10 @@ import (
 
 // Component is a telemetry component for k0s component manager
 type Component struct {
-	ClusterConfig *config.ClusterConfig
-	K0sVars       constant.CfgVars
-	Version       string
+	ClusterConfig     *config.ClusterConfig
+	K0sVars           constant.CfgVars
+	Version           string
+	KubeClientFactory kubeutil.ClientFactory
 
 	kubernetesClient kubernetes.Interface
 	analyticsClient  analyticsClient
@@ -43,7 +44,7 @@ func (c *Component) Init() error {
 }
 
 func (c *Component) retrieveKubeClient(ch chan struct{}) {
-	client, err := kubeutil.Client(c.K0sVars.AdminKubeConfigPath)
+	client, err := c.KubeClientFactory.GetClient()
 	if err != nil {
 		c.log.WithError(err).Warning("can't init kube client")
 		return

--- a/pkg/token/manager.go
+++ b/pkg/token/manager.go
@@ -32,7 +32,7 @@ import (
 // NewManager creates a new token manager using given kubeconfig
 func NewManager(kubeconfig string) (*Manager, error) {
 	logrus.Debugf("loading kubeconfig from: %s", kubeconfig)
-	client, err := k8sutil.Client(kubeconfig)
+	client, err := k8sutil.NewClient(kubeconfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Fixes #610

**What this PR Includes**
This PR refactors all the components that needs kube client to use the one shared clients through `ClientFactory` insterface. The implementation is made as a "lazy-loading" factory so that we can create the factory itself before any components that uses it as at that point we do not yet have the capabilities (admin kubeconfig namely) to create the actual clients.
