### PR TITLE
Make Calico IP autodetection method configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,6 +90,7 @@ spec:
       mtu: 1450
       wireguard: false
       flexVolumeDriverPath: /usr/libexec/k0s/kubelet-plugins/volume/exec/nodeagent~uds
+      ipAutodetectionMethod: ""
   podSecurityPolicy:
     defaultPolicy: 00-k0s-privileged
   workerProfiles: []
@@ -178,6 +179,7 @@ Using type `etcd` will make k0s to create and manage an elastic etcd cluster wit
 - `mtu`: MTU to use for overlay network (default `1450`)
 - `wireguard`: enable wireguard based encryption (default `false`). Your host system must be wireguard ready. See https://docs.projectcalico.org/security/encrypt-cluster-pod-traffic for details.
 - `flexVolumeDriverPath`: The host path to use for Calicos flex-volume-driver (default: `/usr/libexec/k0s/kubelet-plugins/volume/exec/nodeagent~uds`). This should only need to be changed if the default path is unwriteable. See https://github.com/projectcalico/calico/issues/2712 for details. This option should ideally be paired with a custom volumePluginDir in the profile used on your worker nodes.
+- `ipAutodetectionMethod`: To force non-default behaviour for Calico to pick up the interface for pod network inter-node routing. (default `""`, i.e. not set so Calico will use it's own defaults) See more at: https://docs.projectcalico.org/reference/node/configuration#ip-autodetection-methods
 
 ### `spec.podSecurityPolicy`
 

--- a/pkg/apis/v1beta1/calico.go
+++ b/pkg/apis/v1beta1/calico.go
@@ -17,27 +17,29 @@ package v1beta1
 
 // Calico defines the calico related config options
 type Calico struct {
-	Mode                 string `yaml:"mode"`
-	VxlanPort            int    `yaml:"vxlanPort"`
-	VxlanVNI             int    `yaml:"vxlanVNI"`
-	MTU                  int    `yaml:"mtu"`
-	EnableWireguard      bool   `yaml:"wireguard"`
-	FlexVolumeDriverPath string `yaml:"flexVolumeDriverPath"`
-	WithWindowsNodes     bool   `yaml:"withWindowsNodes"`
-	Overlay              string `yaml:"overlay" validate:"oneof=Always Never CrossSubnet"`
+	Mode                  string `yaml:"mode"`
+	VxlanPort             int    `yaml:"vxlanPort"`
+	VxlanVNI              int    `yaml:"vxlanVNI"`
+	MTU                   int    `yaml:"mtu"`
+	EnableWireguard       bool   `yaml:"wireguard"`
+	FlexVolumeDriverPath  string `yaml:"flexVolumeDriverPath"`
+	WithWindowsNodes      bool   `yaml:"withWindowsNodes"`
+	Overlay               string `yaml:"overlay" validate:"oneof=Always Never CrossSubnet"`
+	IPAutodetectionMethod string `yaml:"ipAutodetectionMethod"`
 }
 
 // DefaultCalico returns sane defaults for calico
 func DefaultCalico() *Calico {
 	return &Calico{
-		Mode:                 "vxlan",
-		VxlanPort:            4789,
-		VxlanVNI:             4096,
-		MTU:                  1450,
-		EnableWireguard:      false,
-		FlexVolumeDriverPath: "/usr/libexec/k0s/kubelet-plugins/volume/exec/nodeagent~uds",
-		WithWindowsNodes:     false,
-		Overlay:              "Always",
+		Mode:                  "vxlan",
+		VxlanPort:             4789,
+		VxlanVNI:              4096,
+		MTU:                   1450,
+		EnableWireguard:       false,
+		FlexVolumeDriverPath:  "/usr/libexec/k0s/kubelet-plugins/volume/exec/nodeagent~uds",
+		WithWindowsNodes:      false,
+		Overlay:               "Always",
+		IPAutodetectionMethod: "",
 	}
 }
 
@@ -51,6 +53,7 @@ func (c *Calico) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	c.WithWindowsNodes = false
 	c.FlexVolumeDriverPath = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds"
 	c.Overlay = "Always"
+	c.IPAutodetectionMethod = ""
 
 	type ycalico Calico
 	yc := (*ycalico)(c)

--- a/pkg/component/server/calico.go
+++ b/pkg/component/server/calico.go
@@ -60,6 +60,7 @@ type calicoConfig struct {
 	CalicoNodeImage            string
 	CalicoKubeControllersImage string
 	Overlay                    string
+	IPAutodetectionMethod      string
 }
 
 // NewCalico creates new Calico reconciler component
@@ -210,6 +211,7 @@ func (c *Calico) getConfig() (calicoConfig, error) {
 		CalicoKubeControllersImage: c.clusterConf.Images.Calico.KubeControllers.URI(),
 		WithWindowsNodes:           c.clusterConf.Spec.Network.Calico.WithWindowsNodes,
 		Overlay:                    c.clusterConf.Spec.Network.Calico.Overlay,
+		IPAutodetectionMethod:      c.clusterConf.Spec.Network.Calico.IPAutodetectionMethod,
 	}
 
 	return config, nil

--- a/static/manifests/calico/DaemonSet/calico-node.yaml
+++ b/static/manifests/calico/DaemonSet/calico-node.yaml
@@ -157,6 +157,10 @@ spec:
             # Auto detect the iptables backend
             - name: FELIX_IPTABLESBACKEND
               value: "auto"
+            {{- if ne .IPAutodetectionMethod "" -}}
+            - name: IP_AUTODETECTION_METHOD
+              value: {{ .IPAutodetectionMethod }}
+            {{- end -}}
             {{- if eq .Mode "ipip" }}
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Fixes #479 

**What this PR Includes**
This PR makes Calico [IP auto detection method](https://docs.projectcalico.org/reference/node/configuration#ip-autodetection-methods) configurable