### PR TITLE
Use --containerd for kubelet to get properly tagged container metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ smoketests: $(smoketests)
 
 .PHONY: check-unit
 check-unit: pkg/assets/zz_generated_offsets_$(TARGET_OS).go
-	go test -race ./pkg/...
+	go test -race ./pkg/... ./internal/...
 
 .PHONY: clean
 clean:

--- a/internal/util/mapped_args.go
+++ b/internal/util/mapped_args.go
@@ -1,0 +1,17 @@
+package util
+
+import "fmt"
+
+// MappedArgs defines map like arguments that can be "evaluated" into args=value pairs
+type MappedArgs map[string]string
+
+// ToArgs maps the data into cmd arguments like foo=bar baz=baf
+func (m MappedArgs) ToArgs() []string {
+	args := make([]string, len(m))
+	idx := 0
+	for k, v := range m {
+		args[idx] = fmt.Sprintf("%s=%s", k, v)
+		idx++
+	}
+	return args
+}

--- a/internal/util/mapped_args_test.go
+++ b/internal/util/mapped_args_test.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args MappedArgs
+		want []string
+	}{
+		{
+			"basic",
+			MappedArgs{
+				"foo":   "bar",
+				"bar":   "baf",
+				"empty": "",
+			},
+			[]string{"foo=bar", "bar=baf", "empty="},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.args.ToArgs()
+			sort.Strings(got)
+			sort.Strings(tt.want)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>


**Issue**
Fixes #625 

**What this PR Includes**
Add `--containerd` flag for kubelet, see #625 for reasoning

Refactors also the kubelet args to handled through a map like struct rather than by appending.

### Results

```
# kubectl get --raw /api/v1/nodes/worker0/proxy/metrics/cadvisor | grep container_cpu_usage_seconds_total
...
container_cpu_usage_seconds_total{container="calico-node",cpu="total",id="/kubepods/burstable/pod1934af51-8605-43be-af6a-694a7609fe39/49ee6e4f6d73131787a6ebf1cc5712ccd2ce51f0de6a20dcebe314a651518862",image="docker.io/calico/node:v3.16.2",name="49ee6e4f6d73131787a6ebf1cc5712ccd2ce51f0de6a20dcebe314a651518862",namespace="kube-system",pod="calico-node-q2zrs"} 4.645504918 1610539818134
container_cpu_usage_seconds_total{container="coredns",cpu="total",id="/kubepods/burstable/podac39c331-3241-4862-bba0-02ecffe87a96/17e782d50ea22ed887e0310e6ec1b6256e8fd506a71ae0a5608627728865b1b0",image="docker.io/coredns/coredns:1.7.0",name="17e782d50ea22ed887e0310e6ec1b6256e8fd506a71ae0a5608627728865b1b0",namespace="kube-system",pod="coredns-5c98d7d4d8-vk4qj"} 0.449496196 1610539815486
container_cpu_usage_seconds_total{container="konnectivity-agent",cpu="total",id="/kubepods/besteffort/pod0a45dd65-b8e6-4ad9-8553-5aeeadc504d8/d089de881db514ea72d35fe58ed595e5a8d8cfbc59afb197dbc55705a3d4437a",image="us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent:v0.0.13",name="d089de881db514ea72d35fe58ed595e5a8d8cfbc59afb197dbc55705a3d4437a",namespace="kube-system",pod="konnectivity-agent-44vl9"} 0.098674767 1610539824013
container_cpu_usage_seconds_total{container="kube-proxy",cpu="total",id="/kubepods/besteffort/pod1e156803-4ea7-4136-aa3b-6ffd9e36ff73/07a59d6572bc3d057cfdc9015b7170f76a03c59972f56f1c2ec6f82b49269bf2",image="k8s.gcr.io/kube-proxy:v1.20.1",name="07a59d6572bc3d057cfdc9015b7170f76a03c59972f56f1c2ec6f82b49269bf2",namespace="kube-system",pod="kube-proxy-6vrmp"} 0.333822931 1610539821231
container_cpu_usage_seconds_total{container="metrics-server",cpu="total",id="/kubepods/burstable/pod29cf3381-1911-440b-8107-c1d5d5b42596/c2a3caefcf1d68632092bc7698cd5f465ca36e5e91f8b3cb74b392091e0c1627",image="gcr.io/k8s-staging-metrics-server/metrics-server:v0.3.7",name="c2a3caefcf1d68632092bc7698cd5f465ca36e5e91f8b3cb74b392091e0c1627",namespace="kube-system",pod="metrics-server-6fbcd86f7b-cf4t5"} 2.030560777 1610539826562
```