### PR TITLE
Bump kubernetes to 1.20.2

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,7 +102,7 @@ images:
     version: v0.3.7
   kubeproxy:
     image: k8s.gcr.io/kube-proxy
-    version: v1.20.1
+    version: v1.20.2
   coredns:
     image: docker.io/coredns/coredns
     version: 1.7.0

--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -1,7 +1,7 @@
 
 runc_version = 1.0.0-rc92
 containerd_version = 1.4.3
-kubernetes_version = 1.20.1
+kubernetes_version = 1.20.2
 kine_version = 0.6.0
 etcd_version = 3.4.14
 konnectivity_version = 0.0.14

--- a/examples/footloose-ha-controllers/Dockerfile
+++ b/examples/footloose-ha-controllers/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/footloose/ubuntu18.04
 
 ADD k0s.service /etc/systemd/system/k0s.service
 
-RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.20.1/bin/linux/amd64/kubectl && \
+RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf

--- a/inttest/conformance/README.md
+++ b/inttest/conformance/README.md
@@ -32,12 +32,12 @@ This can be done in two ways.
 In the same directory as your `main.tf` file, create an additional file `terraform.tfvars` with the following input:
 ```
 k0s_version=v0.9.0
-k8s_version=v1.20.1
+k8s_version=v1.20.2
 onobuoy_version=0.20.0
 ```  
 ### 2. Environment variables
 ```
-TF_VAR_k0s_version=v0.7.0-beta1 TF_VAR_sonobuoy_version=0.18.0 TF_VAR_k8s_version=v1.20.1 terraform apply
+TF_VAR_k0s_version=v0.7.0-beta1 TF_VAR_sonobuoy_version=0.18.0 TF_VAR_k8s_version=v1.20.2 terraform apply
 ```
 **NOTE:** By default, terraform will fetch sonobuoy version **0.20.0**. If you want to use a different version you can override this with one of the above methods. 
 

--- a/inttest/conformance/terraform/main.tf
+++ b/inttest/conformance/terraform/main.tf
@@ -13,7 +13,7 @@ variable "sonobuoy_version" {
 }
 
 variable "k8s_version" {
-  // format: v1.20.1
+  // format: v1.20.2
   type = string
 }
 

--- a/inttest/sonobuoy/signetwork_test.go
+++ b/inttest/sonobuoy/signetwork_test.go
@@ -64,7 +64,7 @@ func (s *NetworkSuite) TestSigNetwork() {
 		`--e2e-focus=\[sig-network\].*\[Conformance\]`,
 		`--e2e-skip=\[Serial\]`,
 		"--e2e-parallel=y",
-		"--kube-conformance-image-version=v1.20.1",
+		"--kube-conformance-image-version=v1.20.2",
 	}
 	s.T().Log("running sonobuoy, this may take a while")
 	sonoFinished := make(chan bool)

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -58,7 +58,7 @@ const (
 	MetricsImage               = "gcr.io/k8s-staging-metrics-server/metrics-server"
 	MetricsImageVersion        = "v0.3.7"
 	KubeProxyImage             = "k8s.gcr.io/kube-proxy"
-	KubeProxyImageVersion      = "v1.20.1"
+	KubeProxyImageVersion      = "v1.20.2"
 	CoreDNSImage               = "docker.io/coredns/coredns"
 	CoreDNSImageVersion        = "1.7.0"
 	CalicoImage                = "calico/cni"


### PR DESCRIPTION
Signed-off-by: Natanael Copa <ncopa@mirantis.com>



**What this PR Includes**

Bump kubernetes version 1.20.2