### PR TITLE
Use MS pause image instead of custom built one on windows

### DIFF
--- a/pkg/component/worker/calico_installer_windows.go
+++ b/pkg/component/worker/calico_installer_windows.go
@@ -4,16 +4,17 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/Microsoft/hcsshim"
-	"github.com/avast/retry-go"
-	"github.com/k0sproject/k0s/pkg/token"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
-	"k8s.io/client-go/tools/clientcmd"
 	"net/http"
 	"os"
 	"os/exec"
 	"time"
+
+	"github.com/Microsoft/hcsshim"
+	"github.com/avast/retry-go"
+	"github.com/k0sproject/k0s/pkg/token"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 type CalicoInstaller struct {
@@ -148,7 +149,8 @@ func getSourceVip() (string, error) {
 
 // installCalicoPowershell is port of the original calico installer
 // with droped customization and no need to download kubernetes components
-// since we have staged them
+// since we have staged them.
+// We also skip building the pause image as we're using the semi-official MS image from mcr.microsoft.com/oss/kubernetes/pause:1.4.1
 // the original script is done by Tigera, Inc
 // and can be accessed over the web on https://docs.projectcalico.org/scripts/install-calico-windows.ps1
 const installCalicoPowershell = `
@@ -204,11 +206,8 @@ function PrepareDockerFile()
 function PrepareKubernetes()
 {
     DownloadFiles
-    PrepareDockerFile
     ipmo C:\k\hns.psm1
 
-    # Prepare POD infra Images
-    c:\k\InstallImages.ps1
 }
 
 function GetPlatformType()

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -101,7 +101,7 @@ func (k *Kubelet) Run() error {
 		}
 		args["--cgroups-per-qos"] = "false"
 		args["--enforce-node-allocatable"] = ""
-		args["--pod-infra-container-image"] = "kubeletwin/pause"
+		args["--pod-infra-container-image"] = "mcr.microsoft.com/oss/kubernetes/pause:1.4.1"
 		args["--network-plugin"] = "cni"
 		args["--cni-bin-dir"] = "C:\\k\\cni"
 		args["--cni-conf-dir"] = "C:\\k\\cni\\config"


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>


**Issue**
Fixes #513 

**What this PR Includes**
Changes the Calico install part in Windows a bit to skip building the custom pause image and use hardcoded `mcr.microsoft.com/oss/kubernetes/pause:1.4.1` instead. That image has good support for various Win versions:
```
$ manifest-tool inspect mcr.microsoft.com/oss/kubernetes/pause:1.4.1 | grep "OS Vers"
1           - OS Vers: 10.0.17763.1457
2           - OS Vers: 10.0.18362.1082
3           - OS Vers: 10.0.18363.1082
4           - OS Vers: 10.0.19041.508
```

**Testing**

Tested on AWS with one Linux and one Win worker:
```
root@ip-172-31-46-107:~# kubectl get node,pod -o wide
NAME                                                STATUS   ROLES    AGE    VERSION        INTERNAL-IP     EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION    CONTAINER-RUNTIME
node/ip-172-31-37-128.eu-north-1.compute.internal   Ready    <none>   148m   v1.20.2        172.31.37.128   <none>        Windows Server 2019 Datacenter   10.0.17763.1697   docker://19.3.14
node/ip-172-31-46-107                               Ready    <none>   162m   v1.20.0-k0s1   172.31.46.107   <none>        Ubuntu 18.04.5 LTS               5.4.0-1029-aws    containerd://1.4.3

NAME      READY   STATUS    RESTARTS   AGE    IP              NODE                                           NOMINATED NODE   READINESS GATES
pod/iis   1/1     Running   0          105m   10.244.59.135   ip-172-31-37-128.eu-north-1.compute.internal   <none>           <none>
pod/win   1/1     Running   1          104m   10.244.59.136   ip-172-31-37-128.eu-north-1.compute.internal   <none>           <none>
root@ip-172-31-46-107:~# curl 10.244.59.135
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html xmlns="http://www.w3.org/1999/xhtml">
<head>
<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
<title>IIS Windows Server</title>
<style type="text/css">
<!--
body {
        color:#000000;
        background-color:#0072C6;
        margin:0;
}

#container {
        margin-left:auto;
        margin-right:auto;
        text-align:center;
        }

a img {
        border:none;
}

-->
</style>
</head>
<body>
<div id="container">
<a href="http://go.microsoft.com/fwlink/?linkid=66138&amp;clcid=0x409"><img src="iisstart.png" alt="IIS" width="960" height="600" /></a>
</div>
</body>
```

