### PR TITLE
Validate config via k0s validate sub-command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,6 +79,7 @@ func init() {
 	rootCmd.AddCommand(installCmd)
 	rootCmd.AddCommand(completionCmd)
 	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(validateCmd)
 
 	rootCmd.DisableAutoGenTag = true
 	longDesc = "k0s - The zero friction Kubernetes - https://k0sproject.io"

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 Mirantis, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	config "github.com/k0sproject/k0s/pkg/apis/v1beta1"
+	"github.com/spf13/cobra"
+)
+
+var (
+	validateCmd = &cobra.Command{
+		Use:   "validate",
+		Short: "Helper command for validating the config file",
+		Long: `Example:
+   k0s validate --config path_to_config.yaml`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := validateConfig(cfgFile)
+			if err != nil {
+				fmt.Println(err)
+			}
+			return nil
+		},
+	}
+)
+
+func validateConfig(cfgPath string) error {
+	clusterConfig, err := config.FromYaml(cfgPath)
+	if err != nil {
+		return err
+	}
+
+	errors := clusterConfig.Validate()
+	if len(errors) > 0 {
+		messages := make([]string, len(errors))
+		for _, e := range errors {
+			messages = append(messages, e.Error())
+		}
+		return fmt.Errorf(strings.Join(messages, "\n"))
+	}
+	return nil
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -27,8 +27,12 @@ var (
 	validateCmd = &cobra.Command{
 		Use:   "validate",
 		Short: "Helper command for validating the config file",
+	}
+	validateConfigCmd = &cobra.Command{
+		Use:   "config",
+		Short: "Helper command for validating the config file",
 		Long: `Example:
-   k0s validate --config path_to_config.yaml`,
+   k0s validate config --config path_to_config.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := validateConfig(cfgFile)
 			if err != nil {
@@ -39,6 +43,9 @@ var (
 	}
 )
 
+func init() {
+	validateCmd.AddCommand(validateConfigCmd)
+}
 func validateConfig(cfgPath string) error {
 	clusterConfig, err := config.FromYaml(cfgPath)
 	if err != nil {

--- a/docs/cli/k0s.md
+++ b/docs/cli/k0s.md
@@ -14,7 +14,7 @@ k0s - The zero friction Kubernetes - https://k0sproject.io
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
   -h, --help                     help for k0s
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO
@@ -27,7 +27,9 @@ k0s - The zero friction Kubernetes - https://k0sproject.io
 * [k0s install](k0s_install.md)	 - Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)
 * [k0s kubeconfig](k0s_kubeconfig.md)	 - Create a kubeconfig file for a specified user
 * [k0s server](k0s_server.md)	 - Run server
+* [k0s status](k0s_status.md)	 - Helper command for get general information about k0s
 * [k0s token](k0s_token.md)	 - Manage join tokens
+* [k0s validate](k0s_validate.md)	 - Helper command for validating the config file
 * [k0s version](k0s_version.md)	 - Print the k0s version
 * [k0s worker](k0s_worker.md)	 - Run worker
 

--- a/docs/cli/k0s_api.md
+++ b/docs/cli/k0s_api.md
@@ -19,7 +19,7 @@ k0s api [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_completion.md
+++ b/docs/cli/k0s_completion.md
@@ -50,7 +50,7 @@ k0s completion [bash|zsh|fish|powershell]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_default-config.md
+++ b/docs/cli/k0s_default-config.md
@@ -19,7 +19,7 @@ k0s default-config [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_docs.md
+++ b/docs/cli/k0s_docs.md
@@ -19,7 +19,7 @@ k0s docs [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_etcd_leave.md
+++ b/docs/cli/k0s_etcd_leave.md
@@ -20,7 +20,7 @@ k0s etcd leave [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_etcd_member-list.md
+++ b/docs/cli/k0s_etcd_member-list.md
@@ -19,7 +19,7 @@ k0s etcd member-list [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_install.md
+++ b/docs/cli/k0s_install.md
@@ -15,7 +15,7 @@ Helper command for setting up k0s on a brand-new system. Must be run as root (or
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_install_server.md
+++ b/docs/cli/k0s_install_server.md
@@ -21,6 +21,7 @@ With server subcommand you can setup a single node cluster by running:
 ### Options
 
 ```
+      --cri-socket string   contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]
       --enable-worker       enable worker (default false)
   -h, --help                help for server
       --profile string      worker profile to use on the node (default "default")
@@ -34,7 +35,7 @@ With server subcommand you can setup a single node cluster by running:
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_install_worker.md
+++ b/docs/cli/k0s_install_worker.md
@@ -36,7 +36,7 @@ Windows flags like "--api-server", "--cidr-range" and "--cluster-dns" will be ig
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_kubeconfig.md
+++ b/docs/cli/k0s_kubeconfig.md
@@ -19,7 +19,7 @@ k0s kubeconfig [command] [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_kubeconfig_admin.md
+++ b/docs/cli/k0s_kubeconfig_admin.md
@@ -31,7 +31,7 @@ k0s kubeconfig admin [command] [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_kubeconfig_create.md
+++ b/docs/cli/k0s_kubeconfig_create.md
@@ -36,7 +36,7 @@ k0s kubeconfig create [username] [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_server.md
+++ b/docs/cli/k0s_server.md
@@ -21,6 +21,7 @@ k0s server [join-token] [flags]
 ### Options
 
 ```
+      --cri-socket string   contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]
       --enable-worker       enable worker (default false)
   -h, --help                help for server
       --profile string      worker profile to use on the node (default "default")
@@ -34,7 +35,7 @@ k0s server [join-token] [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_status.md
+++ b/docs/cli/k0s_status.md
@@ -1,11 +1,22 @@
-## k0s etcd
+## k0s status
 
-Manage etcd cluster
+Helper command for get general information about k0s
+
+```
+k0s status [flags]
+```
+
+### Examples
+
+```
+The command will return information about system init, PID, k0s role, kubeconfig and similar.
+```
 
 ### Options
 
 ```
-  -h, --help   help for etcd
+  -h, --help         help for status
+  -o, --out string   sets type of out put to json or yaml
 ```
 
 ### Options inherited from parent commands
@@ -21,6 +32,4 @@ Manage etcd cluster
 ### SEE ALSO
 
 * [k0s](k0s.md)	 - k0s - Zero Friction Kubernetes
-* [k0s etcd leave](k0s_etcd_leave.md)	 - Sign off a given etc node from etcd cluster
-* [k0s etcd member-list](k0s_etcd_member-list.md)	 - Returns etcd cluster members list
 

--- a/docs/cli/k0s_token.md
+++ b/docs/cli/k0s_token.md
@@ -20,7 +20,7 @@ k0s token [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_token_create.md
+++ b/docs/cli/k0s_token_create.md
@@ -22,7 +22,7 @@ k0s token create [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_validate.md
+++ b/docs/cli/k0s_validate.md
@@ -1,11 +1,11 @@
-## k0s etcd
+## k0s validate
 
-Manage etcd cluster
+Helper command for validating the config file
 
 ### Options
 
 ```
-  -h, --help   help for etcd
+  -h, --help   help for validate
 ```
 
 ### Options inherited from parent commands
@@ -21,6 +21,5 @@ Manage etcd cluster
 ### SEE ALSO
 
 * [k0s](k0s.md)	 - k0s - Zero Friction Kubernetes
-* [k0s etcd leave](k0s_etcd_leave.md)	 - Sign off a given etc node from etcd cluster
-* [k0s etcd member-list](k0s_etcd_member-list.md)	 - Returns etcd cluster members list
+* [k0s validate config](k0s_validate_config.md)	 - Helper command for validating the config file
 

--- a/docs/cli/k0s_validate_config.md
+++ b/docs/cli/k0s_validate_config.md
@@ -1,11 +1,20 @@
-## k0s etcd
+## k0s validate config
 
-Manage etcd cluster
+Helper command for validating the config file
+
+### Synopsis
+
+Example:
+   k0s validate config --config path_to_config.yaml
+
+```
+k0s validate config [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for etcd
+  -h, --help   help for config
 ```
 
 ### Options inherited from parent commands
@@ -20,7 +29,5 @@ Manage etcd cluster
 
 ### SEE ALSO
 
-* [k0s](k0s.md)	 - k0s - Zero Friction Kubernetes
-* [k0s etcd leave](k0s_etcd_leave.md)	 - Sign off a given etc node from etcd cluster
-* [k0s etcd member-list](k0s_etcd_member-list.md)	 - Returns etcd cluster members list
+* [k0s validate](k0s_validate.md)	 - Helper command for validating the config file
 

--- a/docs/cli/k0s_version.md
+++ b/docs/cli/k0s_version.md
@@ -19,7 +19,7 @@ k0s version [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_worker.md
+++ b/docs/cli/k0s_worker.md
@@ -38,7 +38,7 @@ k0s worker [join-token] [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info,konnectivity-server=1,kube-apiserver=1])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
Fixes #644 

So this PR allows for 
```
$k0s validate -c cfg.yaml
```

It is relying on yaml parsing and `https://github.com/k0sproject/k0s/blob/main/cmd/helpers.go#L36` which is validating just network and worker profiles.

For example if formatting is not ok it will return:
```
$k0s validate -c cfg.yaml 
yaml: line 2: mapping values are not allowed in this context
```

of if values are incorrect it will return:
```
$k0s validate -c cfg.yaml 

unsupported network provider: blah
```

I know it wasn't on the roadmap for the current release but it would help with k0sctl.
