### PR TITLE
Exit with error from "k0s status" if k0s is not running

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -71,7 +71,7 @@ var (
 					return err
 				}
 			} else {
-				fmt.Println("K0s not running")
+				fmt.Fprintln(os.Stderr, "K0s not running")
 				os.Exit(1)
 			}
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -70,6 +70,9 @@ var (
 				if status.Role, err = getRole(status.Pid); err != nil {
 					return err
 				}
+			} else {
+				fmt.Println("K0s not running")
+				os.Exit(1)
 			}
 
 			status.output = output


### PR DESCRIPTION
If k0s isn't running `k0s status` will exit with status code 1
```
# ./k0s status 
K0s not running
# echo $?
1
```