### PR TITLE
Get rid of empty values from default-config output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/docker/libnetwork v0.5.6
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/fatih/color v1.10.0 // indirect
-	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/huandu/xstrings v1.3.2 // indirect

--- a/pkg/apis/v1beta1/calico.go
+++ b/pkg/apis/v1beta1/calico.go
@@ -25,7 +25,7 @@ type Calico struct {
 	FlexVolumeDriverPath  string `yaml:"flexVolumeDriverPath"`
 	WithWindowsNodes      bool   `yaml:"withWindowsNodes"`
 	Overlay               string `yaml:"overlay" validate:"oneof=Always Never CrossSubnet"`
-	IPAutodetectionMethod string `yaml:"ipAutodetectionMethod"`
+	IPAutodetectionMethod string `yaml:"ipAutodetectionMethod,omitempty"`
 }
 
 // DefaultCalico returns sane defaults for calico

--- a/pkg/apis/v1beta1/cluster.go
+++ b/pkg/apis/v1beta1/cluster.go
@@ -45,30 +45,40 @@ type ClusterMeta struct {
 // ClusterSpec ...
 type ClusterSpec struct {
 	API               *APISpec               `yaml:"api"`
-	ControllerManager *ControllerManagerSpec `yaml:"controllerManager"`
-	Scheduler         *SchedulerSpec         `yaml:"scheduler"`
+	ControllerManager *ControllerManagerSpec `yaml:"controllerManager,omitempty"`
+	Scheduler         *SchedulerSpec         `yaml:"scheduler,omitempty"`
 	Storage           *StorageSpec           `yaml:"storage"`
 	Network           *Network               `yaml:"network"`
 	PodSecurityPolicy *PodSecurityPolicy     `yaml:"podSecurityPolicy"`
-	WorkerProfiles    WorkerProfiles         `yaml:"workerProfiles"`
+	WorkerProfiles    WorkerProfiles         `yaml:"workerProfiles,omitempty"`
 }
 
 // APISpec ...
 type APISpec struct {
 	Address         string            `yaml:"address"`
-	ExternalAddress string            `yaml:"externalAddress"`
+	ExternalAddress string            `yaml:"externalAddress,omitempty"`
 	SANs            []string          `yaml:"sans"`
-	ExtraArgs       map[string]string `yaml:"extraArgs"`
+	ExtraArgs       map[string]string `yaml:"extraArgs,omitempty"`
 }
 
 // ControllerManagerSpec ...
 type ControllerManagerSpec struct {
-	ExtraArgs map[string]string `yaml:"extraArgs"`
+	ExtraArgs map[string]string `yaml:"extraArgs,omitempty"`
+}
+
+// IsZero needed to omit empty object from yaml output
+func (c *ControllerManagerSpec) IsZero() bool {
+	return len(c.ExtraArgs) == 0
 }
 
 // SchedulerSpec ...
 type SchedulerSpec struct {
-	ExtraArgs map[string]string `yaml:"extraArgs"`
+	ExtraArgs map[string]string `yaml:"extraArgs,omitempty"`
+}
+
+// IsZero needed to omit empty object from yaml output
+func (s *SchedulerSpec) IsZero() bool {
+	return len(s.ExtraArgs) == 0
 }
 
 // InstallSpec defines the required fields for the `k0s install` command
@@ -176,19 +186,24 @@ func DefaultAPISpec() *APISpec {
 	addresses, _ := util.AllAddresses()
 	publicAddress, _ := util.FirstPublicAddress()
 	return &APISpec{
-		SANs:    append(addresses, publicAddress),
-		Address: publicAddress,
+		SANs:      addresses,
+		Address:   publicAddress,
+		ExtraArgs: make(map[string]string),
 	}
 }
 
 // DefaultClusterSpec default settings
 func DefaultClusterSpec() *ClusterSpec {
 	return &ClusterSpec{
-		Storage:           DefaultStorageSpec(),
-		Network:           DefaultNetwork(),
-		API:               DefaultAPISpec(),
-		ControllerManager: &ControllerManagerSpec{},
-		Scheduler:         &SchedulerSpec{},
+		Storage: DefaultStorageSpec(),
+		Network: DefaultNetwork(),
+		API:     DefaultAPISpec(),
+		ControllerManager: &ControllerManagerSpec{
+			ExtraArgs: make(map[string]string),
+		},
+		Scheduler: &SchedulerSpec{
+			ExtraArgs: make(map[string]string),
+		},
 		PodSecurityPolicy: DefaultPodSecurityPolicy(),
 	}
 }

--- a/pkg/apis/v1beta1/storage.go
+++ b/pkg/apis/v1beta1/storage.go
@@ -32,7 +32,7 @@ const (
 // StorageSpec defines the storage related config options
 type StorageSpec struct {
 	Type string      `yaml:"type"`
-	Kine *KineConfig `yaml:"kine"`
+	Kine *KineConfig `yaml:"kine,omitempty"`
 	Etcd *EtcdConfig `yaml:"etcd"`
 }
 

--- a/pkg/component/server/kubeletconfig_test.go
+++ b/pkg/component/server/kubeletconfig_test.go
@@ -20,9 +20,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ghodss/yaml"
+	"github.com/k0sproject/k0s/pkg/apis/helm.k0sproject.io/v1beta1"
 	config "github.com/k0sproject/k0s/pkg/apis/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
+	"gopkg.in/yaml.v2"
 
 	"github.com/stretchr/testify/require"
 )
@@ -135,7 +136,7 @@ func defaultConfigWithUserProvidedProfiles(t *testing.T) *KubeletConfig {
 func requireConfigMap(t *testing.T, spec string, name string) {
 	dst := map[string]interface{}{}
 	require.NoError(t, yaml.Unmarshal([]byte(spec), &dst))
-
+	dst = v1beta1.CleanUpGenericMap(dst)
 	require.Equal(t, "ConfigMap", dst["kind"])
 	require.Equal(t, name, dst["metadata"].(map[string]interface{})["name"])
 	spec, foundSpec := dst["data"].(map[string]interface{})["kubelet"].(string)
@@ -146,6 +147,7 @@ func requireConfigMap(t *testing.T, spec string, name string) {
 func requireRole(t *testing.T, spec string, expectedResourceNames []string) {
 	dst := map[string]interface{}{}
 	require.NoError(t, yaml.Unmarshal([]byte(spec), &dst))
+	dst = v1beta1.CleanUpGenericMap(dst)
 	require.Equal(t, "Role", dst["kind"])
 	require.Equal(t, "system:bootstrappers:kubelet-configmaps", dst["metadata"].(map[string]interface{})["name"])
 	currentResourceNames := []string{}
@@ -158,6 +160,7 @@ func requireRole(t *testing.T, spec string, expectedResourceNames []string) {
 func requireRoleBinding(t *testing.T, spec string) {
 	dst := map[string]interface{}{}
 	require.NoError(t, yaml.Unmarshal([]byte(spec), &dst))
+	dst = v1beta1.CleanUpGenericMap(dst)
 	require.Equal(t, "RoleBinding", dst["kind"])
 	require.Equal(t, "system:bootstrappers:kubelet-configmaps", dst["metadata"].(map[string]interface{})["name"])
 }


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>


**Issue**
Fixes #658 #520 

**What this PR Includes**
Gets rid of the empty values from `k0s default-config` output. After the changes:
```
$ ./k0s default-config
apiVersion: k0s.k0sproject.io/v1beta1
images:
  konnectivity:
    image: us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent
    version: v0.0.13
  metricsserver:
    image: gcr.io/k8s-staging-metrics-server/metrics-server
    version: v0.3.7
  kubeproxy:
    image: k8s.gcr.io/kube-proxy
    version: v1.20.2
  coredns:
    image: docker.io/coredns/coredns
    version: 1.7.0
  calico:
    cni:
      image: calico/cni
      version: v3.16.2
    flexvolume:
      image: calico/pod2daemon-flexvol
      version: v3.16.2
    node:
      image: calico/node
      version: v3.16.2
    kubecontrollers:
      image: calico/kube-controllers
      version: v3.16.2
installConfig:
  users:
    etcdUser: etcd
    kineUser: kube-apiserver
    konnectivityUser: konnectivity-server
    kubeAPIserverUser: kube-apiserver
    kubeSchedulerUser: kube-scheduler
kind: Cluster
metadata:
  name: k0s
spec:
  api:
    address: 172.31.36.24
    sans:
    - 172.31.36.24
    - 172.17.0.1
    - 172.24.0.1
    - 172.25.0.1
    - 172.26.0.1
    - 172.19.0.1
    - 172.27.0.1
    - 172.18.0.1
  storage:
    type: etcd
    etcd:
      peerAddress: 172.31.36.24
  network:
    podCIDR: 10.244.0.0/16
    serviceCIDR: 10.96.0.0/12
    provider: calico
    calico:
      mode: vxlan
      vxlanPort: 4789
      vxlanVNI: 4096
      mtu: 1450
      wireguard: false
      flexVolumeDriverPath: /usr/libexec/k0s/kubelet-plugins/volume/exec/nodeagent~uds
      withWindowsNodes: false
      overlay: Always
  podSecurityPolicy:
    defaultPolicy: 00-k0s-privileged
telemetry:
  interval: 10m0s
  enabled: true
```