### PR TITLE
Make supervisor exit on fatal errors

### DIFF
--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -27,7 +27,7 @@ func TestSupervisor(t *testing.T) {
 			},
 		},
 		SupervisorTest{
-			shouldFail: false,
+			shouldFail: true,
 			proc: Supervisor{
 				Name:    "supervisor-test-non-executable",
 				BinPath: "/tmp",


### PR DESCRIPTION
Verify that executable actually starts and return an error if it does
not. This covers the case when binary does not exist or has wrong
permissions or exec(2) fails for any other reason.

fixes #225

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

---
name: Pull Request
about: Create a Pull Request
title: ''
labels: ''
assignees: ''

---

**Issue**
Fixes #225

**What this PR Includes**
Refactor supervisor to verify that executable actually starts and return failure if it doesn't so k0s can abort the startup.

Note that this does not make k0s shutdown if a process successfully starts up but immediately exits with error for some reason (cannot bind to port, disk full or similar).