### PR TITLE
Use warning/info instead of error messages for default config

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -34,8 +34,8 @@ func ConfigFromYaml(cfgPath string) (clusterConfig *config.ClusterConfig, err er
 	}
 
 	if err != nil {
-		logrus.Errorf("Failed to read cluster config: %s", err.Error())
-		logrus.Error("THINGS MIGHT NOT WORK PROPERLY AS WE'RE GONNA USE DEFAULTS")
+		logrus.Warnf("Failed to read cluster config: %s", err.Error())
+		logrus.Info("Using default config")
 		clusterConfig = config.DefaultClusterConfig()
 	}
 	// validate


### PR DESCRIPTION
fixes #668

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

---
name: Pull Request
about: Create a Pull Request
title: ''
labels: ''
assignees: ''

---

**Issue**
Fixes #668

**What this PR Includes**
Dot show error message when default config is used. Display a warning + info instead
