### PR TITLE
Fix install variable to be passed as '--key=value'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ k0s.exe k0s: $(GO_SRCS)
 lint: pkg/assets/zz_generated_offsets_$(TARGET_OS).go
 	$(golint) run ./...
 
-smoketests := check-addons check-basic check-byocri check-hacontrolplane check-kine check-network check-singlenode
+smoketests := check-addons check-basic check-byocri check-hacontrolplane check-kine check-network check-singlenode check-install
 .PHONY: $(smoketests)
 $(smoketests): k0s
 	$(MAKE) -C inttest $@

--- a/cmd/installServer.go
+++ b/cmd/installServer.go
@@ -35,8 +35,9 @@ With server subcommand you can setup a single node cluster by running:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flagsAndVals := []string{"server"}
 			cmd.Flags().Visit(func(f *pflag.Flag) {
-				flagsAndVals = append(flagsAndVals, fmt.Sprintf("--%s", f.Name), f.Value.String())
+				flagsAndVals = append(flagsAndVals, fmt.Sprintf("--%s=%s", f.Name, f.Value.String()))
 			})
+
 			return setup("server", flagsAndVals)
 		},
 	}

--- a/cmd/installWorker.go
+++ b/cmd/installWorker.go
@@ -33,7 +33,7 @@ Windows flags like "--api-server", "--cidr-range" and "--cluster-dns" will be ig
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flagsAndVals := []string{"worker"}
 			cmd.Flags().Visit(func(f *pflag.Flag) {
-				flagsAndVals = append(flagsAndVals, fmt.Sprintf("--%s", f.Name), f.Value.String())
+				flagsAndVals = append(flagsAndVals, fmt.Sprintf("--%s=%s", f.Name, f.Value.String()))
 			})
 
 			return setup("worker", flagsAndVals)

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -30,7 +30,7 @@ check-network-vm: bin/sonobuoy
 		go test -count=1 -v -timeout 20m github.com/k0sproject/k0s/inttest/sonobuoy/ -run ^TestVMNetworkSuite$
 
 TIMEOUT ?= 4m
-smoketests := check-addons check-basic check-byocri check-hacontrolplane check-kine check-singlenode
+smoketests := check-addons check-basic check-byocri check-hacontrolplane check-kine check-singlenode check-install
 
 check-byocri: TIMEOUT=5m
 

--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -23,3 +23,5 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.20.0/b
        && chmod +x ./kubectl \
        && mv ./kubectl /usr/local/bin/kubectl
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
+# This lets etcd start when running on arm in smokes
+ENV ETCD_UNSUPPORTED_ARCH=arm64

--- a/inttest/install/singlenode_test.go
+++ b/inttest/install/singlenode_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2020 Mirantis, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package install
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type InstallSuite struct {
+	common.FootlooseSuite
+}
+
+func (s *InstallSuite) TestK0sGetsUp() {
+	ssh, err := s.SSH("controller0")
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	_, err = ssh.ExecWithOutput("k0s install server --enable-worker")
+	s.Require().NoError(err)
+
+	_, err = ssh.ExecWithOutput("rc-service k0sserver start")
+	s.Require().NoError(err)
+
+	err = s.WaitForKubeAPI("controller0", "")
+	s.Require().NoError(err)
+
+	kc, err := s.KubeClient("controller0", "")
+	s.NoError(err)
+
+	err = s.WaitForNodeReady("controller0", kc)
+	s.NoError(err)
+
+	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
+		Limit: 100,
+	})
+	s.NoError(err)
+
+	podCount := len(pods.Items)
+
+	s.T().Logf("found %d pods in kube-system", podCount)
+	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+
+	s.T().Log("waiting to see calico pods ready")
+	s.NoError(common.WaitForCalicoReady(kc), "calico did not start")
+}
+
+func TestInstallSuite(t *testing.T) {
+	s := InstallSuite{
+		common.FootlooseSuite{
+			ControllerCount: 1,
+		},
+	}
+	suite.Run(t, &s)
+}


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Fixes #667 

**What this PR Includes**
This changes the install args to be passed as `--key=value`. Adds also a simple smoke case for single node `k0s install server --enable-worker` case