### PR TITLE
k0s terminology: server -> controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ ADD docker-entrypoint.sh /entrypoint.sh
 ADD ./k0s /usr/local/bin/k0s 
 ENTRYPOINT [ "/bin/sh", "/entrypoint.sh" ]
 
-CMD ["k0s", "server", "--enable-worker"]
+CMD ["k0s", "controller", "--enable-worker"]

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ With strong enough arguments we might take in new addons but in general those sh
 Move the built `k0s` binary to each of the nodes.
 
 ```
-k0s server
+k0s controller
 ```
 
 This creates all the necessary certs and configs in `/var/lib/k0s/pki`. k0s runs all control plane components in separate "naked" processes, does not depend on kubelet or container engine.

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -53,8 +53,6 @@ func init() {
 	controllerCmd.Flags().BoolVar(&enableWorker, "enable-worker", false, "enable worker (default false)")
 	controllerCmd.Flags().StringVar(&tokenFile, "token-file", "", "Path to the file containing join-token.")
 	controllerCmd.Flags().StringVar(&criSocket, "cri-socket", "", "contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]")
-
-	serverCmd.Flags().AddFlagSet(controllerCmd.Flags())
 	installControllerCmd.Flags().AddFlagSet(controllerCmd.Flags())
 
 }
@@ -64,8 +62,9 @@ var (
 	enableWorker            bool
 	controllerToken         string
 	controllerCmd           = &cobra.Command{
-		Use:   "controller [join-token]",
-		Short: "Run controller",
+		Use:     "controller [join-token]",
+		Short:   "Run controller",
+		Aliases: []string{"server"},
 		Example: `	Command to associate master nodes:
 	CLI argument:
 	$ k0s controller [join-token]
@@ -93,30 +92,6 @@ var (
 		},
 	}
 )
-
-// backward-compatibility for "server" command
-var serverCmd = &cobra.Command{
-	Use:   "server [join-token]",
-	Short: "alias for controller command. WARN: will be depracated in favor of controller command in future releases",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 0 {
-			controllerToken = args[0]
-		}
-		if len(controllerToken) > 0 && len(tokenFile) > 0 {
-			return fmt.Errorf("You can only pass one token argument either as a CLI argument 'k0s controller [join-token]' or as a flag 'k0s controller --token-file [path]'")
-		}
-
-		if len(tokenFile) > 0 {
-			bytes, err := ioutil.ReadFile(tokenFile)
-			if err != nil {
-				return err
-			}
-			controllerToken = string(bytes)
-		}
-
-		return startController(controllerToken)
-	},
-}
 
 // If we've got CA in place we assume the node has already joined previously
 func needToJoin(k0sVars constant.CfgVars) bool {

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -39,7 +39,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/applier"
 	"github.com/k0sproject/k0s/pkg/certificate"
 	"github.com/k0sproject/k0s/pkg/component"
-	"github.com/k0sproject/k0s/pkg/component/server"
+	"github.com/k0sproject/k0s/pkg/component/controller"
 	"github.com/k0sproject/k0s/pkg/component/worker"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/performance"
@@ -49,35 +49,36 @@ import (
 )
 
 func init() {
-	serverCmd.Flags().StringVar(&serverWorkerProfile, "profile", "default", "worker profile to use on the node")
-	serverCmd.Flags().BoolVar(&enableWorker, "enable-worker", false, "enable worker (default false)")
-	serverCmd.Flags().StringVar(&tokenFile, "token-file", "", "Path to the file containing join-token.")
-	serverCmd.Flags().StringVar(&criSocket, "cri-socket", "", "contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]")
-	installServerCmd.Flags().AddFlagSet(serverCmd.Flags())
+	controllerCmd.Flags().StringVar(&controllerWorkerProfile, "profile", "default", "worker profile to use on the node")
+	controllerCmd.Flags().BoolVar(&enableWorker, "enable-worker", false, "enable worker (default false)")
+	controllerCmd.Flags().StringVar(&tokenFile, "token-file", "", "Path to the file containing join-token.")
+	controllerCmd.Flags().StringVar(&criSocket, "cri-socket", "", "contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]")
+
+	serverCmd.Flags().AddFlagSet(controllerCmd.Flags())
+	installControllerCmd.Flags().AddFlagSet(controllerCmd.Flags())
 
 }
 
 var (
-	serverWorkerProfile string
-	enableWorker        bool
-	serverToken         string
-
-	serverCmd = &cobra.Command{
-		Use:   "server [join-token]",
-		Short: "Run server",
+	controllerWorkerProfile string
+	enableWorker            bool
+	controllerToken         string
+	controllerCmd           = &cobra.Command{
+		Use:   "controller [join-token]",
+		Short: "Run controller",
 		Example: `	Command to associate master nodes:
 	CLI argument:
-	$ k0s server [join-token]
+	$ k0s controller [join-token]
 
 	or CLI flag:
-	$ k0s server --token-file [path_to_file]
+	$ k0s controller --token-file [path_to_file]
 	Note: Token can be passed either as a CLI argument or as a flag`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
-				serverToken = args[0]
+				controllerToken = args[0]
 			}
-			if len(serverToken) > 0 && len(tokenFile) > 0 {
-				return fmt.Errorf("You can only pass one token argument either as a CLI argument 'k0s server [join-token]' or as a flag 'k0s server --token-file [path]'")
+			if len(controllerToken) > 0 && len(tokenFile) > 0 {
+				return fmt.Errorf("You can only pass one token argument either as a CLI argument 'k0s controller [join-token]' or as a flag 'k0s controller --token-file [path]'")
 			}
 
 			if len(tokenFile) > 0 {
@@ -85,13 +86,37 @@ var (
 				if err != nil {
 					return err
 				}
-				serverToken = string(bytes)
+				controllerToken = string(bytes)
 			}
 
-			return startServer(serverToken)
+			return startController(controllerToken)
 		},
 	}
 )
+
+// backward-compatibility for "server" command
+var serverCmd = &cobra.Command{
+	Use:   "server [join-token]",
+	Short: "alias for controller command. WARN: will be depracated in favor of controller command in future releases",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			controllerToken = args[0]
+		}
+		if len(controllerToken) > 0 && len(tokenFile) > 0 {
+			return fmt.Errorf("You can only pass one token argument either as a CLI argument 'k0s controller [join-token]' or as a flag 'k0s controller --token-file [path]'")
+		}
+
+		if len(tokenFile) > 0 {
+			bytes, err := ioutil.ReadFile(tokenFile)
+			if err != nil {
+				return err
+			}
+			controllerToken = string(bytes)
+		}
+
+		return startController(controllerToken)
+	},
+}
 
 // If we've got CA in place we assume the node has already joined previously
 func needToJoin(k0sVars constant.CfgVars) bool {
@@ -102,8 +127,8 @@ func needToJoin(k0sVars constant.CfgVars) bool {
 	return true
 }
 
-func startServer(token string) error {
-	perfTimer := performance.NewTimer("server-start").Buffer().Start()
+func startController(token string) error {
+	perfTimer := performance.NewTimer("controller-start").Buffer().Start()
 	clusterConfig, err := ConfigFromYaml(cfgFile)
 	if err != nil {
 		return err
@@ -130,12 +155,12 @@ func startServer(token string) error {
 			return errors.Wrapf(err, "failed to create join client")
 		}
 
-		componentManager.AddSync(&server.CASyncer{
+		componentManager.AddSync(&controller.CASyncer{
 			JoinClient: joinClient,
 			K0sVars:    k0sVars,
 		})
 	}
-	componentManager.AddSync(&server.Certificates{
+	componentManager.AddSync(&controller.Certificates{
 		ClusterSpec: clusterConfig.Spec,
 		CertManager: certificateManager,
 		K0sVars:     k0sVars,
@@ -152,12 +177,12 @@ func startServer(token string) error {
 
 	switch clusterConfig.Spec.Storage.Type {
 	case v1beta1.KineStorageType, "":
-		storageBackend = &server.Kine{
+		storageBackend = &controller.Kine{
 			Config:  clusterConfig.Spec.Storage.Kine,
 			K0sVars: k0sVars,
 		}
 	case v1beta1.EtcdStorageType:
-		storageBackend = &server.Etcd{
+		storageBackend = &controller.Etcd{
 			CertManager: certificateManager,
 			Config:      clusterConfig.Spec.Storage.Etcd,
 			Join:        join,
@@ -174,7 +199,7 @@ func startServer(token string) error {
 	// common factory to get the admin kube client that's needed in many components
 	adminClientFactory := kubernetes.NewAdminClientFactory(k0sVars)
 
-	componentManager.Add(&server.APIServer{
+	componentManager.Add(&controller.APIServer{
 		ClusterConfig: clusterConfig,
 		K0sVars:       k0sVars,
 		LogLevel:      logging["kube-apiserver"],
@@ -182,30 +207,30 @@ func startServer(token string) error {
 	})
 
 	if clusterConfig.Spec.API.ExternalAddress != "" {
-		componentManager.Add(&server.ControllerLease{
+		componentManager.Add(&controller.K0sLease{
 			ClusterConfig:     clusterConfig,
 			KubeClientFactory: adminClientFactory,
 		})
 	}
 
-	componentManager.Add(&server.Konnectivity{
+	componentManager.Add(&controller.Konnectivity{
 		ClusterConfig:     clusterConfig,
 		LogLevel:          logging["konnectivity-server"],
 		K0sVars:           k0sVars,
 		KubeClientFactory: adminClientFactory,
 	})
-	componentManager.Add(&server.Scheduler{
+	componentManager.Add(&controller.Scheduler{
 		ClusterConfig: clusterConfig,
 		LogLevel:      logging["kube-scheduler"],
 		K0sVars:       k0sVars,
 	})
-	componentManager.Add(&server.ControllerManager{
+	componentManager.Add(&controller.Manager{
 		ClusterConfig: clusterConfig,
 		LogLevel:      logging["kube-controller-manager"],
 		K0sVars:       k0sVars,
 	})
 	componentManager.Add(&applier.Manager{K0sVars: k0sVars, KubeClientFactory: adminClientFactory})
-	componentManager.Add(&server.K0SControlAPI{
+	componentManager.Add(&controller.K0SControlAPI{
 		ConfigPath: cfgFile,
 		K0sVars:    k0sVars,
 	})
@@ -221,11 +246,11 @@ func startServer(token string) error {
 
 	// One leader elector per controller
 	// TODO: Make all other needed components use this "global" leader elector
-	leaderElector := server.NewLeaderElector(clusterConfig, adminClientFactory)
+	leaderElector := controller.NewLeaderElector(clusterConfig, adminClientFactory)
 	componentManager.Add(leaderElector)
 
 	if clusterConfig.Spec.API.ExternalAddress != "" {
-		componentManager.Add(server.NewEndpointReconciler(
+		componentManager.Add(controller.NewEndpointReconciler(
 			clusterConfig,
 			leaderElector,
 			adminClientFactory,
@@ -252,7 +277,7 @@ func startServer(token string) error {
 	go func() {
 		select {
 		case <-c:
-			logrus.Info("Shutting down k0s server")
+			logrus.Info("Shutting down k0s controller")
 			cancel()
 		case <-ctx.Done():
 			logrus.Debug("Context done in go-routine")
@@ -264,7 +289,7 @@ func startServer(token string) error {
 	err = componentManager.Start(ctx)
 	perfTimer.Checkpoint("finished-starting-components")
 	if err != nil {
-		logrus.Errorf("failed to start server components: %s", err)
+		logrus.Errorf("failed to start controller components: %s", err)
 		c <- syscall.SIGTERM
 	}
 
@@ -284,7 +309,7 @@ func startServer(token string) error {
 
 	if err == nil && enableWorker {
 		perfTimer.Checkpoint("starting-worker")
-		err = enableServerWorker(clusterConfig, k0sVars, componentManager, serverWorkerProfile)
+		err = enableControllerWorker(clusterConfig, k0sVars, componentManager, controllerWorkerProfile)
 		if err != nil {
 			logrus.Errorf("failed to start worker components: %s", err)
 			if err := componentManager.Stop(); err != nil {
@@ -319,21 +344,21 @@ func createClusterReconcilers(clusterConf *config.ClusterConfig, k0sVars constan
 	reconcilers := make(map[string]component.Component)
 	clusterSpec := clusterConf.Spec
 
-	defaultPSP, err := server.NewDefaultPSP(clusterSpec, k0sVars)
+	defaultPSP, err := controller.NewDefaultPSP(clusterSpec, k0sVars)
 	if err != nil {
 		logrus.Warnf("failed to initialize default PSP reconciler: %s", err.Error())
 	} else {
 		reconcilers["default-psp"] = defaultPSP
 	}
 
-	proxy, err := server.NewKubeProxy(clusterConf, k0sVars)
+	proxy, err := controller.NewKubeProxy(clusterConf, k0sVars)
 	if err != nil {
 		logrus.Warnf("failed to initialize kube-proxy reconciler: %s", err.Error())
 	} else {
 		reconcilers["kube-proxy"] = proxy
 	}
 
-	coreDNS, err := server.NewCoreDNS(clusterConf, k0sVars, cf)
+	coreDNS, err := controller.NewCoreDNS(clusterConf, k0sVars, cf)
 	if err != nil {
 		logrus.Warnf("failed to initialize CoreDNS reconciler: %s", err.Error())
 	} else {
@@ -342,28 +367,28 @@ func createClusterReconcilers(clusterConf *config.ClusterConfig, k0sVars constan
 
 	initNetwork(reconcilers, clusterConf, k0sVars.DataDir)
 
-	manifestsSaver, err := server.NewManifestsSaver("helm", k0sVars.DataDir)
+	manifestsSaver, err := controller.NewManifestsSaver("helm", k0sVars.DataDir)
 	if err != nil {
 		logrus.Warnf("failed to initialize reconcilers manifests saver: %s", err.Error())
 	}
-	reconcilers["crd"] = server.NewCRD(manifestsSaver)
-	reconcilers["helmAddons"] = server.NewHelmAddons(clusterConf, manifestsSaver, k0sVars, cf)
+	reconcilers["crd"] = controller.NewCRD(manifestsSaver)
+	reconcilers["helmAddons"] = controller.NewHelmAddons(clusterConf, manifestsSaver, k0sVars, cf)
 
-	metricServer, err := server.NewMetricServer(clusterConf, k0sVars, cf)
+	metricServer, err := controller.NewMetricServer(clusterConf, k0sVars, cf)
 	if err != nil {
-		logrus.Warnf("failed to initialize metric server reconciler: %s", err.Error())
+		logrus.Warnf("failed to initialize metric controller reconciler: %s", err.Error())
 	} else {
 		reconcilers["metricServer"] = metricServer
 	}
 
-	kubeletConfig, err := server.NewKubeletConfig(clusterSpec, k0sVars)
+	kubeletConfig, err := controller.NewKubeletConfig(clusterSpec, k0sVars)
 	if err != nil {
 		logrus.Warnf("failed to initialize kubelet config reconciler: %s", err.Error())
 	} else {
 		reconcilers["kubeletConfig"] = kubeletConfig
 	}
 
-	systemRBAC, err := server.NewSystemRBAC(k0sVars.ManifestsDir)
+	systemRBAC, err := controller.NewSystemRBAC(k0sVars.ManifestsDir)
 	if err != nil {
 		logrus.Warnf("failed to initialize system RBAC reconciler: %s", err.Error())
 	} else {
@@ -379,15 +404,15 @@ func initNetwork(reconcilers map[string]component.Component, conf *config.Cluste
 		logrus.Warnf("network provider set to custom, k0s will not manage it")
 		return
 	}
-	calicoSaver, err := server.NewManifestsSaver("calico", dataDir)
+	calicoSaver, err := controller.NewManifestsSaver("calico", dataDir)
 	if err != nil {
 		logrus.Warnf("failed to initialize reconcilers manifests saver: %s", err.Error())
 	}
-	calicoInitSaver, err := server.NewManifestsSaver("calico_init", dataDir)
+	calicoInitSaver, err := controller.NewManifestsSaver("calico_init", dataDir)
 	if err != nil {
 		logrus.Warnf("failed to initialize reconcilers manifests saver: %s", err.Error())
 	}
-	calico, err := server.NewCalico(conf, calicoInitSaver, calicoSaver)
+	calico, err := controller.NewCalico(conf, calicoInitSaver, calicoSaver)
 
 	if err != nil {
 		logrus.Warnf("failed to initialize calico reconciler: %s", err.Error())
@@ -398,9 +423,9 @@ func initNetwork(reconcilers map[string]component.Component, conf *config.Cluste
 
 }
 
-func enableServerWorker(clusterConfig *config.ClusterConfig, k0sVars constant.CfgVars, componentManager *component.Manager, profile string) error {
+func enableControllerWorker(clusterConfig *config.ClusterConfig, k0sVars constant.CfgVars, componentManager *component.Manager, profile string) error {
 	if !util.FileExists(k0sVars.KubeletAuthConfigPath) {
-		// wait for server to start up
+		// wait for controller to start up
 		err := retry.Do(func() error {
 			if !util.FileExists(k0sVars.AdminKubeConfigPath) {
 				return fmt.Errorf("file does not exist: %s", k0sVars.AdminKubeConfigPath)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -28,7 +28,7 @@ import (
 )
 
 func init() {
-	installCmd.AddCommand(installServerCmd)
+	installCmd.AddCommand(installControllerCmd)
 	installCmd.AddCommand(installWorkerCmd)
 }
 
@@ -47,9 +47,9 @@ func setup(role string, args []string) error {
 		logrus.Fatal("this command must be run as root!")
 	}
 
-	if role == "server" {
-		if err := createServerUsers(); err != nil {
-			logrus.Errorf("failed to create server users: %v", err)
+	if role == "controller" {
+		if err := createControllerUsers(); err != nil {
+			logrus.Errorf("failed to create controller users: %v", err)
 		}
 	}
 
@@ -60,7 +60,7 @@ func setup(role string, args []string) error {
 	return nil
 }
 
-func createServerUsers() error {
+func createControllerUsers() error {
 	clusterConfig, err := ConfigFromYaml(cfgFile)
 	if err != nil {
 		return err

--- a/cmd/installController.go
+++ b/cmd/installController.go
@@ -23,22 +23,22 @@ import (
 )
 
 var (
-	installServerCmd = &cobra.Command{
-		Use:   "server",
-		Short: "Helper command for setting up k0s as server node on a brand-new system. Must be run as root (or with sudo)",
-		Example: `All default values of server command will be passed to the service stub unless overriden. 
+	installControllerCmd = &cobra.Command{
+		Use:   "controller",
+		Short: "Helper command for setting up k0s as controller node on a brand-new system. Must be run as root (or with sudo)",
+		Example: `All default values of controller command will be passed to the service stub unless overriden. 
 
-With server subcommand you can setup a single node cluster by running:
+With controller subcommand you can setup a single node cluster by running:
 
-	k0s install server --enable-worker
+	k0s install controller --enable-worker
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			flagsAndVals := []string{"server"}
+			flagsAndVals := []string{"controller"}
 			cmd.Flags().Visit(func(f *pflag.Flag) {
 				flagsAndVals = append(flagsAndVals, fmt.Sprintf("--%s=%s", f.Name, f.Value.String()))
 			})
 
-			return setup("server", flagsAndVals)
+			return setup("controller", flagsAndVals)
 		},
 	}
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,7 +70,8 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(tokenCmd)
-	rootCmd.AddCommand(serverCmd)
+	rootCmd.AddCommand(controllerCmd)
+	rootCmd.AddCommand(serverCmd) // backward-compatibility for "server" command
 	rootCmd.AddCommand(workerCmd)
 	rootCmd.AddCommand(APICmd)
 	rootCmd.AddCommand(etcdCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,7 +71,6 @@ func init() {
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(tokenCmd)
 	rootCmd.AddCommand(controllerCmd)
-	rootCmd.AddCommand(serverCmd) // backward-compatibility for "server" command
 	rootCmd.AddCommand(workerCmd)
 	rootCmd.AddCommand(APICmd)
 	rootCmd.AddCommand(etcdCmd)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -127,8 +127,8 @@ func (s K0sStatus) String() {
 
 }
 func getSysInit(role string) (sysInit string, stubFile string, err error) {
-	if role == "server+worker" {
-		role = "server"
+	if role == "controller+worker" {
+		role = "controller"
 	}
 	if sysInit, err = install.GetSysInit(); err != nil {
 		return sysInit, stubFile, err
@@ -160,9 +160,9 @@ func getRole(pid int) (role string, err error) {
 	}
 	cmdln := string(raw)
 	if strings.Contains(cmdln, "enable-worker") {
-		return "server+worker", nil
-	} else if strings.Contains(cmdln, "server") {
-		return "server", nil
+		return "controller+worker", nil
+	} else if strings.Contains(cmdln, "controller") {
+		return "controller", nil
 	} else if strings.Contains(cmdln, "worker") {
 		return "worker", nil
 	}

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -171,7 +171,7 @@ func startWorker(token string) error {
 	go func() {
 		select {
 		case <-c:
-			logrus.Info("Shutting down k0s server")
+			logrus.Info("Shutting down k0s controller")
 			cancel()
 		case <-ctx.Done():
 			logrus.Debug("Context done in go-routine")

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,7 +6,7 @@ kay-zero-ess
 
 ### How do I run a single node cluster?
 
-`k0s server --enable-worker`
+`k0s controller --enable-worker`
 
 ### How do I connect to the cluster?
 
@@ -18,9 +18,9 @@ export KUBECONFIG=/path/to/admin.conf
 kubectl ...
 ```
 
-### Why doesn't `kubectl get nodes` list the k0s server?
+### Why doesn't `kubectl get nodes` list the k0s controllers?
 
 As a default, the control plane does not run kubelet at all, and will not
-accept any workloads, so the server will not show up on the node list in
-kubectl. If you want your server to accept workloads and run pods, you do so with:
-`k0s server --enable-worker` (recommended only as test/dev/POC environments).
+accept any workloads, so the controller will not show up on the node list in
+kubectl. If you want your controller to accept workloads and run pods, you do so with:
+`k0s controller --enable-worker` (recommended only as test/dev/POC environments).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ k0s creates, manages and configures each of the components. k0s runs all control
 
 Typically Kubernetes control plane supports only etcd as the datastore. In addition to etcd, k0s supports many other datastore options. This is achieved by including [kine](https://github.com/rancher/kine/). Kine allows wide variety of backend data stores to be used such as MySQL, PostgreSQL, SQLite and dqlite. See more in storage [documentation](configuration.md#specstorage)
 
-In case of k0s managed etcd, k0s manages the full lifecycle of the etcd cluster. This means for example that by joining a new controller node with `k0s server "long-join-token"` k0s will automatically adjust the etcd cluster membership info to allow the new member to join the cluster.
+In case of k0s managed etcd, k0s manages the full lifecycle of the etcd cluster. This means for example that by joining a new controller node with `k0s controller "long-join-token"` k0s will automatically adjust the etcd cluster membership info to allow the new member to join the cluster.
 
 **Note:** Currently k0s cannot shrink the etcd cluster. For now user needs to manually remove the etcd member and only after that shutdown the k0s controller on the removed node.
 

--- a/docs/cli/k0s.md
+++ b/docs/cli/k0s.md
@@ -14,19 +14,19 @@ k0s - The zero friction Kubernetes - https://k0sproject.io
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
   -h, --help                     help for k0s
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO
 
 * [k0s api](k0s_api.md)	 - Run the controller api
 * [k0s completion](k0s_completion.md)	 - Generate completion script
+* [k0s controller](k0s_controller.md)	 - Run controller
 * [k0s default-config](k0s_default-config.md)	 - Output the default k0s configuration yaml to stdout
 * [k0s docs](k0s_docs.md)	 - Generate Markdown docs for the k0s binary
 * [k0s etcd](k0s_etcd.md)	 - Manage etcd cluster
 * [k0s install](k0s_install.md)	 - Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)
 * [k0s kubeconfig](k0s_kubeconfig.md)	 - Create a kubeconfig file for a specified user
-* [k0s server](k0s_server.md)	 - Run server
 * [k0s status](k0s_status.md)	 - Helper command for get general information about k0s
 * [k0s token](k0s_token.md)	 - Manage join tokens
 * [k0s validate](k0s_validate.md)	 - Helper command for validating the config file

--- a/docs/cli/k0s_api.md
+++ b/docs/cli/k0s_api.md
@@ -19,7 +19,7 @@ k0s api [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_completion.md
+++ b/docs/cli/k0s_completion.md
@@ -50,7 +50,7 @@ k0s completion [bash|zsh|fish|powershell]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_controller.md
+++ b/docs/cli/k0s_controller.md
@@ -1,9 +1,9 @@
-## k0s server
+## k0s controller
 
-Run server
+Run controller
 
 ```
-k0s server [join-token] [flags]
+k0s controller [join-token] [flags]
 ```
 
 ### Examples
@@ -11,10 +11,10 @@ k0s server [join-token] [flags]
 ```
 	Command to associate master nodes:
 	CLI argument:
-	$ k0s server [join-token]
+	$ k0s controller [join-token]
 
 	or CLI flag:
-	$ k0s server --token-file [path_to_file]
+	$ k0s controller --token-file [path_to_file]
 	Note: Token can be passed either as a CLI argument or as a flag
 ```
 
@@ -23,7 +23,7 @@ k0s server [join-token] [flags]
 ```
       --cri-socket string   contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]
       --enable-worker       enable worker (default false)
-  -h, --help                help for server
+  -h, --help                help for controller
       --profile string      worker profile to use on the node (default "default")
       --token-file string   Path to the file containing join-token.
 ```
@@ -35,7 +35,7 @@ k0s server [join-token] [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_default-config.md
+++ b/docs/cli/k0s_default-config.md
@@ -19,7 +19,7 @@ k0s default-config [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_docs.md
+++ b/docs/cli/k0s_docs.md
@@ -19,7 +19,7 @@ k0s docs [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_etcd.md
+++ b/docs/cli/k0s_etcd.md
@@ -15,7 +15,7 @@ Manage etcd cluster
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_etcd_leave.md
+++ b/docs/cli/k0s_etcd_leave.md
@@ -20,7 +20,7 @@ k0s etcd leave [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_etcd_member-list.md
+++ b/docs/cli/k0s_etcd_member-list.md
@@ -19,7 +19,7 @@ k0s etcd member-list [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_install.md
+++ b/docs/cli/k0s_install.md
@@ -15,12 +15,12 @@ Helper command for setting up k0s on a brand-new system. Must be run as root (or
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO
 
 * [k0s](k0s.md)	 - k0s - Zero Friction Kubernetes
-* [k0s install server](k0s_install_server.md)	 - Helper command for setting up k0s as server node on a brand-new system. Must be run as root (or with sudo)
+* [k0s install controller](k0s_install_controller.md)	 - Helper command for setting up k0s as controller node on a brand-new system. Must be run as root (or with sudo)
 * [k0s install worker](k0s_install_worker.md)	 - Helper command for setting up k0s as a worker node on a brand-new system. Must be run as root (or with sudo)
 

--- a/docs/cli/k0s_install_controller.md
+++ b/docs/cli/k0s_install_controller.md
@@ -1,19 +1,19 @@
-## k0s install server
+## k0s install controller
 
-Helper command for setting up k0s as server node on a brand-new system. Must be run as root (or with sudo)
+Helper command for setting up k0s as controller node on a brand-new system. Must be run as root (or with sudo)
 
 ```
-k0s install server [flags]
+k0s install controller [flags]
 ```
 
 ### Examples
 
 ```
-All default values of server command will be passed to the service stub unless overriden. 
+All default values of controller command will be passed to the service stub unless overriden. 
 
-With server subcommand you can setup a single node cluster by running:
+With controller subcommand you can setup a single node cluster by running:
 
-	k0s install server --enable-worker
+	k0s install controller --enable-worker
 	
 ```
 
@@ -22,7 +22,7 @@ With server subcommand you can setup a single node cluster by running:
 ```
       --cri-socket string   contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]
       --enable-worker       enable worker (default false)
-  -h, --help                help for server
+  -h, --help                help for controller
       --profile string      worker profile to use on the node (default "default")
       --token-file string   Path to the file containing join-token.
 ```
@@ -34,7 +34,7 @@ With server subcommand you can setup a single node cluster by running:
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_install_worker.md
+++ b/docs/cli/k0s_install_worker.md
@@ -35,7 +35,7 @@ Windows flags like "--api-server", "--cidr-range" and "--cluster-dns" will be ig
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_kubeconfig.md
+++ b/docs/cli/k0s_kubeconfig.md
@@ -19,7 +19,7 @@ k0s kubeconfig [command] [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_kubeconfig_admin.md
+++ b/docs/cli/k0s_kubeconfig_admin.md
@@ -31,7 +31,7 @@ k0s kubeconfig admin [command] [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_kubeconfig_create.md
+++ b/docs/cli/k0s_kubeconfig_create.md
@@ -36,7 +36,7 @@ k0s kubeconfig create [username] [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_status.md
+++ b/docs/cli/k0s_status.md
@@ -26,7 +26,7 @@ The command will return information about system init, PID, k0s role, kubeconfig
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_token.md
+++ b/docs/cli/k0s_token.md
@@ -20,7 +20,7 @@ k0s token [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_token_create.md
+++ b/docs/cli/k0s_token_create.md
@@ -6,18 +6,10 @@ Create join token
 k0s token create [flags]
 ```
 
-### Examples
-
-```
-k0s token create --role worker --expiry 100h //sets expiration time to 100 hours
-k0s token create --role worker --expiry 10m  //sets expiration time to 10 minutes
-
-```
-
 ### Options
 
 ```
-      --expiry string   Expiration time of the token. Format 1.5h, 2h45m or 300ms. (default "0s")
+      --expiry string   set duration time for token (default "0")
   -h, --help            help for create
       --role string     Either worker or controller (default "worker")
       --wait            wait forever (default false)
@@ -30,7 +22,7 @@ k0s token create --role worker --expiry 10m  //sets expiration time to 10 minute
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_validate.md
+++ b/docs/cli/k0s_validate.md
@@ -15,7 +15,7 @@ Helper command for validating the config file
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_validate_config.md
+++ b/docs/cli/k0s_validate_config.md
@@ -24,7 +24,7 @@ k0s validate config [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_version.md
+++ b/docs/cli/k0s_version.md
@@ -19,7 +19,7 @@ k0s version [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/cli/k0s_worker.md
+++ b/docs/cli/k0s_worker.md
@@ -38,7 +38,7 @@ k0s worker [join-token] [flags]
       --data-dir string          Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
   -d, --debug                    Debug logging (default: false)
       --debugListenOn string     Http listenOn for debug pprof handler (default ":6060")
-  -l, --logging stringToString   Logging Levels for the different components (default [containerd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info])
+  -l, --logging stringToString   Logging Levels for the different components (default [konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1,kube-proxy=1,etcd=info,containerd=info])
 ```
 
 ### SEE ALSO

--- a/docs/create-cluster.md
+++ b/docs/create-cluster.md
@@ -13,7 +13,7 @@ That's it, really.
 Create a [configuration](configuration.md) file if you wish to tune some of the settings.
 
 ```
-$ k0s server -c k0s.yaml
+$ k0s controller -c k0s.yaml
 ```
 
 That's it, really. k0s process will act as a "supervisor" for all the control plane components. In few seconds you'll have the control plane up-and-running.
@@ -69,7 +69,7 @@ k0s token create --role=controller --expiry=1h
 
 On the new controller, run:
 ```sh
-k0s server "long-join-token"
+k0s controller "long-join-token"
 ```
 
 ## Adding a Cluster User

--- a/docs/examples/ansible-playbook.md
+++ b/docs/examples/ansible-playbook.md
@@ -68,7 +68,7 @@ $ cp -rfp inventory/sample inventory/multipass
 
 Now we need to create our inventory. The before built virtual machines need to be assigned to the different host groups required by the playbook's logic.
 
-- `initial_controller` = must contain a single node that creates the worker and server tokens needed by the other nodes.
+- `initial_controller` = must contain a single node that creates the worker and controller tokens needed by the other nodes.
 - `controller` = can contain nodes that, together with the host from `initial_controller` form a highly available isolated control plane.
 - `worker` = must contain at least one node so that we can deploy Kubernetes objects.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,11 +4,11 @@ Sub-command `k0s install` allows users to easily install k0s as a service, and d
 
 ## Caveats
 * This command is strictly a helper command. It is not meant to provide a fully-automated solution, since you can run k0s in multiple, very different ways.
-* It configures your service set-up as either a worker or a server, and will have different tasks, depending on the role you pick.
+* It configures your service set-up as either a worker or a controller, and will have different tasks, depending on the role you pick.
 * Supported services: OpenRC & Systemd
 
-## Server setup
-This is the default mode of operation. When a server role is picked, the installer will do the following:
+## Controller setup
+This is the default mode of operation. When a controller role is picked, the installer will do the following:
 
 * Create user accounts for the different components (see https://github.com/k0sproject/k0s/blob/main/pkg/apis/v1beta1/system.go#L6)
 * Create a service file (OpenRC/Systemd) and redirects logging to `/var/log/k0s.log`.
@@ -20,7 +20,7 @@ This is the default mode of operation. When a server role is picked, the install
 * If the `--debug` flag is used, it will also pass this flag along to the service file.
 
 ## Single-node setup
-* Single-node configuration can be installed with 'k0s install server --enable-worker' command.
+* Single-node configuration can be installed with 'k0s install controller --enable-worker' command.
 
 ## Additional Documentation
 see: [k0s install](cli/k0s_install.md)

--- a/docs/k0s-in-docker.md
+++ b/docs/k0s-in-docker.md
@@ -38,7 +38,7 @@ services:
   k0s:
     container_name: k0s
     image: docker.io/k0sproject/k0s:latest
-    command: k0s server --config=/etc/k0s/config.yaml --enable-worker
+    command: k0s controller --config=/etc/k0s/config.yaml --enable-worker
     hostname: k0s
     privileged: true
     volumes:

--- a/docs/k0s-single-node.md
+++ b/docs/k0s-single-node.md
@@ -33,7 +33,7 @@ k0s default-config | tee ${HOME}/.k0s/k0s.yaml
 
 #### 3. Start k0s
 ```sh
-sudo k0s server -c ${HOME}/.k0s/k0s.yaml --enable-worker &
+sudo k0s controller -c ${HOME}/.k0s/k0s.yaml --enable-worker &
 ```
 
 ## Use kubectl to access k0s

--- a/docs/raspberry-pi4.md
+++ b/docs/raspberry-pi4.md
@@ -155,7 +155,7 @@ After=network.target
 
 [Service]
 EnvironmentFile=/etc/sysconfig/k0s
-ExecStart=/usr/bin/k0s server
+ExecStart=/usr/bin/k0s controller
 KillMode=process
 Restart=always
 RestartSec=120

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,11 +36,11 @@ The easiest but most crude way to workaround is to disable the systemd-resolved 
 
 Read more at CoreDNS [troubleshooting docs](https://coredns.io/plugins/loop/#troubleshooting-loops-in-kubernetes-clusters).
 
-## `k0s server` fails on ARM boxes
+## `k0s controller` fails on ARM boxes
 
 In the logs you probably see ETCD not starting up properly.
 
-Etcd is [not fully supported](https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/supported-platform.md#current-support) on ARM architecture, thus you need to run `k0s server` and thus also etcd process with env `ETCD_UNSUPPORTED_ARCH=arm64`.
+Etcd is [not fully supported](https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/supported-platform.md#current-support) on ARM architecture, thus you need to run `k0s controller` and thus also etcd process with env `ETCD_UNSUPPORTED_ARCH=arm64`.
 
 As Etcd is not fully supported on ARM architecture it also means that k0s controlplane with etcd itself is not fully supported on ARM either.
 
@@ -73,7 +73,7 @@ spec:
         volumePluginDir: /etc/k0s/kubelet-plugins/volume/exec/
 ```
 
-With this config you can start your server as usual. Any workers will need to be started with
+With this config you can start your controller as usual. Any workers will need to be started with
 
 `k0s worker --profile coreos [TOKEN]`
 

--- a/examples/footloose-mysql/README.md
+++ b/examples/footloose-mysql/README.md
@@ -45,7 +45,7 @@ footloose ssh root@controller0
 Bootstrap the controlplane:
 ```
 # cd /root/k0s
-# ./k0s server
+# ./k0s controller
 ```
 
 Yes, really. It's that easy. In less than a minute we'll have the control plane up-and-running.
@@ -69,7 +69,7 @@ footloose ssh root@controller1
 Bootstrap the controlplane:
 ```
 # cd /root/k0s
-# ./k0s server --join-address https://<controller0 IP>:9443 "that_long_token"
+# ./k0s controller --join-address https://<controller0 IP>:9443 "that_long_token"
 ```
 
 And voilà, our second controller node is up-and-running in no time.

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -206,10 +206,10 @@ func (s *FootlooseSuite) InitMainController(cfgPath string, dataDir string) erro
 
 	if dataDir != "" {
 		installCmd = fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=arm64 k0s --debug install --data-dir=%s --config=%s", dataDir, cfgPath)
-		startCmd = fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=arm64 nohup k0s --debug server --data-dir=%s --config=%s >/tmp/k0s-server.log 2>&1 &", dataDir, cfgPath)
+		startCmd = fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=arm64 nohup k0s --debug controller --data-dir=%s --config=%s >/tmp/k0s-controller.log 2>&1 &", dataDir, cfgPath)
 	} else {
 		installCmd = fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=arm64 k0s --debug install --config=%s", cfgPath)
-		startCmd = fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=arm64 nohup k0s --debug server --config=%s >/tmp/k0s-server.log 2>&1 &", cfgPath)
+		startCmd = fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=arm64 nohup k0s --debug controller --config=%s >/tmp/k0s-controller.log 2>&1 &", cfgPath)
 	}
 	_, err = ssh.ExecWithOutput(installCmd)
 	if err != nil {
@@ -231,7 +231,7 @@ func (s *FootlooseSuite) JoinController(idx int, token string, dataDir string) e
 		return err
 	}
 	defer ssh.Disconnect()
-	_, err = ssh.ExecWithOutput(fmt.Sprintf("nohup k0s --debug server %s >/tmp/k0s-server.log 2>&1 &", token))
+	_, err = ssh.ExecWithOutput(fmt.Sprintf("nohup k0s --debug controller %s >/tmp/k0s-controller.log 2>&1 &", token))
 	if err != nil {
 		return err
 	}

--- a/inttest/common/vmsuite.go
+++ b/inttest/common/vmsuite.go
@@ -84,7 +84,7 @@ func (s *VMSuite) InitMainController() error {
 	}
 	defer ssh.Disconnect()
 
-	startControllerCmd := "sudo nohup k0s --debug server >/tmp/k0s-server.log 2>&1 &"
+	startControllerCmd := "sudo nohup k0s --debug controller >/tmp/k0s-controller.log 2>&1 &"
 	_, err = ssh.ExecWithOutput(startControllerCmd)
 	if err != nil {
 		return err

--- a/inttest/conformance/terraform/main.tf
+++ b/inttest/conformance/terraform/main.tf
@@ -35,7 +35,7 @@ resource "null_resource" "controller" {
   provisioner "remote-exec" {
     inline = [
       "sudo curl -SsLf get.k0s.sh | sudo K0S_VERSION=${var.k0s_version} sh",
-      "sudo nohup k0s server --enable-worker >/home/ubuntu/k0s-master.log 2>&1 &",
+      "sudo nohup k0s controller --enable-worker >/home/ubuntu/k0s-master.log 2>&1 &",
       "echo 'Wait 10 seconds for cluster to start!!!'",
       "sleep 10",
       "sudo snap install kubectl --classic"

--- a/inttest/install/singlenode_test.go
+++ b/inttest/install/singlenode_test.go
@@ -34,10 +34,10 @@ func (s *InstallSuite) TestK0sGetsUp() {
 	s.Require().NoError(err)
 	defer ssh.Disconnect()
 
-	_, err = ssh.ExecWithOutput("k0s install server --enable-worker")
+	_, err = ssh.ExecWithOutput("k0s install controller --enable-worker")
 	s.Require().NoError(err)
 
-	_, err = ssh.ExecWithOutput("rc-service k0sserver start")
+	_, err = ssh.ExecWithOutput("rc-service k0scontroller start")
 	s.Require().NoError(err)
 
 	err = s.WaitForKubeAPI("controller0", "")

--- a/pkg/component/controller/apiendpointreconciler.go
+++ b/pkg/component/controller/apiendpointreconciler.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"context"

--- a/pkg/component/controller/apiendpointreconciler_test.go
+++ b/pkg/component/controller/apiendpointreconciler_test.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"context"

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"fmt"

--- a/pkg/component/controller/calico.go
+++ b/pkg/component/controller/calico.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"bytes"

--- a/pkg/component/controller/calico_test.go
+++ b/pkg/component/controller/calico_test.go
@@ -1,4 +1,4 @@
-package server
+package controller
 
 import (
 	"testing"

--- a/pkg/component/controller/casyncer.go
+++ b/pkg/component/controller/casyncer.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"io/ioutil"

--- a/pkg/component/controller/certificates.go
+++ b/pkg/component/controller/certificates.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"context"

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"fmt"
@@ -31,8 +31,8 @@ import (
 	"github.com/k0sproject/k0s/pkg/supervisor"
 )
 
-// ControllerManager implement the component interface to run kube scheduler
-type ControllerManager struct {
+// Manager implement the component interface to run kube scheduler
+type Manager struct {
 	ClusterConfig *config.ClusterConfig
 	gid           int
 	K0sVars       constant.CfgVars
@@ -52,7 +52,7 @@ var cmDefaultArgs = map[string]string{
 }
 
 // Init extracts the needed binaries
-func (a *ControllerManager) Init() error {
+func (a *Manager) Init() error {
 	var err error
 	// controller manager running as api-server user as they both need access to same sa.key
 	a.uid, err = util.GetUID(constant.ApiserverUser)
@@ -68,8 +68,8 @@ func (a *ControllerManager) Init() error {
 	return assets.Stage(a.K0sVars.BinDir, "kube-controller-manager", constant.BinDirMode)
 }
 
-// Run runs kube ControllerManager
-func (a *ControllerManager) Run() error {
+// Run runs kube Manager
+func (a *Manager) Run() error {
 	logrus.Info("Starting kube-controller-manager")
 	ccmAuthConf := filepath.Join(a.K0sVars.CertRootDir, "ccm.conf")
 	args := map[string]string{
@@ -123,10 +123,10 @@ func (a *ControllerManager) Run() error {
 	return a.supervisor.Supervise()
 }
 
-// Stop stops ControllerManager
-func (a *ControllerManager) Stop() error {
+// Stop stops Manager
+func (a *Manager) Stop() error {
 	return a.supervisor.Stop()
 }
 
 // Health-check interface
-func (a *ControllerManager) Healthy() error { return nil }
+func (a *Manager) Healthy() error { return nil }

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"path"

--- a/pkg/component/controller/crd.go
+++ b/pkg/component/controller/crd.go
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package server
+package controller
 
 import (
 	"fmt"
+
 	"github.com/k0sproject/k0s/static"
 )
 

--- a/pkg/component/controller/defaultpsp.go
+++ b/pkg/component/controller/defaultpsp.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"path"

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"context"

--- a/pkg/component/controller/helmaddons.go
+++ b/pkg/component/controller/helmaddons.go
@@ -1,4 +1,4 @@
-package server
+package controller
 
 import (
 	"bytes"

--- a/pkg/component/controller/k0scontrolapi.go
+++ b/pkg/component/controller/k0scontrolapi.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"fmt"

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"fmt"

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"context"
@@ -253,7 +253,7 @@ metadata:
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-roleRef:
+roleRef:Oq
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: system:auth-delegator

--- a/pkg/component/controller/kubeletconfig.go
+++ b/pkg/component/controller/kubeletconfig.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"bytes"

--- a/pkg/component/controller/kubeletconfig_test.go
+++ b/pkg/component/controller/kubeletconfig_test.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"path/filepath"

--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"path"

--- a/pkg/component/controller/leaderelector.go
+++ b/pkg/component/controller/leaderelector.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"context"

--- a/pkg/component/controller/manifests.go
+++ b/pkg/component/controller/manifests.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package server
+package controller
 
 import (
 	"fmt"

--- a/pkg/component/controller/metricserver.go
+++ b/pkg/component/controller/metricserver.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"context"

--- a/pkg/component/controller/metricserver_test.go
+++ b/pkg/component/controller/metricserver_test.go
@@ -1,4 +1,4 @@
-package server
+package controller
 
 import (
 	"context"

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"fmt"

--- a/pkg/component/controller/systemrbac.go
+++ b/pkg/component/controller/systemrbac.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package controller
 
 import (
 	"path"

--- a/pkg/install/service.go
+++ b/pkg/install/service.go
@@ -31,7 +31,7 @@ func EnsureService(args []string) error {
 
 	prg := &program{}
 	for _, v := range args {
-		if v == "server" || v == "worker" {
+		if v == "controller" || v == "worker" {
 			k0sDisplayName = "k0s " + v
 			k0sServiceName = k0sServiceName + v
 			break


### PR DESCRIPTION
Signed-off-by: Karen Almog <kalmog@mirantis.com>

---

**Issue**
Fixes #603

**What this PR Includes**
This PR standardizes the different terminology used throughout the code base and documentations whereby the k0s controller was sometimes named "server" and sometimes "controller". Per the discussion in the attached issue, we've decided "controller" would work best.

**Notes**
- For backward compatibility, the older `k0s server` command is left intact, with a warning.
- To test the above, the single node integration test still use the `k0s server` command. When the command will be rendered deprecated, this test should be changed as well.