### PR TITLE
Add support for setting node labels is k0s worker command

### DIFF
--- a/cmd/installController.go
+++ b/cmd/installController.go
@@ -16,10 +16,7 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var (
@@ -33,12 +30,9 @@ With controller subcommand you can setup a single node cluster by running:
 	k0s install controller --enable-worker
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			flagsAndVals := []string{"controller"}
-			cmd.Flags().Visit(func(f *pflag.Flag) {
-				flagsAndVals = append(flagsAndVals, fmt.Sprintf("--%s=%s", f.Name, f.Value.String()))
-			})
-
-			return setup("controller", flagsAndVals)
+			flagsAndVals := []string{"server"}
+			flagsAndVals = append(flagsAndVals, cmdFlagsToArgs(cmd)...)
+			return setup("server", flagsAndVals)
 		},
 	}
 )

--- a/cmd/installWorker.go
+++ b/cmd/installWorker.go
@@ -16,10 +16,7 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var (
@@ -32,10 +29,7 @@ All default values of worker command will be passed to the service stub unless o
 Windows flags like "--api-server", "--cidr-range" and "--cluster-dns" will be ignored since install command doesn't yet support Windows services`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flagsAndVals := []string{"worker"}
-			cmd.Flags().Visit(func(f *pflag.Flag) {
-				flagsAndVals = append(flagsAndVals, fmt.Sprintf("--%s=%s", f.Name, f.Value.String()))
-			})
-
+			flagsAndVals = append(flagsAndVals, cmdFlagsToArgs(cmd)...)
 			return setup("worker", flagsAndVals)
 		},
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2021 Mirantis, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func cmdFlagsToArgs(cmd *cobra.Command) []string {
+	flagsAndVals := []string{}
+	// Use visitor to collect all flags and vals into slice
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		fmt.Println("flag type:", f.Value.Type())
+		switch f.Value.Type() {
+		case "stringSlice", "stringToString":
+			val := f.Value.String()
+			flagsAndVals = append(flagsAndVals, fmt.Sprintf(`--%s="%s"`, f.Name, strings.Trim(val, "[]")))
+		default:
+			flagsAndVals = append(flagsAndVals, fmt.Sprintf("--%s=%s", f.Name, f.Value.String()))
+		}
+	})
+	return flagsAndVals
+}

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -47,6 +47,7 @@ func init() {
 	workerCmd.Flags().BoolVar(&cloudProvider, "enable-cloud-provider", false, "Whether or not to enable cloud provider support in kubelet")
 	workerCmd.Flags().StringVar(&tokenFile, "token-file", "", "Path to the file containing token.")
 	workerCmd.Flags().StringToStringVarP(&cmdLogLevels, "logging", "l", defaultLogLevels, "Logging Levels for the different components")
+	workerCmd.Flags().StringSliceVarP(&labels, "labels", "", []string{}, "Node labels, list of key=value pairs")
 	installWorkerCmd.Flags().AddFlagSet(workerCmd.Flags())
 }
 
@@ -60,6 +61,8 @@ var (
 	clusterDNS    string
 
 	cloudProvider bool
+
+	labels []string
 
 	workerCmd = &cobra.Command{
 		Use:   "worker [join-token]",
@@ -133,6 +136,7 @@ func startWorker(token string) error {
 		KubeletConfigClient: kubeletConfigClient,
 		LogLevel:            logging["kubelet"],
 		Profile:             workerProfile,
+		Labels:              labels,
 	})
 
 	if runtime.GOOS == "windows" {

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -41,6 +41,10 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady("worker0", kc)
 	s.NoError(err)
 
+	labels, err := s.GetNodeLabels("worker0", kc)
+	s.NoError(err)
+	s.Equal("bar", labels["k0sproject.io/foo"])
+
 	err = s.WaitForNodeReady("worker1", kc)
 	s.NoError(err)
 

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -276,9 +276,9 @@ func (s *FootlooseSuite) RunWorkers(dataDir string) error {
 
 	var workerCommand string
 	if dataDir != "" {
-		workerCommand = fmt.Sprintf(`nohup k0s --debug --data-dir=%s worker "%s" - >/tmp/k0s-worker.log 2>&1 &`, dataDir, token)
+		workerCommand = fmt.Sprintf(`nohup k0s --debug --data-dir=%s worker --labels="k0sproject.io/foo=bar" "%s" - >/tmp/k0s-worker.log 2>&1 &`, dataDir, token)
 	} else {
-		workerCommand = fmt.Sprintf(`nohup k0s --debug worker "%s" >/tmp/k0s-worker.log 2>&1 &`, token)
+		workerCommand = fmt.Sprintf(`nohup k0s --debug worker --labels="k0sproject.io/foo=bar" "%s" >/tmp/k0s-worker.log 2>&1 &`, token)
 	}
 
 	for i := 0; i < s.WorkerCount; i++ {
@@ -386,6 +386,15 @@ func (s *FootlooseSuite) WaitForNodeReady(node string, kc *kubernetes.Clientset)
 
 		return false, nil
 	})
+}
+
+// GetNodeLabels return the labels of given node
+func (s *FootlooseSuite) GetNodeLabels(node string, kc *kubernetes.Clientset) (map[string]string, error) {
+	n, err := kc.CoreV1().Nodes().Get(context.TODO(), node, v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return n.Labels, nil
 }
 
 // WaitForKubeAPI waits until we see kube API online on given node.

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -47,6 +47,7 @@ type Kubelet struct {
 	dataDir             string
 	supervisor          supervisor.Supervisor
 	ClusterDNS          string
+	Labels              []string
 }
 
 // Init extracts the needed binaries
@@ -93,6 +94,10 @@ func (k *Kubelet) Run() error {
 		"--runtime-cgroups":      "/system.slice/containerd.service",
 		"--kubelet-cgroups":      "/system.slice/containerd.service",
 		"--cert-dir":             filepath.Join(k.dataDir, "pki"),
+	}
+
+	if len(k.Labels) > 0 {
+		args["--node-labels"] = strings.Join(k.Labels, ",")
 	}
 
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>


**Issue**
Fixes #522

**What this PR Includes**
Enables users to set node labels for k0s workers.

E.g.
```
k0s worker --token-file k0s.token --labels="k0sproject.io/foo=bar"
```
results in:
```
/ # kubectl get node --show-labels
NAME      STATUS   ROLES    AGE   VERSION        LABELS
worker0   Ready    <none>   87s   v1.20.2-k0s1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,k0sproject.io/foo=bar,kubernetes.io/arch=amd64,kubernetes.io/hostname=worker0,kubernetes.io/os=linux
worker1   Ready    <none>   86s   v1.20.2-k0s1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,k0sproject.io/foo=bar,kubernetes.io/arch=amd64,kubernetes.io/hostname=worker1,kubernetes.io/os=linux
```