### PR TITLE
Fix for broken worker join in case of spec.api.address set to be ipv6 address

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	k8s.io/cli-runtime v0.20.2
 	k8s.io/client-go v0.20.2
 	k8s.io/kubectl v0.20.2
+	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 )
 
 // We need to force to a git commit of 3.4.13 release, see https://github.com/etcd-io/etcd/issues/12109

--- a/pkg/apis/v1beta1/dualstack.go
+++ b/pkg/apis/v1beta1/dualstack.go
@@ -1,5 +1,10 @@
 package v1beta1
 
+import (
+	"fmt"
+	"net"
+)
+
 // DualStack defines network configuration for ipv4\ipv6 mixed cluster setup
 type DualStack struct {
 	Enabled         bool   `yaml:"enabled,omitempty"`
@@ -19,6 +24,21 @@ func (ds DualStack) EnableDualStackFeatureGate(args map[string]string) {
 		fg = fg + ",IPv6DualStack=true"
 		args["feature-gates"] = fg
 	}
+}
+
+// InternalAPIAddress calculates the internal API address of configured service CIDR block.
+func (ds DualStack) InternalAPIAddress() (string, error) {
+	if !ds.Enabled {
+		return "", nil
+	}
+	_, ipnet, err := net.ParseCIDR(ds.IPv6ServiceCIDR)
+	if err != nil {
+		return "", fmt.Errorf("can't parse ds.IPv6ServiceCidr `%s`: %v", ds.IPv6ServiceCIDR, err)
+	}
+
+	address := ipnet.IP.To16()
+	address[15] = address[15] + 1
+	return address.String(), nil
 }
 
 // DefaultDualStack builds default values

--- a/pkg/apis/v1beta1/dualstack.go
+++ b/pkg/apis/v1beta1/dualstack.go
@@ -1,10 +1,5 @@
 package v1beta1
 
-import (
-	"fmt"
-	"net"
-)
-
 // DualStack defines network configuration for ipv4\ipv6 mixed cluster setup
 type DualStack struct {
 	Enabled         bool   `yaml:"enabled,omitempty"`
@@ -24,21 +19,6 @@ func (ds DualStack) EnableDualStackFeatureGate(args map[string]string) {
 		fg = fg + ",IPv6DualStack=true"
 		args["feature-gates"] = fg
 	}
-}
-
-// InternalAPIAddress calculates the internal API address of configured service CIDR block.
-func (ds DualStack) InternalAPIAddress() (string, error) {
-	if !ds.Enabled {
-		return "", nil
-	}
-	_, ipnet, err := net.ParseCIDR(ds.IPv6ServiceCIDR)
-	if err != nil {
-		return "", fmt.Errorf("can't parse ds.IPv6ServiceCidr `%s`: %v", ds.IPv6ServiceCIDR, err)
-	}
-
-	address := ipnet.IP.To16()
-	address[15] = address[15] + 1
-	return address.String(), nil
 }
 
 // DefaultDualStack builds default values

--- a/pkg/apis/v1beta1/network.go
+++ b/pkg/apis/v1beta1/network.go
@@ -82,7 +82,6 @@ func (n *Network) InternalAPIAddress() (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to parse service CIDR %s: %s", n.ServiceCIDR, err.Error())
 	}
-
 	address := ipnet.IP.To4()
 	address[3] = address[3] + 1
 	return address.String(), nil
@@ -109,7 +108,7 @@ func (n *Network) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // BuildServiceCIDR returns actual argument value for service cidr
 func (n *Network) BuildServiceCIDR() string {
 	if n.DualStack.Enabled {
-		return n.ServiceCIDR + "," + n.DualStack.IPv6ServiceCIDR
+		return n.DualStack.IPv6ServiceCIDR + "," + n.ServiceCIDR
 	}
 	return n.ServiceCIDR
 }
@@ -117,7 +116,7 @@ func (n *Network) BuildServiceCIDR() string {
 // BuildPodCIDR returns actual argument value for pod cidr
 func (n *Network) BuildPodCIDR() string {
 	if n.DualStack.Enabled {
-		return n.PodCIDR + "," + n.DualStack.IPv6PodCIDR
+		return n.DualStack.IPv6PodCIDR + "," + n.PodCIDR
 	}
 	return n.PodCIDR
 }

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -42,6 +42,7 @@ type APIServer struct {
 }
 
 var apiDefaultArgs = map[string]string{
+
 	"allow-privileged":                   "true",
 	"enable-admission-plugins":           "NodeRestriction",
 	"requestheader-extra-headers-prefix": "X-Remote-Extra-",

--- a/pkg/component/controller/certificates.go
+++ b/pkg/component/controller/certificates.go
@@ -210,20 +210,11 @@ func (c *Certificates) Init() error {
 
 	hostnames = append(hostnames, c.ClusterSpec.API.Sans()...)
 
-	internalAPIAddress, err := c.ClusterSpec.Network.InternalAPIAddress()
+	internalAPIAddress, err := c.ClusterSpec.Network.InternalAPIAddresses()
 	if err != nil {
 		return err
 	}
-	hostnames = append(hostnames, internalAPIAddress)
-
-	internalAPIAddressIPv6, err := c.ClusterSpec.Network.DualStack.InternalAPIAddress()
-	if err != nil {
-		return fmt.Errorf("can't parse IPv6 internal API address: %v", err)
-	}
-
-	if internalAPIAddressIPv6 != "" {
-		hostnames = append(hostnames, internalAPIAddressIPv6)
-	}
+	hostnames = append(hostnames, internalAPIAddress...)
 
 	eg.Go(func() error {
 		serverReq := certificate.Request{

--- a/pkg/component/controller/certificates.go
+++ b/pkg/component/controller/certificates.go
@@ -78,8 +78,8 @@ func (c *Certificates) Init() error {
 
 	eg, _ := errgroup.WithContext(context.Background())
 	// Common CA
-
-	caCertPath, caCertKey := filepath.Join(c.K0sVars.CertRootDir, "ca.crt"), filepath.Join(c.K0sVars.CertRootDir, "ca.key")
+	caCertPath := filepath.Join(c.K0sVars.CertRootDir, "ca.crt")
+	caCertKey := filepath.Join(c.K0sVars.CertRootDir, "ca.key")
 
 	if err := c.CertManager.EnsureCA("ca", "kubernetes-ca"); err != nil {
 		return err
@@ -215,6 +215,15 @@ func (c *Certificates) Init() error {
 		return err
 	}
 	hostnames = append(hostnames, internalAPIAddress)
+
+	internalAPIAddressIPv6, err := c.ClusterSpec.Network.DualStack.InternalAPIAddress()
+	if err != nil {
+		return fmt.Errorf("can't parse IPv6 internal API address: %v", err)
+	}
+
+	if internalAPIAddressIPv6 != "" {
+		hostnames = append(hostnames, internalAPIAddressIPv6)
+	}
 
 	eg.Go(func() error {
 		serverReq := certificate.Request{


### PR DESCRIPTION
Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>

---
name: Pull Request
about: Create a Pull Request
title: ''
labels: ''
assignees: ''

---

**Issue**
Fixes #688

**What this PR Includes**
    Change the way spec.network.api build API urls (use brackets in case of ipv6 address).
    Change order in CIDR definitions in case of dualstack
    Add ipv6 address to the apiserver certificate, if dualstack is enabled