### PR TITLE
fix the path order for k0s components

### DIFF
--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -175,7 +175,7 @@ func getEnv(dataDir string) []string {
 	env := os.Environ()
 	for i, e := range env {
 		if strings.HasPrefix(e, "PATH=") {
-			env[i] = fmt.Sprintf("PATH=%s:%s", os.Getenv("PATH"), path.Join(dataDir, "bin"))
+			env[i] = fmt.Sprintf("PATH=%s:%s", path.Join(dataDir, "bin"), os.Getenv("PATH"))
 		}
 	}
 	return env


### PR DESCRIPTION
Signed-off-by: Karen Almog <kalmog@mirantis.com>

**What this PR Includes**
supervisor components path is currently passed to the end of the PATH variable, which might cause external components to be used instead of k0s internal components. This PR fixes this.