### PR TITLE
Fix order of PATH for binaries

### DIFF
--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -175,7 +175,7 @@ func getEnv(dataDir string) []string {
 	env := os.Environ()
 	for i, e := range env {
 		if strings.HasPrefix(e, "PATH=") {
-			env[i] = fmt.Sprintf("PATH=%s:%s", os.Getenv("PATH"), path.Join(dataDir, "bin"))
+			env[i] = fmt.Sprintf("PATH=%s:%s", path.Join(dataDir, "bin"), os.Getenv("PATH"))
 		}
 	}
 	return env


### PR DESCRIPTION
Search the k0s path first so those binaries are preferred over system
binaries.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

---
name: Pull Request
about: Create a Pull Request
title: ''
labels: ''
assignees: ''

