### PR TITLE
Fix regression: kubeconfig cmd prints log output

### DIFF
--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -86,8 +86,7 @@ Note: A certificate once signed cannot be revoked for a particular user`,
 	optionally add groups:
 	$ k0s kubeconfig create [username] --groups [groups]`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Disable logrus and cfssl logging for user commands to avoid printing debug info to stdout
-			logrus.SetLevel(logrus.FatalLevel)
+			// disable cfssl log
 			log.Level = log.LevelFatal
 
 			if len(args) == 0 {
@@ -180,6 +179,9 @@ Note: A certificate once signed cannot be revoked for a particular user`,
 )
 
 func getAPIURL() (string, error) {
+	// Disable logrus
+	logrus.SetLevel(logrus.FatalLevel)
+
 	clusterConfig, err := ConfigFromYaml(cfgFile)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Signed-off-by: Karen Almog <kalmog@mirantis.com>

---

**Issue**
PR #669 introduced a regression where by moving the config parsing function, the `k0s kubeconfig admin` command again prints out log lines at the top of the kubeconfig file in the following form:

```
time="2021-02-12 08:42:10" level=warning msg="Failed to read cluster config: failed to read config file at /home/ubuntu/src_k0s/k0s.yaml: open /home/ubuntu/sr
c_k0s/k0s.yaml: no such file or directory"
time="2021-02-12 08:42:10" level=info msg="Using default config"
```
**What this PR Includes**
This PR fixes the described issue above.