### PR TITLE
resolve conflict between k0s global flags and kubectl subcommand flags

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -42,6 +42,10 @@ import (
 	"github.com/k0sproject/k0s/pkg/kubernetes"
 )
 
+func init() {
+	addPersistentFlags(APICmd)
+}
+
 var (
 	kubeClient    k8s.Interface
 	clusterConfig *v1beta1.ClusterConfig

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -54,8 +54,7 @@ func init() {
 	controllerCmd.Flags().StringVar(&tokenFile, "token-file", "", "Path to the file containing join-token.")
 	controllerCmd.Flags().StringVar(&criSocket, "cri-socket", "", "contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]")
 	controllerCmd.Flags().StringToStringVarP(&cmdLogLevels, "logging", "l", defaultLogLevels, "Logging Levels for the different components")
-	installControllerCmd.Flags().AddFlagSet(controllerCmd.Flags())
-
+	addPersistentFlags(controllerCmd)
 }
 
 var (

--- a/cmd/etcd.go
+++ b/cmd/etcd.go
@@ -31,6 +31,7 @@ func init() {
 
 	etcdCmd.AddCommand(etcdLeaveCmd)
 	etcdCmd.AddCommand(etcdListCmd)
+	addPersistentFlags(etcdCmd)
 }
 
 var (

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -30,6 +30,7 @@ import (
 func init() {
 	installCmd.AddCommand(installControllerCmd)
 	installCmd.AddCommand(installWorkerCmd)
+	addPersistentFlags(installCmd)
 }
 
 var (

--- a/cmd/installController.go
+++ b/cmd/installController.go
@@ -19,6 +19,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func init() {
+	installControllerCmd.Flags().AddFlagSet(controllerCmd.Flags())
+}
+
 var (
 	installControllerCmd = &cobra.Command{
 		Use:   "controller",

--- a/cmd/installWorker.go
+++ b/cmd/installWorker.go
@@ -19,6 +19,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func init() {
+	installWorkerCmd.Flags().AddFlagSet(workerCmd.Flags())
+}
+
 var (
 	installWorkerCmd = &cobra.Command{
 		Use:   "worker",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,10 +21,10 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/spf13/cobra/doc"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/k0sproject/k0s/pkg/build"
@@ -53,11 +53,10 @@ var defaultLogLevels = map[string]string{
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default: ./k0s.yaml)")
 	rootCmd.PersistentFlags().StringVar(&dataDir, "data-dir", "", "Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!")
 	rootCmd.PersistentFlags().StringVar(&debugListenOn, "debugListenOn", ":6060", "Http listenOn for debug pprof handler")
-	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Debug logging (default: false)")
 
+	addPersistentFlags(rootCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(tokenCmd)
@@ -78,7 +77,6 @@ func init() {
 	if build.EulaNotice != "" {
 		longDesc = longDesc + "\n" + build.EulaNotice
 	}
-
 	rootCmd.Long = longDesc
 }
 
@@ -141,6 +139,13 @@ func setLogging(inputLogs map[string]string) map[string]string {
 		defaultLogLevels[k] = inputLogs[k]
 	}
 	return defaultLogLevels
+}
+
+func addPersistentFlags(cmd *cobra.Command) {
+	flagset := &pflag.FlagSet{}
+	flagset.StringVarP(&cfgFile, "config", "c", "", "config file (default: ./k0s.yaml)")
+	flagset.BoolVarP(&debug, "debug", "d", false, "Debug logging (default: false)")
+	cmd.Flags().AddFlagSet(flagset)
 }
 
 func Execute() {

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -29,6 +29,7 @@ func init() {
 	tokenCmd.AddCommand(tokenCreateCmd)
 	tokenCmd.AddCommand(tokenListCmd)
 	tokenCmd.AddCommand(tokenInvalidateCmd)
+	addPersistentFlags(tokenCmd)
 }
 
 var (

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -46,7 +46,9 @@ var (
 
 func init() {
 	validateCmd.AddCommand(validateConfigCmd)
+	addPersistentFlags(validateCmd)
 }
+
 func validateConfig(cfgPath string) (err error) {
 	var clusterConfig *config.ClusterConfig
 

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -49,20 +49,19 @@ func init() {
 	workerCmd.Flags().StringToStringVarP(&cmdLogLevels, "logging", "l", defaultLogLevels, "Logging Levels for the different components")
 	workerCmd.Flags().StringSliceVarP(&labels, "labels", "", []string{}, "Node labels, list of key=value pairs")
 	installWorkerCmd.Flags().AddFlagSet(workerCmd.Flags())
+	addPersistentFlags(workerCmd)
 }
 
 var (
-	workerProfile string
-	tokenArg      string
-	tokenFile     string
-	criSocket     string
 	apiServer     string
 	cidrRange     string
-	clusterDNS    string
-
 	cloudProvider bool
-
-	labels []string
+	clusterDNS    string
+	criSocket     string
+	labels        []string
+	tokenArg      string
+	tokenFile     string
+	workerProfile string
 
 	workerCmd = &cobra.Command{
 		Use:   "worker [join-token]",


### PR DESCRIPTION
Signed-off-by: Karen Almog <kalmog@mirantis.com>

---

**Issue**
This PR fixes an issue with a collision between one of k0s persistent cobra flags and a nested kubectl command flag.
