### PR TITLE
Token invalidation

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -28,6 +28,7 @@ func init() {
 
 	tokenCmd.AddCommand(tokenCreateCmd)
 	tokenCmd.AddCommand(tokenListCmd)
+	tokenCmd.AddCommand(tokenInvalidateCmd)
 }
 
 var (
@@ -40,8 +41,5 @@ var (
 	tokenCmd = &cobra.Command{
 		Use:   "token",
 		Short: "Manage join tokens",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return tokenCreateCmd.Usage()
-		},
 	}
 )

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -16,23 +16,8 @@ limitations under the License.
 package cmd
 
 import (
-	"bytes"
-	"encoding/base64"
-	"fmt"
-	"html/template"
-	"io/ioutil"
-	"path/filepath"
-	"time"
-
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
-
-	config "github.com/k0sproject/k0s/pkg/apis/v1beta1"
-	"github.com/k0sproject/k0s/pkg/token"
 )
 
 func init() {
@@ -40,17 +25,9 @@ func init() {
 	if kubeConfig == "" {
 		kubeConfig = viper.GetString("KUBECONFIG")
 	}
-	tokenCreateCmd.Flags().StringVar(&tokenExpiry, "expiry", "0s", "Expiration time of the token. Format 1.5h, 2h45m or 300ms.")
-	tokenCreateCmd.Flags().StringVar(&tokenRole, "role", "worker", "Either worker or controller")
-	tokenCreateCmd.Flags().BoolVar(&waitCreate, "wait", false, "wait forever (default false)")
-
-	// shell completion options
-	_ = tokenCreateCmd.MarkFlagRequired("role")
-	_ = tokenCreateCmd.RegisterFlagCompletionFunc("role", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"worker", "controller"}, cobra.ShellCompDirectiveDefault
-	})
 
 	tokenCmd.AddCommand(tokenCreateCmd)
+	tokenCmd.AddCommand(tokenListCmd)
 }
 
 var (
@@ -58,27 +35,6 @@ var (
 	tokenExpiry string
 	tokenRole   string
 	waitCreate  bool
-
-	kubeconfigTemplate = template.Must(template.New("kubeconfig").Parse(`
-apiVersion: v1
-clusters:
-- cluster:
-    server: {{.JoinURL}}
-    certificate-authority-data: {{.CACert}}
-  name: k0s
-contexts:
-- context:
-    cluster: k0s
-    user: {{.User}}
-  name: k0s
-current-context: k0s
-kind: Config
-preferences: {}
-users:
-- name: {{.User}}
-  user:
-    token: {{.Token}}
-`))
 
 	// tokenCmd creates new token management command
 	tokenCmd = &cobra.Command{
@@ -88,88 +44,4 @@ users:
 			return tokenCreateCmd.Usage()
 		},
 	}
-
-	tokenCreateCmd = &cobra.Command{
-		Use:   "create",
-		Short: "Create join token",
-		Example: `k0s token create --role worker --expiry 100h //sets expiration time to 100 hours
-k0s token create --role worker --expiry 10m  //sets expiration time to 10 minutes
-`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// Disable logrus for token commands
-			logrus.SetLevel(logrus.FatalLevel)
-
-			clusterConfig, err := ConfigFromYaml(cfgFile)
-			if err != nil {
-				return err
-			}
-			expiry, err := time.ParseDuration(tokenExpiry)
-			if err != nil {
-				return err
-			}
-
-			var bootstrapConfig string
-			// we will retry every second for two minutes and then error
-			err = retry.OnError(wait.Backoff{
-				Steps:    120,
-				Duration: 1 * time.Second,
-				Factor:   1.0,
-				Jitter:   0.1,
-			}, func(err error) bool {
-				return waitCreate
-			}, func() error {
-				bootstrapConfig, err = createKubeletBootstrapConfig(clusterConfig, tokenRole, expiry)
-
-				return err
-			})
-			if err != nil {
-				return err
-			}
-
-			fmt.Println(bootstrapConfig)
-
-			return nil
-		},
-	}
 )
-
-func createKubeletBootstrapConfig(clusterConfig *config.ClusterConfig, role string, expiry time.Duration) (string, error) {
-	caCert, err := ioutil.ReadFile(filepath.Join(k0sVars.CertRootDir, "ca.crt"))
-	if err != nil {
-		msg := fmt.Sprintf("failed to read cluster ca certificate from %s. is the control plane initialized on this node?", filepath.Join(k0sVars.CertRootDir, "ca.crt"))
-		return "", errors.Wrapf(err, msg)
-	}
-	manager, err := token.NewManager(filepath.Join(k0sVars.AdminKubeConfigPath))
-	if err != nil {
-		return "", err
-	}
-	tokenString, err := manager.Create(expiry, role)
-	if err != nil {
-		return "", err
-	}
-	data := struct {
-		CACert  string
-		Token   string
-		User    string
-		JoinURL string
-		APIUrl  string
-	}{
-		CACert: base64.StdEncoding.EncodeToString(caCert),
-		Token:  tokenString,
-	}
-	if role == "worker" {
-		data.User = "kubelet-bootstrap"
-		data.JoinURL = clusterConfig.Spec.API.APIAddressURL()
-	} else {
-		data.User = "controller-bootstrap"
-		data.JoinURL = clusterConfig.Spec.API.K0sControlPlaneAPIAddress()
-	}
-
-	var buf bytes.Buffer
-
-	err = kubeconfigTemplate.Execute(&buf, &data)
-	if err != nil {
-		return "", err
-	}
-	return token.JoinEncode(&buf)
-}

--- a/cmd/tokencreate.go
+++ b/cmd/tokencreate.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2020 Mirantis, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"path/filepath"
+	"time"
+
+	config "github.com/k0sproject/k0s/pkg/apis/v1beta1"
+	"github.com/k0sproject/k0s/pkg/token"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+)
+
+func init() {
+	tokenCreateCmd.Flags().StringVar(&tokenExpiry, "expiry", "0s", "Expiration time of the token. Format 1.5h, 2h45m or 300ms.")
+	tokenCreateCmd.Flags().StringVar(&tokenRole, "role", "worker", "Either worker or controller")
+	tokenCreateCmd.Flags().BoolVar(&waitCreate, "wait", false, "wait forever (default false)")
+
+	// shell completion options
+	_ = tokenCreateCmd.MarkFlagRequired("role")
+	_ = tokenCreateCmd.RegisterFlagCompletionFunc("role", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"worker", "controller"}, cobra.ShellCompDirectiveDefault
+	})
+}
+
+var (
+	kubeconfigTemplate = template.Must(template.New("kubeconfig").Parse(`
+apiVersion: v1
+clusters:
+- cluster:
+    server: {{.JoinURL}}
+    certificate-authority-data: {{.CACert}}
+  name: k0s
+contexts:
+- context:
+    cluster: k0s
+    user: {{.User}}
+  name: k0s
+current-context: k0s
+kind: Config
+preferences: {}
+users:
+- name: {{.User}}
+  user:
+    token: {{.Token}}
+`))
+
+	tokenCreateCmd = &cobra.Command{
+		Use:   "create",
+		Short: "Create join token",
+		Example: `k0s token create --role worker --expiry 100h //sets expiration time to 100 hours
+k0s token create --role worker --expiry 10m  //sets expiration time to 10 minutes
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Disable logrus for token commands
+			logrus.SetLevel(logrus.FatalLevel)
+
+			clusterConfig, err := ConfigFromYaml(cfgFile)
+			if err != nil {
+				return err
+			}
+			expiry, err := time.ParseDuration(tokenExpiry)
+			if err != nil {
+				return err
+			}
+
+			var bootstrapConfig string
+			// we will retry every second for two minutes and then error
+			err = retry.OnError(wait.Backoff{
+				Steps:    120,
+				Duration: 1 * time.Second,
+				Factor:   1.0,
+				Jitter:   0.1,
+			}, func(err error) bool {
+				return waitCreate
+			}, func() error {
+				bootstrapConfig, err = createKubeletBootstrapConfig(clusterConfig, tokenRole, expiry)
+
+				return err
+			})
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(bootstrapConfig)
+
+			return nil
+		},
+	}
+)
+
+func createKubeletBootstrapConfig(clusterConfig *config.ClusterConfig, role string, expiry time.Duration) (string, error) {
+	caCert, err := ioutil.ReadFile(filepath.Join(k0sVars.CertRootDir, "ca.crt"))
+	if err != nil {
+		msg := fmt.Sprintf("failed to read cluster ca certificate from %s. is the control plane initialized on this node?", filepath.Join(k0sVars.CertRootDir, "ca.crt"))
+		return "", errors.Wrapf(err, msg)
+	}
+	manager, err := token.NewManager(filepath.Join(k0sVars.AdminKubeConfigPath))
+	if err != nil {
+		return "", err
+	}
+	tokenString, err := manager.Create(expiry, role)
+	if err != nil {
+		return "", err
+	}
+	data := struct {
+		CACert  string
+		Token   string
+		User    string
+		JoinURL string
+		APIUrl  string
+	}{
+		CACert: base64.StdEncoding.EncodeToString(caCert),
+		Token:  tokenString,
+	}
+	if role == "worker" {
+		data.User = "kubelet-bootstrap"
+		data.JoinURL = clusterConfig.Spec.API.APIAddressURL()
+	} else {
+		data.User = "controller-bootstrap"
+		data.JoinURL = clusterConfig.Spec.API.K0sControlPlaneAPIAddress()
+	}
+
+	var buf bytes.Buffer
+
+	err = kubeconfigTemplate.Execute(&buf, &data)
+	if err != nil {
+		return "", err
+	}
+	return token.JoinEncode(&buf)
+}

--- a/cmd/tokeninvalidate.go
+++ b/cmd/tokeninvalidate.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 Mirantis, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/k0sproject/k0s/pkg/token"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+
+}
+
+var (
+	tokenInvalidateCmd = &cobra.Command{
+		Use:     "invalidate",
+		Short:   "Invalidates existing join token",
+		Example: "k0s token invalidate xyz123",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return fmt.Errorf("invalidate requires at least one token Id to invalidate")
+			}
+			manager, err := token.NewManager(filepath.Join(k0sVars.AdminKubeConfigPath))
+			if err != nil {
+				return err
+			}
+
+			for _, id := range args {
+				err := manager.Remove(id)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("token %s deleted succesfully\n", id)
+			}
+			return nil
+		},
+	}
+)

--- a/cmd/tokenlist.go
+++ b/cmd/tokenlist.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2020 Mirantis, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/k0sproject/k0s/pkg/token"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	tokenListCmd.Flags().StringVar(&tokenRole, "role", "", "Either worker,controller or empty for all roles")
+}
+
+var (
+	tokenListCmd = &cobra.Command{
+		Use:     "list",
+		Short:   "List join tokens",
+		Example: `k0s token list --role worker // list worker tokens`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			manager, err := token.NewManager(filepath.Join(k0sVars.AdminKubeConfigPath))
+			if err != nil {
+				return err
+			}
+
+			tokens, err := manager.List(tokenRole)
+			if err != nil {
+				return err
+			}
+			if len(tokens) == 0 {
+				fmt.Println("No k0s join tokens found")
+				return nil
+			}
+
+			//fmt.Printf("Tokens: %v \n", tokens)
+			table := tablewriter.NewWriter(os.Stdout)
+			table.SetHeader([]string{"ID", "Role", "Expires at"})
+			table.SetAutoWrapText(false)
+			table.SetAutoFormatHeaders(true)
+			table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+			table.SetAlignment(tablewriter.ALIGN_LEFT)
+			table.SetCenterSeparator("")
+			table.SetColumnSeparator("")
+			table.SetRowSeparator("")
+			table.SetHeaderLine(false)
+			table.SetBorder(false)
+			table.SetTablePadding("\t") // pad with tabs
+			table.SetNoWhiteSpace(true)
+			for _, t := range tokens {
+				table.Append(t.ToArray())
+			}
+
+			table.Render()
+
+			return nil
+		},
+	}
+)

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/olekukonko/tablewriter v0.0.2
 	github.com/onsi/ginkgo v1.14.1 // indirect
 	github.com/onsi/gomega v1.10.2 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -651,6 +651,7 @@ github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQ
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
+github.com/olekukonko/tablewriter v0.0.2 h1:sq53g+DWf0J6/ceFUHpQ0nAEb6WgM++fq16MZ91cS6o=
 github.com/olekukonko/tablewriter v0.0.2/go.mod h1:rSAaSIOAGT9odnlyGlUfAJaoc5w2fSBUmeGDbRWPxyQ=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION

**Issue**
Fixes #617

**What this PR Includes**
This PR adds two commands:
- `k0s token list`, with the possibility to filter based on `--role=worker|controller`
- `k0s token invalidate xyz123 boobaa`

This makes it possible for the cluster admin to actually go and invalidate (remove) an existing token so it cannot be used to join a new node to the cluster.