### PR TITLE
Add tini as init process into k0s container images 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12
 
-RUN apk add --no-cache bash coreutils findutils iptables curl
+RUN apk add --no-cache bash coreutils findutils iptables curl tini
 
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.20.1/bin/linux/amd64/kubectl \
        && chmod +x ./kubectl \
@@ -9,6 +9,8 @@ ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
 ADD docker-entrypoint.sh /entrypoint.sh
 ADD ./k0s /usr/local/bin/k0s 
-ENTRYPOINT [ "/bin/sh", "/entrypoint.sh" ]
+
+ENTRYPOINT ["/sbin/tini", "--", "/bin/sh", "/entrypoint.sh" ]
+
 
 CMD ["k0s", "controller", "--enable-worker"]


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Fixes #698

**What this PR Includes**
This PR adds tini as init process so we do not "leak" zombies.