### PR TITLE
Make config parsing fail when reading invalid or non-existing config

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -27,16 +27,17 @@ import (
 
 // ConfigFromYaml returns given k0s config or default config
 func ConfigFromYaml(cfgPath string) (clusterConfig *config.ClusterConfig, err error) {
-	if isInputFromPipe() {
+	if cfgPath == "" {
+		logrus.Info("no config file given, using defaults")
+		clusterConfig = config.DefaultClusterConfig()
+	} else if isInputFromPipe() {
 		clusterConfig, err = config.FromYamlPipe(os.Stdin)
 	} else {
 		clusterConfig, err = config.FromYamlFile(cfgPath)
 	}
 
 	if err != nil {
-		logrus.Warnf("Failed to read cluster config: %s", err.Error())
-		logrus.Info("Using default config")
-		clusterConfig = config.DefaultClusterConfig()
+		return nil, err
 	}
 	// validate
 	errors := clusterConfig.Validate()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra/doc"
 
@@ -28,7 +27,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/k0sproject/k0s/internal/util"
 	"github.com/k0sproject/k0s/pkg/build"
 	"github.com/k0sproject/k0s/pkg/constant"
 )
@@ -59,12 +57,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&dataDir, "data-dir", "", "Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!")
 	rootCmd.PersistentFlags().StringVar(&debugListenOn, "debugListenOn", ":6060", "Http listenOn for debug pprof handler")
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Debug logging (default: false)")
-
-	// initialize configuration
-	err := initConfig()
-	if err != nil {
-		fmt.Printf("err: %v", err)
-	}
 
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(configCmd)
@@ -135,28 +127,6 @@ var (
 		},
 	}
 )
-
-func initConfig() error {
-	// look for k0s.yaml in PWD
-	if cfgFile == "" {
-		execFolderPath, err := os.Getwd()
-		if err != nil {
-			return err
-		}
-		cfgFile = filepath.Join(execFolderPath, "k0s.yaml")
-	}
-
-	// check if config file exists
-	if util.FileExists(cfgFile) {
-		viper.SetConfigFile(cfgFile)
-		logrus.Debugf("Using config file: %v", cfgFile)
-	}
-
-	// Add env vars to Config
-	viper.AutomaticEnv()
-
-	return nil
-}
 
 func generateDocs() error {
 	if err := doc.GenMarkdownTree(rootCmd, "./docs/cli"); err != nil {

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -32,7 +32,7 @@ type BasicSuite struct {
 
 func (s *BasicSuite) TestK0sGetsUp() {
 	customDataDir := "/var/lib/k0s/custom-data-dir"
-	s.NoError(s.InitMainController("/tmp/k0s.yaml", customDataDir))
+	s.NoError(s.InitMainController("", customDataDir))
 	s.NoError(s.RunWorkers(customDataDir))
 
 	kc, err := s.KubeClient("controller0", customDataDir)

--- a/inttest/byocri/byocri_test.go
+++ b/inttest/byocri/byocri_test.go
@@ -33,7 +33,7 @@ type BYOCRISuite struct {
 
 func (s *BYOCRISuite) TestK0sGetsUp() {
 
-	s.NoError(s.InitMainController("/tmp/k0s.yaml", ""))
+	s.NoError(s.InitMainController("", ""))
 	s.Require().NoError(s.runDockerWorker())
 
 	kc, err := s.KubeClient("controller0", "")

--- a/inttest/hacontrolplane/hacontrolplane_test.go
+++ b/inttest/hacontrolplane/hacontrolplane_test.go
@@ -74,7 +74,7 @@ func (s *HAControlplaneSuite) getCa(controllerIdx int) string {
 }
 
 func (s *HAControlplaneSuite) TestDeregistration() {
-	s.NoError(s.InitMainController("/tmp/k0s.yaml", ""))
+	s.NoError(s.InitMainController("", ""))
 	token, err := s.GetJoinToken("controller", "")
 	s.NoError(err)
 	s.NoError(s.JoinController(1, token, ""))


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Fixes #705 

**What this PR Includes**

Currently when k0s commands are reading a non-existing config or invalid config it'll, sometimes even silently, fall back to use default config. This PR makes the config parsing actually fail the commands properly.