### PR TITLE
Fix leftover server role references in install command

### DIFF
--- a/cmd/installController.go
+++ b/cmd/installController.go
@@ -21,8 +21,9 @@ import (
 
 var (
 	installControllerCmd = &cobra.Command{
-		Use:   "controller",
-		Short: "Helper command for setting up k0s as controller node on a brand-new system. Must be run as root (or with sudo)",
+		Use:     "controller",
+		Short:   "Helper command for setting up k0s as controller node on a brand-new system. Must be run as root (or with sudo)",
+		Aliases: []string{"server"},
 		Example: `All default values of controller command will be passed to the service stub unless overriden. 
 
 With controller subcommand you can setup a single node cluster by running:
@@ -30,9 +31,9 @@ With controller subcommand you can setup a single node cluster by running:
 	k0s install controller --enable-worker
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			flagsAndVals := []string{"server"}
+			flagsAndVals := []string{"controller"}
 			flagsAndVals = append(flagsAndVals, cmdFlagsToArgs(cmd)...)
-			return setup("server", flagsAndVals)
+			return setup("controller", flagsAndVals)
 		},
 	}
 )

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -28,7 +28,6 @@ func cmdFlagsToArgs(cmd *cobra.Command) []string {
 	flagsAndVals := []string{}
 	// Use visitor to collect all flags and vals into slice
 	cmd.Flags().Visit(func(f *pflag.Flag) {
-		fmt.Println("flag type:", f.Value.Type())
 		switch f.Value.Type() {
 		case "stringSlice", "stringToString":
 			val := f.Value.String()


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>


**Issue**
Currently when running `k0s install controller` the service unit gets created as `k0s.service` as the code still tries to match `server` role in install.

**What this PR Includes**
Fixes the leftover server role references in install command functionality.