### PR TITLE
Disable leader elector on single controllers setup (#540)

### DIFF
--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -221,7 +221,12 @@ func startController(token string) error {
 
 	// One leader elector per controller
 	// TODO: Make all other needed components use this "global" leader elector
-	leaderElector := controller.NewLeaderElector(clusterConfig, adminClientFactory)
+	var leaderElector controller.LeaderElector
+	if clusterConfig.Spec.API.ExternalAddress != "" {
+		leaderElector = controller.NewLeaderElector(clusterConfig, adminClientFactory)
+	} else {
+		leaderElector = &controller.DummyLeaderElector{Leader: true}
+	}
 	componentManager.Add(leaderElector)
 
 	if clusterConfig.Spec.API.ExternalAddress != "" {

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -278,7 +278,7 @@ func startController(token string) error {
 	}
 
 	// in-cluster component reconcilers
-	reconcilers := createClusterReconcilers(clusterConfig, k0sVars, adminClientFactory)
+	reconcilers := createClusterReconcilers(clusterConfig, k0sVars, adminClientFactory, leaderElector)
 	if err == nil {
 		perfTimer.Checkpoint("starting-reconcilers")
 
@@ -324,7 +324,7 @@ func startController(token string) error {
 	return nil
 }
 
-func createClusterReconcilers(clusterConf *config.ClusterConfig, k0sVars constant.CfgVars, cf kubernetes.ClientFactory) map[string]component.Component {
+func createClusterReconcilers(clusterConf *config.ClusterConfig, k0sVars constant.CfgVars, cf kubernetes.ClientFactory, leaderElector controller.LeaderElector) map[string]component.Component {
 	reconcilers := make(map[string]component.Component)
 	clusterSpec := clusterConf.Spec
 
@@ -356,7 +356,7 @@ func createClusterReconcilers(clusterConf *config.ClusterConfig, k0sVars constan
 		logrus.Warnf("failed to initialize reconcilers manifests saver: %s", err.Error())
 	}
 	reconcilers["crd"] = controller.NewCRD(manifestsSaver)
-	reconcilers["helmAddons"] = controller.NewHelmAddons(clusterConf, manifestsSaver, k0sVars, cf)
+	reconcilers["helmAddons"] = controller.NewHelmAddons(clusterConf, manifestsSaver, k0sVars, cf, leaderElector)
 
 	metricServer, err := controller.NewMetricServer(clusterConf, k0sVars, cf)
 	if err != nil {

--- a/pkg/component/controller/apiendpointreconciler_test.go
+++ b/pkg/component/controller/apiendpointreconciler_test.go
@@ -27,30 +27,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type fakeAlwaysLeaderElector struct {
-}
-
-func (f *fakeAlwaysLeaderElector) Run() error     { return nil }
-func (f *fakeAlwaysLeaderElector) Init() error    { return nil }
-func (f *fakeAlwaysLeaderElector) Stop() error    { return nil }
-func (f *fakeAlwaysLeaderElector) Healthy() error { return nil }
-
-func (f *fakeAlwaysLeaderElector) IsLeader() bool {
-	return true
-}
-
-type fakeNeverLeaderElector struct {
-}
-
-func (f *fakeNeverLeaderElector) Run() error     { return nil }
-func (f *fakeNeverLeaderElector) Init() error    { return nil }
-func (f *fakeNeverLeaderElector) Stop() error    { return nil }
-func (f *fakeNeverLeaderElector) Healthy() error { return nil }
-
-func (f *fakeNeverLeaderElector) IsLeader() bool {
-	return false
-}
-
 var expectedAddresses = []string{
 	"185.199.108.153",
 	"185.199.109.153",
@@ -70,7 +46,7 @@ func TestBasicReconcilerWithNoLeader(t *testing.T) {
 		},
 	}
 
-	r := NewEndpointReconciler(config, &fakeNeverLeaderElector{}, fakeFactory)
+	r := NewEndpointReconciler(config, &DummyLeaderElector{Leader: false}, fakeFactory)
 
 	assert.NoError(t, r.Init())
 
@@ -95,7 +71,7 @@ func TestBasicReconcilerWithNoExistingEndpoint(t *testing.T) {
 		},
 	}
 
-	r := NewEndpointReconciler(config, &fakeAlwaysLeaderElector{}, fakeFactory)
+	r := NewEndpointReconciler(config, &DummyLeaderElector{Leader: true}, fakeFactory)
 
 	assert.NoError(t, r.Init())
 
@@ -129,7 +105,7 @@ func TestBasicReconcilerWithEmptyEndpointSubset(t *testing.T) {
 		},
 	}
 
-	r := NewEndpointReconciler(config, &fakeAlwaysLeaderElector{}, fakeFactory)
+	r := NewEndpointReconciler(config, &DummyLeaderElector{Leader: true}, fakeFactory)
 
 	assert.NoError(t, r.Init())
 
@@ -170,7 +146,7 @@ func TestReconcilerWithNoNeedForUpdate(t *testing.T) {
 			},
 		},
 	}
-	r := NewEndpointReconciler(config, &fakeAlwaysLeaderElector{}, fakeFactory)
+	r := NewEndpointReconciler(config, &DummyLeaderElector{Leader: true}, fakeFactory)
 
 	assert.NoError(t, r.Init())
 

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -110,6 +110,11 @@ func (a *Manager) Run() error {
 	for name, value := range args {
 		cmArgs = append(cmArgs, fmt.Sprintf("--%s=%s", name, value))
 	}
+
+	if a.ClusterConfig.Spec.API.ExternalAddress == "" {
+		cmArgs = append(cmArgs, "--leader-elect=false")
+	}
+
 	a.supervisor = supervisor.Supervisor{
 		Name:    "kube-controller-manager",
 		BinPath: assets.BinPath("kube-controller-manager", a.K0sVars.BinDir),

--- a/pkg/component/controller/csrapprover_test.go
+++ b/pkg/component/controller/csrapprover_test.go
@@ -70,7 +70,7 @@ func TestBasicCRSApprover(t *testing.T) {
 			},
 		},
 	}
-	c := NewCSRApprover(config, &fakeAlwaysLeaderElector{}, fakeFactory)
+	c := NewCSRApprover(config, &DummyLeaderElector{Leader: true}, fakeFactory)
 
 	assert.NoError(t, c.Init())
 	assert.NoError(t, c.approveCSR())

--- a/pkg/component/controller/dummyleaderelector.go
+++ b/pkg/component/controller/dummyleaderelector.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2021 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controller
+
+type DummyLeaderElector struct {
+	Leader bool
+}
+
+func (l *DummyLeaderElector) Init() error    { return nil }
+func (l *DummyLeaderElector) Run() error     { return nil }
+func (l *DummyLeaderElector) Stop() error    { return nil }
+func (l *DummyLeaderElector) IsLeader() bool { return l.Leader }
+func (l *DummyLeaderElector) Healthy() error { return nil }

--- a/pkg/component/controller/dummyleaderelector.go
+++ b/pkg/component/controller/dummyleaderelector.go
@@ -16,11 +16,29 @@ limitations under the License.
 package controller
 
 type DummyLeaderElector struct {
-	Leader bool
+	Leader    bool
+	callbacks []func()
 }
 
 func (l *DummyLeaderElector) Init() error    { return nil }
-func (l *DummyLeaderElector) Run() error     { return nil }
 func (l *DummyLeaderElector) Stop() error    { return nil }
 func (l *DummyLeaderElector) IsLeader() bool { return l.Leader }
 func (l *DummyLeaderElector) Healthy() error { return nil }
+
+func (l *DummyLeaderElector) AddAcquiredLeaseCallback(fn func()) {
+	l.callbacks = append(l.callbacks, fn)
+}
+
+func (l *DummyLeaderElector) AddLostLeaseCallback(fn func()) {}
+
+func (l *DummyLeaderElector) Run() error {
+	if !l.Leader {
+		return nil
+	}
+	for _, fn := range l.callbacks {
+		if fn != nil {
+			fn()
+		}
+	}
+	return nil
+}

--- a/pkg/component/controller/leaderelector.go
+++ b/pkg/component/controller/leaderelector.go
@@ -31,6 +31,8 @@ import (
 // LeaderElector is the common leader elector component to manage each controller leader status
 type LeaderElector interface {
 	IsLeader() bool
+	AddAcquiredLeaseCallback(fn func())
+	AddLostLeaseCallback(fn func())
 	component.Component
 }
 

--- a/pkg/component/controller/leaderelector.go
+++ b/pkg/component/controller/leaderelector.go
@@ -43,6 +43,9 @@ type leaderElector struct {
 	leaderStatus      atomic.Value
 	kubeClientFactory kubeutil.ClientFactory
 	leaseCancel       context.CancelFunc
+
+	acquiredLeaseCallbacks []func()
+	lostLeaseCallbacks     []func()
 }
 
 // NewLeaderElector creates new leader elector
@@ -84,13 +87,31 @@ func (l *leaderElector) Run() error {
 			case <-events.AcquiredLease:
 				l.L.Info("acquired leader lease")
 				l.leaderStatus.Store(true)
+				runCallbacks(l.acquiredLeaseCallbacks)
 			case <-events.LostLease:
 				l.L.Info("lost leader lease")
 				l.leaderStatus.Store(false)
+				runCallbacks(l.lostLeaseCallbacks)
 			}
 		}
 	}()
 	return nil
+}
+
+func runCallbacks(callbacks []func()) {
+	for _, fn := range callbacks {
+		if fn != nil {
+			fn()
+		}
+	}
+}
+
+func (l *leaderElector) AddAcquiredLeaseCallback(fn func()) {
+	l.acquiredLeaseCallbacks = append(l.acquiredLeaseCallbacks, fn)
+}
+
+func (l *leaderElector) AddLostLeaseCallback(fn func()) {
+	l.lostLeaseCallbacks = append(l.lostLeaseCallbacks, fn)
 }
 
 func (l *leaderElector) Stop() error {

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -72,6 +72,10 @@ func (a *Scheduler) Run() error {
 	for name, value := range args {
 		schedulerArgs = append(schedulerArgs, fmt.Sprintf("--%s=%s", name, value))
 	}
+	if a.ClusterConfig.Spec.API.ExternalAddress == "" {
+		schedulerArgs = append(schedulerArgs, "--leader-elect=false")
+	}
+
 	a.supervisor = supervisor.Supervisor{
 		Name:    "kube-scheduler",
 		BinPath: assets.BinPath("kube-scheduler", a.K0sVars.BinDir),

--- a/pkg/constant/constant_windows.go
+++ b/pkg/constant/constant_windows.go
@@ -1,4 +1,5 @@
 // +build windows
+
 /*
 Copyright 2021 k0s authors
 
@@ -14,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package constant
 
 import "fmt"


### PR DESCRIPTION
---
name: Pull Request
about: Create a Pull Request
title: ''
labels: ''
assignees: ''

---

**Issue**
Fixes #540

**What this PR Includes**

- disable leader elector when there is no `ExternalAddress` (single controller setup)
- refactor helm addon to re-use the controller.LeaderElector
- re-use controller.LeaderElector for the stack applier.