### PR TITLE
Add 'global' flags to config validation command properly

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -46,7 +46,7 @@ var (
 
 func init() {
 	validateCmd.AddCommand(validateConfigCmd)
-	addPersistentFlags(validateCmd)
+	addPersistentFlags(validateConfigCmd)
 }
 
 func validateConfig(cfgPath string) (err error) {


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
`k0s validate config` does not take the config in properly

**What this PR Includes**
Fixes the setting of global flags to validate command