### PR TITLE
Add ability to pass extra args for kubelet process

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -48,20 +48,23 @@ func init() {
 	workerCmd.Flags().StringVar(&tokenFile, "token-file", "", "Path to the file containing token.")
 	workerCmd.Flags().StringToStringVarP(&cmdLogLevels, "logging", "l", defaultLogLevels, "Logging Levels for the different components")
 	workerCmd.Flags().StringSliceVarP(&labels, "labels", "", []string{}, "Node labels, list of key=value pairs")
+	workerCmd.Flags().StringVar(&kubeletExtraArgs, "kubelet-extra-args", "", "extra args for kubelet")
+
 	installWorkerCmd.Flags().AddFlagSet(workerCmd.Flags())
 	addPersistentFlags(workerCmd)
 }
 
 var (
-	apiServer     string
-	cidrRange     string
-	cloudProvider bool
-	clusterDNS    string
-	criSocket     string
-	labels        []string
-	tokenArg      string
-	tokenFile     string
-	workerProfile string
+	apiServer        string
+	cidrRange        string
+	cloudProvider    bool
+	clusterDNS       string
+	criSocket        string
+	labels           []string
+	tokenArg         string
+	tokenFile        string
+	workerProfile    string
+	kubeletExtraArgs string
 
 	workerCmd = &cobra.Command{
 		Use:   "worker [join-token]",
@@ -136,6 +139,7 @@ func startWorker(token string) error {
 		LogLevel:            logging["kubelet"],
 		Profile:             workerProfile,
 		Labels:              labels,
+		ExtraArgs:           kubeletExtraArgs,
 	})
 
 	if runtime.GOOS == "windows" {

--- a/docs/worker-node-config.md
+++ b/docs/worker-node-config.md
@@ -1,0 +1,24 @@
+# Configuration options for worker nodes
+
+Currently `k0s worker` command does not take in any special yaml configuration. There still is ways how to configure the workers, the following chapters provide instructions for ways you can configure how the worker runs various components.
+
+## Node labels
+
+`k0s worker` command accepts `--labels` flag with which you can make the newly joined worker node the register itself in the Kubernetes API with the given set of labels.
+
+So for example when running the worker with `k0s worker --token-file k0s.token --labels="k0sproject.io/foo=bar,k0sproject.io/other=xyz"` will result in:
+```
+/ # kubectl get node --show-labels
+NAME      STATUS     ROLES    AGE   VERSION        LABELS
+worker0   NotReady   <none>   10s   v1.20.2-k0s1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,k0sproject.io/foo=bar,k0sproject.io/other=xyz,kubernetes.io/arch=amd64,kubernetes.io/hostname=worker0,kubernetes.io/os=linux
+```
+
+**Note:** Setting the labels is only effective on the first registration of the node and changing them afterwards has no effect.
+
+
+## Kubelet args
+
+`k0s worker` command accepts a generic flag to pass in any set of argument for kubelet process.
+
+For example running `k0s worker --token-file=k0s.token --kubelet-extra-args="--node-ip=1.2.3.4 --address=0.0.0.0"` will "pass on" the given flags to kubelet as-is. As the flags are passed as-is make sure you are passing in properly formatted and valued flags as k0s will NOT validate those at all.
+

--- a/internal/util/flags.go
+++ b/internal/util/flags.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2021 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import "strings"
+
+// SplitFlags splits arbitrary set of flags into MappedArgs struct
+func SplitFlags(input string) MappedArgs {
+	mArgs := MappedArgs{}
+	args := strings.Split(input, " ")
+	for _, a := range args {
+		av := strings.SplitN(a, "=", 2)
+		if len(av) < 1 {
+			continue
+		}
+		if len(av) == 1 {
+			mArgs[av[0]] = ""
+		} else {
+			mArgs[av[0]] = av[1]
+		}
+	}
+
+	return mArgs
+}

--- a/internal/util/flags_test.go
+++ b/internal/util/flags_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlagSplitting(t *testing.T) {
+	args := "--foo=bar --foobar=xyz,asd --bool-flag"
+
+	m := SplitFlags(args)
+
+	assert.Equal(t, 3, len(m))
+	assert.Equal(t, "bar", m["--foo"])
+	assert.Equal(t, "xyz,asd", m["--foobar"])
+	assert.Equal(t, "", m["--bool-flag"])
+}
+
+func TestFlagSplittingBoolFlags(t *testing.T) {
+	args := "--bool-flag"
+
+	m := SplitFlags(args)
+
+	assert.Equal(t, 1, len(m))
+	assert.Equal(t, "", m["--bool-flag"])
+}

--- a/internal/util/mapped_args.go
+++ b/internal/util/mapped_args.go
@@ -15,3 +15,12 @@ func (m MappedArgs) ToArgs() []string {
 	}
 	return args
 }
+
+// Merge merges two maps together
+func (m MappedArgs) Merge(other MappedArgs) {
+	if len(other) > 0 {
+		for k, v := range other {
+			m[k] = v
+		}
+	}
+}

--- a/internal/util/mapped_args_test.go
+++ b/internal/util/mapped_args_test.go
@@ -33,3 +33,17 @@ func TestToArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestMerge(t *testing.T) {
+	original := MappedArgs{
+		"foo": "bar",
+	}
+
+	original.Merge(MappedArgs{
+		"another": "val",
+		"foo":     "overridden",
+	})
+
+	assert.Equal(t, "overridden", original["foo"])
+	assert.Equal(t, "val", original["another"])
+}

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -66,6 +66,9 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	s.Require().NoError(s.checkCertPerms("controller0"))
 	s.Require().NoError(s.checkCSRs("worker0", kc))
 	s.Require().NoError(s.checkCSRs("worker1", kc))
+
+	s.Require().NoError(s.verifyKubeletAddressFlag("worker0"))
+	s.Require().NoError(s.verifyKubeletAddressFlag("worker1"))
 }
 
 func (s *BasicSuite) checkCertPerms(node string) error {
@@ -82,6 +85,25 @@ func (s *BasicSuite) checkCertPerms(node string) error {
 
 	if output != "" {
 		return fmt.Errorf("some private files having non 640 permissions: %s", output)
+	}
+
+	return nil
+}
+
+// Verifies that kubelet process has the address flag set
+func (s *BasicSuite) verifyKubeletAddressFlag(node string) error {
+	ssh, err := s.SSH(node)
+	if err != nil {
+		return err
+	}
+	defer ssh.Disconnect()
+
+	output, err := ssh.ExecWithOutput(`grep -e '--address=0.0.0.0' /proc/$(pidof kubelet)/cmdline`)
+	if err != nil {
+		return err
+	}
+	if output != "--address=0.0.0.0" {
+		return fmt.Errorf("kubelet does not have the address flag set")
 	}
 
 	return nil

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -35,7 +35,7 @@ type BasicSuite struct {
 func (s *BasicSuite) TestK0sGetsUp() {
 	customDataDir := "/var/lib/k0s/custom-data-dir"
 	s.NoError(s.InitMainController([]string{fmt.Sprintf("--data-dir=%s", customDataDir)}))
-	s.NoError(s.RunWorkers(customDataDir))
+	s.NoError(s.RunWorkers(customDataDir, `--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args="--address=0.0.0.0 --event-burst=10"`))
 
 	kc, err := s.KubeClient("controller0", customDataDir)
 	s.NoError(err)

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -270,7 +270,7 @@ func (s *FootlooseSuite) GetJoinToken(role string, dataDir string) (string, erro
 }
 
 // RunWorkers joins all the workers to the cluster
-func (s *FootlooseSuite) RunWorkers(dataDir string) error {
+func (s *FootlooseSuite) RunWorkers(dataDir string, args ...string) error {
 	ssh, err := s.SSH("controller0")
 	if err != nil {
 		return err
@@ -283,13 +283,10 @@ func (s *FootlooseSuite) RunWorkers(dataDir string) error {
 	if token == "" {
 		return fmt.Errorf("got empty token for worker join")
 	}
-
-	var workerCommand string
 	if dataDir != "" {
-		workerCommand = fmt.Sprintf(`nohup k0s --debug --data-dir=%s worker --labels="k0sproject.io/foo=bar" --kubelet-extra-args="--address=0.0.0.0" "%s" - >/tmp/k0s-worker.log 2>&1 &`, dataDir, token)
-	} else {
-		workerCommand = fmt.Sprintf(`nohup k0s --debug worker --labels="k0sproject.io/foo=bar" --kubelet-extra-args="--address=0.0.0.0" "%s" >/tmp/k0s-worker.log 2>&1 &`, token)
+		args = append(args, fmt.Sprintf("--data-dir=%s", dataDir))
 	}
+	workerCommand := fmt.Sprintf(`nohup k0s --debug worker %s "%s" >/tmp/k0s-worker.log 2>&1 &`, strings.Join(args, " "), token)
 
 	for i := 0; i < s.WorkerCount; i++ {
 		workerNode := fmt.Sprintf("worker%d", i)

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -286,9 +286,9 @@ func (s *FootlooseSuite) RunWorkers(dataDir string) error {
 
 	var workerCommand string
 	if dataDir != "" {
-		workerCommand = fmt.Sprintf(`nohup k0s worker --debug --data-dir=%s --labels="k0sproject.io/foo=bar" "%s" - >/tmp/k0s-worker.log 2>&1 &`, dataDir, token)
+		workerCommand = fmt.Sprintf(`nohup k0s --debug --data-dir=%s worker --labels="k0sproject.io/foo=bar" --kubelet-extra-args="--address=0.0.0.0" "%s" - >/tmp/k0s-worker.log 2>&1 &`, dataDir, token)
 	} else {
-		workerCommand = fmt.Sprintf(`nohup k0s worker --debug  --labels="k0sproject.io/foo=bar" "%s" >/tmp/k0s-worker.log 2>&1 &`, token)
+		workerCommand = fmt.Sprintf(`nohup k0s --debug worker --labels="k0sproject.io/foo=bar" --kubelet-extra-args="--address=0.0.0.0" "%s" >/tmp/k0s-worker.log 2>&1 &`, token)
 	}
 
 	for i := 0; i < s.WorkerCount; i++ {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
       - Docker:                  k0s-in-docker.md
       - Windows (experimental):  experimental-windows.md
       - System Requirements:     system-requirements.md
+      - Worker node configuration: worker-node-config.md
   - Architecture:
       - Architecture: architecture.md
       - Networking:   networking.md

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -48,6 +48,7 @@ type Kubelet struct {
 	supervisor          supervisor.Supervisor
 	ClusterDNS          string
 	Labels              []string
+	ExtraArgs           string
 }
 
 // Init extracts the needed binaries
@@ -149,6 +150,13 @@ func (k *Kubelet) Run() error {
 	if k.EnableCloudProvider {
 		args["--cloud-provider"] = "external"
 	}
+
+	// Handle the extra args as last so they can be used to overrride some k0s "hardcodings"
+	if k.ExtraArgs != "" {
+		extras := util.SplitFlags(k.ExtraArgs)
+		args.Merge(extras)
+	}
+
 	logrus.Infof("starting kubelet with args: %v", args)
 	k.supervisor = supervisor.Supervisor{
 		Name:    cmd,


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>


**Issue**
Fixes #707
Fixes #643 

**What this PR Includes**
This PR allows one to pass any set of extra args to kubelet:
```
k0s worker --kubelet-extra-args="--some-arg=foo --bool-flag --some-other=bar"
```