### PR TITLE
Add config flag to token create command

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -30,7 +30,9 @@ import (
 func init() {
 	installCmd.AddCommand(installControllerCmd)
 	installCmd.AddCommand(installWorkerCmd)
-	addPersistentFlags(installCmd)
+
+	addPersistentFlags(installControllerCmd)
+	addPersistentFlags(installWorkerCmd)
 }
 
 var (

--- a/cmd/tokencreate.go
+++ b/cmd/tokencreate.go
@@ -38,6 +38,8 @@ func init() {
 	tokenCreateCmd.Flags().StringVar(&tokenRole, "role", "worker", "Either worker or controller")
 	tokenCreateCmd.Flags().BoolVar(&waitCreate, "wait", false, "wait forever (default false)")
 
+	addPersistentFlags(tokenCreateCmd)
+
 	// shell completion options
 	_ = tokenCreateCmd.MarkFlagRequired("role")
 	_ = tokenCreateCmd.RegisterFlagCompletionFunc("role", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -216,8 +216,8 @@ func (s *FootlooseSuite) InitMainController(k0sArgs []string) error {
 		opts = fmt.Sprintf("%s %s", opts, arg)
 	}
 
-	installCmd := fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=arm64 k0s --debug install controller %s", opts)
-	startCmd := fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=arm64 nohup k0s --debug controller %s >/tmp/k0s-controller.log 2>&1 &", opts)
+	installCmd := fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=arm64 k0s install controller --debug %s", opts)
+	startCmd := fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=arm64 nohup k0s controller --debug %s >/tmp/k0s-controller.log 2>&1 &", opts)
 
 	_, err = ssh.ExecWithOutput(installCmd)
 	if err != nil {
@@ -241,7 +241,7 @@ func (s *FootlooseSuite) JoinController(idx int, token string, dataDir string) e
 		return err
 	}
 	defer ssh.Disconnect()
-	_, err = ssh.ExecWithOutput(fmt.Sprintf("nohup k0s --debug controller %s >/tmp/k0s-controller.log 2>&1 &", token))
+	_, err = ssh.ExecWithOutput(fmt.Sprintf("nohup k0s controller --debug %s >/tmp/k0s-controller.log 2>&1 &", token))
 	if err != nil {
 		return err
 	}
@@ -286,9 +286,9 @@ func (s *FootlooseSuite) RunWorkers(dataDir string) error {
 
 	var workerCommand string
 	if dataDir != "" {
-		workerCommand = fmt.Sprintf(`nohup k0s --debug --data-dir=%s worker --labels="k0sproject.io/foo=bar" "%s" - >/tmp/k0s-worker.log 2>&1 &`, dataDir, token)
+		workerCommand = fmt.Sprintf(`nohup k0s worker --debug --data-dir=%s --labels="k0sproject.io/foo=bar" "%s" - >/tmp/k0s-worker.log 2>&1 &`, dataDir, token)
 	} else {
-		workerCommand = fmt.Sprintf(`nohup k0s --debug worker --labels="k0sproject.io/foo=bar" "%s" >/tmp/k0s-worker.log 2>&1 &`, token)
+		workerCommand = fmt.Sprintf(`nohup k0s worker --debug  --labels="k0sproject.io/foo=bar" "%s" >/tmp/k0s-worker.log 2>&1 &`, token)
 	}
 
 	for i := 0; i < s.WorkerCount; i++ {

--- a/inttest/common/vmsuite.go
+++ b/inttest/common/vmsuite.go
@@ -84,7 +84,7 @@ func (s *VMSuite) InitMainController() error {
 	}
 	defer ssh.Disconnect()
 
-	startControllerCmd := "sudo nohup k0s --debug controller >/tmp/k0s-controller.log 2>&1 &"
+	startControllerCmd := "sudo nohup k0s controller --debug >/tmp/k0s-controller.log 2>&1 &"
 	_, err = ssh.ExecWithOutput(startControllerCmd)
 	if err != nil {
 		return err
@@ -141,7 +141,7 @@ func (s *VMSuite) RunWorkers() error {
 	if token == "" {
 		return fmt.Errorf("got empty token for worker join")
 	}
-	workerCommand := fmt.Sprintf(`sudo nohup k0s --debug worker "%s" >/tmp/k0s-worker.log 2>&1 &`, token)
+	workerCommand := fmt.Sprintf(`sudo nohup k0s worker --debug "%s" >/tmp/k0s-worker.log 2>&1 &`, token)
 	for i := 0; i < len(s.WorkerIPs); i++ {
 		workerNode := s.WorkerIPs[i]
 		sshWorker, err := s.SSH(workerNode)


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
```
# /usr/local/bin/k0s token create --config /etc/k0s/k0s.yaml --role worker --expiry 10m0s
Error: unknown flag: --config
Usage:
  k0s token create [flags]
Examples:
k0s token create --role worker --expiry 100h //sets expiration time to 100 hours
k0s token create --role worker --expiry 10m  //sets expiration time to 10 minutes
Flags:
      --expiry string   Expiration time of the token. Format 1.5h, 2h45m or 300ms. (default "0s")
  -h, --help            help for create
      --role string     Either worker or controller (default "worker")
      --wait            wait forever (default false)
Global Flags:
      --data-dir string        Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
      --debugListenOn string   Http listenOn for debug pprof handler (default ":6060")
unknown flag: --config
2021-02-22 12:17:02.618698 I | unknown flag: --config
```

**What this PR Includes**
Fixes back the token command to have `--config` flag