### PR TITLE
Bump containerd to 1.4.4 (CVE-2021-21334)

### DIFF
--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -1,6 +1,6 @@
 
 runc_version = 1.0.0-rc93
-containerd_version = 1.4.3
+containerd_version = 1.4.4
 kubernetes_version = 1.20.4
 kine_version = 0.6.0
 etcd_version = 3.4.15


### PR DESCRIPTION
The fourth patch release for containerd 1.4 contains a fix for
CVE-2021-21334 along with various other minor issues.

fixes #760 