### PR TITLE
Fix for dualstack setup: make service cidr ordering depends on the actual API address family

### DIFF
--- a/pkg/apis/v1beta1/network.go
+++ b/pkg/apis/v1beta1/network.go
@@ -142,11 +142,18 @@ func (n *Network) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // BuildServiceCIDR returns actual argument value for service cidr
-func (n *Network) BuildServiceCIDR() string {
-	if n.DualStack.Enabled {
+func (n *Network) BuildServiceCIDR(addr string) string {
+	if !n.DualStack.Enabled {
+		return n.ServiceCIDR
+	}
+	// because in the dual-stack mode k8s
+	// relies on the ordering of the given CIDRs
+	// we need to first give family on which
+	// api server listens
+	if IsIPv6String(addr) {
 		return n.DualStack.IPv6ServiceCIDR + "," + n.ServiceCIDR
 	}
-	return n.ServiceCIDR
+	return n.ServiceCIDR + "," + n.DualStack.IPv6ServiceCIDR
 }
 
 // BuildPodCIDR returns actual argument value for pod cidr

--- a/pkg/apis/v1beta1/network_test.go
+++ b/pkg/apis/v1beta1/network_test.go
@@ -61,6 +61,26 @@ func (s *NetworkSuite) TestAddresses() {
 		s.NoError(err)
 		s.Equal([]string{"10.96.0.249", "fd00::1"}, api)
 	})
+
+	s.T().Run("BuildServiceCIDR ordering", func(t *testing.T) {
+		t.Run("single_stack_default", func(t *testing.T) {
+			n := DefaultNetwork()
+			s.Equal(n.ServiceCIDR, n.BuildServiceCIDR("10.96.0.249"))
+
+		})
+		t.Run("dual_stack_api_listens_on_ipv4", func(t *testing.T) {
+			n := DefaultNetwork()
+			n.DualStack.Enabled = true
+			n.DualStack.IPv6ServiceCIDR = "fd00::/108"
+			s.Equal(n.ServiceCIDR+","+n.DualStack.IPv6ServiceCIDR, n.BuildServiceCIDR("10.96.0.249"))
+		})
+		t.Run("dual_stack_api_listens_on_ipv6", func(t *testing.T) {
+			n := DefaultNetwork()
+			n.DualStack.Enabled = true
+			n.DualStack.IPv6ServiceCIDR = "fd00::/108"
+			s.Equal(n.DualStack.IPv6ServiceCIDR+","+n.ServiceCIDR, n.BuildServiceCIDR("fe80::cf8:3cff:fef2:c5ca"))
+		})
+	})
 }
 
 func (s *NetworkSuite) TestCalicoDefaults() {

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -97,7 +97,7 @@ func (a *APIServer) Run() error {
 		"requestheader-allowed-names":      "front-proxy-client",
 		"requestheader-client-ca-file":     path.Join(a.K0sVars.CertRootDir, "front-proxy-ca.crt"),
 		"service-account-key-file":         path.Join(a.K0sVars.CertRootDir, "sa.pub"),
-		"service-cluster-ip-range":         a.ClusterConfig.Spec.Network.BuildServiceCIDR(),
+		"service-cluster-ip-range":         a.ClusterConfig.Spec.Network.BuildServiceCIDR(a.ClusterConfig.Spec.API.Address),
 		"tls-cert-file":                    path.Join(a.K0sVars.CertRootDir, "server.crt"),
 		"tls-private-key-file":             path.Join(a.K0sVars.CertRootDir, "server.key"),
 		"egress-selector-config-file":      path.Join(a.K0sVars.DataDir, "konnectivity.conf"),

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -83,7 +83,7 @@ func (a *Manager) Run() error {
 		"root-ca-file":                     path.Join(a.K0sVars.CertRootDir, "ca.crt"),
 		"service-account-private-key-file": path.Join(a.K0sVars.CertRootDir, "sa.key"),
 		"cluster-cidr":                     a.ClusterConfig.Spec.Network.BuildPodCIDR(),
-		"service-cluster-ip-range":         a.ClusterConfig.Spec.Network.BuildServiceCIDR(),
+		"service-cluster-ip-range":         a.ClusterConfig.Spec.Network.BuildServiceCIDR(a.ClusterConfig.Spec.API.Address),
 		"profiling":                        "false",
 		"v":                                a.LogLevel,
 	}


### PR DESCRIPTION
Since k8s components rely on the CIDR ordering in the "service-ip-range" argument we need to order them correspondingly with actual kube-apiserver address.

Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>

