### PR TITLE
Fix exitcode on failure (#790)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -148,7 +148,8 @@ func addPersistentFlags(cmd *cobra.Command) {
 }
 
 func Execute() {
-	// just a hack to trick linter which requires to check for errors
-	// cobra itself already prints out all errors that happen in subcommands
-	_ = rootCmd.Execute()
+	err := rootCmd.Execute()
+	if err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
Make sure we exit with error when a command fails

Fix regression introduced with commit d801eb1b768f (convert relative
file path to absolute)

Signed-off-by: Natanael Copa <ncopa@mirantis.com>


**Issue**
Fixes #790

**What this PR Includes**
I believe this should fix some if not all of the flakiness we have seen in the smoke tests recently
