### PR TITLE
Simplify etcd health check by trying to get a value from the kv store

### DIFF
--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -257,8 +257,8 @@ func (e *Etcd) setupCerts() error {
 func (e *Etcd) Healthy() error {
 	logrus.WithField("component", "etcd").Debug("checking etcd endpoint for health")
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
 	err := etcd.CheckEtcdReady(ctx, e.K0sVars.CertRootDir, e.K0sVars.EtcdCertDir)
-	cancel()
 	return err
 }
 

--- a/pkg/etcd/health.go
+++ b/pkg/etcd/health.go
@@ -2,13 +2,8 @@ package etcd
 
 import (
 	"context"
-	"net/http"
-	"net/url"
-	"path/filepath"
-	"time"
 
 	"github.com/sirupsen/logrus"
-	"go.etcd.io/etcd/pkg/transport"
 )
 
 // CheckEtcdReady returns true if etcd responds to the metrics endpoint with a status code of 200
@@ -18,42 +13,6 @@ func CheckEtcdReady(ctx context.Context, certDir string, etcdCertDir string) err
 		logrus.Errorf("failed to initialize etcd client: %v", err)
 		return err
 	}
-	memberList, err := c.client.MemberList(ctx)
-	if err != nil {
-		logrus.Errorf("failed to fetch etcd member list: %v\n", err)
-		return err
-	}
 
-	u, err := url.Parse(memberList.Members[0].ClientURLs[0])
-	if err != nil {
-		logrus.Errorf("cannot fetch health endpoint: %v\n", err)
-		return err
-	}
-
-	// the metrics endpoint was selected as a health endpoint in the official etcd docs: https://etcd.io/docs/v3.4.0/op-guide/monitoring/
-	u.Path = "/metrics"
-
-	tr, err := transport.NewTransport(transport.TLSInfo{
-		CertFile:      filepath.Join(certDir, "apiserver-etcd-client.crt"),
-		KeyFile:       filepath.Join(certDir, "apiserver-etcd-client.key"),
-		TrustedCAFile: filepath.Join(etcdCertDir, "ca.crt"),
-	}, 5*time.Second)
-	if err != nil {
-		logrus.Errorf("error encountered setting up healthcheck TLS config: %v\n", err)
-	}
-
-	resp, err := tr.RoundTrip(&http.Request{
-		Header: make(http.Header),
-		Method: http.MethodGet,
-		URL:    u,
-	})
-	if err != nil {
-		logrus.Errorf("error accessing health endpoint: %v\n", err)
-		return err
-	}
-	if resp.StatusCode != http.StatusOK {
-		logrus.Printf("received unexpected status code from endpoint. expected %v, received %v", http.StatusOK, resp.StatusCode)
-	}
-
-	return nil
+	return c.Health(ctx)
 }


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
The current etcd health check mechanism is bit complex and had couple flaws:
- always got the peers and used the first peer for the health check
- ignored http response codes != 200

**What this PR Includes**
This PR simplifies the health check by trying to get a value from the KV store. This is also done in the official etcdctl tool with command `etcdctl endpoint health`, see https://github.com/etcd-io/etcd/blob/3ead91ca3edf66112d56c453169343515bba71c3/etcdctl/ctlv3/command/ep_command.go#L124-L135
