### PR TITLE
Make etcd use jwt tokens

### DIFF
--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -60,3 +60,18 @@ func GetExecPath(fileName string) (*string, error) {
 
 	return &path, nil
 }
+
+func ChownFile(file, owner string, permissions os.FileMode) error {
+	// Chown the file properly for the owner
+	uid, _ := GetUID(owner)
+	err := os.Chown(file, uid, -1)
+	if err != nil && os.Geteuid() == 0 {
+		return err
+	}
+	err = os.Chmod(file, permissions)
+	if err != nil && os.Geteuid() == 0 {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/component/controller/certificates.go
+++ b/pkg/component/controller/certificates.go
@@ -17,12 +17,7 @@ package controller
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
 	"encoding/base64"
-	"encoding/pem"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -130,7 +125,7 @@ func (c *Certificates) Init() error {
 			return err
 		}
 
-		return generateKeyPair("sa", c.K0sVars, constant.ApiserverUser)
+		return c.CertManager.CreateKeyPair("sa", c.K0sVars, constant.ApiserverUser)
 	})
 
 	eg.Go(func() error {
@@ -259,7 +254,7 @@ func (c *Certificates) Stop() error {
 
 func kubeConfig(dest, url, caCert, clientCert, clientKey, owner string) error {
 	if util.FileExists(dest) {
-		return chownFile(dest, owner, constant.CertSecureMode)
+		return util.ChownFile(dest, owner, constant.CertSecureMode)
 	}
 	data := struct {
 		URL        string
@@ -283,84 +278,7 @@ func kubeConfig(dest, url, caCert, clientCert, clientKey, owner string) error {
 		return err
 	}
 
-	return chownFile(output.Name(), owner, constant.CertSecureMode)
-}
-
-func chownFile(file, owner string, permissions os.FileMode) error {
-	// Chown the file properly for the owner
-	uid, _ := util.GetUID(owner)
-	err := os.Chown(file, uid, -1)
-	if err != nil && os.Geteuid() == 0 {
-		return err
-	}
-	err = os.Chmod(file, permissions)
-	if err != nil && os.Geteuid() == 0 {
-		return err
-	}
-
-	return nil
-}
-
-func generateKeyPair(name string, k0sVars constant.CfgVars, owner string) error {
-	keyFile := filepath.Join(k0sVars.CertRootDir, fmt.Sprintf("%s.key", name))
-	pubFile := filepath.Join(k0sVars.CertRootDir, fmt.Sprintf("%s.pub", name))
-
-	if util.FileExists(keyFile) && util.FileExists(pubFile) {
-		return chownFile(keyFile, owner, constant.CertSecureMode)
-	}
-
-	reader := rand.Reader
-	bitSize := 2048
-
-	key, err := rsa.GenerateKey(reader, bitSize)
-	if err != nil {
-		return err
-	}
-
-	var privateKey = &pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(key),
-	}
-
-	outFile, err := os.OpenFile(keyFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, constant.CertSecureMode)
-	if err != nil {
-		return err
-	}
-	defer outFile.Close()
-
-	err = chownFile(keyFile, owner, constant.CertSecureMode)
-	if err != nil {
-		return err
-	}
-
-	err = pem.Encode(outFile, privateKey)
-	if err != nil {
-		return err
-	}
-
-	// note to the next reader: key.Public() != key.PublicKey
-	pubBytes, err := x509.MarshalPKIXPublicKey(key.Public())
-	if err != nil {
-		return err
-	}
-
-	var pemkey = &pem.Block{
-		Type:  "PUBLIC KEY",
-		Bytes: pubBytes,
-	}
-
-	pemfile, err := os.Create(pubFile)
-	if err != nil {
-		return err
-	}
-	defer pemfile.Close()
-
-	err = pem.Encode(pemfile, pemkey)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return util.ChownFile(output.Name(), owner, constant.CertSecureMode)
 }
 
 // Health-check interface


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Fixes #621

**What this PR Includes**
Etcd will now be configured with jwt auth. The JWT sign key pair is created only for fresh setup and thus existing setup will be un-touched.

Includes also some refactorings, mainly for some generic utility re-locations.