### PR TITLE
Fix install commands to also pass any args to service units

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -63,6 +63,7 @@ With controller subcommand you can setup a single node cluster by running:
 			}
 			flagsAndVals := []string{"controller"}
 			flagsAndVals = append(flagsAndVals, cmdFlagsToArgs(cmd)...)
+			flagsAndVals = append(flagsAndVals, args...)
 			if err := setup("controller", flagsAndVals); err != nil {
 				cmd.SilenceUsage = true
 				return err
@@ -87,6 +88,7 @@ Windows flags like "--api-server", "--cidr-range" and "--cluster-dns" will be ig
 
 			flagsAndVals := []string{"worker"}
 			flagsAndVals = append(flagsAndVals, cmdFlagsToArgs(cmd)...)
+			flagsAndVals = append(flagsAndVals, args...)
 			if err := setup("worker", flagsAndVals); err != nil {
 				cmd.SilenceUsage = true
 				return err


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Currently `k0s install worker <token>` drops the token from the service unit.

**What this PR Includes**
This PR adds all args to the service unit file:
```
/ # ./k0s install worker "foobar"
INFO[2021-03-19 11:33:52] Installing k0s service                       
/ # cat /etc/init.d/k0sworker 
#!/sbin/openrc-run
supervisor=supervise-daemon
name="k0s worker"
description="k0s - Zero Friction Kubernetes"
command=/k0s
command_args="worker foobar "
name=$(basename $(readlink -f $command))
supervise_daemon_args="--stdout /var/log/${name}.log --stderr /var/log/${name}.err"
depend() { 
        need net 
        use dns 
        after firewall
}
```