### PR TITLE
Cleanup/refactor footloose inttests

### DIFF
--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -65,7 +65,7 @@ func (as *AddonsSuite) TestHelmBasedAddons() {
 }
 
 func (as *AddonsSuite) doPrometheusDelete(chartName string) {
-	cfg := as.getKubeConfig("controller0")
+	cfg := as.getKubeConfig(as.ControllerNode(0))
 	chartClient, err := clientset.New(cfg)
 	as.Require().NoError(err)
 	as.Require().NoError(chartClient.Charts("kube-system").Delete(context.Background(), chartName, v1.DeleteOptions{}))
@@ -86,7 +86,7 @@ func (as *AddonsSuite) doPrometheusDelete(chartName string) {
 
 func (as *AddonsSuite) waitForPrometheusRelease(addonName string, rev int64) (string, string) {
 	as.T().Logf("waiting to see prometheus release ready in kube API, generation %d", rev)
-	cfg := as.getKubeConfig("controller0")
+	cfg := as.getKubeConfig(as.ControllerNode(0))
 	chartClient, err := clientset.New(cfg)
 	as.Require().NoError(err)
 	var chartName string
@@ -135,7 +135,7 @@ func (as *AddonsSuite) waitForPrometheusRelease(addonName string, rev int64) (st
 
 func (as *AddonsSuite) waitForPrometheusServerEnvs(releaseName string) error {
 	as.T().Logf("waiting to see prometheus release to have envs set from values yaml")
-	kc, err := as.KubeClient("controller0", "")
+	kc, err := as.KubeClient(as.ControllerNode(0), "")
 	if err != nil {
 		return err
 	}
@@ -217,8 +217,7 @@ func TestAddonsSuite(t *testing.T) {
 }
 
 func (as *AddonsSuite) putFile(path string, content string) {
-	controllerNode := fmt.Sprintf("controller%d", 0)
-	ssh, err := as.SSH(controllerNode)
+	ssh, err := as.SSH(as.ControllerNode(0))
 	as.Require().NoError(err)
 	defer ssh.Disconnect()
 	_, err = ssh.ExecWithOutput(fmt.Sprintf("echo '%s' >%s", content, path))

--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -45,7 +45,7 @@ func (as *AddonsSuite) TestHelmBasedAddons() {
 	addonName := "test-addon"
 	as.putFile("/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithAddon, addonName))
 
-	as.Require().NoError(as.InitMainController("--config=/tmp/k0s.yaml"))
+	as.Require().NoError(as.InitController(0, "--config=/tmp/k0s.yaml"))
 	as.waitForPrometheusRelease(addonName, 1)
 
 	values := map[string]interface{}{

--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -135,7 +135,7 @@ func (as *AddonsSuite) waitForPrometheusRelease(addonName string, rev int64) (st
 
 func (as *AddonsSuite) waitForPrometheusServerEnvs(releaseName string) error {
 	as.T().Logf("waiting to see prometheus release to have envs set from values yaml")
-	kc, err := as.KubeClient(as.ControllerNode(0), "")
+	kc, err := as.KubeClient(as.ControllerNode(0))
 	if err != nil {
 		return err
 	}

--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -43,7 +43,7 @@ type AddonsSuite struct {
 
 func (as *AddonsSuite) TestHelmBasedAddons() {
 	addonName := "test-addon"
-	as.putFile("/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithAddon, addonName))
+	as.PutFile(as.ControllerNode(0), "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithAddon, addonName))
 
 	as.Require().NoError(as.InitController(0, "--config=/tmp/k0s.yaml"))
 	as.waitForPrometheusRelease(addonName, 1)
@@ -186,7 +186,7 @@ func (as *AddonsSuite) doPrometheusUpdate(addonName string, values map[string]in
 	buf := bytes.NewBuffer([]byte{})
 	as.Require().NoError(tw.WriteToBuffer(buf))
 
-	as.putFile(path, buf.String())
+	as.PutFile(as.ControllerNode(0), path, buf.String())
 }
 
 func (as *AddonsSuite) getKubeConfig(node string) *restclient.Config {
@@ -214,15 +214,6 @@ func TestAddonsSuite(t *testing.T) {
 
 	suite.Run(t, &s)
 
-}
-
-func (as *AddonsSuite) putFile(path string, content string) {
-	ssh, err := as.SSH(as.ControllerNode(0))
-	as.Require().NoError(err)
-	defer ssh.Disconnect()
-	_, err = ssh.ExecWithOutput(fmt.Sprintf("echo '%s' >%s", content, path))
-
-	as.Require().NoError(err)
 }
 
 const k0sConfigWithAddon = `

--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -45,7 +45,7 @@ func (as *AddonsSuite) TestHelmBasedAddons() {
 	addonName := "test-addon"
 	as.putFile("/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithAddon, addonName))
 
-	as.Require().NoError(as.InitMainController([]string{"--config=/tmp/k0s.yaml"}))
+	as.Require().NoError(as.InitMainController("--config=/tmp/k0s.yaml"))
 	as.waitForPrometheusRelease(addonName, 1)
 
 	values := map[string]interface{}{

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -26,8 +26,6 @@ import (
 	capi "k8s.io/api/certificates/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 type BasicSuite struct {
@@ -73,22 +71,9 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	s.Require().NoError(s.verifyKubeletAddressFlag(s.WorkerNode(0)))
 	s.Require().NoError(s.verifyKubeletAddressFlag(s.WorkerNode(1)))
 
-	s.Require().NoError(common.WaitForMetricsReady(s.getKubeConfig(s.ControllerNode(0))))
-}
-
-func (s *BasicSuite) getKubeConfig(node string) *restclient.Config {
-	machine, err := s.MachineForName(node)
-	s.Require().NoError(err)
-	ssh, err := s.SSH(node)
-	s.Require().NoError(err)
-	kubeConf, err := ssh.ExecWithOutput("cat /var/lib/k0s/custom-data-dir/pki/admin.conf")
-	s.Require().NoError(err)
-	cfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeConf))
-	s.Require().NoError(err)
-	hostPort, err := machine.HostPort(6443)
-	s.Require().NoError(err)
-	cfg.Host = fmt.Sprintf("localhost:%d", hostPort)
-	return cfg
+	cfg, err := s.GetKubeConfig(s.ControllerNode(0), dataDirOpt)
+	s.NoError(err)
+	s.Require().NoError(common.WaitForMetricsReady(cfg))
 }
 
 func (s *BasicSuite) checkCertPerms(node string) error {

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -36,7 +36,7 @@ type BasicSuite struct {
 
 func (s *BasicSuite) TestK0sGetsUp() {
 	customDataDir := "/var/lib/k0s/custom-data-dir"
-	s.NoError(s.InitMainController([]string{fmt.Sprintf("--data-dir=%s", customDataDir)}))
+	s.NoError(s.InitMainController(fmt.Sprintf("--data-dir=%s", customDataDir)))
 	s.NoError(s.RunWorkers(customDataDir, `--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args="--address=0.0.0.0 --event-burst=10"`))
 
 	kc, err := s.KubeClient("controller0", customDataDir)

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -36,8 +36,9 @@ type BasicSuite struct {
 
 func (s *BasicSuite) TestK0sGetsUp() {
 	customDataDir := "/var/lib/k0s/custom-data-dir"
-	s.NoError(s.InitMainController(fmt.Sprintf("--data-dir=%s", customDataDir)))
-	s.NoError(s.RunWorkers(customDataDir, `--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args="--address=0.0.0.0 --event-burst=10"`))
+	dataDirOpt := fmt.Sprintf("--data-dir=%s", customDataDir)
+	s.NoError(s.InitMainController(dataDirOpt))
+	s.NoError(s.RunWorkers(dataDirOpt, `--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args="--address=0.0.0.0 --event-burst=10"`))
 
 	kc, err := s.KubeClient("controller0", customDataDir)
 	s.NoError(err)

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -40,7 +40,7 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	s.NoError(s.InitController(0, dataDirOpt))
 	s.NoError(s.RunWorkers(dataDirOpt, `--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args="--address=0.0.0.0 --event-burst=10"`))
 
-	kc, err := s.KubeClient(s.ControllerNode(0), customDataDir)
+	kc, err := s.KubeClient(s.ControllerNode(0), dataDirOpt)
 	s.NoError(err)
 
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -40,17 +40,17 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	s.NoError(s.InitController(0, dataDirOpt))
 	s.NoError(s.RunWorkers(dataDirOpt, `--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args="--address=0.0.0.0 --event-burst=10"`))
 
-	kc, err := s.KubeClient("controller0", customDataDir)
+	kc, err := s.KubeClient(s.ControllerNode(0), customDataDir)
 	s.NoError(err)
 
-	err = s.WaitForNodeReady("worker0", kc)
+	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
 	s.NoError(err)
 
-	labels, err := s.GetNodeLabels("worker0", kc)
+	labels, err := s.GetNodeLabels(s.WorkerNode(0), kc)
 	s.NoError(err)
 	s.Equal("bar", labels["k0sproject.io/foo"])
 
-	err = s.WaitForNodeReady("worker1", kc)
+	err = s.WaitForNodeReady(s.WorkerNode(1), kc)
 	s.NoError(err)
 
 	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
@@ -66,14 +66,14 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	s.T().Log("waiting to see calico pods ready")
 	s.NoError(common.WaitForCalicoReady(kc), "calico did not start")
 
-	s.Require().NoError(s.checkCertPerms("controller0"))
-	s.Require().NoError(s.checkCSRs("worker0", kc))
-	s.Require().NoError(s.checkCSRs("worker1", kc))
+	s.Require().NoError(s.checkCertPerms(s.ControllerNode(0)))
+	s.Require().NoError(s.checkCSRs(s.WorkerNode(0), kc))
+	s.Require().NoError(s.checkCSRs(s.WorkerNode(1), kc))
 
-	s.Require().NoError(s.verifyKubeletAddressFlag("worker0"))
-	s.Require().NoError(s.verifyKubeletAddressFlag("worker1"))
+	s.Require().NoError(s.verifyKubeletAddressFlag(s.WorkerNode(0)))
+	s.Require().NoError(s.verifyKubeletAddressFlag(s.WorkerNode(1)))
 
-	s.Require().NoError(common.WaitForMetricsReady(s.getKubeConfig("controller0")))
+	s.Require().NoError(common.WaitForMetricsReady(s.getKubeConfig(s.ControllerNode(0))))
 }
 
 func (s *BasicSuite) getKubeConfig(node string) *restclient.Config {

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -37,7 +37,7 @@ type BasicSuite struct {
 func (s *BasicSuite) TestK0sGetsUp() {
 	customDataDir := "/var/lib/k0s/custom-data-dir"
 	dataDirOpt := fmt.Sprintf("--data-dir=%s", customDataDir)
-	s.NoError(s.InitMainController(dataDirOpt))
+	s.NoError(s.InitController(0, dataDirOpt))
 	s.NoError(s.RunWorkers(dataDirOpt, `--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args="--address=0.0.0.0 --event-burst=10"`))
 
 	kc, err := s.KubeClient("controller0", customDataDir)

--- a/inttest/byocri/byocri_test.go
+++ b/inttest/byocri/byocri_test.go
@@ -36,7 +36,7 @@ func (s *BYOCRISuite) TestK0sGetsUp() {
 	s.NoError(s.InitController(0))
 	s.Require().NoError(s.runDockerWorker())
 
-	kc, err := s.KubeClient(s.ControllerNode(0), "")
+	kc, err := s.KubeClient(s.ControllerNode(0))
 	s.NoError(err)
 
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)

--- a/inttest/byocri/byocri_test.go
+++ b/inttest/byocri/byocri_test.go
@@ -33,7 +33,7 @@ type BYOCRISuite struct {
 
 func (s *BYOCRISuite) TestK0sGetsUp() {
 
-	s.NoError(s.InitMainController())
+	s.NoError(s.InitController(0))
 	s.Require().NoError(s.runDockerWorker())
 
 	kc, err := s.KubeClient("controller0", "")

--- a/inttest/byocri/byocri_test.go
+++ b/inttest/byocri/byocri_test.go
@@ -33,7 +33,7 @@ type BYOCRISuite struct {
 
 func (s *BYOCRISuite) TestK0sGetsUp() {
 
-	s.NoError(s.InitMainController([]string{}))
+	s.NoError(s.InitMainController())
 	s.Require().NoError(s.runDockerWorker())
 
 	kc, err := s.KubeClient("controller0", "")

--- a/inttest/byocri/byocri_test.go
+++ b/inttest/byocri/byocri_test.go
@@ -36,10 +36,10 @@ func (s *BYOCRISuite) TestK0sGetsUp() {
 	s.NoError(s.InitController(0))
 	s.Require().NoError(s.runDockerWorker())
 
-	kc, err := s.KubeClient("controller0", "")
+	kc, err := s.KubeClient(s.ControllerNode(0), "")
 	s.NoError(err)
 
-	err = s.WaitForNodeReady("worker0", kc)
+	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
 	s.NoError(err)
 
 	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
@@ -64,7 +64,7 @@ func (s *BYOCRISuite) runDockerWorker() error {
 	if token == "" {
 		return fmt.Errorf("got empty token for worker join")
 	}
-	sshWorker, err := s.SSH("worker0")
+	sshWorker, err := s.SSH(s.WorkerNode(0))
 	if err != nil {
 		return err
 	}

--- a/inttest/byocri/byocri_test.go
+++ b/inttest/byocri/byocri_test.go
@@ -57,7 +57,7 @@ func (s *BYOCRISuite) TestK0sGetsUp() {
 }
 
 func (s *BYOCRISuite) runDockerWorker() error {
-	token, err := s.GetJoinToken("worker", "")
+	token, err := s.GetJoinToken("worker")
 	if err != nil {
 		return err
 	}

--- a/inttest/common/filetools.go
+++ b/inttest/common/filetools.go
@@ -4,8 +4,7 @@ import "fmt"
 
 // GetFile gets file from the controller with given index
 func (s *FootlooseSuite) GetFileFromController(controllerIdx int, path string) string {
-	node := fmt.Sprintf("controller%d", controllerIdx)
-	sshCon, err := s.SSH(node)
+	sshCon, err := s.SSH(s.ControllerNode(controllerIdx))
 	s.Require().NoError(err)
 	content, err := sshCon.ExecWithOutput(fmt.Sprintf("cat %s", path))
 	s.Require().NoError(err)

--- a/inttest/common/filetools.go
+++ b/inttest/common/filetools.go
@@ -11,3 +11,14 @@ func (s *FootlooseSuite) GetFileFromController(controllerIdx int, path string) s
 
 	return content
 }
+
+// PutFile writes content to file on given node
+func (s *FootlooseSuite) PutFile(node, path, content string) {
+	ssh, err := s.SSH(node)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+	// TODO: send data via pipe instead, so we can write data with single quotes '
+	_, err = ssh.ExecWithOutput(fmt.Sprintf("echo '%s' >%s", content, path))
+
+	s.Require().NoError(err)
+}

--- a/inttest/common/filetools.go
+++ b/inttest/common/filetools.go
@@ -6,6 +6,7 @@ import "fmt"
 func (s *FootlooseSuite) GetFileFromController(controllerIdx int, path string) string {
 	sshCon, err := s.SSH(s.ControllerNode(controllerIdx))
 	s.Require().NoError(err)
+	defer sshCon.Disconnect()
 	content, err := sshCon.ExecWithOutput(fmt.Sprintf("cat %s", path))
 	s.Require().NoError(err)
 

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/yaml.v2"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/k0sproject/k0s/internal/util"
@@ -326,7 +327,7 @@ func (s *FootlooseSuite) MachineForName(name string) (*cluster.Machine, error) {
 }
 
 // KubeClient return kube client by loading the admin access config from given node
-func (s *FootlooseSuite) KubeClient(node string, k0sKubeconfigArgs ...string) (*kubernetes.Clientset, error) {
+func (s *FootlooseSuite) GetKubeConfig(node string, k0sKubeconfigArgs ...string) (*rest.Config, error) {
 	machine, err := s.MachineForName(node)
 	if err != nil {
 		return nil, err
@@ -349,6 +350,15 @@ func (s *FootlooseSuite) KubeClient(node string, k0sKubeconfigArgs ...string) (*
 		return nil, errors.Wrap(err, "footloose machine has to have 6443 port mapped")
 	}
 	cfg.Host = fmt.Sprintf("localhost:%d", hostPort)
+	return cfg, nil
+}
+
+// KubeClient return kube client by loading the admin access config from given node
+func (s *FootlooseSuite) KubeClient(node string, k0sKubeconfigArgs ...string) (*kubernetes.Clientset, error) {
+	cfg, err := s.GetKubeConfig(node, k0sKubeconfigArgs...)
+	if err != nil {
+		return nil, err
+	}
 	return kubernetes.NewForConfig(cfg)
 }
 

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -156,6 +156,7 @@ func (s *FootlooseSuite) TearDownSuite() {
 		}
 
 		s.T().Logf("wrote log of node %s to %s", m.Hostname(), logPath)
+		ssh.Disconnect()
 	}
 
 	if s.keepEnvironment() {
@@ -336,6 +337,8 @@ func (s *FootlooseSuite) GetKubeConfig(node string, k0sKubeconfigArgs ...string)
 	if err != nil {
 		return nil, err
 	}
+	defer ssh.Disconnect()
+
 	kubeConfigCmd := fmt.Sprintf("k0s kubeconfig admin %s", strings.Join(k0sKubeconfigArgs, " "))
 	kubeConf, err := ssh.ExecWithOutput(kubeConfigCmd)
 	if err != nil {

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -211,10 +211,6 @@ func getDataDirOpt(args []string) string {
 	return ""
 }
 
-func getDataDir(args []string) string {
-	return strings.TrimPrefix(getDataDirOpt(args), "--data-dir=")
-}
-
 // InitController initializes a controller
 func (s *FootlooseSuite) InitController(idx int, k0sArgs ...string) error {
 	controllerNode := s.ControllerNode(idx)
@@ -235,7 +231,7 @@ func (s *FootlooseSuite) InitController(idx int, k0sArgs ...string) error {
 }
 
 // GetJoinToken generates join token for the asked role
-func (s *FootlooseSuite) GetJoinToken(role string, dataDir string) (string, error) {
+func (s *FootlooseSuite) GetJoinToken(role string, extraArgs ...string) (string, error) {
 	// assume we have main on node 0 always
 	controllerNode := s.ControllerNode(0)
 	s.Contains([]string{"controller", "worker"}, role, "Bad role")
@@ -244,7 +240,7 @@ func (s *FootlooseSuite) GetJoinToken(role string, dataDir string) (string, erro
 		return "", err
 	}
 	defer ssh.Disconnect()
-	token, err := ssh.ExecWithOutput(fmt.Sprintf("k0s token create --role=%s --data-dir=%s", role, dataDir))
+	token, err := ssh.ExecWithOutput(fmt.Sprintf("k0s token create --role=%s %s", role, strings.Join(extraArgs, " ")))
 	if err != nil {
 		return "", fmt.Errorf("can't get join token: %v", err)
 	}
@@ -262,7 +258,7 @@ func (s *FootlooseSuite) RunWorkers(args ...string) error {
 		return err
 	}
 	defer ssh.Disconnect()
-	token, err := s.GetJoinToken("worker", getDataDir(args))
+	token, err := s.GetJoinToken("worker", getDataDirOpt(args))
 	if err != nil {
 		return err
 	}

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -203,7 +203,7 @@ func getDataDir(args []string) string {
 }
 
 // InitMainController inits first controller assuming it's first controller in the cluster
-func (s *FootlooseSuite) InitMainController(k0sArgs []string) error {
+func (s *FootlooseSuite) InitMainController(k0sArgs ...string) error {
 	controllerNode := fmt.Sprintf("controller%d", 0)
 	ssh, err := s.SSH(controllerNode)
 	if err != nil {
@@ -211,10 +211,7 @@ func (s *FootlooseSuite) InitMainController(k0sArgs []string) error {
 	}
 	defer ssh.Disconnect()
 
-	opts := ""
-	for _, arg := range k0sArgs {
-		opts = fmt.Sprintf("%s %s", opts, arg)
-	}
+	opts := strings.Join(k0sArgs, " ")
 
 	installCmd := fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=arm64 k0s install controller --debug %s", opts)
 	startCmd := fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=arm64 nohup k0s controller --debug %s >/tmp/k0s-controller.log 2>&1 &", opts)

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -267,21 +267,18 @@ func (s *FootlooseSuite) GetJoinToken(role string, dataDir string) (string, erro
 }
 
 // RunWorkers joins all the workers to the cluster
-func (s *FootlooseSuite) RunWorkers(dataDir string, args ...string) error {
+func (s *FootlooseSuite) RunWorkers(args ...string) error {
 	ssh, err := s.SSH("controller0")
 	if err != nil {
 		return err
 	}
 	defer ssh.Disconnect()
-	token, err := s.GetJoinToken("worker", dataDir)
+	token, err := s.GetJoinToken("worker", getDataDir(args))
 	if err != nil {
 		return err
 	}
 	if token == "" {
 		return fmt.Errorf("got empty token for worker join")
-	}
-	if dataDir != "" {
-		args = append(args, fmt.Sprintf("--data-dir=%s", dataDir))
 	}
 	workerCommand := fmt.Sprintf(`nohup k0s --debug worker %s "%s" >/tmp/k0s-worker.log 2>&1 &`, strings.Join(args, " "), token)
 

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -73,12 +73,12 @@ func (ds *DualstackSuite) SetupSuite() {
 	ds.putFile("/tmp/k0s.yaml", k0sConfigWithAddon)
 	ds.Require().NoError(ds.InitController(0, "--config=/tmp/k0s.yaml"))
 	ds.Require().NoError(ds.RunWorkers())
-	client, err := k8s.NewForConfig(ds.getKubeConfig("controller0"))
+	client, err := k8s.NewForConfig(ds.getKubeConfig(ds.ControllerNode(0)))
 	ds.Require().NoError(err)
-	err = ds.WaitForNodeReady("worker0", client)
+	err = ds.WaitForNodeReady(ds.WorkerNode(0), client)
 	ds.Require().NoError(err)
 
-	err = ds.WaitForNodeReady("worker1", client)
+	err = ds.WaitForNodeReady(ds.WorkerNode(1), client)
 	ds.Require().NoError(err)
 
 	ds.client = client
@@ -100,8 +100,7 @@ func TestDualStack(t *testing.T) {
 }
 
 func (ds *DualstackSuite) putFile(path string, content string) {
-	controllerNode := fmt.Sprintf("controller%d", 0)
-	ssh, err := ds.SSH(controllerNode)
+	ssh, err := ds.SSH(ds.ControllerNode(0))
 	ds.Require().NoError(err)
 	defer ssh.Disconnect()
 	_, err = ssh.ExecWithOutput(fmt.Sprintf("echo '%s' >%s", content, path))

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -72,7 +72,7 @@ func (ds *DualstackSuite) SetupSuite() {
 	ds.FootlooseSuite.SetupSuite()
 	ds.putFile("/tmp/k0s.yaml", k0sConfigWithAddon)
 	ds.Require().NoError(ds.InitMainController("--config=/tmp/k0s.yaml"))
-	ds.Require().NoError(ds.RunWorkers("/var/lib/k0s"))
+	ds.Require().NoError(ds.RunWorkers())
 	client, err := k8s.NewForConfig(ds.getKubeConfig("controller0"))
 	ds.Require().NoError(err)
 	err = ds.WaitForNodeReady("worker0", client)

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -71,7 +71,7 @@ func (ds *DualstackSuite) getKubeConfig(node string) *restclient.Config {
 func (ds *DualstackSuite) SetupSuite() {
 	ds.FootlooseSuite.SetupSuite()
 	ds.putFile("/tmp/k0s.yaml", k0sConfigWithAddon)
-	ds.Require().NoError(ds.InitMainController([]string{"--config=/tmp/k0s.yaml"}))
+	ds.Require().NoError(ds.InitMainController("--config=/tmp/k0s.yaml"))
 	ds.Require().NoError(ds.RunWorkers("/var/lib/k0s"))
 	client, err := k8s.NewForConfig(ds.getKubeConfig("controller0"))
 	ds.Require().NoError(err)

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -70,7 +70,7 @@ func (ds *DualstackSuite) getKubeConfig(node string) *restclient.Config {
 
 func (ds *DualstackSuite) SetupSuite() {
 	ds.FootlooseSuite.SetupSuite()
-	ds.putFile("/tmp/k0s.yaml", k0sConfigWithAddon)
+	ds.PutFile(ds.ControllerNode(0), "/tmp/k0s.yaml", k0sConfigWithAddon)
 	ds.Require().NoError(ds.InitController(0, "--config=/tmp/k0s.yaml"))
 	ds.Require().NoError(ds.RunWorkers())
 	client, err := k8s.NewForConfig(ds.getKubeConfig(ds.ControllerNode(0)))
@@ -96,16 +96,6 @@ func TestDualStack(t *testing.T) {
 	}
 
 	suite.Run(t, &s)
-
-}
-
-func (ds *DualstackSuite) putFile(path string, content string) {
-	ssh, err := ds.SSH(ds.ControllerNode(0))
-	ds.Require().NoError(err)
-	defer ssh.Disconnect()
-	_, err = ssh.ExecWithOutput(fmt.Sprintf("echo '%s' >%s", content, path))
-
-	ds.Require().NoError(err)
 
 }
 

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -71,7 +71,7 @@ func (ds *DualstackSuite) getKubeConfig(node string) *restclient.Config {
 func (ds *DualstackSuite) SetupSuite() {
 	ds.FootlooseSuite.SetupSuite()
 	ds.putFile("/tmp/k0s.yaml", k0sConfigWithAddon)
-	ds.Require().NoError(ds.InitMainController("--config=/tmp/k0s.yaml"))
+	ds.Require().NoError(ds.InitController(0, "--config=/tmp/k0s.yaml"))
 	ds.Require().NoError(ds.RunWorkers())
 	client, err := k8s.NewForConfig(ds.getKubeConfig("controller0"))
 	ds.Require().NoError(err)

--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -1,9 +1,10 @@
-FROM alpine:3.12
+FROM alpine:3.13
 
 RUN apk add openrc openssh-server bash busybox-initscripts coreutils findutils iptables curl
 # enable syslog and sshd
 RUN rc-update add cgroups boot
 RUN rc-update add syslog boot
+RUN rc-update add machine-id boot
 RUN rc-update add sshd default
 RUN rc-update add local default
 # remove -docker keyword so we actually mount cgroups in container
@@ -12,11 +13,6 @@ RUN sed -i -e '/keyword/s/-docker//' /etc/init.d/cgroups
 RUN sed -i -e 's/^\(tty[0-9]\)/# \1/' /etc/inittab
 # enable root logins
 RUN sed -i -e 's/^root:!:/root::/' /etc/shadow
-RUN echo "#!/bin/sh" > /etc/local.d/machine-id.start \
-       && echo "if ! [ -f /etc/machine-id ]; then" >> /etc/local.d/machine-id.start \
-       && echo "  dd if=/dev/urandom status=none bs=16 count=1 | md5sum | cut -d' ' -f1 > /etc/machine-id" >> /etc/local.d/machine-id.start \
-       && echo "fi" >> /etc/local.d/machine-id.start \
-       && chmod +x /etc/local.d/machine-id.start
 
 # Put kubectl into place to ease up debugging
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.20.0/bin/linux/amd64/kubectl \

--- a/inttest/hacontrolplane/hacontrolplane_test.go
+++ b/inttest/hacontrolplane/hacontrolplane_test.go
@@ -74,10 +74,10 @@ func (s *HAControlplaneSuite) getCa(controllerIdx int) string {
 }
 
 func (s *HAControlplaneSuite) TestDeregistration() {
-	s.NoError(s.InitMainController())
+	s.NoError(s.InitController(0))
 	token, err := s.GetJoinToken("controller", "")
 	s.NoError(err)
-	s.NoError(s.JoinController(1, token, ""))
+	s.NoError(s.InitController(1, token))
 
 	ca0 := s.getCa(0)
 	s.Contains(ca0, "-----BEGIN CERTIFICATE-----")
@@ -107,7 +107,7 @@ func (s *HAControlplaneSuite) TestDeregistration() {
 	s.Require().NoError(err)
 	_, err = sshC1.ExecWithOutput("kill $(pidof k0s) && while pidof k0s; do sleep 0.1s; done")
 	s.Require().NoError(err)
-	s.NoError(s.JoinController(1, token, ""))
+	s.NoError(s.InitController(1, token))
 
 	// Make one member leave the etcd cluster
 	s.makeNodeLeave(1, membersFromJoined["controller1"])

--- a/inttest/hacontrolplane/hacontrolplane_test.go
+++ b/inttest/hacontrolplane/hacontrolplane_test.go
@@ -64,6 +64,12 @@ func (s *HAControlplaneSuite) makeNodeLeave(executeOnControllerIdx int, peerAddr
 }
 
 func (s *HAControlplaneSuite) TestDeregistration() {
+	// Verify that k0s return failure (https://github.com/k0sproject/k0s/issues/790)
+	sshC0, err := s.SSH(s.ControllerNode(0))
+	s.Require().NoError(err)
+	_, err = sshC0.ExecWithOutput("k0s etcd member-list")
+	s.Require().Error(err)
+
 	s.NoError(s.InitController(0))
 	token, err := s.GetJoinToken("controller")
 	s.NoError(err)

--- a/inttest/hacontrolplane/hacontrolplane_test.go
+++ b/inttest/hacontrolplane/hacontrolplane_test.go
@@ -63,26 +63,16 @@ func (s *HAControlplaneSuite) makeNodeLeave(executeOnControllerIdx int, peerAddr
 	s.NoError(err)
 }
 
-func (s *HAControlplaneSuite) getCa(controllerIdx int) string {
-	sshCon, err := s.SSH(s.ControllerNode(controllerIdx))
-	s.NoError(err)
-	defer sshCon.Disconnect()
-	ca, err := sshCon.ExecWithOutput("cat /var/lib/k0s/pki/ca.crt")
-	s.NoError(err)
-
-	return ca
-}
-
 func (s *HAControlplaneSuite) TestDeregistration() {
 	s.NoError(s.InitController(0))
 	token, err := s.GetJoinToken("controller", "")
 	s.NoError(err)
 	s.NoError(s.InitController(1, token))
 
-	ca0 := s.getCa(0)
+	ca0 := s.GetFileFromController(0, "/var/lib/k0s/pki/ca.crt")
 	s.Contains(ca0, "-----BEGIN CERTIFICATE-----")
 
-	ca1 := s.getCa(1)
+	ca1 := s.GetFileFromController(1, "/var/lib/k0s/pki/ca.crt")
 	s.Contains(ca1, "-----BEGIN CERTIFICATE-----")
 
 	s.Equal(ca0, ca1)

--- a/inttest/hacontrolplane/hacontrolplane_test.go
+++ b/inttest/hacontrolplane/hacontrolplane_test.go
@@ -74,7 +74,7 @@ func (s *HAControlplaneSuite) getCa(controllerIdx int) string {
 }
 
 func (s *HAControlplaneSuite) TestDeregistration() {
-	s.NoError(s.InitMainController([]string{}))
+	s.NoError(s.InitMainController())
 	token, err := s.GetJoinToken("controller", "")
 	s.NoError(err)
 	s.NoError(s.JoinController(1, token, ""))

--- a/inttest/hacontrolplane/hacontrolplane_test.go
+++ b/inttest/hacontrolplane/hacontrolplane_test.go
@@ -65,7 +65,7 @@ func (s *HAControlplaneSuite) makeNodeLeave(executeOnControllerIdx int, peerAddr
 
 func (s *HAControlplaneSuite) TestDeregistration() {
 	s.NoError(s.InitController(0))
-	token, err := s.GetJoinToken("controller", "")
+	token, err := s.GetJoinToken("controller")
 	s.NoError(err)
 	s.NoError(s.InitController(1, token))
 

--- a/inttest/hacontrolplane/hacontrolplane_test.go
+++ b/inttest/hacontrolplane/hacontrolplane_test.go
@@ -35,6 +35,7 @@ func (s *HAControlplaneSuite) getMembers(fromControllerIdx int) map[string]strin
 	// which in general even makes sense, we can test tooling as well
 	sshCon, err := s.SSH(s.ControllerNode(fromControllerIdx))
 	s.NoError(err)
+	defer sshCon.Disconnect()
 	output, err := sshCon.ExecWithOutput("k0s etcd member-list")
 	output = lastLine(output)
 	s.NoError(err)
@@ -50,6 +51,7 @@ func (s *HAControlplaneSuite) getMembers(fromControllerIdx int) map[string]strin
 func (s *HAControlplaneSuite) makeNodeLeave(executeOnControllerIdx int, peerAddress string) {
 	sshCon, err := s.SSH(s.ControllerNode(executeOnControllerIdx))
 	s.NoError(err)
+	defer sshCon.Disconnect()
 	for i := 0; i < 20; i++ {
 		_, err = sshCon.ExecWithOutput(fmt.Sprintf("k0s etcd leave %s", peerAddress))
 		if err == nil {
@@ -64,6 +66,7 @@ func (s *HAControlplaneSuite) makeNodeLeave(executeOnControllerIdx int, peerAddr
 func (s *HAControlplaneSuite) getCa(controllerIdx int) string {
 	sshCon, err := s.SSH(s.ControllerNode(controllerIdx))
 	s.NoError(err)
+	defer sshCon.Disconnect()
 	ca, err := sshCon.ExecWithOutput("cat /var/lib/k0s/pki/ca.crt")
 	s.NoError(err)
 
@@ -102,6 +105,7 @@ func (s *HAControlplaneSuite) TestDeregistration() {
 	// It should just ignore the token as there's CA etc already in place
 	sshC1, err := s.SSH(s.ControllerNode(1))
 	s.Require().NoError(err)
+	defer sshC1.Disconnect()
 	_, err = sshC1.ExecWithOutput("kill $(pidof k0s) && while pidof k0s; do sleep 0.1s; done")
 	s.Require().NoError(err)
 	s.NoError(s.InitController(1, token))

--- a/inttest/install/singlenode_test.go
+++ b/inttest/install/singlenode_test.go
@@ -39,10 +39,10 @@ func (s *InstallSuite) TestK0sGetsUp() {
 	_, err = ssh.ExecWithOutput("rc-service k0scontroller start")
 	s.Require().NoError(err)
 
-	err = s.WaitForKubeAPI(s.ControllerNode(0), "")
+	err = s.WaitForKubeAPI(s.ControllerNode(0))
 	s.Require().NoError(err)
 
-	kc, err := s.KubeClient(s.ControllerNode(0), "")
+	kc, err := s.KubeClient(s.ControllerNode(0))
 	s.NoError(err)
 
 	err = s.WaitForNodeReady(s.ControllerNode(0), kc)

--- a/inttest/install/singlenode_test.go
+++ b/inttest/install/singlenode_test.go
@@ -29,7 +29,7 @@ type InstallSuite struct {
 }
 
 func (s *InstallSuite) TestK0sGetsUp() {
-	ssh, err := s.SSH("controller0")
+	ssh, err := s.SSH(s.ControllerNode(0))
 	s.Require().NoError(err)
 	defer ssh.Disconnect()
 
@@ -39,13 +39,13 @@ func (s *InstallSuite) TestK0sGetsUp() {
 	_, err = ssh.ExecWithOutput("rc-service k0scontroller start")
 	s.Require().NoError(err)
 
-	err = s.WaitForKubeAPI("controller0", "")
+	err = s.WaitForKubeAPI(s.ControllerNode(0), "")
 	s.Require().NoError(err)
 
-	kc, err := s.KubeClient("controller0", "")
+	kc, err := s.KubeClient(s.ControllerNode(0), "")
 	s.NoError(err)
 
-	err = s.WaitForNodeReady("controller0", kc)
+	err = s.WaitForNodeReady(s.ControllerNode(0), kc)
 	s.NoError(err)
 
 	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{

--- a/inttest/kine/kine_test.go
+++ b/inttest/kine/kine_test.go
@@ -34,7 +34,7 @@ func (s *KineSuite) TestK0sGetsUp() {
 	s.NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
 	s.NoError(s.RunWorkers())
 
-	kc, err := s.KubeClient(s.ControllerNode(0), "")
+	kc, err := s.KubeClient(s.ControllerNode(0))
 	s.NoError(err)
 
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)

--- a/inttest/kine/kine_test.go
+++ b/inttest/kine/kine_test.go
@@ -31,17 +31,17 @@ type KineSuite struct {
 }
 
 func (s *KineSuite) TestK0sGetsUp() {
-	s.putFile("controller0", "/tmp/k0s.yaml", k0sConfigWithKine)
+	s.putFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfigWithKine)
 	s.NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
 	s.NoError(s.RunWorkers())
 
-	kc, err := s.KubeClient("controller0", "")
+	kc, err := s.KubeClient(s.ControllerNode(0), "")
 	s.NoError(err)
 
-	err = s.WaitForNodeReady("worker0", kc)
+	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
 	s.NoError(err)
 
-	err = s.WaitForNodeReady("worker1", kc)
+	err = s.WaitForNodeReady(s.WorkerNode(1), kc)
 	s.NoError(err)
 
 	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{

--- a/inttest/kine/kine_test.go
+++ b/inttest/kine/kine_test.go
@@ -32,7 +32,7 @@ type KineSuite struct {
 
 func (s *KineSuite) TestK0sGetsUp() {
 	s.putFile("controller0", "/tmp/k0s.yaml", k0sConfigWithKine)
-	s.NoError(s.InitMainController("--config=/tmp/k0s.yaml"))
+	s.NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
 	s.NoError(s.RunWorkers())
 
 	kc, err := s.KubeClient("controller0", "")

--- a/inttest/kine/kine_test.go
+++ b/inttest/kine/kine_test.go
@@ -32,7 +32,7 @@ type KineSuite struct {
 
 func (s *KineSuite) TestK0sGetsUp() {
 	s.putFile("controller0", "/tmp/k0s.yaml", k0sConfigWithKine)
-	s.NoError(s.InitMainController([]string{"--config=/tmp/k0s.yaml"}))
+	s.NoError(s.InitMainController("--config=/tmp/k0s.yaml"))
 	s.NoError(s.RunWorkers(""))
 
 	kc, err := s.KubeClient("controller0", "")

--- a/inttest/kine/kine_test.go
+++ b/inttest/kine/kine_test.go
@@ -33,7 +33,7 @@ type KineSuite struct {
 func (s *KineSuite) TestK0sGetsUp() {
 	s.putFile("controller0", "/tmp/k0s.yaml", k0sConfigWithKine)
 	s.NoError(s.InitMainController("--config=/tmp/k0s.yaml"))
-	s.NoError(s.RunWorkers(""))
+	s.NoError(s.RunWorkers())
 
 	kc, err := s.KubeClient("controller0", "")
 	s.NoError(err)

--- a/inttest/kine/kine_test.go
+++ b/inttest/kine/kine_test.go
@@ -17,7 +17,6 @@ package kine
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -31,7 +30,7 @@ type KineSuite struct {
 }
 
 func (s *KineSuite) TestK0sGetsUp() {
-	s.putFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfigWithKine)
+	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfigWithKine)
 	s.NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
 	s.NoError(s.RunWorkers())
 
@@ -66,15 +65,6 @@ func TestKineSuite(t *testing.T) {
 		},
 	}
 	suite.Run(t, &s)
-}
-
-func (s *KineSuite) putFile(node string, path string, content string) {
-	ssh, err := s.SSH(node)
-	s.Require().NoError(err)
-	defer ssh.Disconnect()
-	_, err = ssh.ExecWithOutput(fmt.Sprintf("echo '%s' >%s", content, path))
-
-	s.Require().NoError(err)
 }
 
 const k0sConfigWithKine = `

--- a/inttest/multicontroller/multicontroller_test.go
+++ b/inttest/multicontroller/multicontroller_test.go
@@ -45,15 +45,15 @@ func (s *MultiControllerSuite) TestK0sGetsUp() {
 	s.T().Logf("ip address: %s", ipAddress)
 
 	s.putFile("controller0", "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
-	s.NoError(s.InitMainController("--config=/tmp/k0s.yaml"))
+	s.NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
 
 	token, err := s.GetJoinToken("controller", "")
 	s.NoError(err)
 	s.putFile("controller1", "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
-	s.NoError(s.JoinController(1, token, ""))
+	s.NoError(s.InitController(1, "--config=/tmp/k0s.yaml", token))
 
 	s.putFile("controller2", "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
-	s.NoError(s.JoinController(2, token, ""))
+	s.NoError(s.InitController(2, "--config=/tmp/k0s.yaml", token))
 	s.NoError(s.RunWorkers())
 
 	kc, err := s.KubeClient("controller0", "")

--- a/inttest/multicontroller/multicontroller_test.go
+++ b/inttest/multicontroller/multicontroller_test.go
@@ -44,15 +44,15 @@ func (s *MultiControllerSuite) TestK0sGetsUp() {
 	ipAddress := s.getMainIPAddress()
 	s.T().Logf("ip address: %s", ipAddress)
 
-	s.putFile(s.ControllerNode(0), "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
+	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
 	s.NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
 
 	token, err := s.GetJoinToken("controller", "")
 	s.NoError(err)
-	s.putFile(s.ControllerNode(1), "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
+	s.PutFile(s.ControllerNode(1), "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
 	s.NoError(s.InitController(1, "--config=/tmp/k0s.yaml", token))
 
-	s.putFile(s.ControllerNode(2), "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
+	s.PutFile(s.ControllerNode(2), "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
 	s.NoError(s.InitController(2, "--config=/tmp/k0s.yaml", token))
 	s.NoError(s.RunWorkers())
 
@@ -84,15 +84,6 @@ func TestMultiControllerSuite(t *testing.T) {
 		},
 	}
 	suite.Run(t, &s)
-}
-
-func (s *MultiControllerSuite) putFile(node string, path string, content string) {
-	ssh, err := s.SSH(node)
-	s.Require().NoError(err)
-	defer ssh.Disconnect()
-	_, err = ssh.ExecWithOutput(fmt.Sprintf("echo '%s' >%s", content, path))
-
-	s.Require().NoError(err)
 }
 
 const k0sConfigWithMultiController = `

--- a/inttest/multicontroller/multicontroller_test.go
+++ b/inttest/multicontroller/multicontroller_test.go
@@ -47,7 +47,7 @@ func (s *MultiControllerSuite) TestK0sGetsUp() {
 	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
 	s.NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
 
-	token, err := s.GetJoinToken("controller", "")
+	token, err := s.GetJoinToken("controller")
 	s.NoError(err)
 	s.PutFile(s.ControllerNode(1), "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
 	s.NoError(s.InitController(1, "--config=/tmp/k0s.yaml", token))

--- a/inttest/multicontroller/multicontroller_test.go
+++ b/inttest/multicontroller/multicontroller_test.go
@@ -54,7 +54,7 @@ func (s *MultiControllerSuite) TestK0sGetsUp() {
 
 	s.putFile("controller2", "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
 	s.NoError(s.JoinController(2, token, ""))
-	s.NoError(s.RunWorkers(""))
+	s.NoError(s.RunWorkers())
 
 	kc, err := s.KubeClient("controller0", "")
 	s.NoError(err)

--- a/inttest/multicontroller/multicontroller_test.go
+++ b/inttest/multicontroller/multicontroller_test.go
@@ -45,7 +45,7 @@ func (s *MultiControllerSuite) TestK0sGetsUp() {
 	s.T().Logf("ip address: %s", ipAddress)
 
 	s.putFile("controller0", "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
-	s.NoError(s.InitMainController([]string{"--config=/tmp/k0s.yaml"}))
+	s.NoError(s.InitMainController("--config=/tmp/k0s.yaml"))
 
 	token, err := s.GetJoinToken("controller", "")
 	s.NoError(err)

--- a/inttest/multicontroller/multicontroller_test.go
+++ b/inttest/multicontroller/multicontroller_test.go
@@ -56,7 +56,7 @@ func (s *MultiControllerSuite) TestK0sGetsUp() {
 	s.NoError(s.InitController(2, "--config=/tmp/k0s.yaml", token))
 	s.NoError(s.RunWorkers())
 
-	kc, err := s.KubeClient(s.ControllerNode(0), "")
+	kc, err := s.KubeClient(s.ControllerNode(0))
 	s.NoError(err)
 
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)

--- a/inttest/singlenode/singlenode_test.go
+++ b/inttest/singlenode/singlenode_test.go
@@ -32,10 +32,10 @@ type SingleNodeSuite struct {
 func (s *SingleNodeSuite) TestK0sGetsUp() {
 	s.NoError(s.InitController(0, "--single"))
 
-	kc, err := s.KubeClient("controller0", "")
+	kc, err := s.KubeClient(s.ControllerNode(0), "")
 	s.NoError(err)
 
-	err = s.WaitForNodeReady("controller0", kc)
+	err = s.WaitForNodeReady(s.ControllerNode(0), kc)
 	s.NoError(err)
 
 	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{

--- a/inttest/singlenode/singlenode_test.go
+++ b/inttest/singlenode/singlenode_test.go
@@ -32,7 +32,7 @@ type SingleNodeSuite struct {
 func (s *SingleNodeSuite) TestK0sGetsUp() {
 	s.NoError(s.InitController(0, "--single"))
 
-	kc, err := s.KubeClient(s.ControllerNode(0), "")
+	kc, err := s.KubeClient(s.ControllerNode(0))
 	s.NoError(err)
 
 	err = s.WaitForNodeReady(s.ControllerNode(0), kc)

--- a/inttest/singlenode/singlenode_test.go
+++ b/inttest/singlenode/singlenode_test.go
@@ -30,7 +30,7 @@ type SingleNodeSuite struct {
 }
 
 func (s *SingleNodeSuite) TestK0sGetsUp() {
-	s.NoError(s.InitMainController("--single"))
+	s.NoError(s.InitController(0, "--single"))
 
 	kc, err := s.KubeClient("controller0", "")
 	s.NoError(err)

--- a/inttest/singlenode/singlenode_test.go
+++ b/inttest/singlenode/singlenode_test.go
@@ -30,7 +30,7 @@ type SingleNodeSuite struct {
 }
 
 func (s *SingleNodeSuite) TestK0sGetsUp() {
-	s.NoError(s.InitMainController([]string{"--single"}))
+	s.NoError(s.InitMainController("--single"))
 
 	kc, err := s.KubeClient("controller0", "")
 	s.NoError(err)


### PR DESCRIPTION
**What this PR Includes**
Cleanup and refactor the footloose integration tests.

- de-duplicate the copy/paste code
- use variadic args instead of always pass a dataDir option (so it is optional)
- add a regression test for #790 
- disconnect ssh when it should to avoid dangling ssh connections
- dont use hardcoded node names