### PR TITLE
Add readyness check for kube api-server

### DIFF
--- a/inttest/hacontrolplane/hacontrolplane_test.go
+++ b/inttest/hacontrolplane/hacontrolplane_test.go
@@ -71,9 +71,11 @@ func (s *HAControlplaneSuite) TestDeregistration() {
 	s.Require().Error(err)
 
 	s.NoError(s.InitController(0))
+	s.NoError(s.WaitJoinAPI(s.ControllerNode(0)))
 	token, err := s.GetJoinToken("controller")
 	s.NoError(err)
 	s.NoError(s.InitController(1, token))
+	s.NoError(s.WaitJoinAPI(s.ControllerNode(1)))
 
 	ca0 := s.GetFileFromController(0, "/var/lib/k0s/pki/ca.crt")
 	s.Contains(ca0, "-----BEGIN CERTIFICATE-----")
@@ -105,6 +107,7 @@ func (s *HAControlplaneSuite) TestDeregistration() {
 	_, err = sshC1.ExecWithOutput("kill $(pidof k0s) && while pidof k0s; do sleep 0.1s; done")
 	s.Require().NoError(err)
 	s.NoError(s.InitController(1, token))
+	s.NoError(s.WaitJoinAPI(s.ControllerNode(1)))
 
 	// Make one member leave the etcd cluster
 	s.makeNodeLeave(1, membersFromJoined[s.ControllerNode(1)])


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Currently we do not wait for the API to be ready before we start to apply manifests and other components. On a slow system where the first boot of api takes a while, this can lead to following:
```
time="2021-03-25 14:41:20" level=warning msg="stack apply failed" bundle=bootstraprbac component=applier error="mapping error: no matches for kind \"ClusterRoleBinding\" in version \"rbac.authorization.k8s.io/v1\""
```
Basically means the api has not initialized yet properly and thus does not recognize some of the API groups yet.


**What this PR Includes**
Adds a readiness check for the api server according to https://kubernetes.io/docs/reference/using-api/health-checks/

Added some finetunings for the HA controller smoke case as it became slightly flaky now when the controller actually waits for the k8s api before starting other components. Few times the second controller errored out as the join api was not yet up-and-running. So now there's a wait (and erroring out) if the join api is not getting up.