### PR TITLE
Add back ETCD_UNSUPPORTED_ARCH=arm64 for smoke test controllers

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -364,10 +364,15 @@ jobs:
 
   smoketest-arm:
     name: Smoke test on arm64
-    needs: build
     runs-on: [self-hosted,linux,arm64]
 
     steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.13
+        id: go
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
@@ -395,7 +400,7 @@ jobs:
       
       - name: Build
         run: make build
-        
+
       - name: Run test .
         run: make -C inttest check-basic
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -362,6 +362,50 @@ jobs:
           path: |
             /tmp/*.log
 
+  smoketest-arm:
+    name: Smoke test on arm64
+    needs: build
+    runs-on: [self-hosted,linux,arm64]
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        name: Go modules cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Bindata
+        uses: actions/cache@v2
+        id: generated-bindata
+        with:
+          path: |
+            .bins.linux.stamp
+            embedded-bins/staging/linux/bin/
+            bindata_linux
+            pkg/assets/zz_generated_offsets_linux.go
+
+          key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-arm64
+          restore-keys: |
+            ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-arm64
+      
+      - name: Build
+        run: make build
+        
+      - name: Run test .
+        run: make -C inttest check-basic
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -222,7 +222,7 @@ func (s *FootlooseSuite) InitController(idx int, k0sArgs ...string) error {
 	}
 	defer ssh.Disconnect()
 
-	startCmd := fmt.Sprintf("nohup k0s controller --debug %s >/tmp/k0s-controller.log 2>&1 &", strings.Join(k0sArgs, " "))
+	startCmd := fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=arm64 nohup k0s controller --debug %s >/tmp/k0s-controller.log 2>&1 &", strings.Join(k0sArgs, " "))
 	_, err = ssh.ExecWithOutput(startCmd)
 	if err != nil {
 		s.T().Logf("failed to execute '%s' on %s", startCmd, controllerNode)


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Basic smoke failing on arm64 during release builds

**What this PR Includes**
This adds back the `ETCD_UNSUPPORTED_ARCH=arm64` env when starting controllers during smoke tests which was dropped in a5152c0c5c0840ed101b334dc098add7dff61f67

This also adds a run of the basic smoke on arm64 runner in the PR phase so we'll detect earlier if something major like this gets broken.