### PR TITLE
Add worker flags to controller

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -94,6 +94,7 @@ func NewControllerCmd() *cobra.Command {
 	// append flags
 	cmd.Flags().AddFlagSet(config.GetPersistentFlagSet())
 	cmd.PersistentFlags().AddFlagSet(config.GetControllerFlags())
+	cmd.PersistentFlags().AddFlagSet(config.GetWorkerFlags())
 	return cmd
 }
 
@@ -462,10 +463,13 @@ func (c *CmdOpts) startControllerWorker(ctx context.Context, profile string) err
 	workerComponentManager.Add(worker.NewOCIBundleReconciler(c.K0sVars))
 	workerComponentManager.Add(&worker.Kubelet{
 		CRISocket:           c.CriSocket,
-		KubeletConfigClient: kubeletConfigClient,
-		Profile:             profile,
-		LogLevel:            c.Logging["kubelet"],
+		EnableCloudProvider: c.CloudProvider,
 		K0sVars:             c.K0sVars,
+		KubeletConfigClient: kubeletConfigClient,
+		LogLevel:            c.Logging["kubelet"],
+		Profile:             c.WorkerProfile,
+		Labels:              c.Labels,
+		ExtraArgs:           c.KubeletExtraArgs,
 	})
 
 	if err := workerComponentManager.Init(); err != nil {

--- a/cmd/install/controller.go
+++ b/cmd/install/controller.go
@@ -51,5 +51,6 @@ With controller subcommand you can setup a single node cluster by running:
 	// append flags
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	cmd.Flags().AddFlagSet(config.GetControllerFlags())
+	cmd.Flags().AddFlagSet(config.GetWorkerFlags())
 	return cmd
 }


### PR DESCRIPTION
**Issue**
Fixes #808 

**What this PR Includes**
The `controller` and `install controller` commands support all worker flags. This is useful when used with `--single` or `--enable-worker` flags.

Signed-off-by: 0SkillAllLuck <43417046+0SkillAllLuck@users.noreply.github.com>