### PR TITLE
extended k0s version cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+include embedded-bins/Makefile.variables
 
 GO_SRCS := $(shell find . -type f -name '*.go' -a ! -name 'zz_generated*')
 
@@ -69,7 +70,7 @@ k0s.exe: pkg/assets/zz_generated_offsets_windows.go
 k0s.exe k0s: static/gen_manifests.go
 
 k0s.exe k0s: $(GO_SRCS)
-	CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(GOARCH) go build -ldflags="$(LD_FLAGS) -X github.com/k0sproject/k0s/pkg/build.Version=$(VERSION) -X \"github.com/k0sproject/k0s/pkg/build.EulaNotice=$(EULA_NOTICE)\" -X github.com/k0sproject/k0s/pkg/telemetry.segmentToken=$(SEGMENT_TOKEN)" \
+	CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(GOARCH) go build -ldflags="$(LD_FLAGS) -X github.com/k0sproject/k0s/pkg/build.Version=$(VERSION) -X github.com/k0sproject/k0s/pkg/build.RuncVersion=$(runc_version) -X github.com/k0sproject/k0s/pkg/build.ContainerdVersion=$(containerd_version) -X github.com/k0sproject/k0s/pkg/build.KubernetesVersion=$(kubernetes_version) -X github.com/k0sproject/k0s/pkg/build.KineVersion=$(kine_version) -X github.com/k0sproject/k0s/pkg/build.EtcdVersion=$(etcd_version) -X github.com/k0sproject/k0s/pkg/build.KonnectivityVersion=$(konnectivity_version) -X \"github.com/k0sproject/k0s/pkg/build.EulaNotice=$(EULA_NOTICE)\" -X github.com/k0sproject/k0s/pkg/telemetry.segmentToken=$(SEGMENT_TOKEN)" \
 		    -o $@.code main.go
 	cat $@.code bindata_$(TARGET_OS) > $@.tmp && chmod +x $@.tmp && mv $@.tmp $@
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ import (
 	"github.com/k0sproject/k0s/cmd/status"
 	"github.com/k0sproject/k0s/cmd/token"
 	"github.com/k0sproject/k0s/cmd/validate"
+	"github.com/k0sproject/k0s/cmd/version"
 	"github.com/k0sproject/k0s/cmd/worker"
 	"github.com/k0sproject/k0s/pkg/apis/v1beta1"
 	"github.com/k0sproject/k0s/pkg/build"
@@ -78,8 +79,8 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(kubeconfig.NewKubeConfigCmd())
 	cmd.AddCommand(kubectl.NewK0sKubectlCmd())
 	cmd.AddCommand(airgap.NewAirgapCmd())
+	cmd.AddCommand(version.NewVersionCmd())
 
-	cmd.AddCommand(newVersionCmd())
 	cmd.AddCommand(newDocsCmd())
 	cmd.AddCommand(newDefaultConfigCmd())
 	cmd.AddCommand(newCompletionCmd())
@@ -92,17 +93,6 @@ func NewRootCmd() *cobra.Command {
 	cmd.Long = longDesc
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	return cmd
-}
-
-func newVersionCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "version",
-		Short: "Print the k0s version",
-
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(build.Version)
-		},
-	}
 }
 
 func newDocsCmd() *cobra.Command {

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,67 @@
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/k0sproject/k0s/pkg/build"
+	"github.com/spf13/cobra"
+)
+
+var (
+	all   bool
+	isJsn bool
+)
+
+func NewVersionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the k0s version",
+
+		Run: func(cmd *cobra.Command, args []string) {
+			info := versionInfo{
+				Version:      build.Version,
+				Runc:         build.RuncVersion,
+				Containerd:   build.ContainerdVersion,
+				Kubernetes:   build.KubernetesVersion,
+				Kine:         build.KineVersion,
+				Etcd:         build.EtcdVersion,
+				Konnectivity: build.KonnectivityVersion,
+			}
+
+			info.String()
+		},
+	}
+
+	// append flags
+	cmd.PersistentFlags().BoolVarP(&all, "all", "a", false, "use to print all k0s version info")
+	cmd.PersistentFlags().BoolVarP(&isJsn, "json", "j", false, "use to print all k0s version info in json")
+	return cmd
+}
+
+type versionInfo struct {
+	Version      string `json:"k0s,omitempty"`
+	Runc         string `json:"runc,omitempty"`
+	Containerd   string `json:"containerd,omitempty"`
+	Kubernetes   string `json:"kubernetes,omitempty"`
+	Kine         string `json:"kine,omitempty"`
+	Etcd         string `json:"etcd,omitempty"`
+	Konnectivity string `json:"konnectivity,omitempty"`
+}
+
+func (v versionInfo) String() {
+	if all {
+		fmt.Println("k0s :", v.Version)
+		fmt.Println("runc :", v.Runc)
+		fmt.Println("containerd :", v.Containerd)
+		fmt.Println("kubernetes :", v.Kubernetes)
+		fmt.Println("kine :", v.Kine)
+		fmt.Println("etcd :", v.Etcd)
+		fmt.Println("konnectivity :", v.Konnectivity)
+	} else if isJsn {
+		jsn, _ := json.MarshalIndent(v, "", "   ")
+		fmt.Println(string(jsn))
+	} else {
+		fmt.Println(v.Version)
+	}
+}

--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -1,10 +1,4 @@
-
-runc_version = 1.0.0-rc93
-containerd_version = 1.4.4
-kubernetes_version = 1.20.5
-kine_version = 0.6.0
-etcd_version = 3.4.15
-konnectivity_version = 0.0.14
+include Makefile.variables
 
 GOOS ?= linux
 export GOOS

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,0 +1,6 @@
+runc_version = 1.0.0-rc93
+containerd_version = 1.4.4
+kubernetes_version = 1.20.5
+kine_version = 0.6.0
+etcd_version = 3.4.15
+konnectivity_version = 0.0.14

--- a/pkg/build/version.go
+++ b/pkg/build/version.go
@@ -2,3 +2,10 @@ package build
 
 // Version gets overridden at build time using -X main.Version=$VERSION
 var Version string
+
+var RuncVersion string
+var ContainerdVersion string
+var KubernetesVersion string
+var KineVersion string
+var EtcdVersion string
+var KonnectivityVersion string


### PR DESCRIPTION
I've extended `k0s version` with 
```
k0s version -h
Print the k0s version

Usage:
  k0s version [flags]

Flags:
  -a, --all    use to print all k0s version info
  -h, --help   help for version
  -j, --json   use to print all k0s version info in json

Global Flags:
      --data-dir string        Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!
      --debugListenOn string   Http listenOn for debug pprof handler (default ":6060")
```

closes #655