### PR TITLE
Bump konnectivity to 0.0.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ k0s.exe k0s: $(GO_SRCS)
 		    -o $@.code main.go
 	cat $@.code bindata_$(TARGET_OS) > $@.tmp && chmod +x $@.tmp && mv $@.tmp $@
 
-.bins.windows.stamp .bins.linux.stamp:
+.bins.windows.stamp .bins.linux.stamp: embedded-bins/Makefile.variables
 	$(MAKE) -C embedded-bins buildmode=$(EMBEDDED_BINS_BUILDMODE) TARGET_OS=$(patsubst .bins.%.stamp,%,$@)
 	touch $@
 

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -3,4 +3,4 @@ containerd_version = 1.4.4
 kubernetes_version = 1.20.5
 kine_version = 0.6.0
 etcd_version = 3.4.15
-konnectivity_version = 0.0.14
+konnectivity_version = 0.0.16


### PR DESCRIPTION
Force rebuild of embedded bins when Makefile.variables changes

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

**What this PR Includes**
upgrade konnectivity to 0.0.16