### PR TITLE
Use fmt.Errorf everywhere for error handling

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/avast/retry-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -130,7 +129,7 @@ func (c *CmdOpts) startController() error {
 		join = true
 		joinClient, err = token.JoinClientFromToken(c.TokenArg)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create join client")
+			return fmt.Errorf("failed to create join client: %w", err)
 		}
 
 		componentManager.AddSync(&controller.CASyncer{
@@ -170,7 +169,7 @@ func (c *CmdOpts) startController() error {
 			LogLevel:    c.Logging["etcd"],
 		}
 	default:
-		return errors.New(fmt.Sprintf("Invalid storage type: %s", c.ClusterConfig.Spec.Storage.Type))
+		return fmt.Errorf("Invalid storage type: %s", c.ClusterConfig.Spec.Storage.Type)
 	}
 	logrus.Infof("Using storage backend %s", c.ClusterConfig.Spec.Storage.Type)
 	componentManager.Add(storageBackend)

--- a/cmd/kubeconfig/admin.go
+++ b/cmd/kubeconfig/admin.go
@@ -16,6 +16,7 @@ limitations under the License.
 package kubeconfig
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -23,7 +24,6 @@ import (
 	"github.com/cloudflare/cfssl/log"
 	"github.com/k0sproject/k0s/internal/util"
 	"github.com/k0sproject/k0s/pkg/config"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -45,12 +45,12 @@ func kubeConfigAdminCmd() *cobra.Command {
 
 				clusterAPIURL, err := c.getAPIURL()
 				if err != nil {
-					return errors.Wrap(err, "failed to fetch cluster's API Address: %v.")
+					return fmt.Errorf("failed to fetch cluster's API Address: %w", err)
 				}
 				newContent := strings.Replace(string(content), "https://localhost:6443", clusterAPIURL, -1)
 				os.Stdout.Write([]byte(newContent))
 			} else {
-				return errors.Errorf("failed to read admin config, is the control plane initialized on this node?")
+				return fmt.Errorf("failed to read admin config, is the control plane initialized on this node?")
 			}
 			return nil
 		},

--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -19,8 +19,8 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+
 	"github.com/cloudflare/cfssl/log"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"html/template"
@@ -75,7 +75,7 @@ Note: A certificate once signed cannot be revoked for a particular user`,
 			log.Level = log.LevelFatal
 
 			if len(args) == 0 {
-				return errors.New("Username is mandatory")
+				return fmt.Errorf("Username is mandatory")
 			}
 			var username = args[0]
 			c := CmdOpts(config.GetCmdOpts())
@@ -86,7 +86,7 @@ Note: A certificate once signed cannot be revoked for a particular user`,
 			}
 			caCert, err := ioutil.ReadFile(path.Join(c.K0sVars.CertRootDir, "ca.crt"))
 			if err != nil {
-				return errors.Wrapf(err, "failed to read cluster ca certificate, is the control plane initialized on this node?")
+				return fmt.Errorf("failed to read cluster ca certificate: %w, is the control plane initialized on this node?", err)
 			}
 			caCertPath, caCertKey := path.Join(c.K0sVars.CertRootDir, "ca.crt"), path.Join(c.K0sVars.CertRootDir, "ca.key")
 			userReq := certificate.Request{

--- a/internal/util/interfaces.go
+++ b/internal/util/interfaces.go
@@ -16,9 +16,9 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"net"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -28,7 +28,7 @@ func AllAddresses() ([]string, error) {
 
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list network interfaces")
+		return nil, fmt.Errorf("failed to list network interfaces: %w", err)
 	}
 
 	for _, a := range addrs {
@@ -49,7 +49,7 @@ func AllAddresses() ([]string, error) {
 func FirstPublicAddress() (string, error) {
 	ifs, err := net.Interfaces()
 	if err != nil {
-		return "127.0.0.1", errors.Wrap(err, "failed to list network interfaces")
+		return "127.0.0.1", fmt.Errorf("failed to list network interfaces: %w", err)
 	}
 	for _, i := range ifs {
 		if i.Name == "vxlan.calico" {

--- a/internal/util/templatewriter.go
+++ b/internal/util/templatewriter.go
@@ -16,12 +16,12 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"html/template"
 	"io"
 	"os"
 
 	"github.com/Masterminds/sprig"
-	"github.com/pkg/errors"
 
 	"github.com/k0sproject/k0s/pkg/constant"
 )
@@ -38,7 +38,7 @@ type TemplateWriter struct {
 func (p *TemplateWriter) Write() error {
 	podFile, err := os.OpenFile(p.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, constant.CertMode)
 	if err != nil {
-		return errors.Wrapf(err, "failed to open pod file for %s", p.Name)
+		return fmt.Errorf("failed to open pod file for %s: %w", p.Name, err)
 	}
 	return p.WriteToBuffer(podFile)
 }
@@ -47,11 +47,11 @@ func (p *TemplateWriter) Write() error {
 func (p *TemplateWriter) WriteToBuffer(w io.Writer) error {
 	t, err := template.New(p.Name).Funcs(sprig.FuncMap()).Parse(p.Template)
 	if err != nil {
-		return errors.Wrapf(err, "failed to parse template for %s", p.Name)
+		return fmt.Errorf("failed to parse template for %s: %w", p.Name, err)
 	}
 	err = t.Execute(w, p.Data)
 	if err != nil {
-		return errors.Wrapf(err, "failed to execute template for %s", p.Name)
+		return fmt.Errorf("failed to execute template for %s: %w", p.Name, err)
 	}
 
 	return nil

--- a/pkg/apis/v1beta1/cluster.go
+++ b/pkg/apis/v1beta1/cluster.go
@@ -16,11 +16,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 
 	"github.com/k0sproject/k0s/pkg/constant"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -96,7 +96,7 @@ func (c *ClusterConfig) Validate() []error {
 func FromYamlFile(filename string, k0sVars constant.CfgVars) (*ClusterConfig, error) {
 	buf, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read config file at %s", filename)
+		return nil, fmt.Errorf("failed to read config file at %s: %w", filename, err)
 	}
 
 	return FromYamlString(string(buf), k0sVars)

--- a/pkg/apis/v1beta1/network.go
+++ b/pkg/apis/v1beta1/network.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/pkg/errors"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -81,7 +80,7 @@ func (n *Network) Validate() []error {
 func (n *Network) DNSAddress() (string, error) {
 	_, ipnet, err := net.ParseCIDR(n.ServiceCIDR)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to parse service CIDR %s: %s", n.ServiceCIDR, err.Error())
+		return "", fmt.Errorf("failed to parse service CIDR %s: %w", n.ServiceCIDR, err)
 	}
 
 	address := ipnet.IP.To4()
@@ -93,7 +92,7 @@ func (n *Network) DNSAddress() (string, error) {
 	}
 
 	if !ipnet.Contains(address) {
-		return "", errors.Wrapf(err, "failed to calculate a valid DNS address: %s", address.String())
+		return "", fmt.Errorf("failed to calculate a valid DNS address: %s", address.String())
 	}
 
 	return address.String(), nil
@@ -109,7 +108,7 @@ func (n *Network) InternalAPIAddresses() ([]string, error) {
 
 	parsedCIDRs, err := utilnet.ParseCIDRs(cidrs)
 	if err != nil {
-		return nil, fmt.Errorf("can't parse service cidr to build internal API address: %v", err)
+		return nil, fmt.Errorf("can't parse service cidr to build internal API address: %w", err)
 	}
 
 	stringifiedAddresses := make([]string, len(parsedCIDRs))

--- a/pkg/applier/manager.go
+++ b/pkg/applier/manager.go
@@ -17,9 +17,9 @@ package applier
 
 import (
 	"context"
+	"fmt"
 	"path"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/fsnotify.v1"
 
@@ -48,7 +48,7 @@ type Manager struct {
 func (m *Manager) Init() error {
 	err := util.InitDirectory(m.K0sVars.ManifestsDir, constant.ManifestsDirMode)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create manifest bundle dir %s", m.K0sVars.ManifestsDir)
+		return fmt.Errorf("failed to create manifest bundle dir %s: %w", m.K0sVars.ManifestsDir, err)
 	}
 	m.log = logrus.WithField("component", "applier-manager")
 	m.stacks = make(map[string]*StackApplier)

--- a/pkg/assets/stage.go
+++ b/pkg/assets/stage.go
@@ -17,12 +17,12 @@ package assets
 
 import (
 	"compress/gzip"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/k0sproject/k0s/internal/util"
@@ -71,7 +71,7 @@ func Stage(dataDir string, name string, filemode os.FileMode) error {
 
 	err := util.InitDirectory(filepath.Dir(p), filemode)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create dir %s", filepath.Dir(p))
+		return fmt.Errorf("failed to create dir %s: %w", filepath.Dir(p), err)
 	}
 
 	if ExecutableIsOlder(p) {
@@ -101,11 +101,11 @@ func Stage(dataDir string, name string, filemode os.FileMode) error {
 
 	// find location at EOF - BinDataSize + offs
 	if _, err := infile.Seek(-BinDataSize+bin.offset, 2); err != nil {
-		return errors.Wrapf(err, "Failed to find embedded file position for %s", name)
+		return fmt.Errorf("Failed to find embedded file position for %s: %w", name, err)
 	}
 	gz, err := gzip.NewReader(io.LimitReader(infile, bin.size))
 	if err != nil {
-		return errors.Wrapf(err, "Failed to create gzip reader for %s", name)
+		return fmt.Errorf("Failed to create gzip reader for %s: %w", name, err)
 	}
 
 	logrus.Debug("Writing static file: ", p)
@@ -114,7 +114,7 @@ func Stage(dataDir string, name string, filemode os.FileMode) error {
 		return err
 	}
 	if err := os.Chmod(p, 0550); err != nil {
-		return errors.Wrapf(err, "Failed to chmod %s", name)
+		return fmt.Errorf("Failed to chmod %s: %w", name, err)
 	}
 	return nil
 }
@@ -123,15 +123,15 @@ func copyTo(p string, gz io.Reader) error {
 	_ = os.Remove(p)
 	f, err := os.Create(p)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create %s", p)
+		return fmt.Errorf("failed to create %s: %w", p, err)
 	}
 	defer f.Close()
 	if err != nil {
-		return errors.Wrapf(err, "failed to create %s", p)
+		return fmt.Errorf("failed to create %s: %w", p, err)
 	}
 	_, err = io.Copy(f, gz)
 	if err != nil {
-		return errors.Wrapf(err, "failed to write to %s", p)
+		return fmt.Errorf("failed to write to %s: %w", p, err)
 	}
 	return nil
 }

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -21,8 +21,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-
 	"github.com/cloudflare/cfssl/certinfo"
 	"github.com/cloudflare/cfssl/cli"
 	"github.com/cloudflare/cfssl/cli/genkey"
@@ -171,11 +169,11 @@ func (m *Manager) EnsureCertificate(certReq Request, ownerName string) (Certific
 
 	cert, err := ioutil.ReadFile(certFile)
 	if err != nil {
-		return Certificate{}, errors.Wrapf(err, "failed to read ca cert %s for %s", certFile, certReq.Name)
+		return Certificate{}, fmt.Errorf("failed to read ca cert %s for %s: %w", certFile, certReq.Name, err)
 	}
 	key, err := ioutil.ReadFile(keyFile)
 	if err != nil {
-		return Certificate{}, errors.Wrapf(err, "failed to read ca key %s for %s", keyFile, certReq.Name)
+		return Certificate{}, fmt.Errorf("failed to read ca key %s for %s: %w", keyFile, certReq.Name, err)
 	}
 
 	return Certificate{

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/k0sproject/k0s/internal/util"
@@ -76,7 +75,7 @@ func (a *APIServer) Init() error {
 	var err error
 	a.uid, err = util.GetUID(constant.ApiserverUser)
 	if err != nil {
-		logrus.Warning(errors.Wrap(err, "Running kube-apiserver as root"))
+		logrus.Warning(fmt.Errorf("Running kube-apiserver as root: %w", err))
 	}
 	return assets.Stage(a.K0sVars.BinDir, "kube-apiserver", constant.BinDirMode)
 }
@@ -159,7 +158,7 @@ func (a *APIServer) Run() error {
 			fmt.Sprintf("--etcd-certfile=%s", path.Join(a.K0sVars.CertRootDir, "apiserver-etcd-client.crt")),
 			fmt.Sprintf("--etcd-keyfile=%s", path.Join(a.K0sVars.CertRootDir, "apiserver-etcd-client.key")))
 	default:
-		return errors.New(fmt.Sprintf("invalid storage type: %s", a.ClusterConfig.Spec.Storage.Type))
+		return fmt.Errorf("invalid storage type: %s", a.ClusterConfig.Spec.Storage.Type)
 	}
 	return a.supervisor.Supervise()
 }
@@ -175,7 +174,7 @@ func (a *APIServer) writeKonnectivityConfig() error {
 	}
 	err := tw.Write()
 	if err != nil {
-		return errors.Wrap(err, "failed to write konnectivity config")
+		return fmt.Errorf("failed to write konnectivity config: %w", err)
 	}
 
 	return nil

--- a/pkg/component/controller/calico.go
+++ b/pkg/component/controller/calico.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/k0sproject/k0s/static"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/k0sproject/k0s/internal/util"
@@ -102,7 +101,7 @@ func (c *Calico) Run() error {
 		contents, err := static.Asset(fmt.Sprintf("manifests/calico/CustomResourceDefinition/%s", filename))
 
 		if err != nil {
-			return errors.Wrapf(err, "failed to fetch crd %s", filename)
+			return fmt.Errorf("failed to fetch crd %s: %w", filename, err)
 		}
 
 		tw := util.TemplateWriter{

--- a/pkg/component/controller/casyncer.go
+++ b/pkg/component/controller/casyncer.go
@@ -16,10 +16,10 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/k0sproject/k0s/internal/util"
@@ -38,7 +38,7 @@ type CASyncer struct {
 func (c *CASyncer) Init() error {
 	caData, err := c.JoinClient.GetCA()
 	if err != nil {
-		return errors.Wrapf(err, "failed to sync CA")
+		return fmt.Errorf("failed to sync CA: %w", err)
 	}
 	// Dump certs into files
 	return writeCerts(caData, c.K0sVars)

--- a/pkg/component/controller/certificates.go
+++ b/pkg/component/controller/certificates.go
@@ -30,8 +30,6 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/pkg/errors"
-
 	"github.com/k0sproject/k0s/internal/util"
 	config "github.com/k0sproject/k0s/pkg/apis/v1beta1"
 	"github.com/k0sproject/k0s/pkg/certificate"
@@ -89,7 +87,7 @@ func (c *Certificates) Init() error {
 	logrus.Debugf("CA key and cert exists, loading")
 	cert, err := ioutil.ReadFile(caCertPath)
 	if err != nil {
-		return errors.Wrapf(err, "failed to read ca cert")
+		return fmt.Errorf("failed to read ca cert: %w", err)
 	}
 	c.CACert = string(cert)
 	kubeConfigAPIUrl := fmt.Sprintf("https://localhost:%d", c.ClusterSpec.API.Port)

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -21,7 +21,6 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/k0sproject/k0s/internal/util"
@@ -57,13 +56,13 @@ func (a *Manager) Init() error {
 	// controller manager running as api-server user as they both need access to same sa.key
 	a.uid, err = util.GetUID(constant.ApiserverUser)
 	if err != nil {
-		logrus.Warning(errors.Wrap(err, "Running kube-controller-manager as root"))
+		logrus.Warning(fmt.Errorf("Running kube-controller-manager as root: %w", err))
 	}
 
 	// controller manager should be the only component that needs access to
 	// ca.key so let it own it.
 	if err := os.Chown(path.Join(a.K0sVars.CertRootDir, "ca.key"), a.uid, -1); err != nil && os.Geteuid() == 0 {
-		logrus.Warning(errors.Wrap(err, "Can't change permissions for the ca.key"))
+		logrus.Warning(fmt.Errorf("Can't change permissions for the ca.key: %w", err))
 	}
 	return assets.Stage(a.K0sVars.BinDir, "kube-controller-manager", constant.BinDirMode)
 }

--- a/pkg/component/controller/csrapprover.go
+++ b/pkg/component/controller/csrapprover.go
@@ -29,7 +29,6 @@ import (
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/v1beta1"
 	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	authorization "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/certificates/v1"
@@ -269,7 +268,7 @@ func parseCSR(obj *v1.CertificateSigningRequest) (*x509.CertificateRequest, erro
 	pemBytes := obj.Spec.Request
 	block, _ := pem.Decode(pemBytes)
 	if block == nil || block.Type != "CERTIFICATE REQUEST" {
-		return nil, errors.New("PEM block type must be CERTIFICATE REQUEST")
+		return nil, fmt.Errorf("PEM block type must be CERTIFICATE REQUEST")
 	}
 	csr, err := x509.ParseCertificateRequest(block.Bytes)
 	if err != nil {

--- a/pkg/component/controller/defaultpsp.go
+++ b/pkg/component/controller/defaultpsp.go
@@ -16,10 +16,9 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
 	"path"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"github.com/k0sproject/k0s/internal/util"
 	config "github.com/k0sproject/k0s/pkg/apis/v1beta1"
@@ -67,7 +66,7 @@ func (d *DefaultPSP) Run() error {
 	}
 	err = tw.Write()
 	if err != nil {
-		return errors.Wrap(err, "error writing default PSP manifests, will NOT retry")
+		return fmt.Errorf("error writing default PSP manifests, will NOT retry: %w", err)
 	}
 	return nil
 }

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/k0sproject/k0s/internal/util"
@@ -46,13 +45,13 @@ func (k *Kine) Init() error {
 	var err error
 	k.uid, err = util.GetUID(constant.KineUser)
 	if err != nil {
-		logrus.Warning(errors.Wrap(err, "Running kine as root"))
+		logrus.Warning(fmt.Errorf("Running kine as root: %w", err))
 	}
 
 	kineSocketDir := filepath.Dir(k.K0sVars.KineSocketPath)
 	err = util.InitDirectory(kineSocketDir, 0755)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create %s", kineSocketDir)
+		return fmt.Errorf("failed to create %s: %w", kineSocketDir, err)
 	}
 	if err := os.Chown(kineSocketDir, k.uid, k.gid); err != nil && os.Geteuid() == 0 {
 		logrus.Warningf("failed to chown %s", kineSocketDir)
@@ -66,11 +65,11 @@ func (k *Kine) Init() error {
 		// Make sure the db basedir exists
 		err = util.InitDirectory(filepath.Dir(dsURL.Path), 0750)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create dir %s", filepath.Dir(dsURL.Path))
+			return fmt.Errorf("failed to create dir %s: %w", filepath.Dir(dsURL.Path), err)
 		}
 		err = os.Chown(filepath.Dir(dsURL.Path), k.uid, k.gid)
 		if err != nil && os.Geteuid() == 0 {
-			return errors.Wrapf(err, "failed to chown dir %s", filepath.Dir(dsURL.Path))
+			return fmt.Errorf("failed to chown dir %s: %w", filepath.Dir(dsURL.Path), err)
 		}
 		if err := os.Chown(dsURL.Path, k.uid, k.gid); err != nil && os.Geteuid() == 0 {
 			logrus.Warningf("datasource file %s does not exist", dsURL.Path)

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/k0sproject/k0s/internal/util"
@@ -44,7 +43,7 @@ func (a *Scheduler) Init() error {
 	var err error
 	a.uid, err = util.GetUID(constant.SchedulerUser)
 	if err != nil {
-		logrus.Warning(errors.Wrap(err, "Running kube-scheduler as root"))
+		logrus.Warning(fmt.Errorf("Running kube-scheduler as root: %w", err))
 	}
 	return assets.Stage(a.K0sVars.BinDir, "kube-scheduler", constant.BinDirMode)
 }

--- a/pkg/component/controller/systemrbac.go
+++ b/pkg/component/controller/systemrbac.go
@@ -16,10 +16,9 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
 	"path"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"github.com/k0sproject/k0s/internal/util"
 	"github.com/k0sproject/k0s/pkg/constant"
@@ -57,7 +56,7 @@ func (s *SystemRBAC) Run() error {
 	}
 	err = tw.Write()
 	if err != nil {
-		return errors.Wrap(err, "error writing bootstrap-rbac manifests, will NOT retry")
+		return fmt.Errorf("error writing bootstrap-rbac manifests, will NOT retry: %w", err)
 
 	}
 	return nil

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/avast/retry-go"
 	"github.com/docker/libnetwork/resolvconf"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/k0sproject/k0s/internal/util"
@@ -66,7 +65,7 @@ func (k *Kubelet) Init() error {
 	k.dataDir = filepath.Join(k.K0sVars.DataDir, "kubelet")
 	err = util.InitDirectory(k.dataDir, constant.DataDirMode)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create %s", k.dataDir)
+		return fmt.Errorf("failed to create %s: %w", k.dataDir, err)
 	}
 
 	return nil
@@ -176,7 +175,7 @@ func (k *Kubelet) Run() error {
 
 		err = ioutil.WriteFile(kubeletConfigPath, []byte(kubeletconfig), constant.CertSecureMode)
 		if err != nil {
-			return errors.Wrap(err, "failed to write kubelet config to disk")
+			return fmt.Errorf("failed to write kubelet config to disk: %w", err)
 		}
 
 		return nil

--- a/pkg/component/worker/kubeletconfigclient.go
+++ b/pkg/component/worker/kubeletconfigclient.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/constant"
 	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
-	"github.com/pkg/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -48,7 +47,7 @@ func (k *KubeletConfigClient) Get(profile string) (string, error) {
 	cmName := fmt.Sprintf("kubelet-config-%s-%s", profile, constant.KubernetesMajorMinorVersion)
 	cm, err := k.kubeClient.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), cmName, v1.GetOptions{})
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get kubelet config from API")
+		return "", fmt.Errorf("failed to get kubelet config from API: %w", err)
 	}
 	config := cm.Data["kubelet"]
 	if config == "" {

--- a/pkg/crictl/crictl.go
+++ b/pkg/crictl/crictl.go
@@ -2,7 +2,7 @@ package crictl
 
 import (
 	"context"
-	"github.com/pkg/errors"
+	"fmt"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -20,10 +20,10 @@ func (c *CriCtl) ListPods() ([]string, error) {
 	client, conn, err := getRuntimeClient(c.addr)
 	defer closeConnection(conn)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create CRI runtime client")
+		return nil, fmt.Errorf("failed to create CRI runtime client: %w", err)
 	}
 	if client == nil {
-		return nil, errors.Errorf("failed to create CRI runtime client")
+		return nil, fmt.Errorf("failed to create CRI runtime client: %w", err)
 	}
 	request := &pb.ListPodSandboxRequest{}
 	logrus.Debugf("ListPodSandboxRequest: %v", request)
@@ -43,10 +43,10 @@ func (c *CriCtl) RemovePod(id string) error {
 	client, conn, err := getRuntimeClient(c.addr)
 	defer closeConnection(conn)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create CRI runtime client")
+		return fmt.Errorf("failed to create CRI runtime client: %w", err)
 	}
 	if client == nil {
-		return errors.Errorf("failed to create CRI runtime client")
+		return fmt.Errorf("failed to create CRI runtime client")
 	}
 	request := &pb.RemovePodSandboxRequest{PodSandboxId: id}
 	logrus.Debugf("RemovePodSandboxRequest: %v", request)
@@ -63,17 +63,17 @@ func (c *CriCtl) StopPod(id string) error {
 	client, conn, err := getRuntimeClient(c.addr)
 	defer closeConnection(conn)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create CRI runtime client")
+		return fmt.Errorf("failed to create CRI runtime client: %w", err)
 	}
 	if client == nil {
-		return errors.Errorf("failed to create CRI runtime client")
+		return fmt.Errorf("failed to create CRI runtime client")
 	}
 	request := &pb.StopPodSandboxRequest{PodSandboxId: id}
 	logrus.Debugf("StopPodSandboxRequest: %v", request)
 	r, err := client.StopPodSandbox(context.Background(), request)
 	logrus.Debugf("StopPodSandboxResponse: %v", r)
 	if err != nil {
-		return errors.Wrapf(err, "failed to stop pod sandbox")
+		return fmt.Errorf("failed to stop pod sandbox: %w", err)
 	}
 	logrus.Debugf("Stopped pod sandbox %s\n", id)
 	return nil
@@ -82,7 +82,7 @@ func (c *CriCtl) StopPod(id string) error {
 func getRuntimeClient(addr string) (pb.RuntimeServiceClient, *grpc.ClientConn, error) {
 	conn, err := getRuntimeClientConnection(addr)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "connect")
+		return nil, nil, fmt.Errorf("connect: %w", err)
 	}
 	runtimeClient := pb.NewRuntimeServiceClient(conn)
 	return runtimeClient, conn, nil
@@ -91,7 +91,7 @@ func getRuntimeClient(addr string) (pb.RuntimeServiceClient, *grpc.ClientConn, e
 func getRuntimeClientConnection(addr string) (*grpc.ClientConn, error) {
 	conn, err := grpc.Dial(addr, grpc.WithInsecure())
 	if err != nil {
-		errMsg := errors.Wrapf(err, "connect endpoint %s, make sure you are running as root and the endpoint has been started", addr)
+		errMsg := fmt.Errorf("connect endpoint %s, make sure you are running as root and the endpoint has been started: %w", addr, err)
 		logrus.Error(errMsg)
 	} else {
 		logrus.Debugf("connected successfully using endpoint: %s", addr)

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
 	"go.etcd.io/etcd/pkg/transport"
@@ -100,7 +98,7 @@ func (c *Client) AddMember(ctx context.Context, name, peerAddress string) ([]str
 func (c *Client) GetPeerIDByAddress(ctx context.Context, peerAddress string) (uint64, error) {
 	resp, err := c.client.MemberList(ctx)
 	if err != nil {
-		return 0, errors.Wrap(err, "etcd member list failed")
+		return 0, fmt.Errorf("etcd member list failed: %w", err)
 	}
 	for _, m := range resp.Members {
 		for _, peerURL := range m.PeerURLs {
@@ -109,7 +107,7 @@ func (c *Client) GetPeerIDByAddress(ctx context.Context, peerAddress string) (ui
 			}
 		}
 	}
-	return 0, errors.Errorf("peer not found: %s", peerAddress)
+	return 0, fmt.Errorf("peer not found: %s", peerAddress)
 }
 
 // DeleteMember deletes member by peer name

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -16,10 +16,10 @@ limitations under the License.
 package kubernetes
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/k0sproject/k0s/pkg/constant"
-	"github.com/pkg/errors"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
@@ -64,7 +64,7 @@ func (c *clientFactory) GetClient() (kubernetes.Interface, error) {
 	if c.restConfig == nil {
 		c.restConfig, err = clientcmd.BuildConfigFromFlags("", c.configPath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to load kubeconfig")
+			return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
 		}
 	}
 
@@ -90,7 +90,7 @@ func (c *clientFactory) GetDynamicClient() (dynamic.Interface, error) {
 	if c.restConfig == nil {
 		c.restConfig, err = clientcmd.BuildConfigFromFlags("", c.configPath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to load kubeconfig")
+			return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
 		}
 	}
 
@@ -115,7 +115,7 @@ func (c *clientFactory) GetDiscoveryClient() (discovery.CachedDiscoveryInterface
 	if c.restConfig == nil {
 		c.restConfig, err = clientcmd.BuildConfigFromFlags("", c.configPath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to load kubeconfig")
+			return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
 		}
 	}
 
@@ -139,12 +139,12 @@ func NewClient(kubeconfig string) (kubernetes.Interface, error) {
 	// use the current context in kubeconfig
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load kubeconfig")
+		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create k8s client")
+		return nil, fmt.Errorf("failed to create k8s client: %w", err)
 	}
 
 	return clientset, nil

--- a/pkg/token/joinclient.go
+++ b/pkg/token/joinclient.go
@@ -23,7 +23,6 @@ import (
 	"os"
 
 	"github.com/k0sproject/k0s/pkg/apis/v1beta1"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -39,7 +38,7 @@ type JoinClient struct {
 func JoinClientFromToken(encodedToken string) (*JoinClient, error) {
 	tokenBytes, err := DecodeJoinToken(encodedToken)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to decode token")
+		return nil, fmt.Errorf("failed to decode token: %w", err)
 	}
 
 	clientConfig, err := clientcmd.NewClientConfigFromBytes(tokenBytes)

--- a/pkg/token/kubeconfig.go
+++ b/pkg/token/kubeconfig.go
@@ -26,8 +26,6 @@ import (
 
 	config "github.com/k0sproject/k0s/pkg/apis/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
-
-	"github.com/pkg/errors"
 )
 
 var (
@@ -54,10 +52,10 @@ users:
 )
 
 func CreateKubeletBootstrapConfig(clusterConfig *config.ClusterConfig, k0sVars constant.CfgVars, role string, expiry time.Duration) (string, error) {
-	caCert, err := ioutil.ReadFile(filepath.Join(k0sVars.CertRootDir, "ca.crt"))
+	crtFile := filepath.Join(k0sVars.CertRootDir, "ca.crt")
+	caCert, err := ioutil.ReadFile(crtFile)
 	if err != nil {
-		msg := fmt.Sprintf("failed to read cluster ca certificate from %s. is the control plane initialized on this node?", filepath.Join(k0sVars.CertRootDir, "ca.crt"))
-		return "", errors.Wrapf(err, msg)
+		return "", fmt.Errorf("failed to read cluster ca certificate from %s: %w. is the control plane initialized on this node?", crtFile, err)
 	}
 	manager, err := NewManager(filepath.Join(k0sVars.AdminKubeConfigPath))
 	if err != nil {


### PR DESCRIPTION
**Issue**
Fixes #227

**What this PR Includes**
Replace use of github.com/pkg/errors with standard fmt.Errorf
