### PR TITLE
De-duplicate the smoketest list and add top-level 'smoketests' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 include embedded-bins/Makefile.variables
+include inttest/Makefile.variables
 
 GO_SRCS := $(shell find . -type f -name '*.go' -a ! -name 'zz_generated*')
 
@@ -82,11 +83,12 @@ k0s.exe k0s: $(GO_SRCS)
 lint: pkg/assets/zz_generated_offsets_$(TARGET_OS).go
 	$(golint) run ./...
 
-smoketests := check-addons check-basic check-byocri check-dualstack check-hacontrolplane check-install check-kine check-multicontroller check-network check-singlenode check-customports check-calico check-cnichange
 .PHONY: $(smoketests)
 $(smoketests): k0s
 	$(MAKE) -C inttest $@
 
+.PHONY: smoketests
+smoketests:  $(smoketests)
 
 .PHONY: check-unit
 check-unit: pkg/assets/zz_generated_offsets_$(TARGET_OS).go static/gen_manifests.go

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -30,13 +30,14 @@ check-network-vm: bin/sonobuoy
 		go test -count=1 -v -timeout 30m github.com/k0sproject/k0s/inttest/sonobuoy/ -run ^TestVMNetworkSuite$
 
 TIMEOUT ?= 4m
-smoketests := check-addons check-basic check-byocri check-dualstack check-hacontrolplane check-install check-kine check-multicontroller check-singlenode check-customports check-calico check-cnichange
 
 check-byocri: TIMEOUT=5m
 # Basic also check to get metrics api service et all ready, will take some time
 check-basic: TIMEOUT=6m
 
 .PHONY: $(smoketests)
+include Makefile.variables
+
 $(smoketests): .footloose-alpine.stamp
 	K0S_PATH=$(realpath ../k0s) go test -count=1 -v -timeout $(TIMEOUT) github.com/k0sproject/k0s/inttest/$(subst check-,,$@)
 

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -1,0 +1,14 @@
+smoketests := \
+	check-addons \
+	check-basic \
+	check-byocri \
+	check-calico \
+	check-cnichange \
+	check-customports \
+	check-dualstack \
+	check-hacontrolplane \
+	check-install \
+	check-kine \
+	check-multicontroller \
+	check-singlenode
+


### PR DESCRIPTION
Use a shared Makefile.variables with the list of the smoketests so we
don't need to maintain this list in both top-level Makefile and
inttest/Makefile.

Also add back the toplevel 'smoketests' which was removed in commit
7cf4d9fe1c78 (Implement test case for custom ports worker join)

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

