### PR TITLE
Fix network vm test

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -27,7 +27,7 @@ check-network: bin/sonobuoy .footloose-alpine.stamp
 
 check-network-vm: bin/sonobuoy
 	K0S_PATH=$(realpath ../k0s) SONOBUOY_PATH=$(realpath bin/sonobuoy) \
-		go test -count=1 -v -timeout 20m github.com/k0sproject/k0s/inttest/sonobuoy/ -run ^TestVMNetworkSuite$
+		go test -count=1 -v -timeout 30m github.com/k0sproject/k0s/inttest/sonobuoy/ -run ^TestVMNetworkSuite$
 
 TIMEOUT ?= 4m
 smoketests := check-addons check-basic check-byocri check-dualstack check-hacontrolplane check-install check-kine check-multicontroller check-singlenode check-customports check-calico check-cnichange

--- a/inttest/common/vmsuite.go
+++ b/inttest/common/vmsuite.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/stretchr/testify/suite"
@@ -200,6 +201,15 @@ func (s *VMSuite) WaitForNodeReady(node string, kc *kubernetes.Clientset) error 
 
 // KubeClient return kube client by loading the admin access config from given node
 func (s *VMSuite) KubeClient(node string) (*kubernetes.Clientset, error) {
+	cfg, err := s.GetKubeConfig(node)
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(cfg)
+}
+
+// KubeClient return kube client by loading the admin access config from given node
+func (s *VMSuite) GetKubeConfig(node string) (*rest.Config, error) {
 	ssh, err := s.SSH(node)
 	if err != nil {
 		return nil, err
@@ -220,6 +230,5 @@ func (s *VMSuite) KubeClient(node string) (*kubernetes.Clientset, error) {
 	// Our CA data is valid for localhost, but we need to change that in order to connect from outside
 	cfg.Insecure = true
 	cfg.TLSClientConfig.CAData = nil
-
-	return kubernetes.NewForConfig(cfg)
+	return cfg, nil
 }

--- a/inttest/sonobuoy/signetwork_test.go
+++ b/inttest/sonobuoy/signetwork_test.go
@@ -44,11 +44,17 @@ func (s *NetworkSuite) TestSigNetwork() {
 	kc, err := s.KubeClient(s.ControllerIP)
 	s.NoError(err)
 
+	kubeConfig, err := s.GetKubeConfig(s.ControllerIP)
+	s.NoError(err)
+
 	err = s.WaitForNodeReady("worker-0", kc)
 	s.NoError(err)
 
 	err = s.WaitForNodeReady("worker-1", kc)
 	s.NoError(err)
+
+	s.T().Log("waiting to see metrics ready")
+	s.Require().NoError(common.WaitForMetricsReady(kubeConfig))
 
 	kubeconfigPath := s.dumpKubeConfig()
 	s.T().Logf("kubeconfig at: %s", kubeconfigPath)

--- a/inttest/terraform/test-cluster/.gitignore
+++ b/inttest/terraform/test-cluster/.gitignore
@@ -1,0 +1,3 @@
+.terraform.lock*
+CTRL_IPS
+WORKER_IPS

--- a/inttest/terraform/test-cluster/controller.tf
+++ b/inttest/terraform/test-cluster/controller.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "cluster-controller" {
   subnet_id                   = aws_subnet.cluster-subnet.id
   vpc_security_group_ids      = [aws_security_group.cluster_allow_ssh.id]
   associate_public_ip_address = true
+  source_dest_check = false
 
   root_block_device {
     volume_type = "gp2"

--- a/inttest/terraform/test-cluster/worker.tf
+++ b/inttest/terraform/test-cluster/worker.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "cluster-workers" {
   subnet_id                   = aws_subnet.cluster-subnet.id
   vpc_security_group_ids      = [aws_security_group.cluster_allow_ssh.id]
   associate_public_ip_address = true
+  source_dest_check = false
 
   root_block_device {
     volume_type = "gp2"

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -55,7 +55,7 @@ const (
 	DefaultPSP = "00-k0s-privileged"
 	// Image Constants
 	KonnectivityImage                  = "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent"
-	KonnectivityImageVersion           = "v0.0.13"
+	KonnectivityImageVersion           = "v0.0.16"
 	MetricsImage                       = "gcr.io/k8s-staging-metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.3.7"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"


### PR DESCRIPTION

**Issue**
Fixes nightly VM based sig-network tests

**What this PR Includes**

This PR fixes the nightly networking tests by disabling AWS src/dst checks on the VMs as that'll block kube-router routing the cluster networking properly. As added stability, the VM test suite now also waits to see metrics fully operational before kicking off the sig-network sonobouy run as that's always a good indication that all networking and controller-worker comms pipes are up-and-running.