### PR TITLE
Configurable compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,13 @@ go_bindata := go get github.com/kevinburke/go-bindata/...@v3.22.0 && "${GOPATH}/
 endif
 
 GOLANG_IMAGE = golang:1.16-alpine
-GO = docker run --rm -v "$(CURDIR)":/go/src/github.com/k0sproject/k0s \
+GO = GOCACHE=/tmp/.cache docker run --rm -v "$(CURDIR)":/go/src/github.com/k0sproject/k0s \
 	-w /go/src/github.com/k0sproject/k0s \
 	-e GOOS \
 	-e CGO_ENABLED \
 	-e GOARCH \
+	-e GOCACHE \
+	--user $$(id -u) \
 	$(GOLANG_IMAGE) go
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,11 @@ k0s.exe: pkg/assets/zz_generated_offsets_windows.go
 k0s.exe k0s: static/gen_manifests.go
 
 k0s.exe k0s: $(GO_SRCS)
-	CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(GOARCH) $(GO) build -ldflags="$(LD_FLAGS)" -o $@.code main.go
-	cat $@.code bindata_$(TARGET_OS) > $@.tmp && chmod +x $@.tmp && mv $@.tmp $@
+	CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(GOARCH) $(GO) build -v -ldflags="$(LD_FLAGS)" -o $@.code main.go
+	cat $@.code bindata_$(TARGET_OS) > $@.tmp \
+		&& rm -f $@.code \
+		&& chmod +x $@.tmp \
+		&& mv $@.tmp $@
 
 .bins.windows.stamp .bins.linux.stamp: embedded-bins/Makefile.variables
 	$(MAKE) -C embedded-bins buildmode=$(EMBEDDED_BINS_BUILDMODE) TARGET_OS=$(patsubst .bins.%.stamp,%,$@)

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,21 @@ GOARCH ?= $(shell go env GOARCH)
 GOPATH ?= $(shell go env GOPATH)
 DEBUG ?= false
 
+VERSION ?= $(shell git describe --tags)
 ifeq ($(DEBUG), false)
 LD_FLAGS ?= -w -s
 endif
 
+LD_FLAGS += -X github.com/k0sproject/k0s/pkg/build.Version=$(VERSION)
+LD_FLAGS += -X github.com/k0sproject/k0s/pkg/build.RuncVersion=$(runc_version)
+LD_FLAGS += -X github.com/k0sproject/k0s/pkg/build.ContainerdVersion=$(containerd_version)
+LD_FLAGS += -X github.com/k0sproject/k0s/pkg/build.KubernetesVersion=$(kubernetes_version)
+LD_FLAGS += -X github.com/k0sproject/k0s/pkg/build.KineVersion=$(kine_version)
+LD_FLAGS += -X github.com/k0sproject/k0s/pkg/build.EtcdVersion=$(etcd_version)
+LD_FLAGS += -X github.com/k0sproject/k0s/pkg/build.KonnectivityVersion=$(konnectivity_version)
+LD_FLAGS += -X \"github.com/k0sproject/k0s/pkg/build.EulaNotice=$(EULA_NOTICE)\"
+LD_FLAGS += -X github.com/k0sproject/k0s/pkg/telemetry.segmentToken=$(SEGMENT_TOKEN)
 
-VERSION ?= $(shell git describe --tags)
 golint := $(shell which golangci-lint)
 ifeq ($(golint),)
 golint := go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.31.0 && "${GOPATH}/bin/golangci-lint"
@@ -31,7 +40,6 @@ go_bindata := $(shell which go-bindata)
 ifeq ($(go_bindata),)
 go_bindata := go get github.com/kevinburke/go-bindata/...@v3.22.0 && "${GOPATH}/bin/go-bindata"
 endif
-
 
 
 .PHONY: build
@@ -71,8 +79,7 @@ k0s.exe: pkg/assets/zz_generated_offsets_windows.go
 k0s.exe k0s: static/gen_manifests.go
 
 k0s.exe k0s: $(GO_SRCS)
-	CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(GOARCH) go build -ldflags="$(LD_FLAGS) -X github.com/k0sproject/k0s/pkg/build.Version=$(VERSION) -X github.com/k0sproject/k0s/pkg/build.RuncVersion=$(runc_version) -X github.com/k0sproject/k0s/pkg/build.ContainerdVersion=$(containerd_version) -X github.com/k0sproject/k0s/pkg/build.KubernetesVersion=$(kubernetes_version) -X github.com/k0sproject/k0s/pkg/build.KineVersion=$(kine_version) -X github.com/k0sproject/k0s/pkg/build.EtcdVersion=$(etcd_version) -X github.com/k0sproject/k0s/pkg/build.KonnectivityVersion=$(konnectivity_version) -X \"github.com/k0sproject/k0s/pkg/build.EulaNotice=$(EULA_NOTICE)\" -X github.com/k0sproject/k0s/pkg/telemetry.segmentToken=$(SEGMENT_TOKEN)" \
-		    -o $@.code main.go
+	CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(GOARCH) go build -ldflags="$(LD_FLAGS)" -o $@.code main.go
 	cat $@.code bindata_$(TARGET_OS) > $@.tmp && chmod +x $@.tmp && mv $@.tmp $@
 
 .bins.windows.stamp .bins.linux.stamp: embedded-bins/Makefile.variables

--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -68,12 +68,18 @@ $(addprefix $(bindir)/, $(bins)): | $(bindir)
 	docker create k0sbuild$(basename $<) > $@.tmp
 	mv $@.tmp $@
 
-.docker-image.%.stamp: %/Dockerfile Makefile
-	docker build -t k0sbuild$(basename $@) --build-arg VERSION=$($(patsubst %/Dockerfile,%,$<)_version) -f $< .
+.docker-image.%.stamp: %/Dockerfile Makefile.variables
+	docker build -t k0sbuild$(basename $@) \
+		--build-arg VERSION=$($(patsubst %/Dockerfile,%,$<)_version) \
+		--build-arg BUILDIMAGE=$($(patsubst %/Dockerfile,%,$<)_buildimage) \
+		-f $< .
 	touch $@
 
-.docker-image.%.windows.stamp: %/Dockerfile.windows
-	docker build -t k0sbuild$(basename $@) --build-arg VERSION=$($(patsubst %/Dockerfile.windows,%,$<)_version) -f $< .
+.docker-image.%.windows.stamp: %/Dockerfile.windows Makefile.variables
+	docker build -t k0sbuild$(basename $@) \
+		--build-arg VERSION=$($(patsubst %/Dockerfile.windows,%,$<)_version) \
+		--build-arg BUILDIMAGE=$($(patsubst %/Dockerfile.windows,%,$<)_buildimage) \
+		-f $< .
 	touch $@
 
 else

--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -26,16 +26,15 @@ all: $(addprefix $(bindir)/, $(bins))
 clean:
 	for i in .container.*; do \
 		if [ -f $$i ]; then \
-			docker rm $$(cat $$i); rm $$i; \
+			docker rm $$(cat $$i) && rm $$i; \
 		fi; \
 	done
 	for i in .docker-image.*; do \
 		if [ -f $$i ]; then \
-			docker rmi k0sbuild$$(basename $$i .stamp) ; rm $$i;\
+			docker rmi -f k0sbuild$$(basename $$i .stamp) && rm $$i;\
 		fi; \
 	done
-	rm -rf staging
-	rm -rf .tmp/*
+	rm -rf staging .tmp/* *.tmp
 
 $(bindir):
 	mkdir -p $@

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -4,3 +4,10 @@ kubernetes_version = 1.21.0
 kine_version = 0.6.0
 etcd_version = 3.4.15
 konnectivity_version = 0.0.16
+
+containerd_buildimage = golang:1.15-alpine
+etcd_buildimage = golang:1.13-alpine
+kine_buildimage = golang:1.15-alpine
+konnectivity_buildimage = golang:1.15-alpine
+kubernetes_buildimage = golang:1.16-alpine
+runc_buildimage = golang:1.15-alpine

--- a/embedded-bins/containerd/Dockerfile
+++ b/embedded-bins/containerd/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.15-alpine AS build
+ARG BUILDIMAGE=golang:1.15-alpine
+FROM $BUILDIMAGE AS build
 
 ARG VERSION
 ENV GOPATH=/go

--- a/embedded-bins/etcd/Dockerfile
+++ b/embedded-bins/etcd/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.13-alpine AS build
+ARG BUILDIMAGE=golang:1.13-alpine
+FROM $BUILDIMAGE AS build
 
 ARG VERSION
 

--- a/embedded-bins/kine/Dockerfile
+++ b/embedded-bins/kine/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.15-alpine AS build
+ARG BUILDIMAGE=golang:1.15-alpine
+FROM $BUILDIMAGE AS build
+
 ARG VERSION
 
 RUN apk add build-base git

--- a/embedded-bins/konnectivity/Dockerfile
+++ b/embedded-bins/konnectivity/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.15-alpine AS build
+ARG BUILDIMAGE=golang:1.15-alpine
+FROM $BUILDIMAGE AS build
 
 ARG VERSION
 

--- a/embedded-bins/kubernetes/Dockerfile
+++ b/embedded-bins/kubernetes/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.16-alpine AS build
+ARG BUILDIMAGE=golang:1.16-alpine
+FROM $BUILDIMAGE AS build
 
 ARG VERSION
 ENV GOPATH=/go

--- a/embedded-bins/kubernetes/Dockerfile.windows
+++ b/embedded-bins/kubernetes/Dockerfile.windows
@@ -1,4 +1,5 @@
-FROM golang:1.15-alpine AS build
+ARG BUILDIMAGE=golang:1.15-alpine AS build
+FROM $BUILDIMAGE AS build
 
 ARG VERSION
 ENV GOPATH=/go

--- a/embedded-bins/runc/Dockerfile
+++ b/embedded-bins/runc/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.15-alpine AS build
+ARG BUILDIMAGE=golang:1.15-alpine
+FROM $BUILDIMAGE AS build
 
 ARG VERSION
 ARG LIBSECCOMP_VERSION=2.5.1


### PR DESCRIPTION
**What this PR Includes**
- Make the golang docker image configurable in embedeed-bins/Makefile.variables.
- Use a docker image by default to build `k0s`. This makes it relatively easy to replace the golang version.
To build with the system compiler you can still do: `make GO=go`
- Other minor cleanups in the Makefiles