### PR TITLE
Bump up kube-router to 1.2.1

### DIFF
--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -71,7 +71,7 @@ const (
 	KubeControllerImage                = "docker.io/calico/kube-controllers"
 	KubeControllerImageVersion         = "v3.16.2"
 	KubeRouterCNIImage                 = "docker.io/cloudnativelabs/kube-router"
-	KubeRouterCNIImageVersion          = "v1.1.1"
+	KubeRouterCNIImageVersion          = "v1.2.1"
 	KubeRouterCNIInstallerImage        = "quay.io/k0sproject/cni-node"
 	KubeRouterCNIInstallerImageVersion = "0.1.0"
 )


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>


**Issue**
Fixes #833 

**What this PR Includes**
As reported in #833, kube-router v1.1.1 is bit slow when applying new network policies. This PR bumps up the kube-router version to 1.2.1 which is reported to apply the policies much faster.