### PR TITLE
Fix GH actions cache usage for embedded-bins

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,10 +53,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: embedded-bins BEFORE cache
-        run: ls -lah embedded-bins/
-
-      - name: Bindata
+      - name: Bindata cache
         uses: actions/cache@v2
         id: generated-bindata
         with:
@@ -71,511 +68,503 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}
 
-      - name: embedded-bins AFTER cache
-        run: ls -lah embedded-bins/
-
       - name: Build
-        run: make --debug build
+        run: make build
   
-  #### Everything below commented for cache testing so we don't trigger unnecessary amount of smokes
-      
-      # - name: Run unit tests
-      #   run: make check-unit
-
-      # - name: Cache compiled binary for further testing
-      #   uses: actions/cache@v2
-      #   id: cache-compiled-binary
-      #   with:
-      #     path: |
-      #       k0s
-      #     key: build-${{env.cachePrefix}}
-  # smoketest:
-  #   name: Smoke test
-  #   needs: build
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Get PR Reference and Set Cache Name
-  #       run: |
-  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-  #     - name: Check out code into the Go module directory
-  #       uses: actions/checkout@v2
-
-  #     - name: Cache compiled binary for smoke testing
-  #       uses: actions/cache@v2
-  #       id: restore-compiled-binary
-  #       with:
-  #         path: |
-  #           k0s
-  #         key: build-${{env.cachePrefix}}
-
-  #     - name: Run test .
-  #       run: make -C inttest check-basic
-
-  #     - name: Collect test logs
-  #       if: failure()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         path: |
-  #           /tmp/*.log
-
-  # smoketest-custom-ports:
-  #   name: Smoke test for custom ports (k0s api, kube-api, LB + external address)
-  #   needs: build
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Get PR Reference and Set Cache Name
-  #       run: |
-  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-  #     - name: Check out code into the Go module directory
-  #       uses: actions/checkout@v2
-
-  #     - name: Cache compiled binary for smoke testing
-  #       uses: actions/cache@v2
-  #       id: restore-compiled-binary
-  #       with:
-  #         path: |
-  #           k0s
-  #         key: build-${{env.cachePrefix}}
-
-  #     - name: Run test .
-  #       run: make -C inttest check-customports
-
-  #     - name: Collect test logs
-  #       if: failure()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         path: |
-  #           /tmp/*.log
-
-  # smoketest-calico:
-  #   name: Smoke test for calico setup
-  #   needs: build
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Get PR Reference and Set Cache Name
-  #       run: |
-  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-  #     - name: Check out code into the Go module directory
-  #       uses: actions/checkout@v2
-
-  #     - name: Cache compiled binary for smoke testing
-  #       uses: actions/cache@v2
-  #       id: restore-compiled-binary
-  #       with:
-  #         path: |
-  #           k0s
-  #         key: build-${{env.cachePrefix}}
-
-  #     - name: Run test .
-  #       run: make -C inttest check-calico
-
-  #     - name: Collect test logs
-  #       if: failure()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         path: |
-  #           /tmp/*.log
-
-  # smoketest-cni-change:
-  #   name: Smoke test for preventing CNI change
-  #   needs: build
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Get PR Reference and Set Cache Name
-  #       run: |
-  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-  #     - name: Check out code into the Go module directory
-  #       uses: actions/checkout@v2
-
-  #     - name: Cache compiled binary for smoke testing
-  #       uses: actions/cache@v2
-  #       id: restore-compiled-binary
-  #       with:
-  #         path: |
-  #           k0s
-  #         key: build-${{env.cachePrefix}}
-
-  #     - name: Run test .
-  #       run: make -C inttest check-cnichange
-
-  #     - name: Collect test logs
-  #       if: failure()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         path: |
-  #           /tmp/*.log
-
-
-  # smoketest-hacontrolplane:
-  #   name: Smoke test for HA controlplane operations
-  #   needs: build
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Get PR Reference and Set Cache Name
-  #       run: |
-  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-  #     - name: Check out code into the Go module directory
-  #       uses: actions/checkout@v2
-
-  #     - name: Cache compiled binary for smoke testing
-  #       uses: actions/cache@v2
-  #       id: restore-compiled-binary
-  #       with:
-  #         path: |
-  #           k0s
-  #         key: build-${{env.cachePrefix}}
-
-  #     - name: Run hacontrolplane test .
-  #       run: make -C inttest check-hacontrolplane
-
-  #     - name: Collect test logs
-  #       if: failure()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         path: |
-  #           /tmp/*.log
-
-  # smoketest-byocri:
-  #   name: Smoke test for BYO CRI feature
-  #   needs: build
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Get PR Reference and Set Cache Name
-  #       run: |
-  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-  #     - name: Check out code into the Go module directory
-  #       uses: actions/checkout@v2
-
-  #     - name: Cache compiled binary for smoke testing
-  #       uses: actions/cache@v2
-  #       id: restore-compiled-binary
-  #       with:
-  #         path: |
-  #           k0s
-  #         key: build-${{env.cachePrefix}}
-
-  #     - name: Run BYO CRI test .
-  #       run: make -C inttest check-byocri
-
-  #     - name: Collect test logs
-  #       if: failure()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         path: |
-  #           /tmp/*.log
-
-  # smoketest-addons:
-  #   name: Smoke test for helm based addons
-  #   needs: build
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Get PR Reference and Set Cache Name
-  #       run: |
-  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-  #     - name: Check out code into the Go module directory
-  #       uses: actions/checkout@v2
-
-  #     - name: Cache compiled binary for smoke testing
-  #       uses: actions/cache@v2
-  #       id: restore-compiled-binary
-  #       with:
-  #         path: |
-  #           k0s
-  #         key: build-${{env.cachePrefix}}
-
-  #     - name: Run Helm addon test
-  #       run: make -C inttest check-addons
-
-  #     - name: Collect test logs
-  #       if: failure()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         path: |
-  #           /tmp/*.log
-
-  # smoketest-singlenode:
-  #   name: Smoke test for single node k0s
-  #   needs: build
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Get PR Reference and Set Cache Name
-  #       run: |
-  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-  #     - name: Check out code into the Go module directory
-  #       uses: actions/checkout@v2
-
-  #     - name: Cache compiled binary for smoke testing
-  #       uses: actions/cache@v2
-  #       id: restore-compiled-binary
-  #       with:
-  #         path: |
-  #           k0s
-  #         key: build-${{env.cachePrefix}}
-
-  #     - name: Run singlenode test
-  #       run: make -C inttest check-singlenode
-
-  #     - name: Collect test logs
-  #       if: failure()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         path: |
-  #           /tmp/*.log
-
-  # smoketest-kine:
-  #   name: Smoke test for kine backed
-  #   needs: build
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Get PR Reference and Set Cache Name
-  #       run: |
-  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-  #     - name: Check out code into the Go module directory
-  #       uses: actions/checkout@v2
-
-  #     - name: Cache compiled binary for smoke testing
-  #       uses: actions/cache@v2
-  #       id: restore-compiled-binary
-  #       with:
-  #         path: |
-  #           k0s
-  #         key: build-${{env.cachePrefix}}
-
-  #     - name: Run kine test
-  #       run: make -C inttest check-kine
-
-  #     - name: Collect test logs
-  #       if: failure()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         path: |
-  #           /tmp/*.log
-
-
-  # smoketest-network:
-  #   name: Smoke test for network
-  #   needs: build
-  #   runs-on: ubuntu-latest
-  #   if: false
-
-  #   steps:
-  #     - name: Get PR Reference and Set Cache Name
-  #       run: |
-  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-  #     - name: Check out code into the Go module directory
-  #       uses: actions/checkout@v2
-
-  #     - name: Cache compiled binary for smoke testing
-  #       uses: actions/cache@v2
-  #       id: restore-compiled-binary
-  #       with:
-  #         path: |
-  #           k0s
-  #         key: build-${{env.cachePrefix}}
-
-  #     - name: Run smoke test .
-  #       run: make -C inttest check-etcd
-
-  #     - name: Collect test logs
-  #       if: failure()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         path: |
-  #           /tmp/*.log
-
-  # smoketest-dualstack:
-  #   name: Smoke test for IPv6 dualstack
-  #   needs: build
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Get PR Reference and Set Cache Name
-  #       run: |
-  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-  #     - name: Check out code into the Go module directory
-  #       uses: actions/checkout@v2
-
-  #     - name: Cache compiled binary for smoke testing
-  #       uses: actions/cache@v2
-  #       id: restore-compiled-binary
-  #       with:
-  #         path: |
-  #           k0s
-  #         key: build-${{env.cachePrefix}}
-
-  #     - name: Run smoke test .
-  #       run: make -C inttest check-dualstack
-
-  #     - name: Collect test logs
-  #       if: failure()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         path: |
-  #           /tmp/*.log
-
-  # smoketest-multicontroller:
-  #   name: Smoke test for multi controller
-  #   needs: build
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Get PR Reference and Set Cache Name
-  #       run: |
-  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-  #     - name: Check out code into the Go module directory
-  #       uses: actions/checkout@v2
-
-  #     - name: Cache compiled binary for smoke testing
-  #       uses: actions/cache@v2
-  #       id: restore-compiled-binary
-  #       with:
-  #         path: |
-  #           k0s
-  #         key: build-${{env.cachePrefix}}
-
-  #     - name: Run multicontroller test
-  #       run: make -C inttest check-multicontroller
-
-  #     - name: Collect test logs
-  #       if: failure()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         path: |
-  #           /tmp/*.log
-
-  # smoketest-arm:
-  #   name: Smoke test on arm64
-  #   runs-on: [self-hosted,linux,arm64]
-
-  #   steps:
-  #     - name: Set up Go 1.x
-  #       uses: actions/setup-go@v2
-  #       with:
-  #         go-version: ^1.13
-  #       id: go
-
-  #     - name: Check out code into the Go module directory
-  #       uses: actions/checkout@v2
-
-  #     - uses: actions/cache@v2
-  #       name: Go modules cache
-  #       with:
-  #         path: ~/go/pkg/mod
-  #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-go-
-
-  #     - name: Bindata
-  #       uses: actions/cache@v2
-  #       id: generated-bindata
-  #       with:
-  #         path: |
-  #           .bins.linux.stamp
-  #           embedded-bins/staging/linux/bin/
-  #           bindata_linux
-  #           pkg/assets/zz_generated_offsets_linux.go
-
-  #         key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-arm64
-  #         restore-keys: |
-  #           ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-arm64
-      
-  #     - name: Build
-  #       run: make build
-
-  #     - name: Run test .
-  #       run: make -C inttest check-basic
-
-  #     - name: Collect test logs
-  #       if: failure()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         path: |
-  #           /tmp/*.log
   
-  # smoketest-armv7:
-  #   name: Smoke test on armv7
-  #   runs-on: [self-hosted,linux,arm,lxc] 
-  #   steps:
-  #     # Try again with system go
-  #     # - name: Install GoLang for 32bit ARM
-  #     #   run: |
-  #     #     mkdir -p /usr/local/go
-  #     #     curl -s -L https://golang.org/dl/go1.15.linux-armv6l.tar.gz | tar -C /usr/local -xz
-  #     #     echo "/usr/local/go/bin" >> $GITHUB_PATH
-
-  #     - name: Check out code into the Go module directory
-  #       uses: actions/checkout@v2
-
-  #     - uses: actions/cache@v2
-  #       name: Go modules cache
-  #       with:
-  #         path: ~/go/pkg/mod
-  #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-go-
-
-  #     - name: Bindata
-  #       uses: actions/cache@v2
-  #       id: generated-bindata
-  #       with:
-  #         path: |
-  #           .bins.linux.stamp
-  #           embedded-bins/staging/linux/bin/
-  #           bindata_linux
-  #           pkg/assets/zz_generated_offsets_linux.go
-
-  #         key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-armv7
-  #         restore-keys: |
-  #           ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-armv7
       
-  #     - name: Build
-  #       run: make build
+      - name: Run unit tests
+        run: make check-unit
 
-  #     - name: Run test .
-  #       run: TIMEOUT=15m make -C inttest check-basic
+      - name: Cache compiled binary for further testing
+        uses: actions/cache@v2
+        id: cache-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
+  smoketest:
+    name: Smoke test
+    needs: build
+    runs-on: ubuntu-latest
 
-  #     - name: Collect test logs
-  #       if: failure()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         path: |
-  #           /tmp/*.log
+    steps:
+      - name: Get PR Reference and Set Cache Name
+        run: |
+          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
 
-  # lint:
-  #   name: Lint
-  #   runs-on: ubuntu-latest
-  #   if: github.ref != 'refs/heads/main'
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: codegen
-  #       run: |
-  #         make -j$(nproc) pkg/assets/zz_generated_offsets_linux.go static/gen_manifests.go
-  #       env:
-  #         EMBEDDED_BINS_BUILDMODE: none
+      - name: Cache compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
 
-  #     - name: golangci-lint
-  #       uses: golangci/golangci-lint-action@v2
-  #       with:
-  #         version: v1.29
-  #         config: .golangci.yml
+      - name: Run test .
+        run: make -C inttest check-basic
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
+  smoketest-custom-ports:
+    name: Smoke test for custom ports (k0s api, kube-api, LB + external address)
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR Reference and Set Cache Name
+        run: |
+          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Cache compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
+
+      - name: Run test .
+        run: make -C inttest check-customports
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
+  smoketest-calico:
+    name: Smoke test for calico setup
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR Reference and Set Cache Name
+        run: |
+          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Cache compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
+
+      - name: Run test .
+        run: make -C inttest check-calico
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
+  smoketest-cni-change:
+    name: Smoke test for preventing CNI change
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR Reference and Set Cache Name
+        run: |
+          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Cache compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
+
+      - name: Run test .
+        run: make -C inttest check-cnichange
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
+
+  smoketest-hacontrolplane:
+    name: Smoke test for HA controlplane operations
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR Reference and Set Cache Name
+        run: |
+          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Cache compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
+
+      - name: Run hacontrolplane test .
+        run: make -C inttest check-hacontrolplane
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
+  smoketest-byocri:
+    name: Smoke test for BYO CRI feature
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR Reference and Set Cache Name
+        run: |
+          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Cache compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
+
+      - name: Run BYO CRI test .
+        run: make -C inttest check-byocri
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
+  smoketest-addons:
+    name: Smoke test for helm based addons
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR Reference and Set Cache Name
+        run: |
+          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Cache compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
+
+      - name: Run Helm addon test
+        run: make -C inttest check-addons
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
+  smoketest-singlenode:
+    name: Smoke test for single node k0s
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR Reference and Set Cache Name
+        run: |
+          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Cache compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
+
+      - name: Run singlenode test
+        run: make -C inttest check-singlenode
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
+  smoketest-kine:
+    name: Smoke test for kine backed
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR Reference and Set Cache Name
+        run: |
+          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Cache compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
+
+      - name: Run kine test
+        run: make -C inttest check-kine
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
+
+  smoketest-network:
+    name: Smoke test for network
+    needs: build
+    runs-on: ubuntu-latest
+    if: false
+
+    steps:
+      - name: Get PR Reference and Set Cache Name
+        run: |
+          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Cache compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
+
+      - name: Run smoke test .
+        run: make -C inttest check-etcd
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
+  smoketest-dualstack:
+    name: Smoke test for IPv6 dualstack
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR Reference and Set Cache Name
+        run: |
+          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Cache compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
+
+      - name: Run smoke test .
+        run: make -C inttest check-dualstack
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
+  smoketest-multicontroller:
+    name: Smoke test for multi controller
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR Reference and Set Cache Name
+        run: |
+          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Cache compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
+
+      - name: Run multicontroller test
+        run: make -C inttest check-multicontroller
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
+  smoketest-arm:
+    name: Smoke test on arm64
+    runs-on: [self-hosted,linux,arm64]
+
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.13
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        name: Go modules cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Bindata cache
+        uses: actions/cache@v2
+        id: generated-bindata
+        with:
+          path: |
+            .bins.linux.stamp
+            embedded-bins/staging/linux/bin/
+            bindata_linux
+            pkg/assets/zz_generated_offsets_linux.go
+            embedded-bins/Makefile.variables
+
+          key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-arm64
+          restore-keys: |
+            ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-arm64
+      
+      - name: Build
+        run: make build
+
+      - name: Run test .
+        run: make -C inttest check-basic
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+  
+  smoketest-armv7:
+    name: Smoke test on armv7
+    runs-on: [self-hosted,linux,arm,lxc] 
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        name: Go modules cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Bindata cache
+        uses: actions/cache@v2
+        id: generated-bindata
+        with:
+          path: |
+            .bins.linux.stamp
+            embedded-bins/staging/linux/bin/
+            bindata_linux
+            pkg/assets/zz_generated_offsets_linux.go
+            embedded-bins/Makefile.variables
+
+          key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-armv7
+          restore-keys: |
+            ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-armv7
+      
+      - name: Build
+        run: make build
+
+      - name: Run test .
+        run: TIMEOUT=15m make -C inttest check-basic
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v2
+      - name: codegen
+        run: |
+          make -j$(nproc) pkg/assets/zz_generated_offsets_linux.go static/gen_manifests.go
+        env:
+          EMBEDDED_BINS_BUILDMODE: none
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.29
+          config: .golangci.yml

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,6 +53,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: embedded-bins BEFORE cache
+        run: ls -lah embedded-bins/
+
       - name: Bindata
         uses: actions/cache@v2
         id: generated-bindata
@@ -62,511 +65,517 @@ jobs:
             embedded-bins/staging/linux/bin/
             bindata_linux
             pkg/assets/zz_generated_offsets_linux.go
+            embedded-bins/Makefile.variables
 
           key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}
           restore-keys: |
             ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}
-      - name: Run unit tests
-        run: make check-unit
+
+      - name: embedded-bins AFTER cache
+        run: ls -lah embedded-bins/
 
       - name: Build
-        run: make build
-
-      - name: Cache compiled binary for further testing
-        uses: actions/cache@v2
-        id: cache-compiled-binary
-        with:
-          path: |
-            k0s
-          key: build-${{env.cachePrefix}}
-
-  smoketest:
-    name: Smoke test
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Get PR Reference and Set Cache Name
-        run: |
-          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0s
-          key: build-${{env.cachePrefix}}
-
-      - name: Run test .
-        run: make -C inttest check-basic
-
-      - name: Collect test logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          path: |
-            /tmp/*.log
-
-  smoketest-custom-ports:
-    name: Smoke test for custom ports (k0s api, kube-api, LB + external address)
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Get PR Reference and Set Cache Name
-        run: |
-          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0s
-          key: build-${{env.cachePrefix}}
-
-      - name: Run test .
-        run: make -C inttest check-customports
-
-      - name: Collect test logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          path: |
-            /tmp/*.log
-
-  smoketest-calico:
-    name: Smoke test for calico setup
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Get PR Reference and Set Cache Name
-        run: |
-          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0s
-          key: build-${{env.cachePrefix}}
-
-      - name: Run test .
-        run: make -C inttest check-calico
-
-      - name: Collect test logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          path: |
-            /tmp/*.log
-
-  smoketest-cni-change:
-    name: Smoke test for preventing CNI change
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Get PR Reference and Set Cache Name
-        run: |
-          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0s
-          key: build-${{env.cachePrefix}}
-
-      - name: Run test .
-        run: make -C inttest check-cnichange
-
-      - name: Collect test logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          path: |
-            /tmp/*.log
-
-
-  smoketest-hacontrolplane:
-    name: Smoke test for HA controlplane operations
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Get PR Reference and Set Cache Name
-        run: |
-          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0s
-          key: build-${{env.cachePrefix}}
-
-      - name: Run hacontrolplane test .
-        run: make -C inttest check-hacontrolplane
-
-      - name: Collect test logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          path: |
-            /tmp/*.log
-
-  smoketest-byocri:
-    name: Smoke test for BYO CRI feature
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Get PR Reference and Set Cache Name
-        run: |
-          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0s
-          key: build-${{env.cachePrefix}}
-
-      - name: Run BYO CRI test .
-        run: make -C inttest check-byocri
-
-      - name: Collect test logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          path: |
-            /tmp/*.log
-
-  smoketest-addons:
-    name: Smoke test for helm based addons
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Get PR Reference and Set Cache Name
-        run: |
-          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0s
-          key: build-${{env.cachePrefix}}
-
-      - name: Run Helm addon test
-        run: make -C inttest check-addons
-
-      - name: Collect test logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          path: |
-            /tmp/*.log
-
-  smoketest-singlenode:
-    name: Smoke test for single node k0s
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Get PR Reference and Set Cache Name
-        run: |
-          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0s
-          key: build-${{env.cachePrefix}}
-
-      - name: Run singlenode test
-        run: make -C inttest check-singlenode
-
-      - name: Collect test logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          path: |
-            /tmp/*.log
-
-  smoketest-kine:
-    name: Smoke test for kine backed
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Get PR Reference and Set Cache Name
-        run: |
-          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0s
-          key: build-${{env.cachePrefix}}
-
-      - name: Run kine test
-        run: make -C inttest check-kine
-
-      - name: Collect test logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          path: |
-            /tmp/*.log
-
-
-  smoketest-network:
-    name: Smoke test for network
-    needs: build
-    runs-on: ubuntu-latest
-    if: false
-
-    steps:
-      - name: Get PR Reference and Set Cache Name
-        run: |
-          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0s
-          key: build-${{env.cachePrefix}}
-
-      - name: Run smoke test .
-        run: make -C inttest check-etcd
-
-      - name: Collect test logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          path: |
-            /tmp/*.log
-
-  smoketest-dualstack:
-    name: Smoke test for IPv6 dualstack
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Get PR Reference and Set Cache Name
-        run: |
-          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0s
-          key: build-${{env.cachePrefix}}
-
-      - name: Run smoke test .
-        run: make -C inttest check-dualstack
-
-      - name: Collect test logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          path: |
-            /tmp/*.log
-
-  smoketest-multicontroller:
-    name: Smoke test for multi controller
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Get PR Reference and Set Cache Name
-        run: |
-          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
-          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0s
-          key: build-${{env.cachePrefix}}
-
-      - name: Run multicontroller test
-        run: make -C inttest check-multicontroller
-
-      - name: Collect test logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          path: |
-            /tmp/*.log
-
-  smoketest-arm:
-    name: Smoke test on arm64
-    runs-on: [self-hosted,linux,arm64]
-
-    steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: ^1.13
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        name: Go modules cache
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Bindata
-        uses: actions/cache@v2
-        id: generated-bindata
-        with:
-          path: |
-            .bins.linux.stamp
-            embedded-bins/staging/linux/bin/
-            bindata_linux
-            pkg/assets/zz_generated_offsets_linux.go
-
-          key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-arm64
-          restore-keys: |
-            ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-arm64
-      
-      - name: Build
-        run: make build
-
-      - name: Run test .
-        run: make -C inttest check-basic
-
-      - name: Collect test logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          path: |
-            /tmp/*.log
+        run: make --debug build
   
-  smoketest-armv7:
-    name: Smoke test on armv7
-    runs-on: [self-hosted,linux,arm,lxc] 
-    steps:
-      # Try again with system go
-      # - name: Install GoLang for 32bit ARM
-      #   run: |
-      #     mkdir -p /usr/local/go
-      #     curl -s -L https://golang.org/dl/go1.15.linux-armv6l.tar.gz | tar -C /usr/local -xz
-      #     echo "/usr/local/go/bin" >> $GITHUB_PATH
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        name: Go modules cache
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Bindata
-        uses: actions/cache@v2
-        id: generated-bindata
-        with:
-          path: |
-            .bins.linux.stamp
-            embedded-bins/staging/linux/bin/
-            bindata_linux
-            pkg/assets/zz_generated_offsets_linux.go
-
-          key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-armv7
-          restore-keys: |
-            ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-armv7
+  #### Everything below commented for cache testing so we don't trigger unnecessary amount of smokes
       
-      - name: Build
-        run: make build
+      # - name: Run unit tests
+      #   run: make check-unit
 
-      - name: Run test .
-        run: TIMEOUT=15m make -C inttest check-basic
+      # - name: Cache compiled binary for further testing
+      #   uses: actions/cache@v2
+      #   id: cache-compiled-binary
+      #   with:
+      #     path: |
+      #       k0s
+      #     key: build-${{env.cachePrefix}}
+  # smoketest:
+  #   name: Smoke test
+  #   needs: build
+  #   runs-on: ubuntu-latest
 
-      - name: Collect test logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          path: |
-            /tmp/*.log
+  #   steps:
+  #     - name: Get PR Reference and Set Cache Name
+  #       run: |
+  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v2
 
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v2
-      - name: codegen
-        run: |
-          make -j$(nproc) pkg/assets/zz_generated_offsets_linux.go static/gen_manifests.go
-        env:
-          EMBEDDED_BINS_BUILDMODE: none
+  #     - name: Cache compiled binary for smoke testing
+  #       uses: actions/cache@v2
+  #       id: restore-compiled-binary
+  #       with:
+  #         path: |
+  #           k0s
+  #         key: build-${{env.cachePrefix}}
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.29
-          config: .golangci.yml
+  #     - name: Run test .
+  #       run: make -C inttest check-basic
+
+  #     - name: Collect test logs
+  #       if: failure()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         path: |
+  #           /tmp/*.log
+
+  # smoketest-custom-ports:
+  #   name: Smoke test for custom ports (k0s api, kube-api, LB + external address)
+  #   needs: build
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Get PR Reference and Set Cache Name
+  #       run: |
+  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v2
+
+  #     - name: Cache compiled binary for smoke testing
+  #       uses: actions/cache@v2
+  #       id: restore-compiled-binary
+  #       with:
+  #         path: |
+  #           k0s
+  #         key: build-${{env.cachePrefix}}
+
+  #     - name: Run test .
+  #       run: make -C inttest check-customports
+
+  #     - name: Collect test logs
+  #       if: failure()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         path: |
+  #           /tmp/*.log
+
+  # smoketest-calico:
+  #   name: Smoke test for calico setup
+  #   needs: build
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Get PR Reference and Set Cache Name
+  #       run: |
+  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v2
+
+  #     - name: Cache compiled binary for smoke testing
+  #       uses: actions/cache@v2
+  #       id: restore-compiled-binary
+  #       with:
+  #         path: |
+  #           k0s
+  #         key: build-${{env.cachePrefix}}
+
+  #     - name: Run test .
+  #       run: make -C inttest check-calico
+
+  #     - name: Collect test logs
+  #       if: failure()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         path: |
+  #           /tmp/*.log
+
+  # smoketest-cni-change:
+  #   name: Smoke test for preventing CNI change
+  #   needs: build
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Get PR Reference and Set Cache Name
+  #       run: |
+  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v2
+
+  #     - name: Cache compiled binary for smoke testing
+  #       uses: actions/cache@v2
+  #       id: restore-compiled-binary
+  #       with:
+  #         path: |
+  #           k0s
+  #         key: build-${{env.cachePrefix}}
+
+  #     - name: Run test .
+  #       run: make -C inttest check-cnichange
+
+  #     - name: Collect test logs
+  #       if: failure()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         path: |
+  #           /tmp/*.log
+
+
+  # smoketest-hacontrolplane:
+  #   name: Smoke test for HA controlplane operations
+  #   needs: build
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Get PR Reference and Set Cache Name
+  #       run: |
+  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v2
+
+  #     - name: Cache compiled binary for smoke testing
+  #       uses: actions/cache@v2
+  #       id: restore-compiled-binary
+  #       with:
+  #         path: |
+  #           k0s
+  #         key: build-${{env.cachePrefix}}
+
+  #     - name: Run hacontrolplane test .
+  #       run: make -C inttest check-hacontrolplane
+
+  #     - name: Collect test logs
+  #       if: failure()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         path: |
+  #           /tmp/*.log
+
+  # smoketest-byocri:
+  #   name: Smoke test for BYO CRI feature
+  #   needs: build
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Get PR Reference and Set Cache Name
+  #       run: |
+  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v2
+
+  #     - name: Cache compiled binary for smoke testing
+  #       uses: actions/cache@v2
+  #       id: restore-compiled-binary
+  #       with:
+  #         path: |
+  #           k0s
+  #         key: build-${{env.cachePrefix}}
+
+  #     - name: Run BYO CRI test .
+  #       run: make -C inttest check-byocri
+
+  #     - name: Collect test logs
+  #       if: failure()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         path: |
+  #           /tmp/*.log
+
+  # smoketest-addons:
+  #   name: Smoke test for helm based addons
+  #   needs: build
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Get PR Reference and Set Cache Name
+  #       run: |
+  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v2
+
+  #     - name: Cache compiled binary for smoke testing
+  #       uses: actions/cache@v2
+  #       id: restore-compiled-binary
+  #       with:
+  #         path: |
+  #           k0s
+  #         key: build-${{env.cachePrefix}}
+
+  #     - name: Run Helm addon test
+  #       run: make -C inttest check-addons
+
+  #     - name: Collect test logs
+  #       if: failure()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         path: |
+  #           /tmp/*.log
+
+  # smoketest-singlenode:
+  #   name: Smoke test for single node k0s
+  #   needs: build
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Get PR Reference and Set Cache Name
+  #       run: |
+  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v2
+
+  #     - name: Cache compiled binary for smoke testing
+  #       uses: actions/cache@v2
+  #       id: restore-compiled-binary
+  #       with:
+  #         path: |
+  #           k0s
+  #         key: build-${{env.cachePrefix}}
+
+  #     - name: Run singlenode test
+  #       run: make -C inttest check-singlenode
+
+  #     - name: Collect test logs
+  #       if: failure()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         path: |
+  #           /tmp/*.log
+
+  # smoketest-kine:
+  #   name: Smoke test for kine backed
+  #   needs: build
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Get PR Reference and Set Cache Name
+  #       run: |
+  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v2
+
+  #     - name: Cache compiled binary for smoke testing
+  #       uses: actions/cache@v2
+  #       id: restore-compiled-binary
+  #       with:
+  #         path: |
+  #           k0s
+  #         key: build-${{env.cachePrefix}}
+
+  #     - name: Run kine test
+  #       run: make -C inttest check-kine
+
+  #     - name: Collect test logs
+  #       if: failure()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         path: |
+  #           /tmp/*.log
+
+
+  # smoketest-network:
+  #   name: Smoke test for network
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   if: false
+
+  #   steps:
+  #     - name: Get PR Reference and Set Cache Name
+  #       run: |
+  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v2
+
+  #     - name: Cache compiled binary for smoke testing
+  #       uses: actions/cache@v2
+  #       id: restore-compiled-binary
+  #       with:
+  #         path: |
+  #           k0s
+  #         key: build-${{env.cachePrefix}}
+
+  #     - name: Run smoke test .
+  #       run: make -C inttest check-etcd
+
+  #     - name: Collect test logs
+  #       if: failure()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         path: |
+  #           /tmp/*.log
+
+  # smoketest-dualstack:
+  #   name: Smoke test for IPv6 dualstack
+  #   needs: build
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Get PR Reference and Set Cache Name
+  #       run: |
+  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v2
+
+  #     - name: Cache compiled binary for smoke testing
+  #       uses: actions/cache@v2
+  #       id: restore-compiled-binary
+  #       with:
+  #         path: |
+  #           k0s
+  #         key: build-${{env.cachePrefix}}
+
+  #     - name: Run smoke test .
+  #       run: make -C inttest check-dualstack
+
+  #     - name: Collect test logs
+  #       if: failure()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         path: |
+  #           /tmp/*.log
+
+  # smoketest-multicontroller:
+  #   name: Smoke test for multi controller
+  #   needs: build
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Get PR Reference and Set Cache Name
+  #       run: |
+  #         PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+  #         echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v2
+
+  #     - name: Cache compiled binary for smoke testing
+  #       uses: actions/cache@v2
+  #       id: restore-compiled-binary
+  #       with:
+  #         path: |
+  #           k0s
+  #         key: build-${{env.cachePrefix}}
+
+  #     - name: Run multicontroller test
+  #       run: make -C inttest check-multicontroller
+
+  #     - name: Collect test logs
+  #       if: failure()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         path: |
+  #           /tmp/*.log
+
+  # smoketest-arm:
+  #   name: Smoke test on arm64
+  #   runs-on: [self-hosted,linux,arm64]
+
+  #   steps:
+  #     - name: Set up Go 1.x
+  #       uses: actions/setup-go@v2
+  #       with:
+  #         go-version: ^1.13
+  #       id: go
+
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v2
+
+  #     - uses: actions/cache@v2
+  #       name: Go modules cache
+  #       with:
+  #         path: ~/go/pkg/mod
+  #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-go-
+
+  #     - name: Bindata
+  #       uses: actions/cache@v2
+  #       id: generated-bindata
+  #       with:
+  #         path: |
+  #           .bins.linux.stamp
+  #           embedded-bins/staging/linux/bin/
+  #           bindata_linux
+  #           pkg/assets/zz_generated_offsets_linux.go
+
+  #         key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-arm64
+  #         restore-keys: |
+  #           ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-arm64
+      
+  #     - name: Build
+  #       run: make build
+
+  #     - name: Run test .
+  #       run: make -C inttest check-basic
+
+  #     - name: Collect test logs
+  #       if: failure()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         path: |
+  #           /tmp/*.log
+  
+  # smoketest-armv7:
+  #   name: Smoke test on armv7
+  #   runs-on: [self-hosted,linux,arm,lxc] 
+  #   steps:
+  #     # Try again with system go
+  #     # - name: Install GoLang for 32bit ARM
+  #     #   run: |
+  #     #     mkdir -p /usr/local/go
+  #     #     curl -s -L https://golang.org/dl/go1.15.linux-armv6l.tar.gz | tar -C /usr/local -xz
+  #     #     echo "/usr/local/go/bin" >> $GITHUB_PATH
+
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v2
+
+  #     - uses: actions/cache@v2
+  #       name: Go modules cache
+  #       with:
+  #         path: ~/go/pkg/mod
+  #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-go-
+
+  #     - name: Bindata
+  #       uses: actions/cache@v2
+  #       id: generated-bindata
+  #       with:
+  #         path: |
+  #           .bins.linux.stamp
+  #           embedded-bins/staging/linux/bin/
+  #           bindata_linux
+  #           pkg/assets/zz_generated_offsets_linux.go
+
+  #         key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-armv7
+  #         restore-keys: |
+  #           ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-armv7
+      
+  #     - name: Build
+  #       run: make build
+
+  #     - name: Run test .
+  #       run: TIMEOUT=15m make -C inttest check-basic
+
+  #     - name: Collect test logs
+  #       if: failure()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         path: |
+  #           /tmp/*.log
+
+  # lint:
+  #   name: Lint
+  #   runs-on: ubuntu-latest
+  #   if: github.ref != 'refs/heads/main'
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: codegen
+  #       run: |
+  #         make -j$(nproc) pkg/assets/zz_generated_offsets_linux.go static/gen_manifests.go
+  #       env:
+  #         EMBEDDED_BINS_BUILDMODE: none
+
+  #     - name: golangci-lint
+  #       uses: golangci/golangci-lint-action@v2
+  #       with:
+  #         version: v1.29
+  #         config: .golangci.yml

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,6 +1,6 @@
 runc_version = 1.0.0-rc93
 containerd_version = 1.4.4
-kubernetes_version = 1.20.6
+kubernetes_version = 1.20.5
 kine_version = 0.6.0
 etcd_version = 3.4.15
 konnectivity_version = 0.0.16

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,6 +1,6 @@
 runc_version = 1.0.0-rc93
 containerd_version = 1.4.4
-kubernetes_version = 1.20.5
+kubernetes_version = 1.20.6
 kine_version = 0.6.0
 etcd_version = 3.4.15
 konnectivity_version = 0.0.16


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Caching of the embedded-bin in GH actions is somehow broken and each PR is building ALL the bins now. This makes PR builds super slow. The reason is that we cache the `.stamp` file but as the `Makefile.variables` coms from checkout the timestamps do not match. Hence `make` determines it needs to do a full rebuild of embedded bins:
```
2021-04-16T08:54:53.2946938Z  File 'build' does not exist.
2021-04-16T08:54:53.2952041Z    File 'k0s' does not exist.
2021-04-16T08:54:53.3324428Z        Prerequisite 'embedded-bins/Makefile.variables' is newer than target '.bins.linux.stamp'.
2021-04-16T08:54:53.3325606Z       Must remake target '.bins.linux.stamp'.
```

**What this PR Includes**
This PR makes the `Makefile.variables` to be cached too so the timestamps match with the .stamp file. When we ACTUALLY change the component versions in the `Makefile.variables`, the cache will NOT be used at all as that file is part of the cache hash and thus there's full re-build for embedded bins as expected.
