### PR TITLE
Replace + with - on image tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,14 @@ jobs:
           asset_path: ./k0s
           asset_name: k0s-${{ needs.release.outputs.tag_name }}-amd64
           asset_content_type: application/octet-stream
+
+      - name: Prepare tags
+        id: prep
+        # Basically just replace the '+' with '-' as '+' is not allowed in tags
+        run: |
+          TAGS=${{ needs.release.outputs.tag_name }}
+          TAGS=${TAGS//+/-}
+          echo ::set-output name=tags::${TAGS}
       
       - name: Build image and push to GitHub image registry
         uses: docker/build-push-action@v1
@@ -79,7 +87,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: docker.pkg.github.com
           repository: k0sproject/k0s/k0s
-          tag_with_ref: true
+          tags: ${{ steps.prep.outputs.tags }}
 
       - name: Build image and push to Docker hub
         uses: docker/build-push-action@v1
@@ -88,19 +96,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           registry: docker.io
           repository: k0sproject/k0s
-          tag_with_ref: true
-
-      # Need to remove this from maintenance branches
-      # Done as separate step for better control when we push latest
-      - name: Build image and push to Docker hub
-        if: "!contains(github.ref, '-')"
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          registry: docker.io
-          repository: k0sproject/k0s
-          tags: latest
+          tags: ${{ steps.prep.outputs.tags }}
 
   windows:
     needs: release


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
The new versioning scheme has `+` in the tag names which is not allowed in Docker image builds in the tag names

**What this PR Includes**
Replaces `+` with `-` in the image tags