### PR TITLE
Do not fail if stdin is open but data is broken

### DIFF
--- a/pkg/apis/v1beta1/cluster.go
+++ b/pkg/apis/v1beta1/cluster.go
@@ -137,19 +137,11 @@ func ConfigFromFile(filename string, k0sVars constant.CfgVars) (*ClusterConfig, 
 	return configFromString(string(buf), k0sVars)
 }
 
-func isInputFromPipe() bool {
-	fi, _ := os.Stdin.Stat()
-	return fi.Mode()&os.ModeCharDevice == 0
-}
-
 // ConfigFromStdin tries to read k0s.yaml config from stdin
 func ConfigFromStdin(k0sVars constant.CfgVars) (*ClusterConfig, error) {
-	if !isInputFromPipe() {
-		return nil, fmt.Errorf("can't read configuration from stdin")
-	}
 	input, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
-		return nil, nil
+		return nil, fmt.Errorf("can't read configration from stdin: %v", err)
 	}
 	return configFromString(string(input), k0sVars)
 

--- a/pkg/apis/v1beta1/cluster.go
+++ b/pkg/apis/v1beta1/cluster.go
@@ -17,8 +17,8 @@ package v1beta1
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 
 	"github.com/k0sproject/k0s/pkg/constant"
 	"gopkg.in/yaml.v2"
@@ -127,28 +127,35 @@ func validateSpecs(v Validateable) []error {
 	return v.Validate()
 }
 
-// FromYamlFile ...
-func FromYamlFile(filename string, k0sVars constant.CfgVars) (*ClusterConfig, error) {
+// ConfigFromFile ...
+func ConfigFromFile(filename string, k0sVars constant.CfgVars) (*ClusterConfig, error) {
 	buf, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file at %s: %w", filename, err)
 	}
 
-	return FromYamlString(string(buf), k0sVars)
+	return configFromString(string(buf), k0sVars)
 }
 
-// FromYamlPipe
-func FromYamlPipe(r io.Reader, k0sVars constant.CfgVars) (*ClusterConfig, error) {
-	input, err := ioutil.ReadAll(r)
+func isInputFromPipe() bool {
+	fi, _ := os.Stdin.Stat()
+	return fi.Mode()&os.ModeCharDevice == 0
+}
+
+// ConfigFromStdin tries to read k0s.yaml config from stdin
+func ConfigFromStdin(k0sVars constant.CfgVars) (*ClusterConfig, error) {
+	if !isInputFromPipe() {
+		return nil, fmt.Errorf("can't read configuration from stdin")
+	}
+	input, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
 		return nil, nil
 	}
-	return FromYamlString(string(input), k0sVars)
+	return configFromString(string(input), k0sVars)
 
 }
 
-// FromYamlString
-func FromYamlString(yml string, k0sVars constant.CfgVars) (*ClusterConfig, error) {
+func configFromString(yml string, k0sVars constant.CfgVars) (*ClusterConfig, error) {
 	config := &ClusterConfig{k0sVars: k0sVars}
 	err := yaml.UnmarshalStrict([]byte(yml), &config)
 	if err != nil {

--- a/pkg/apis/v1beta1/cluster_test.go
+++ b/pkg/apis/v1beta1/cluster_test.go
@@ -29,7 +29,7 @@ var (
 )
 
 func TestClusterDefaults(t *testing.T) {
-	c, err := FromYamlString("apiVersion: k0s.k0sproject.io/v1beta1", k0sVars)
+	c, err := configFromString("apiVersion: k0s.k0sproject.io/v1beta1", k0sVars)
 	assert.NoError(t, err)
 	assert.NotNil(t, c.Metadata)
 	assert.Equal(t, "k0s", c.Metadata.Name)
@@ -44,7 +44,7 @@ metadata:
   name: foobar
 `
 
-	c, err := FromYamlString(yamlData, k0sVars)
+	c, err := configFromString(yamlData, k0sVars)
 	assert.NoError(t, err)
 	assert.Equal(t, "etcd", c.Spec.Storage.Type)
 	addr, err := util.FirstPublicAddress()
@@ -63,7 +63,7 @@ spec:
     type: etcd
 `
 
-	c, err := FromYamlString(yamlData, k0sVars)
+	c, err := configFromString(yamlData, k0sVars)
 	assert.NoError(t, err)
 	assert.Equal(t, "etcd", c.Spec.Storage.Type)
 	addr, err := util.FirstPublicAddress()
@@ -84,7 +84,7 @@ spec:
     type: etcd
 `
 
-	c, err := FromYamlString(yamlData, k0sVars)
+	c, err := configFromString(yamlData, k0sVars)
 	assert.NoError(t, err)
 	errors := c.Validate()
 	assert.Equal(t, 0, len(errors))
@@ -103,7 +103,7 @@ spec:
     type: etcd
 `
 
-	c, err := FromYamlString(yamlData, k0sVars)
+	c, err := configFromString(yamlData, k0sVars)
 	assert.NoError(t, err)
 	errors := c.Validate()
 	assert.Equal(t, 0, len(errors))
@@ -122,7 +122,7 @@ spec:
     type: etcd
 `
 
-	c, err := FromYamlString(yamlData, k0sVars)
+	c, err := configFromString(yamlData, k0sVars)
 	assert.NoError(t, err)
 	errors := c.Validate()
 	assert.Equal(t, 1, len(errors))
@@ -141,7 +141,7 @@ spec:
     address: 1.2.3.4
 `
 
-	c, err := FromYamlString(yamlData, k0sVars)
+	c, err := configFromString(yamlData, k0sVars)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://foo.bar.com:6443", c.Spec.API.APIAddressURL())
 	assert.Equal(t, "https://foo.bar.com:9443", c.Spec.API.K0sControlPlaneAPIAddress())
@@ -158,7 +158,7 @@ spec:
     address: 1.2.3.4
 `
 
-	c, err := FromYamlString(yamlData, k0sVars)
+	c, err := configFromString(yamlData, k0sVars)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://1.2.3.4:6443", c.Spec.API.APIAddressURL())
 	assert.Equal(t, "https://1.2.3.4:9443", c.Spec.API.K0sControlPlaneAPIAddress())

--- a/pkg/apis/v1beta1/network_test.go
+++ b/pkg/apis/v1beta1/network_test.go
@@ -103,7 +103,7 @@ spec:
     calico:
 `
 
-	c, err := FromYamlString(yamlData, k0sVars)
+	c, err := configFromString(yamlData, k0sVars)
 	s.NoError(err)
 	n := c.Spec.Network
 
@@ -126,7 +126,7 @@ spec:
     kuberouter:
 `
 
-	c, err := FromYamlString(yamlData, k0sVars)
+	c, err := configFromString(yamlData, k0sVars)
 	s.NoError(err)
 	n := c.Spec.Network
 

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -84,7 +84,7 @@ func DefaultLogLevels() map[string]string {
 
 func GetPersistentFlagSet() *pflag.FlagSet {
 	flagset := &pflag.FlagSet{}
-	flagset.StringVarP(&CfgFile, "config", "c", "", "config file (default: ./k0s.yaml)")
+	flagset.StringVarP(&CfgFile, "config", "c", "", "config file (default: ./k0s.yaml). Use '-' to read the config from stdin")
 	flagset.BoolVarP(&Debug, "debug", "d", false, "Debug logging (default: false)")
 	flagset.StringVar(&DataDir, "data-dir", "", "Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!")
 	flagset.StringVar(&DebugListenOn, "debugListenOn", ":6060", "Http listenOn for Debug pprof handler")


### PR DESCRIPTION
Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>
**Issue**
Fixes #850

**What this PR Includes**
Sometimes we have stdin open but with no data on it (remote execution by ssh, execution in the context of Vagrantfile, probably some other tools as well). This PR prevents us from failing in that case, but do warning and fallback to the default config instead.