### PR TITLE
Fix custom datadir (#771)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ go_bindata := go get github.com/kevinburke/go-bindata/...@v3.22.0 && "${GOPATH}/
 endif
 
 GOLANG_IMAGE = golang:1.16-alpine
-GO = GOCACHE=/tmp/.cache docker run --rm -v "$(CURDIR)":/go/src/github.com/k0sproject/k0s \
+GO ?= GOCACHE=/tmp/.cache docker run --rm -v "$(CURDIR)":/go/src/github.com/k0sproject/k0s \
 	-w /go/src/github.com/k0sproject/k0s \
 	-e GOOS \
 	-e CGO_ENABLED \

--- a/Makefile
+++ b/Makefile
@@ -103,14 +103,13 @@ lint: pkg/assets/zz_generated_offsets_$(TARGET_OS).go
 	$(golint) run ./...
 
 .PHONY: $(smoketests)
+check-airgap: image-bundle/bundle.tar
 $(smoketests): k0s
 	$(MAKE) -C inttest $@
 
 .PHONY: smoketests
 smoketests:  $(smoketests)
 
-check-airgap: image-bundle/bundle.tar k0s
-	$(MAKE) -C inttest check-airgap
 
 .PHONY: check-unit
 check-unit: pkg/assets/zz_generated_offsets_$(TARGET_OS).go static/gen_manifests.go

--- a/go.sum
+++ b/go.sum
@@ -1308,6 +1308,8 @@ k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAG
 k8s.io/kubectl v0.19.2/go.mod h1:4ib3oj5ma6gF95QukTvC7ZBMxp60+UEAhDPjLuBIrV4=
 k8s.io/kubectl v0.20.2 h1:mXExF6N4eQUYmlfXJmfWIheCBLF6/n4VnwQKbQki5iE=
 k8s.io/kubectl v0.20.2/go.mod h1:/bchZw5fZWaGZxaRxxfDQKej/aDEtj/Tf9YSS4Jl0es=
+k8s.io/kubelet v0.20.5 h1:lyt+h1+KeBndLBHwZ/cmlW1Dz5Hu2MGGZSDm6ol9dLI=
+k8s.io/kubelet v0.20.5/go.mod h1:iM18y0xm/1VlznuHFGBd9YVT9MM15TgEWJrJHrZ4mtQ=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/metrics v0.19.2/go.mod h1:IlLaAGXN0q7yrtB+SV0q3JIraf6VtlDr+iuTcX21fCU=
 k8s.io/metrics v0.20.2 h1:o32EchiH4ukpUg86VLLAgkE9a9Ke0lijkzYxE+wSSRk=

--- a/internal/util/templatewriter.go
+++ b/internal/util/templatewriter.go
@@ -17,9 +17,9 @@ package util
 
 import (
 	"fmt"
-	"html/template"
 	"io"
 	"os"
+	"text/template"
 
 	"github.com/Masterminds/sprig"
 
@@ -46,7 +46,7 @@ func (p *TemplateWriter) Write() error {
 
 // WriteToBuffer writes executed template tot he given writer
 func (p *TemplateWriter) WriteToBuffer(w io.Writer) error {
-	t, err := template.New(p.Name).Funcs(sprig.FuncMap()).Parse(p.Template)
+	t, err := template.New(p.Name).Funcs(sprig.TxtFuncMap()).Parse(p.Template)
 	if err != nil {
 		return fmt.Errorf("failed to parse template for %s: %w", p.Name, err)
 	}

--- a/internal/util/templatewriter.go
+++ b/internal/util/templatewriter.go
@@ -40,6 +40,7 @@ func (p *TemplateWriter) Write() error {
 	if err != nil {
 		return fmt.Errorf("failed to open pod file for %s: %w", p.Name, err)
 	}
+	defer podFile.Close()
 	return p.WriteToBuffer(podFile)
 }
 

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/k0sproject/k0s/inttest/common"
 	capi "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -78,6 +79,9 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	s.NoError(err)
 	s.T().Log("waiting to see metrics ready")
 	s.Require().NoError(common.WaitForMetricsReady(cfg))
+
+	_, err = kc.CoreV1().Pods(pods.Items[0].Namespace).GetLogs(pods.Items[0].Name, &corev1.PodLogOptions{}).Stream(context.Background())
+	s.Require().NoError(err)
 }
 
 func (s *BasicSuite) checkCertPerms(node string) error {

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -36,7 +36,10 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	customDataDir := "/var/lib/k0s/custom-data-dir"
 	dataDirOpt := fmt.Sprintf("--data-dir=%s", customDataDir)
 	s.NoError(s.InitController(0, dataDirOpt))
-	s.NoError(s.RunWorkers(dataDirOpt, `--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args="--address=0.0.0.0 --event-burst=10"`))
+
+	token, err := s.GetJoinToken("worker", dataDirOpt)
+	s.NoError(err)
+	s.NoError(s.RunWorkersWithToken(token, `--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args="--address=0.0.0.0 --event-burst=10"`))
 
 	kc, err := s.KubeClient(s.ControllerNode(0), dataDirOpt)
 	s.NoError(err)

--- a/pkg/component/controller/kubeletconfig_test.go
+++ b/pkg/component/controller/kubeletconfig_test.go
@@ -43,8 +43,8 @@ func Test_KubeletConfig(t *testing.T) {
 		manifestYamls := strings.Split(strings.TrimSuffix(buf.String(), "---"), "---")[1:]
 		t.Run("output_must_have_3_manifests", func(t *testing.T) {
 			require.Len(t, manifestYamls, 4, "Must have exactly 4 generated manifests per profile")
-			requireConfigMap(t, manifestYamls[0], "kubelet-config-default-1.20")
-			requireConfigMap(t, manifestYamls[1], "kubelet-config-default-windows-1.20")
+			requireConfigMap(t, manifestYamls[0], "kubelet-config-default-1.21")
+			requireConfigMap(t, manifestYamls[1], "kubelet-config-default-windows-1.21")
 			requireRole(t, manifestYamls[2], []string{
 				formatProfileName("default"),
 				formatProfileName("default-windows"),
@@ -70,7 +70,7 @@ func Test_KubeletConfig(t *testing.T) {
 			// check that each profile has config map, role and role binding
 			resourceNamesForRole := []string{}
 			for idx, profileName := range []string{"default", "default-windows", "profile_XXX", "profile_YYY"} {
-				fullName := "kubelet-config-" + profileName + "-1.20"
+				fullName := "kubelet-config-" + profileName + "-1.21"
 				resourceNamesForRole = append(resourceNamesForRole, formatProfileName(profileName))
 				requireConfigMap(t, manifestYamls[idx], fullName)
 			}

--- a/pkg/component/controller/kubeletconfig_test.go
+++ b/pkg/component/controller/kubeletconfig_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package controller
 
 import (
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -33,7 +32,6 @@ var k0sVars = constant.GetConfig("")
 func Test_KubeletConfig(t *testing.T) {
 	dnsAddr := "dns.local"
 	volumePluginDir := k0sVars.KubeletVolumePluginDir
-	clientCAFile := filepath.Join(k0sVars.CertRootDir, "ca.crt")
 
 	t.Run("default_profile_only", func(t *testing.T) {
 		k, err := NewKubeletConfig(config.DefaultClusterConfig(k0sVars).Spec, k0sVars)
@@ -53,7 +51,7 @@ func Test_KubeletConfig(t *testing.T) {
 		})
 	})
 	t.Run("default_profile_must_have_feature_gates_if_dualstack_setup", func(t *testing.T) {
-		profile := getDefaultProfile(dnsAddr, clientCAFile, volumePluginDir, true)
+		profile := getDefaultProfile(dnsAddr, volumePluginDir, true)
 		require.Equal(t, map[string]bool{
 			"IPv6DualStack": true,
 		}, profile["featureGates"])
@@ -90,12 +88,12 @@ func Test_KubeletConfig(t *testing.T) {
 			require.NoError(t, yaml.Unmarshal([]byte(manifestYamls[3]), &profileYYY))
 
 			// manually apple the same changes to default config and check that there is no diff
-			defaultProfileKubeletConfig := getDefaultProfile(dnsAddr, clientCAFile, volumePluginDir, false)
+			defaultProfileKubeletConfig := getDefaultProfile(dnsAddr, volumePluginDir, false)
 			defaultProfileKubeletConfig["authentication"].(map[string]interface{})["anonymous"].(map[string]interface{})["enabled"] = false
 			defaultWithChangesXXX, err := yaml.Marshal(defaultProfileKubeletConfig)
 			require.NoError(t, err)
 
-			defaultProfileKubeletConfig = getDefaultProfile(dnsAddr, clientCAFile, volumePluginDir, false)
+			defaultProfileKubeletConfig = getDefaultProfile(dnsAddr, volumePluginDir, false)
 			defaultProfileKubeletConfig["authentication"].(map[string]interface{})["webhook"].(map[string]interface{})["cacheTTL"] = "15s"
 			defaultWithChangesYYY, err := yaml.Marshal(defaultProfileKubeletConfig)
 

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -50,7 +50,7 @@ const (
 	// KonnectivityServerUser deinfes the user to use for konnectivity-server
 	KonnectivityServerUser = "konnectivity-server"
 	// KubernetesMajorMinorVersion defines the current embedded major.minor version info
-	KubernetesMajorMinorVersion = "1.20"
+	KubernetesMajorMinorVersion = "1.21"
 	// DefaultPSP defines the system level default PSP to apply
 	DefaultPSP = "00-k0s-privileged"
 	// Image Constants


### PR DESCRIPTION
---
name: Pull Request
about: Create a Pull Request
title: ''
labels: ''
assignees: ''

---

**Issue**
Fixes #771

**What this PR Includes**
- Adds tests to verify issue #771 
- Clean up Makefile a bit (fix a warning and respect GO env var)
- fix kubernetes 1.20 leftovers
- fix a filehandle leak spotted by @jnummelin
- save the kubelet config as a template in configmap, so we can replace the path on worker side
- use text/template instead of html/template in template writer so the special chars are not html-escaped