### PR TITLE
Documentation air-gap clarification

### DIFF
--- a/docs/airgap-install.md
+++ b/docs/airgap-install.md
@@ -13,7 +13,7 @@ You also need to have containerd CLI management tool `ctr` installed on the work
 
 #### 1. Create OCI bundle
 
-To create an OCI bundle, use the same computer architecture (x86-64, ARM64, ARMv7) as you'll have in the target system, because the OCI bundles are build specifically for certain architecture.
+To create an OCI bundle, use the same processor architecture (x86-64, ARM64, ARMv7) as on the target system, because the OCI bundles are built specifically for each architecture.
 
 k0s supports only uncompressed image bundles.
 

--- a/docs/airgap-install.md
+++ b/docs/airgap-install.md
@@ -13,6 +13,8 @@ You also need to have containerd CLI management tool `ctr` installed on the work
 
 #### 1. Create OCI bundle
 
+To create an OCI bundle, use the same computer architecture (x86-64, ARM64, ARMv7) as you'll have in the target system, because the OCI bundles are build specifically for certain architecture.
+
 k0s supports only uncompressed image bundles.
 
 ##### 1.1 Using Docker
@@ -24,6 +26,9 @@ Use following commands to build OCI bundle by utilizing your docker environment.
 ## Create bundle
 # docker image save $(k0s airgap list-images | xargs) -o bundle_file
 ```
+
+**Note:**
+This Docker method doesn't currently work for the ARM architectures due to [kube-proxy image multiarch manifest problem](https://github.com/kubernetes/kubernetes/issues/98229). So, for the ARM architectures, use the method in step 1.2.
 
 ##### 1.2 Using previously set up k0s worker
 To build OCI bundle with images we can utilize the fact that containerd pulls all images during the k0s worker normal bootstrap.
@@ -61,7 +66,6 @@ spec:
   images:
     default_pull_policy: Never
 ```
-
 
 #### 4. Controller
 Set up the controller node as usual. Please refer to the [getting started guide](install.md).

--- a/docs/system-requirements.md
+++ b/docs/system-requirements.md
@@ -30,8 +30,9 @@ k0s part of the storage consumption is presented in the following table. Note th
 
 ## Architecture
 
-- Intel (x86-64)
-- ARM (ARM64)
+- x86-64
+- ARM64
+- ARMv7
 
 ## Networking
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
           - Raspberry Pi 4:               raspberry-pi4.md
           - Ansible Playbook:             examples/ansible-playbook.md
           - Airgap installation:          airgap-install.md
+      - System Requirements:              system-requirements.md
   - Extensions:
       - Manifest Bundles:                 manifests.md
       - Helm Charts:                      helm-charts.md
@@ -29,7 +30,6 @@ nav:
   - Architecture:
       - Overview:                         architecture.md
       - Networking:                       networking.md
-      - System Requirements:              system-requirements.md
   - Configuration:
       - Configuration Options:            configuration.md
       - Worker Node Configuration:        worker-node-config.md


### PR DESCRIPTION
Added a note to air-gap installation tutorial.

Signed-off-by: mviitanen <mviitanen@mirantis.com>

**What this PR Includes**
- This PR clarifies the OCI bundle creation to avoid a problem when creating and using the bundle.
- ARMv7 added as supported architecture.
- System requirements page moved to a new location in the navigation to make it easier to be found.