### PR TITLE
Make kuberouter only request 16Mi memory

### DIFF
--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -245,7 +245,7 @@ spec:
         resources:
           requests:
             cpu: 250m
-            memory: 250Mi
+            memory: 16Mi
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
Measurements shows that it normally uses 9-18Mi. Set the requested
memory to 16Mi.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

---

**What this PR Includes**
reduce the requested memory for kube-router pod