### PR TITLE
Retry pod logs in case of transient failures

### DIFF
--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -79,8 +79,6 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	s.T().Log("waiting to see metrics ready")
 	s.Require().NoError(common.WaitForMetricsReady(cfg))
 
-	s.T().Log("waiting to get logs from pods")
-	s.Require().NoError(common.WaitForPodLogs(kc, pods.Items))
 }
 
 func (s *BasicSuite) checkCertPerms(node string) error {

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/k0sproject/k0s/inttest/common"
 	capi "k8s.io/api/certificates/v1"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -80,8 +79,8 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	s.T().Log("waiting to see metrics ready")
 	s.Require().NoError(common.WaitForMetricsReady(cfg))
 
-	_, err = kc.CoreV1().Pods(pods.Items[0].Namespace).GetLogs(pods.Items[0].Name, &corev1.PodLogOptions{}).Stream(context.Background())
-	s.Require().NoError(err)
+	s.T().Log("waiting to get logs from pods")
+	s.Require().NoError(common.WaitForPodLogs(kc, pods.Items))
 }
 
 func (s *BasicSuite) checkCertPerms(node string) error {

--- a/inttest/customports/customports_test.go
+++ b/inttest/customports/customports_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/k0sproject/k0s/inttest/common"
 	"github.com/stretchr/testify/suite"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "k8s.io/client-go/kubernetes"
 )
@@ -134,6 +133,6 @@ func (ds *Suite) TestControllerJoinsWithCustomPort() {
 	ds.Require().NoError(common.WaitForDaemonSet(kc, "konnectivity-agent"), "konnectivity-agent did not start")
 	ds.Require().NoError(common.WaitForPod(kc, pods.Items[0].Name), "Pod %s did not start", pods.Items[0].Name)
 
-	_, err = kc.CoreV1().Pods(pods.Items[0].Namespace).GetLogs(pods.Items[0].Name, &corev1.PodLogOptions{}).Stream(context.Background())
-	ds.Require().NoError(err)
+	ds.T().Log("waiting to get logs from pods")
+	ds.Require().NoError(common.WaitForPodLogs(kc, pods.Items))
 }


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
The pod logs retrieval is bit flaky in smokes. 

**What this PR Includes**
This adds some retry and also verifies we're trying to get logs from a pod that is actually up and running.