### PR TITLE
Fix release bundle steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Upload Release Assets - Bundle
-        id: upload-release-asset
+        id: upload-release-asset-images
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
@@ -201,7 +201,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Upload Release Assets - Bundle
-        id: upload-release-asset
+        id: upload-release-asset-images
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
@@ -252,7 +252,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Upload Release Assets - Bundle
-        id: upload-release-asset
+        id: upload-release-asset-images
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions

--- a/pkg/airgap/images.go
+++ b/pkg/airgap/images.go
@@ -1,6 +1,8 @@
 package airgap
 
 import (
+	"runtime"
+
 	"github.com/k0sproject/k0s/pkg/apis/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
 )
@@ -12,10 +14,7 @@ var pauseImage = v1beta1.ImageSpec{
 
 // GetImageURIs returns all image tags
 func GetImageURIs(spec *v1beta1.ClusterImages) []string {
-	return []string{
-		spec.Calico.CNI.URI(),
-		spec.Calico.KubeControllers.URI(),
-		spec.Calico.Node.URI(),
+	images := []string{
 		spec.Konnectivity.URI(),
 		spec.CoreDNS.URI(),
 		spec.KubeProxy.URI(),
@@ -24,4 +23,12 @@ func GetImageURIs(spec *v1beta1.ClusterImages) []string {
 		spec.KubeRouter.CNI.URI(),
 		spec.KubeRouter.CNIInstaller.URI(),
 	}
+	// Calico images do not currently support armv7, thus we need to exclude them from the list if we're running this on arm
+	if runtime.GOARCH != "arm" {
+		images = append(images,
+			spec.Calico.CNI.URI(),
+			spec.Calico.KubeControllers.URI(),
+			spec.Calico.Node.URI())
+	}
+	return images
 }


### PR DESCRIPTION
**Issue**
The image bundle release process has currently two issues:
- release.yaml not valid for GH actions as the `id` field has same value for two steps within a job
- Image bundle build on armv7 fails as it tries to include calico images. Those are not available for armv7 and thus the bundling fails.

**What this PR Includes**
- Fix yaml validity
- Exclude calico images when image list executed on arm(v7)


**Note:** This currently has also #869 commits in so I was able to actually test the release. Will be rebased out once that on is merged.

**Note2:** 1.20.0-beta... releases are baked out of this branch, thus those "checks" also show up on the PR checklist.