### PR TITLE
Add OIDC compliant SA issuer configs to kube api-server

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -35,6 +35,9 @@ check-byocri: TIMEOUT=5m
 # Basic also check to get metrics api service et all ready, will take some time
 check-basic: TIMEOUT=6m
 
+# Establishing konnectivity tunnels with the LB in place takes a while, thus a bit longer timeout for the smoke
+check-customports: TIMEOUT=6m
+
 .PHONY: $(smoketests)
 include Makefile.variables
 


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>


**Issue**
Fixes Conformance test case
```
[sig-auth] ServiceAccounts ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer [Conformance]
```

While the existing config is valid, conformance now starting at 1.21.0 verifies also OIDC "validness" of the SA tokens

**What this PR Includes**
This adds proper SA token issuer as the cluster identity.