### PR TITLE
Add k0s start and stop for controlling service state

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,7 +37,9 @@ import (
 	"github.com/k0sproject/k0s/cmd/kubectl"
 	"github.com/k0sproject/k0s/cmd/reset"
 	"github.com/k0sproject/k0s/cmd/restore"
+	"github.com/k0sproject/k0s/cmd/start"
 	"github.com/k0sproject/k0s/cmd/status"
+	"github.com/k0sproject/k0s/cmd/stop"
 	"github.com/k0sproject/k0s/cmd/token"
 	"github.com/k0sproject/k0s/cmd/validate"
 	"github.com/k0sproject/k0s/cmd/version"
@@ -81,6 +83,8 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(kubectl.NewK0sKubectlCmd())
 	cmd.AddCommand(reset.NewResetCmd())
 	cmd.AddCommand(status.NewStatusCmd())
+	cmd.AddCommand(start.NewStartCmd())
+	cmd.AddCommand(stop.NewStopCmd())
 	cmd.AddCommand(token.NewTokenCmd())
 	cmd.AddCommand(validate.NewValidateCmd())
 	cmd.AddCommand(version.NewVersionCmd())

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -36,10 +36,7 @@ func NewStartCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			status, err := svc.Status()
-			if err != nil {
-				return err
-			}
+			status, _ := svc.Status()
 			if status == service.StatusRunning {
 				cmd.SilenceUsage = true
 				return fmt.Errorf("already running")

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -41,6 +41,7 @@ func NewStartCmd() *cobra.Command {
 				return err
 			}
 			if status == service.StatusRunning {
+				cmd.SilenceUsage = true
 				return fmt.Errorf("already running")
 			}
 			return svc.Start()

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package start
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/k0sproject/k0s/pkg/install"
+	"github.com/kardianos/service"
+	"github.com/spf13/cobra"
+)
+
+func NewStartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "start",
+		Short: "Start the k0s service configured on this host. Must be run as root (or with sudo)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if os.Geteuid() != 0 {
+				return fmt.Errorf("this command must be run as root")
+			}
+			svc, err := install.InstalledService()
+			if err != nil {
+				return err
+			}
+			status, err := svc.Status()
+			if err != nil {
+				return err
+			}
+			if status == service.StatusRunning {
+				return fmt.Errorf("already running")
+			}
+			return svc.Start()
+		},
+	}
+
+}

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -41,6 +41,7 @@ func NewStopCmd() *cobra.Command {
 				return err
 			}
 			if status == service.StatusStopped {
+				cmd.SilenceUsage = true
 				return fmt.Errorf("already stopped")
 			}
 			return svc.Stop()

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package stop
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/k0sproject/k0s/pkg/install"
+	"github.com/kardianos/service"
+	"github.com/spf13/cobra"
+)
+
+func NewStopCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the k0s service configured on this host. Must be run as root (or with sudo)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if os.Geteuid() != 0 {
+				return fmt.Errorf("this command must be run as root")
+			}
+			svc, err := install.InstalledService()
+			if err != nil {
+				return err
+			}
+			status, err := svc.Status()
+			if err != nil {
+				return err
+			}
+			if status == service.StatusStopped {
+				return fmt.Errorf("already stopped")
+			}
+			return svc.Stop()
+		},
+	}
+
+}

--- a/docs/cli/k0s.md
+++ b/docs/cli/k0s.md
@@ -26,6 +26,8 @@ k0s - The zero friction Kubernetes - https://k0sproject.io
 * [k0s docs](k0s_docs.md)	 - Generate Markdown docs for the k0s binary
 * [k0s etcd](k0s_etcd.md)	 - Manage etcd cluster
 * [k0s install](k0s_install.md)	 - Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)
+* [k0s start](k0s_stop.md)	 - Start the k0s service after it has been installed using `k0s install`. Must be run as root (or with sudo)
+* [k0s stop](k0s_stop.md)	 - Stop the k0s service after it has been installed using `k0s install`. Must be run as root (or with sudo)
 * [k0s kubeconfig](k0s_kubeconfig.md)	 - Create a kubeconfig file for a specified user
 * [k0s status](k0s_status.md)	 - Helper command for get general information about k0s
 * [k0s token](k0s_token.md)	 - Manage join tokens

--- a/docs/cli/k0s_install.md
+++ b/docs/cli/k0s_install.md
@@ -1,6 +1,6 @@
 ## k0s install
 
-Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)
+Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo).
 
 ### Options
 
@@ -23,4 +23,5 @@ Helper command for setting up k0s on a brand-new system. Must be run as root (or
 * [k0s](k0s.md)	 - k0s - Zero Friction Kubernetes
 * [k0s install controller](k0s_install_controller.md)	 - Helper command for setting up k0s as controller node on a brand-new system. Must be run as root (or with sudo)
 * [k0s install worker](k0s_install_worker.md)	 - Helper command for setting up k0s as a worker node on a brand-new system. Must be run as root (or with sudo)
-
+* [k0s start](k0s_stop.md)	 - Start the k0s service after it has been installed using `k0s install`. Must be run as root (or with sudo)
+* [k0s stop](k0s_stop.md)	 - Stop the k0s service after it has been installed using `k0s install`. Must be run as root (or with sudo)

--- a/docs/cli/k0s_start.md
+++ b/docs/cli/k0s_start.md
@@ -1,0 +1,22 @@
+## k0s start
+
+Start the k0s service after it has been installed using `k0s install`. Must be run as root (or with sudo),
+
+### Options
+
+```
+  -h, --help   help for start
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug                    Debug logging (default: false)
+```
+
+### SEE ALSO
+
+* [k0s stop](k0s_stop.md)	 - Stop the k0s service after it has been installed using `k0s install`. Must be run as root (or with sudo)
+* [k0s install](k0s_install.md)	 - Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)
+* [k0s install controller](k0s_install_controller.md)	 - Helper command for setting up k0s as controller node on a brand-new system. Must be run as root (or with sudo)
+* [k0s install worker](k0s_install_worker.md)	 - Helper command for setting up k0s as a worker node on a brand-new system. Must be run as root (or with sudo)

--- a/docs/cli/k0s_stop.md
+++ b/docs/cli/k0s_stop.md
@@ -1,0 +1,22 @@
+## k0s stop
+
+Stop the k0s service after it has been installed using `k0s install`. Must be run as root (or with sudo).
+
+### Options
+
+```
+  -h, --help   help for start
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug                    Debug logging (default: false)
+```
+
+### SEE ALSO
+
+* [k0s start](k0s_stop.md)	 - Start the k0s service after it has been installed using `k0s install`. Must be run as root (or with sudo)
+* [k0s install](k0s_install.md)	 - Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)
+* [k0s install controller](k0s_install_controller.md)	 - Helper command for setting up k0s as controller node on a brand-new system. Must be run as root (or with sudo)
+* [k0s install worker](k0s_install_worker.md)	 - Helper command for setting up k0s as a worker node on a brand-new system. Must be run as root (or with sudo)

--- a/pkg/install/service.go
+++ b/pkg/install/service.go
@@ -40,6 +40,27 @@ func (p *program) Stop(service.Service) error {
 	return nil
 }
 
+// InstalledService returns a k0s service if one has been installed on the host or an error otherwise.
+func InstalledService() (service.Service, error) {
+	prg := &program{}
+	for _, role := range []string{"controller", "worker"} {
+		c := getServiceConfig(role)
+		s, err := service.New(prg, c)
+		if err != nil {
+			return s, err
+		}
+		status, err := s.Status()
+		if err != nil {
+			return s, err
+		}
+		if status != service.StatusUnknown {
+			return s, nil
+		}
+	}
+	var s service.Service
+	return s, fmt.Errorf("k0s has not been installed as a service")
+}
+
 // EnsureService installs the k0s service, per the given arguments, and the detected platform
 func EnsureService(args []string) error {
 	var deps []string

--- a/pkg/install/service.go
+++ b/pkg/install/service.go
@@ -49,13 +49,7 @@ func InstalledService() (service.Service, error) {
 		if err != nil {
 			return s, err
 		}
-		status, err := s.Status()
-		if err != nil {
-			return s, err
-		}
-		if status != service.StatusUnknown {
-			return s, nil
-		}
+		return s, nil
 	}
 	var s service.Service
 	return s, fmt.Errorf("k0s has not been installed as a service")

--- a/pkg/install/service.go
+++ b/pkg/install/service.go
@@ -43,13 +43,12 @@ func (p *program) Stop(service.Service) error {
 // InstalledService returns a k0s service if one has been installed on the host or an error otherwise.
 func InstalledService() (service.Service, error) {
 	prg := &program{}
-	for _, role := range []string{"controller", "worker", "controller+worker"} {
+	for _, role := range []string{"controller", "worker"} {
 		c := getServiceConfig(role)
 		s, err := service.New(prg, c)
-		if err != nil {
-			return s, err
+		if err == nil {
+			return s, nil
 		}
-		return s, nil
 	}
 	var s service.Service
 	return s, fmt.Errorf("k0s has not been installed as a service")

--- a/pkg/install/service.go
+++ b/pkg/install/service.go
@@ -43,7 +43,7 @@ func (p *program) Stop(service.Service) error {
 // InstalledService returns a k0s service if one has been installed on the host or an error otherwise.
 func InstalledService() (service.Service, error) {
 	prg := &program{}
-	for _, role := range []string{"controller", "worker"} {
+	for _, role := range []string{"controller", "worker", "controller+worker"} {
 		c := getServiceConfig(role)
 		s, err := service.New(prg, c)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Adds `k0s start` and `k0s stop` subcommands for starting / stopping the service if it has been installed.
