### PR TITLE
Bump timeout for ssh to 30 seconds

### DIFF
--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -134,13 +134,13 @@ func (s *FootlooseSuite) SetupSuite() {
 func (s *FootlooseSuite) waitForSSH() {
 	var err error
 	// SSH through cluster should wait until we actually can get it through, but it doesn't
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 30; i++ {
 		err = s.Cluster.SSH(s.ControllerNode(0), "root", "hostname")
 		if err == nil {
 			break
 		}
 		s.T().Logf("retrying ssh to %s", s.ControllerNode(0))
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 	}
 	if err != nil {
 		s.FailNowf("failed to ssh to %s: %s", s.ControllerNode(0), err.Error())


### PR DESCRIPTION
Arm machine may need som more time to generate the ssh host keys,
probably due to lack of entropy. Bump timeout to 30 seconds

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

---
name: Pull Request
about: Create a Pull Request
title: ''
labels: ''
assignees: ''

---

**Issue**
Fixes #{ issue number }

**What this PR Includes**
A short description of what this PR does.