### PR TITLE
bump versions for runc, containerd and etcd

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,7 +68,7 @@ spec:
       version: v0.3.7
     kubeproxy:
       image: k8s.gcr.io/kube-proxy
-      version: v1.21.0
+      version: v1.21.1
     coredns:
       image: docker.io/coredns/coredns
       version: 1.7.0

--- a/docs/install.md
+++ b/docs/install.md
@@ -73,7 +73,7 @@ The Kubernetes command-line tool 'kubectl' is included into k0s. You can use it 
 ```sh
 $ sudo k0s kubectl get nodes
 NAME   STATUS   ROLES    AGE    VERSION
-k0s    Ready    <none>   4m6s   v1.21.0-k0s1
+k0s    Ready    <none>   4m6s   v1.21.1-k0s1
 ```
 
 #### 6. Clean-up

--- a/docs/k0s-multi-node.md
+++ b/docs/k0s-multi-node.md
@@ -131,7 +131,7 @@ The Kubernetes command-line tool 'kubectl' is included into k0s binary. You can 
 ```
 $ sudo k0s kubectl get nodes
 NAME   STATUS   ROLES    AGE    VERSION
-k0s    Ready    <none>   4m6s   v1.21.0-k0s1
+k0s    Ready    <none>   4m6s   v1.21.1-k0s1
 ```
 
 You can also access your cluster easily with [LENS](https://k8slens.dev/). Just copy the kubeconfig 

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,8 +1,8 @@
-runc_version = 1.0.0-rc93
-containerd_version = 1.4.4
+runc_version = 1.0.0-rc94
+containerd_version = 1.4.5
 kubernetes_version = 1.21.0
 kine_version = 0.6.0
-etcd_version = 3.4.15
+etcd_version = 3.4.16
 konnectivity_version = 0.0.16
 
 containerd_buildimage = golang:1.15-alpine

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -3,7 +3,7 @@ containerd_version = 1.4.5
 kubernetes_version = 1.21.1
 kine_version = 0.6.0
 etcd_version = 3.4.16
-konnectivity_version = 0.0.16
+konnectivity_version = 0.0.17
 
 containerd_buildimage = golang:1.15-alpine
 etcd_buildimage = golang:1.13-alpine

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,4 +1,4 @@
-runc_version = 1.0.0-rc94
+runc_version = 1.0.0-rc95
 containerd_version = 1.4.5
 kubernetes_version = 1.21.1
 kine_version = 0.6.0

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,6 +1,6 @@
 runc_version = 1.0.0-rc94
 containerd_version = 1.4.5
-kubernetes_version = 1.21.0
+kubernetes_version = 1.21.1
 kine_version = 0.6.0
 etcd_version = 3.4.16
 konnectivity_version = 0.0.16

--- a/examples/footloose-ha-controllers/Dockerfile
+++ b/examples/footloose-ha-controllers/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/footloose/ubuntu18.04
 
 ADD k0s.service /etc/systemd/system/k0s.service
 
-RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/amd64/kubectl && \
+RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.21.1/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf

--- a/inttest/conformance/README.md
+++ b/inttest/conformance/README.md
@@ -32,12 +32,12 @@ This can be done in two ways.
 In the same directory as your `main.tf` file, create an additional file `terraform.tfvars` with the following input:
 ```
 k0s_version=v0.9.0
-k8s_version=v1.21.0
+k8s_version=v1.21.1
 onobuoy_version=0.20.0
 ```  
 ### 2. Environment variables
 ```
-TF_VAR_k0s_version=v0.7.0-beta1 TF_VAR_sonobuoy_version=0.18.0 TF_VAR_k8s_version=v1.21.0 terraform apply
+TF_VAR_k0s_version=v0.7.0-beta1 TF_VAR_sonobuoy_version=0.18.0 TF_VAR_k8s_version=v1.21.1 terraform apply
 ```
 **NOTE:** By default, terraform will fetch sonobuoy version **0.20.0**. If you want to use a different version you can override this with one of the above methods. 
 

--- a/inttest/conformance/terraform/main.tf
+++ b/inttest/conformance/terraform/main.tf
@@ -13,7 +13,7 @@ variable "sonobuoy_version" {
 }
 
 variable "k8s_version" {
-  // format: v1.21.0
+  // format: v1.21.1
   type = string
 }
 

--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.13
 
+ENV KUBE_VERSION=1.21.1
+
 RUN apk add openrc openssh-server bash busybox-initscripts coreutils findutils iptables curl haproxy
 # enable syslog and sshd
 RUN rc-update add cgroups boot
@@ -15,7 +17,7 @@ RUN sed -i -e 's/^\(tty[0-9]\)/# \1/' /etc/inittab
 RUN sed -i -e 's/^root:!:/root::/' /etc/shadow
 
 # Put kubectl into place to ease up debugging
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.20.0/bin/linux/amd64/kubectl \
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl \
        && chmod +x ./kubectl \
        && mv ./kubectl /usr/local/bin/kubectl
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -56,7 +56,7 @@ const (
 	MetricsImage                       = "gcr.io/k8s-staging-metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.3.7"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"
-	KubeProxyImageVersion              = "v1.20.4"
+	KubeProxyImageVersion              = "v1.21.1"
 	CoreDNSImage                       = "docker.io/coredns/coredns"
 	CoreDNSImageVersion                = "1.7.0"
 	CalicoImage                        = "docker.io/calico/cni"

--- a/pkg/constant/constant_shared_test.go
+++ b/pkg/constant/constant_shared_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2021 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package constant
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKubeProxyVersion(t *testing.T) {
+	kubeVersion := getKubeVersion(t)
+	assert.Equal(t, kubeVersion, strings.TrimPrefix(KubeProxyImageVersion, "v"))
+}
+
+func TestKubernetesMajorMinorVersion(t *testing.T) {
+	kubeVersion := getKubeVersion(t)
+
+	ver := strings.Split(kubeVersion, ".")
+	kubeMinorMajor := ver[0] + "." + ver[1]
+
+	assert.Equal(t, kubeMinorMajor, KubernetesMajorMinorVersion)
+}
+
+func getKubeVersion(t *testing.T) string {
+	cmd := exec.Command("make", "--no-print-directory", "-f", "-", "print-kubernetes_version")
+	cmd.Stdin = bytes.NewBuffer([]byte(makefile))
+
+	out, err := cmd.Output()
+	assert.Nil(t, err)
+
+	return strings.TrimSuffix(string(out), "\n")
+}
+
+const makefile = `
+include ../../embedded-bins/Makefile.variables
+
+print-kubernetes_version:
+	@echo $(kubernetes_version)
+`


### PR DESCRIPTION
- runc 1.0.0-rc95 (CVE-2021-30465)
- containerd 1.4.5
- etcd 3.4.16
- konnectivity 0.0.17
- kubernetes 1.21.1 (CVE-2021-25737)

update kube-proxy container version to match kubernetes and add a unit test for that.