### PR TITLE
Ensure the toplevel `make clean` cleans `inttest`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ clean:
 	rm -f pkg/assets/zz_generated_offsets_*.go k0s k0s.exe .bins.*stamp bindata* static/gen_manifests.go
 	$(MAKE) -C embedded-bins clean
 	$(MAKE) -C image-bundle clean
+	$(MAKE) -C inttest clean
 
 .PHONY: manifests
 manifests:


### PR DESCRIPTION
Signed-off-by: Shane Jarych <sjarych@mirantis.com>