### PR TITLE
Make various k0s/embedded-bins build options configurable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ EMBEDDED_BINS_BUILDMODE ?= docker
 TARGET_OS ?= linux
 GOARCH ?= $(shell go env GOARCH)
 GOPATH ?= $(shell go env GOPATH)
+BUILD_GO_FLAGS :=
+BUILD_GO_CGO_ENABLED ?= 0
+BUILD_GO_LDFLAGS_EXTRA :=
 DEBUG ?= false
 
 VERSION ?= $(shell git describe --tags)
@@ -40,7 +43,7 @@ LD_FLAGS += -X k8s.io/component-base/version.gitMajor="$(KUBECTL_MAJOR)"
 LD_FLAGS += -X k8s.io/component-base/version.gitMinor="$(KUBECTL_MINOR)"
 LD_FLAGS += -X k8s.io/component-base/version.buildDate=$(BUILD_DATE)
 LD_FLAGS += -X k8s.io/component-base/version.gitCommit="not_available"
-
+LD_FLAGS += $(BUILD_GO_LDFLAGS_EXTRA)
 
 golint := $(shell which golangci-lint)
 ifeq ($(golint),)
@@ -99,7 +102,7 @@ k0s.exe: pkg/assets/zz_generated_offsets_windows.go
 k0s.exe k0s: static/gen_manifests.go
 
 k0s.exe k0s: $(GO_SRCS)
-	CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(GOARCH) $(GO) build -v -ldflags="$(LD_FLAGS)" -o $@.code main.go
+	CGO_ENABLED=$(BUILD_GO_CGO_ENABLED) GOOS=$(TARGET_OS) GOARCH=$(GOARCH) $(GO) build $(BUILD_GO_FLAGS) -ldflags='$(LD_FLAGS)' -o $@.code main.go
 	cat $@.code bindata_$(TARGET_OS) > $@.tmp \
 		&& rm -f $@.code \
 		&& chmod +x $@.tmp \

--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -71,6 +71,11 @@ $(addprefix $(bindir)/, $(bins)): | $(bindir)
 	docker build -t k0sbuild$(basename $@) \
 		--build-arg VERSION=$($(patsubst %/Dockerfile,%,$<)_version) \
 		--build-arg BUILDIMAGE=$($(patsubst %/Dockerfile,%,$<)_buildimage) \
+		--build-arg BUILD_GO_TAGS=$($(patsubst %/Dockerfile,%,$<)_build_go_tags) \
+		--build-arg BUILD_GO_CGO_ENABLED=$($(patsubst %/Dockerfile,%,$<)_build_go_cgo_enabled) \
+		--build-arg BUILD_GO_FLAGS=$($(patsubst %/Dockerfile,%,$<)_build_go_flags) \
+		--build-arg BUILD_GO_LDFLAGS=$($(patsubst %/Dockerfile,%,$<)_build_go_ldflags) \
+		--build-arg BUILD_GO_LDFLAGS_EXTRA=$($(patsubst %/Dockerfile,%,$<)_build_go_ldflags_extra) \
 		-f $< .
 	touch $@
 

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,13 +1,47 @@
 runc_version = 1.0.0-rc95
-containerd_version = 1.4.6
-kubernetes_version = 1.21.1
-kine_version = 0.6.0
-etcd_version = 3.4.16
-konnectivity_version = 0.0.17
-
-containerd_buildimage = golang:1.15-alpine
-etcd_buildimage = golang:1.13-alpine
-kine_buildimage = golang:1.15-alpine
-konnectivity_buildimage = golang:1.15-alpine
-kubernetes_buildimage = golang:1.16-alpine
 runc_buildimage = golang:1.15-alpine
+runc_build_go_tags = "seccomp"
+#runc_build_go_cgo_enabled =
+#runc_build_go_flags =
+#runc_build_go_ldflags =
+runc_build_go_ldflags_extra = "-w -s -extldflags=-static"
+
+containerd_version = 1.4.6
+containerd_buildimage = golang:1.15-alpine
+containerd_build_go_tags = "apparmor,selinux"
+#containerd_build_go_cgo_enabled =
+#containerd_build_go_flags =
+#containerd_build_go_ldflags =
+containerd_build_go_ldflags_extra = "-w -s -extldflags=-static"
+
+kubernetes_version = 1.21.1
+kubernetes_buildimage = golang:1.16-alpine
+kubernetes_build_go_tags = "providerless"
+#kubernetes_build_go_cgo_enabled =
+kubernetes_build_go_flags = "-v"
+#kubernetes_build_go_ldflags =
+kubernetes_build_go_ldflags_extra = "-w -s -extldflags=-static"
+
+kine_version = 0.6.0
+kine_buildimage = golang:1.15-alpine
+#kine_build_go_tags =
+#kine_build_go_cgo_enabled =
+#kine_build_go_flags =
+kine_build_go_ldflags = "-w -s"
+kine_build_go_ldflags_extra = "-extldflags=-static"
+
+etcd_version = 3.4.16
+etcd_buildimage = golang:1.13-alpine
+#etcd_build_go_tags =
+etcd_build_go_cgo_enabled = 0
+#etcd_build_go_flags =
+etcd_build_go_ldflags = "-w -s"
+#etcd_build_go_ldflags_extra =
+
+konnectivity_version = 0.0.17
+konnectivity_buildimage = golang:1.15-alpine
+#konnectivity_build_go_tags =
+konnectivity_build_go_cgo_enabled = 0
+konnectivity_build_go_flags = "-a"
+konnectivity_build_go_ldflags = "-w -s"
+konnectivity_build_go_ldflags_extra = "-extldflags=-static"

--- a/embedded-bins/containerd/Dockerfile
+++ b/embedded-bins/containerd/Dockerfile
@@ -2,6 +2,11 @@ ARG BUILDIMAGE=golang:1.15-alpine
 FROM $BUILDIMAGE AS build
 
 ARG VERSION
+ARG BUILD_GO_TAGS
+ARG BUILD_GO_CGO_ENABLED
+ARG BUILD_GO_FLAGS
+ARG BUILD_GO_LDFLAGS
+ARG BUILD_GO_LDFLAGS_EXTRA
 ENV GOPATH=/go
 
 RUN apk upgrade -U -a && apk add \
@@ -12,8 +17,14 @@ RUN apk upgrade -U -a && apk add \
 RUN mkdir -p $GOPATH/src/github.com/containerd/containerd
 RUN git clone -b v$VERSION --depth=1 https://github.com/containerd/containerd.git $GOPATH/src/github.com/containerd/containerd
 WORKDIR /go/src/github.com/containerd/containerd
-RUN make COMMANDS="containerd containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2" \
-	EXTRA_LDFLAGS="-extldflags=-static -s -w"
+RUN go version
+RUN make \
+	CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
+	SHIM_CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
+	GO_TAGS="-tags=${BUILD_GO_TAGS}" \
+	COMMANDS="containerd containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2" \
+	GO_BUILD_FLAGS="${BUILD_GO_FLAGS}" \
+	EXTRA_LDFLAGS="${BUILD_GO_LDFLAGS_EXTRA}"
 
 FROM scratch
 COPY --from=build /go/src/github.com/containerd/containerd/bin/* /bin/

--- a/embedded-bins/etcd/Dockerfile
+++ b/embedded-bins/etcd/Dockerfile
@@ -2,12 +2,24 @@ ARG BUILDIMAGE=golang:1.13-alpine
 FROM $BUILDIMAGE AS build
 
 ARG VERSION
+ARG BUILD_GO_TAGS
+ARG BUILD_GO_CGO_ENABLED
+ARG BUILD_GO_FLAGS
+ARG BUILD_GO_LDFLAGS
+ARG BUILD_GO_LDFLAGS_EXTRA
 
 RUN apk add build-base git
 
 RUN cd / && git clone -b v$VERSION --depth=1 https://github.com/etcd-io/etcd.git
 WORKDIR /etcd
-RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o etcd
+RUN go version
+RUN go mod vendor
+RUN CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
+    go build \
+        ${BUILD_GO_FLAGS} \
+        -tags="${BUILD_GO_TAGS}" \
+        -ldflags="${BUILD_GO_LDFLAGS} ${BUILD_GO_LDFLAGS_EXTRA}" \
+        -o etcd
 
 FROM scratch
 COPY --from=build /etcd/etcd /bin/etcd

--- a/embedded-bins/kine/Dockerfile
+++ b/embedded-bins/kine/Dockerfile
@@ -2,13 +2,24 @@ ARG BUILDIMAGE=golang:1.15-alpine
 FROM $BUILDIMAGE AS build
 
 ARG VERSION
+ARG BUILD_GO_TAGS
+ARG BUILD_GO_CGO_ENABLED
+ARG BUILD_GO_FLAGS
+ARG BUILD_GO_LDFLAGS
+ARG BUILD_GO_LDFLAGS_EXTRA
 
 RUN apk add build-base git
 
 
 RUN cd / && git clone -b v$VERSION --depth=1 https://github.com/rancher/kine.git
 WORKDIR /kine
-RUN go build -ldflags="-extldflags=-static -w -s" -o kine
+RUN go version
+RUN CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
+    go build \
+        ${BUILD_GO_FLAGS} \
+        -tags="${BUILD_GO_TAGS}" \
+        -ldflags="${BUILD_GO_LDFLAGS} ${BUILD_GO_LDFLAGS_EXTRA}" \
+        -o kine
 
 FROM scratch
 COPY --from=build /kine/kine /bin/kine

--- a/embedded-bins/konnectivity/Dockerfile
+++ b/embedded-bins/konnectivity/Dockerfile
@@ -2,14 +2,26 @@ ARG BUILDIMAGE=golang:1.15-alpine
 FROM $BUILDIMAGE AS build
 
 ARG VERSION
+ARG BUILD_GO_TAGS
+ARG BUILD_GO_CGO_ENABLED
+ARG BUILD_GO_FLAGS
+ARG BUILD_GO_LDFLAGS
+ARG BUILD_GO_LDFLAGS_EXTRA
 
 RUN apk add build-base git make
 
 RUN git clone -b v$VERSION --depth=1 https://github.com/kubernetes-sigs/apiserver-network-proxy.git /apiserver-network-proxy
 WORKDIR /apiserver-network-proxy
+RUN go version
 RUN GO111MODULE=on go get github.com/golang/mock/mockgen@v1.4.4 && \
     make gen && \
-    CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static -w -s"' -o bin/proxy-server cmd/server/main.go
+    CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
+    GOOS=linux \
+    go build \
+        ${BUILD_GO_FLAGS} \
+        -tags="${BUILD_GO_TAGS}" \
+        -ldflags="${BUILD_GO_LDFLAGS} ${BUILD_GO_LDFLAGS_EXTRA}" \
+        -o bin/proxy-server cmd/server/main.go
 
 FROM scratch
 COPY --from=build /apiserver-network-proxy/bin/proxy-server /bin/konnectivity-server

--- a/embedded-bins/kubernetes/Dockerfile
+++ b/embedded-bins/kubernetes/Dockerfile
@@ -2,6 +2,11 @@ ARG BUILDIMAGE=golang:1.16-alpine
 FROM $BUILDIMAGE AS build
 
 ARG VERSION
+ARG BUILD_GO_TAGS
+ARG BUILD_GO_CGO_ENABLED
+ARG BUILD_GO_FLAGS
+ARG BUILD_GO_LDFLAGS
+ARG BUILD_GO_LDFLAGS_EXTRA
 ENV GOPATH=/go
 ENV COMMANDS="kubelet kube-apiserver kube-scheduler kube-controller-manager"
 
@@ -10,10 +15,15 @@ RUN apk add build-base git go-bindata linux-headers rsync grep coreutils bash
 RUN mkdir -p $GOPATH/src/github.com/kubernetes/kubernetes
 RUN git clone -b v$VERSION --depth=1 https://github.com/kubernetes/kubernetes.git $GOPATH/src/github.com/kubernetes/kubernetes
 WORKDIR /go/src/github.com/kubernetes/kubernetes
+RUN go version
 RUN \
+	# Ensure that all of the binaries are built with CGO \
+	if [ ${BUILD_GO_CGO_ENABLED:-0} -eq 1 ]; then \
+		export KUBE_CGO_OVERRIDES="${COMMANDS}"; \
+	fi; \
 	for cmd in $COMMANDS; do \
 		export KUBE_GIT_VERSION="v$VERSION-k0s1"; \
-		make GOFLAGS="-v -tags=providerless" GOLDFLAGS="-extldflags=-static -w -s" WHAT=cmd/$cmd || break;\
+		make GOFLAGS="${BUILD_GO_FLAGS} -tags=${BUILD_GO_TAGS}" GOLDFLAGS="${BUILD_GO_LDFLAGS_EXTRA}" WHAT=cmd/$cmd || break;\
 	done
 
 FROM scratch

--- a/embedded-bins/runc/Dockerfile
+++ b/embedded-bins/runc/Dockerfile
@@ -3,6 +3,11 @@ FROM $BUILDIMAGE AS build
 
 ARG VERSION
 ARG LIBSECCOMP_VERSION=2.5.1
+ARG BUILD_GO_TAGS
+ARG BUILD_GO_CGO_ENABLED
+ARG BUILD_GO_FLAGS
+ARG BUILD_GO_LDFLAGS
+ARG BUILD_GO_LDFLAGS_EXTRA
 
 ENV GOPATH=/go
 
@@ -21,7 +26,12 @@ RUN make -C /libseccomp-$LIBSECCOMP_VERSION install
 RUN mkdir -p $GOPATH/src/github.com/opencontainers/runc
 RUN git clone -b v$VERSION --depth=1 https://github.com/opencontainers/runc.git $GOPATH/src/github.com/opencontainers/runc
 WORKDIR /go/src/github.com/opencontainers/runc
-RUN make EXTRA_LDFLAGS="-extldflags=-static -w -s"
+RUN go version
+RUN make \
+	CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
+	BUILDTAGS="${BUILD_GO_TAGS}" \
+	EXTRA_FLAGS="${BUILD_GO_FLAGS}" \
+	EXTRA_LDFLAGS="${BUILD_GO_LDFLAGS_EXTRA}"
 
 FROM scratch
 COPY --from=build /go/src/github.com/opencontainers/runc/runc /bin/runc


### PR DESCRIPTION
For `embedded-bins/Makefile.variables`, this adds the following per component definition:

  - `<comp>_build_go_tags`
  - `<comp>_build_go_cgo_enabled`
  - `<comp>_build_go_flags`
  - `<comp>_build_go_ldflags`
  - `<comp>_build_go_ldflags_extra`

All of the relevant existing default/hardcoded values that lived in the various `embedded-bins/*/Dockerfile` have been moved to`embedded-bins/Makefile.variables`

For the `k0s` build itself, this adds the following envvars:

  - `BUILD_GO_FLAGS`
  - `BUILD_GO_CGO_ENABLED`
  - `BUILD_GO_LDFLAGS_EXTRA`

Signed-off-by: Shane Jarych <sjarych@mirantis.com>