### PR TITLE
Fix token commands role defaulting

### DIFF
--- a/cmd/token/create.go
+++ b/cmd/token/create.go
@@ -28,6 +28,8 @@ import (
 	"github.com/k0sproject/k0s/pkg/token"
 )
 
+var createTokenRole string
+
 func tokenCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -58,7 +60,7 @@ k0s token create --role worker --expiry 10m  //sets expiration time to 10 minute
 			}, func(err error) bool {
 				return waitCreate
 			}, func() error {
-				bootstrapConfig, err = token.CreateKubeletBootstrapConfig(clusterConfig, c.K0sVars, tokenRole, expiry)
+				bootstrapConfig, err = token.CreateKubeletBootstrapConfig(clusterConfig, c.K0sVars, createTokenRole, expiry)
 
 				return err
 			})
@@ -71,11 +73,12 @@ k0s token create --role worker --expiry 10m  //sets expiration time to 10 minute
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&tokenExpiry, "expiry", "0s", "Expiration time of the token. Format 1.5h, 2h45m or 300ms.")
-	cmd.Flags().StringVar(&tokenRole, "role", "worker", "Either worker or controller")
-	cmd.Flags().BoolVar(&waitCreate, "wait", false, "wait forever (default false)")
-
 	// append flags
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+
+	cmd.Flags().StringVar(&tokenExpiry, "expiry", "0s", "Expiration time of the token. Format 1.5h, 2h45m or 300ms.")
+	cmd.Flags().StringVar(&createTokenRole, "role", "worker", "Either worker or controller")
+	cmd.Flags().BoolVar(&waitCreate, "wait", false, "wait forever (default false)")
+
 	return cmd
 }

--- a/cmd/token/list.go
+++ b/cmd/token/list.go
@@ -26,6 +26,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var listTokenRole string
+
 func tokenListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -38,7 +40,7 @@ func tokenListCmd() *cobra.Command {
 				return err
 			}
 
-			tokens, err := manager.List(tokenRole)
+			tokens, err := manager.List(listTokenRole)
 			if err != nil {
 				return err
 			}
@@ -70,7 +72,7 @@ func tokenListCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&tokenRole, "role", "", "Either worker, controller or empty for all roles")
+	cmd.Flags().StringVar(&listTokenRole, "role", "", "Either worker, controller or empty for all roles")
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	return cmd
 }

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -25,7 +25,6 @@ type CmdOpts config.CLIOptions
 
 var (
 	tokenExpiry string
-	tokenRole   string
 	waitCreate  bool
 )
 


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
`k0s token create` incorrectly defaults to controller token

**What this PR Includes**
Makes token create and list to use separate variables for the role as they have different defaults. Currently the list flag makes also the create flag default to empty string 🤦 