### PR TITLE
making sure that token create and list are accepting only controller and worker role

### DIFF
--- a/cmd/token/create.go
+++ b/cmd/token/create.go
@@ -85,7 +85,7 @@ k0s token create --role worker --expiry 10m  //sets expiration time to 10 minute
 }
 
 func checkCreateTokenRole(cmd *cobra.Command, args []string) error {
-	if !(createTokenRole == controllerRole || createTokenRole == workerRole) {
+	if createTokenRole != controllerRole && createTokenRole != workerRole {
 		cmd.SilenceUsage = true
 		return fmt.Errorf("unsupported role %q, supported roles are %q and %q", createTokenRole, controllerRole, workerRole)
 	}

--- a/cmd/token/create.go
+++ b/cmd/token/create.go
@@ -37,6 +37,7 @@ func tokenCreateCmd() *cobra.Command {
 		Example: `k0s token create --role worker --expiry 100h //sets expiration time to 100 hours
 k0s token create --role worker --expiry 10m  //sets expiration time to 10 minutes
 `,
+		PreRunE: checkCreateTokenRole,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Disable logrus for token commands
 			logrus.SetLevel(logrus.FatalLevel)
@@ -81,4 +82,12 @@ k0s token create --role worker --expiry 10m  //sets expiration time to 10 minute
 	cmd.Flags().BoolVar(&waitCreate, "wait", false, "wait forever (default false)")
 
 	return cmd
+}
+
+func checkCreateTokenRole(cmd *cobra.Command, args []string) error {
+	if !(createTokenRole == controllerRole || createTokenRole == workerRole) {
+		cmd.SilenceUsage = true
+		return fmt.Errorf("unsupported role %q, supported roles are %q and %q", createTokenRole, controllerRole, workerRole)
+	}
+	return nil
 }

--- a/cmd/token/list.go
+++ b/cmd/token/list.go
@@ -33,6 +33,7 @@ func tokenListCmd() *cobra.Command {
 		Use:     "list",
 		Short:   "List join tokens",
 		Example: `k0s token list --role worker // list worker tokens`,
+		PreRunE: checkListTokenRole,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := CmdOpts(config.GetCmdOpts())
 			manager, err := token.NewManager(filepath.Join(c.K0sVars.AdminKubeConfigPath))
@@ -75,4 +76,15 @@ func tokenListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&listTokenRole, "role", "", "Either worker, controller or empty for all roles")
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	return cmd
+}
+
+func checkListTokenRole(cmd *cobra.Command, args []string) error {
+	if listTokenRole == "" {
+		cmd.SilenceUsage = true
+		return fmt.Errorf("role not provided, supported roles are %q and %q", "controller", "worker")
+	} else if !(listTokenRole == controllerRole || listTokenRole == workerRole) {
+		cmd.SilenceUsage = true
+		return fmt.Errorf("unsupported role %q, supported roles are %q and %q", listTokenRole, controllerRole, workerRole)
+	}
+	return nil
 }

--- a/cmd/token/list.go
+++ b/cmd/token/list.go
@@ -79,10 +79,7 @@ func tokenListCmd() *cobra.Command {
 }
 
 func checkListTokenRole(cmd *cobra.Command, args []string) error {
-	if listTokenRole == "" {
-		cmd.SilenceUsage = true
-		return fmt.Errorf("role not provided, supported roles are %q and %q", "controller", "worker")
-	} else if !(listTokenRole == controllerRole || listTokenRole == workerRole) {
+	if listTokenRole != "" && (listTokenRole != controllerRole && listTokenRole != workerRole) {
 		cmd.SilenceUsage = true
 		return fmt.Errorf("unsupported role %q, supported roles are %q and %q", listTokenRole, controllerRole, workerRole)
 	}

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -28,6 +28,11 @@ var (
 	waitCreate  bool
 )
 
+const (
+	controllerRole = "controller"
+	workerRole     = "worker"
+)
+
 func NewTokenCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "token",

--- a/pkg/token/kubeconfig.go
+++ b/pkg/token/kubeconfig.go
@@ -78,9 +78,11 @@ func CreateKubeletBootstrapConfig(clusterConfig *config.ClusterConfig, k0sVars c
 	if role == "worker" {
 		data.User = "kubelet-bootstrap"
 		data.JoinURL = clusterConfig.Spec.API.APIAddressURL()
-	} else {
+	} else if role == "controller" {
 		data.User = "controller-bootstrap"
 		data.JoinURL = clusterConfig.Spec.API.K0sControlPlaneAPIAddress()
+	} else {
+		return "", fmt.Errorf("unsupported role %s only supporter roles are %q and %q", role, "controller", "worker")
 	}
 
 	var buf bytes.Buffer

--- a/pkg/token/kubeconfig.go
+++ b/pkg/token/kubeconfig.go
@@ -28,6 +28,11 @@ import (
 	"github.com/k0sproject/k0s/pkg/constant"
 )
 
+const (
+	controllerRole = "controller"
+	workerRole     = "worker"
+)
+
 var (
 	kubeconfigTemplate = template.Must(template.New("kubeconfig").Parse(`
 apiVersion: v1
@@ -75,14 +80,14 @@ func CreateKubeletBootstrapConfig(clusterConfig *config.ClusterConfig, k0sVars c
 		CACert: base64.StdEncoding.EncodeToString(caCert),
 		Token:  tokenString,
 	}
-	if role == "worker" {
+	if role == workerRole {
 		data.User = "kubelet-bootstrap"
 		data.JoinURL = clusterConfig.Spec.API.APIAddressURL()
-	} else if role == "controller" {
+	} else if role == controllerRole {
 		data.User = "controller-bootstrap"
 		data.JoinURL = clusterConfig.Spec.API.K0sControlPlaneAPIAddress()
 	} else {
-		return "", fmt.Errorf("unsupported role %s only supporter roles are %q and %q", role, "controller", "worker")
+		return "", fmt.Errorf("unsupported role %s only supported roles are %q and %q", role, controllerRole, workerRole)
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
Ensuring that token create/list `--role` parameter can only accept values `worker` or `controller`.