### PR TITLE
Use k0s start/stop and sudo in docs examples

### DIFF
--- a/docs/cli/k0s_install_controller.md
+++ b/docs/cli/k0s_install_controller.md
@@ -9,12 +9,12 @@ k0s install controller [flags]
 ### Examples
 
 ```
-All default values of controller command will be passed to the service stub unless overriden. 
+All default values of controller command will be passed to the service stub unless overriden.
 
 With controller subcommand you can setup a single node cluster by running:
 
-	k0s install controller --enable-worker
-	
+	sudo k0s install controller --enable-worker
+
 ```
 
 ### Options

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,10 +1,10 @@
 # Quick Start Guide
 
- On completion of the Quick Start you will have a full Kubernetes cluster with a single node that includes both the controller and the worker. Such a setup is ideal for environments that do not require high-availability and multiple nodes. 
+ On completion of the Quick Start you will have a full Kubernetes cluster with a single node that includes both the controller and the worker. Such a setup is ideal for environments that do not require high-availability and multiple nodes.
 
 ## Prerequisites
 
-**Note**: Before proceeding, make sure to review the [System Requirements](system-requirements.md). 
+**Note**: Before proceeding, make sure to review the [System Requirements](system-requirements.md).
 
 Though the Quick Start material is written for Debian/Ubuntu, you can use it for any Linux distro that is running either a Systemd or OpenRC init system.
 
@@ -20,7 +20,7 @@ $ curl -sSLf https://get.k0s.sh | sudo sh
 
 ### 2. Install k0s as a service
 
-The `k0s install` sub-command installs k0s as a system service on the local host that is running one of the supported init systems: Systemd or OpenRC. You can execute the install for workers, controllers or single node (controller+worker) instances. 
+The `k0s install` sub-command installs k0s as a system service on the local host that is running one of the supported init systems: Systemd or OpenRC. You can execute the install for workers, controllers or single node (controller+worker) instances.
 
 Run the following command to install a single node k0s that includes the controller and worker functions with the default configuration:
 
@@ -28,19 +28,19 @@ Run the following command to install a single node k0s that includes the control
 $ sudo k0s install controller --single
 ```
 
-The `k0s install controller` sub-command accepts the same flags and parameters as the `k0s controller`. Refer to [manual install](k0s-multi-node.md#installation-steps) for a custom config file example. 
+The `k0s install controller` sub-command accepts the same flags and parameters as the `k0s controller`. Refer to [manual install](k0s-multi-node.md#installation-steps) for a custom config file example.
 
 ### 3. Start k0s as a service
 
 To start the k0s service, run:
 
 ```sh
-$ sudo systemctl start k0scontroller
+$ sudo k0s start
 ```
 
 A minute or two typically passes before the node is ready to deploy applications.
 
-(Optional) To enable the k0s service to always start following node restart, run:
+(Optional) To enable the k0s service to always start following node restart on a host running systemd, run:
 
 ```sh
 $ sudo systemctl enable k0scontroller
@@ -48,21 +48,7 @@ $ sudo systemctl enable k0scontroller
 
 ### 4. Check service, logs and k0s status
 
-To check the service status and logs, run:
-
-```sh
-$ sudo systemctl status k0scontroller
-     Loaded: loaded (/etc/systemd/system/k0scontroller.service; enabled; vendor preset: enabled)
-     Active: active (running) since Fri 2021-02-26 08:37:23 UTC; 1min 25s ago
-       Docs: https://docs.k0sproject.io
-   Main PID: 1408647 (k0s)
-      Tasks: 96
-     Memory: 1.2G
-     CGroup: /system.slice/k0scontroller.service
-     ....
-```
-
-To get general information about your k0s instance, run:
+To get general information about your k0s instance's status, run:
 
 ```sh
 $ sudo k0s status
@@ -115,5 +101,5 @@ $ sudo k0s reset
 - [Worker node configuration options](worker-node-config.md): Node labels and kubelet arguments
 - [Support for cloud providers](cloud-providers.md): Load balancer or storage configuration
 - [Installing the Traefik Ingress Controller](examples/traefik-ingress.md):
-  Ingress deployment information 
+  Ingress deployment information
 - [Airgap/Offline installation](airgap-install.md): Airgap deployment

--- a/docs/k0s-multi-node.md
+++ b/docs/k0s-multi-node.md
@@ -1,20 +1,20 @@
 # Manual Install (Advanced)
 
-You can manually set up k0s nodes by creating a multi-node cluster that is locally managed on each node. This involves several steps, to first install each node separately, and to then connect the node together using access tokens. 
+You can manually set up k0s nodes by creating a multi-node cluster that is locally managed on each node. This involves several steps, to first install each node separately, and to then connect the node together using access tokens.
 
 ## Prerequisites
 
-**Note**: Before proceeding, make sure to review the [System Requirements](system-requirements.md). 
+**Note**: Before proceeding, make sure to review the [System Requirements](system-requirements.md).
 
-Though the Manual Install material is written for Debian/Ubuntu, you can use it for any Linux distro that is running either a Systemd or OpenRC init system. 
+Though the Manual Install material is written for Debian/Ubuntu, you can use it for any Linux distro that is running either a Systemd or OpenRC init system.
 
-You can speed up the use of the `k0s` command by enabling [shell completion](shell-completion.md). 
+You can speed up the use of the `k0s` command by enabling [shell completion](shell-completion.md).
 
 ## Install k0s
 
 ### 1. Download k0s
 
-Run the k0s download script to download the latest stable version of k0s and make it executable from /usr/bin/k0s. 
+Run the k0s download script to download the latest stable version of k0s and make it executable from /usr/bin/k0s.
 
 ```
 $ curl -sSLf https://get.k0s.sh | sudo sh
@@ -24,7 +24,7 @@ The download script accepts the following environment variables:
 | Variable              | Purpose                                   |
 |:----------------------|:------------------------------------------|
 | `K0S_VERSION=v0.11.0` | Select the version of k0s to be installed |
-| `DEBUG=true` | Output commands and their arguments at execution. 
+| `DEBUG=true` | Output commands and their arguments at execution.
 
 **Note**: If you require environment variables and use sudo, you may need
 `--preserve-env`:
@@ -41,28 +41,28 @@ Create a configuration file:
 $ k0s default-config > k0s.yaml
 
 ```
-**Note**: For information on settings modification, refer to the [configuration](configuration.md) documentation. 
+**Note**: For information on settings modification, refer to the [configuration](configuration.md) documentation.
 
 ```sh
-$ k0s install controller -c k0s.yaml
+$ sudo k0s install controller -c k0s.yaml
 ```
 ```sh
-$ systemctl start k0scontroller
+$ sudo k0s start
 ```
 
-k0s process acts as a "supervisor" for all of the control plane components. In moments the control plane will be up and running. 
+k0s process acts as a "supervisor" for all of the control plane components. In moments the control plane will be up and running.
 
 ### 3. Create a join token
 
-You need a token to join workers to the cluster. The token embeds information that enables mutual trust between the worker and controller(s) and which allows the node to join the cluster as worker. 
+You need a token to join workers to the cluster. The token embeds information that enables mutual trust between the worker and controller(s) and which allows the node to join the cluster as worker.
 
-To get a token, run the following command on one of the existing controller nodes: 
+To get a token, run the following command on one of the existing controller nodes:
 
 ```sh
 $ k0s token create --role=worker
 ```
 
-The resulting output is a long [token](#tokens) string, which you can use to add a worker to the cluster. 
+The resulting output is a long [token](#tokens) string, which you can use to add a worker to the cluster.
 
 For enhanced security, run the following command to set an expiration time for the token:
 
@@ -75,27 +75,27 @@ $ k0s token create --role=worker --expiry=100h > token-file
 To join the worker, run k0s in the worker mode with the join token you created:
 
 ```sh
-$ k0s install worker --token-file /path/to/token/file
+$ sudo k0s install worker --token-file /path/to/token/file
 ```
 ```sh
-$ systemctl start k0sworker
+$ sudo k0s start
 ```
 
 #### About tokens
 
-The join tokens are base64-encoded [kubeconfigs](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) for several reasons: 
+The join tokens are base64-encoded [kubeconfigs](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) for several reasons:
 
 - Well-defined structure
 - Capable of direct use as bootstrap auth configs for kubelet
 - Embedding of CA info for mutual trust
 
-The bearer token embedded in the kubeconfig is a [bootstrap token](https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/). For controller join tokens and worker join tokens k0s uses different usage attributes to ensure that k0s can validate the token role on the controller side. 
+The bearer token embedded in the kubeconfig is a [bootstrap token](https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/). For controller join tokens and worker join tokens k0s uses different usage attributes to ensure that k0s can validate the token role on the controller side.
 
 ### 5. Add controllers to the cluster
 
-**Note**: Either etcd or an external data store (MySQL or Postgres) via kine must be in use to add new controller nodes to the cluster. Pay strict attention to the [high availability configuration](high-availability.md) and make sure the configuration is identical for all controller nodes. 
+**Note**: Either etcd or an external data store (MySQL or Postgres) via kine must be in use to add new controller nodes to the cluster. Pay strict attention to the [high availability configuration](high-availability.md) and make sure the configuration is identical for all controller nodes.
 
-To create a join token for the new controller, run the following command on an existing controller: 
+To create a join token for the new controller, run the following command on an existing controller:
 
 ```sh
 $ k0s token create --role=controller --expiry=1h > token-file
@@ -107,25 +107,12 @@ On the new controller, run:
 $ sudo k0s install controller --token-file /path/to/token/file
 ```
 ```sh
-$ systemctl start k0scontroller
+$ k0s start
 ```
 
-### 6. Check service and k0s status
+### 6. Check k0s status
 
-To check the service status and log:
-```
-$ sudo systemctl status k0scontroller
-     Loaded: loaded (/etc/systemd/system/k0scontroller.service; enabled; vendor preset: enabled)
-     Active: active (running) since Fri 2021-02-26 08:37:23 UTC; 1min 25s ago
-       Docs: https://docs.k0sproject.io
-   Main PID: 1408647 (k0s)
-      Tasks: 96
-     Memory: 1.2G
-     CGroup: /system.slice/k0scontroller.service
-     ....
-```
-
-To get general information about your k0s instance:
+To get general information about your k0s instance's status:
 
 ```
 $ sudo k0s status
@@ -145,13 +132,13 @@ NAME   STATUS   ROLES    AGE    VERSION
 k0s    Ready    <none>   4m6s   v1.21.1-k0s1
 ```
 
-You can also access your cluster easily with [Lens](https://k8slens.dev/), simply by copying the kubeconfig and pasting it to Lens: 
+You can also access your cluster easily with [Lens](https://k8slens.dev/), simply by copying the kubeconfig and pasting it to Lens:
 
 ```sh
 sudo cat /var/lib/k0s/pki/admin.conf
 ```
 
-**Note**: To access the cluster from an external network you must replace `localhost` in the kubeconfig with the host ip address for your controller. 
+**Note**: To access the cluster from an external network you must replace `localhost` in the kubeconfig with the host ip address for your controller.
 
 ## Next Steps
 

--- a/docs/k0s-reset.md
+++ b/docs/k0s-reset.md
@@ -2,32 +2,32 @@
 
 Use the k0s CLI `reset` command to uninstall k0s, by removing all k0s-related files from the host.
 
-`reset` operates under the assumption that k0s is installed as a service on the host. To prevent accidental triggering, the command will not run if the k0s service is running, so you must first stop the service: 
+`reset` operates under the assumption that k0s is installed as a service on the host. To prevent accidental triggering, the command will not run if the k0s service is running, so you must first stop the service:
 
-1. Stop the controller nodes:
+1. Stop the service on controller nodes:
 
     ```sh
-    $ systemctl stop k0scontroller
+    $ sudo k0s stop
     ```
 
 2. Invoke the `reset` command:
- 
+
     ```sh
     $ k0s reset
-    INFO[2021-02-25 15:58:41] Uninstalling the k0s service                 
-    INFO[2021-02-25 15:58:42] no config file given, using defaults         
-    INFO[2021-02-25 15:58:42] deleting user: etcd                          
-    INFO[2021-02-25 15:58:42] deleting user: kube-apiserver                
-    INFO[2021-02-25 15:58:42] deleting user: konnectivity-server           
-    INFO[2021-02-25 15:58:42] deleting user: kube-scheduler                
-    INFO[2021-02-25 15:58:42] starting containerd for cleanup operations... 
-    INFO[2021-02-25 15:58:42] containerd succesfully started               
-    INFO[2021-02-25 15:58:42] attempting to clean up kubelet volumes...    
-    INFO[2021-02-25 15:58:42] successfully removed kubelet mounts!         
-    INFO[2021-02-25 15:58:42] attempting to clean up network namespaces... 
-    INFO[2021-02-25 15:58:42] successfully removed network namespaces!     
-    INFO[2021-02-25 15:58:42] attempting to stop containers...             
-    INFO[2021-02-25 15:58:49] successfully removed k0s containers!         
-    INFO[2021-02-25 15:58:49] deleting k0s generated data-dir (/var/lib/k0s) and run-dir (/run/k0s) 
-    ERRO[2021-02-25 15:58:50] k0s cleanup operations done. To ensure a full reset, a node reboot is recommended. 
+    INFO[2021-02-25 15:58:41] Uninstalling the k0s service
+    INFO[2021-02-25 15:58:42] no config file given, using defaults
+    INFO[2021-02-25 15:58:42] deleting user: etcd
+    INFO[2021-02-25 15:58:42] deleting user: kube-apiserver
+    INFO[2021-02-25 15:58:42] deleting user: konnectivity-server
+    INFO[2021-02-25 15:58:42] deleting user: kube-scheduler
+    INFO[2021-02-25 15:58:42] starting containerd for cleanup operations...
+    INFO[2021-02-25 15:58:42] containerd succesfully started
+    INFO[2021-02-25 15:58:42] attempting to clean up kubelet volumes...
+    INFO[2021-02-25 15:58:42] successfully removed kubelet mounts!
+    INFO[2021-02-25 15:58:42] attempting to clean up network namespaces...
+    INFO[2021-02-25 15:58:42] successfully removed network namespaces!
+    INFO[2021-02-25 15:58:42] attempting to stop containers...
+    INFO[2021-02-25 15:58:49] successfully removed k0s containers!
+    INFO[2021-02-25 15:58:49] deleting k0s generated data-dir (/var/lib/k0s) and run-dir (/run/k0s)
+    ERRO[2021-02-25 15:58:50] k0s cleanup operations done. To ensure a full reset, a node reboot is recommended.
     ```

--- a/docs/k0s-single-node.md
+++ b/docs/k0s-single-node.md
@@ -2,7 +2,7 @@
 These instructions outline a quick method for running a local k0s master and worker in a single node.
 
  **_NOTE:_**  This method of running k0s is only recommended for dev, test or POC environments.
- 
+
 ## Prerequisites
 
 Install k0s as documented in the [installation instructions](install.md).
@@ -12,7 +12,7 @@ Install k0s as documented in the [installation instructions](install.md).
 ```sh
 $ sudo k0s install controller --single
 INFO[2021-02-25 15:34:59] Installing k0s service
-$ sudo systemctl start k0scontroller.service
+$ sudo k0s start
 ```
 
 ## Use k0s to access the cluster


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Changes the `systemctl <start|stop>` examples to use `k0s <start|stop>`. Also added `sudo` to the `k0s install` examples. Removed the `systemctl status` examples.
