### PR TITLE
Bump konnectivity to 0.0.19

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -38,7 +38,7 @@ etcd_build_go_cgo_enabled = 0
 etcd_build_go_ldflags = "-w -s"
 #etcd_build_go_ldflags_extra =
 
-konnectivity_version = 0.0.17
+konnectivity_version = 0.0.19
 konnectivity_buildimage = golang:1.15-alpine
 #konnectivity_build_go_tags =
 konnectivity_build_go_cgo_enabled = 0


### PR DESCRIPTION
Signed-off-by: Natanael Copa <ncopa@mirantis.com>


**What this PR Includes**
Update konnectivity to 0.0.19

