### PR TITLE
Drop telemetry interval

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,6 @@ spec:
   podSecurityPolicy:
     defaultPolicy: 00-k0s-privileged
   telemetry:
-    interval: 10m0s
     enabled: true
   installConfig:
     users:
@@ -276,11 +275,10 @@ The `spec.konnectivity` key is the config file key in which you configure Konnec
 
 To improve the end-user experience k0s is configured by defaul to collect telemetry data from clusters and send it to the k0s development team. To disable the telemetry function, change the `enabled` setting to `false`.
 
-The default `interval` setting is `10m0s` (10 minutes), though you can edit this to any valid value in `time.Duration` string representation.
+The telemetry interval is ten minutes.
 
 ```yaml
 spec:
     telemetry:
-      interval: 10m0s
       enabled: true
 ```

--- a/pkg/apis/v1beta1/telemetry.go
+++ b/pkg/apis/v1beta1/telemetry.go
@@ -1,20 +1,16 @@
 package v1beta1
 
-import "time"
-
 var _ Validateable = (*ClusterTelemetry)(nil)
 
 // ClusterTelemetry holds telemetry related settings
 type ClusterTelemetry struct {
-	Interval time.Duration `yaml:"interval"`
-	Enabled  bool          `yaml:"enabled"`
+	Enabled bool `yaml:"enabled"`
 }
 
 // DefaultClusterTelemetry default settings
 func DefaultClusterTelemetry() *ClusterTelemetry {
 	return &ClusterTelemetry{
-		Interval: time.Minute * 10,
-		Enabled:  true,
+		Enabled: true,
 	}
 }
 

--- a/pkg/telemetry/component.go
+++ b/pkg/telemetry/component.go
@@ -21,10 +21,11 @@ type Component struct {
 	kubernetesClient kubernetes.Interface
 	analyticsClient  analyticsClient
 
-	log      *logrus.Entry
-	stopCh   chan struct{}
-	interval time.Duration
+	log    *logrus.Entry
+	stopCh chan struct{}
 }
+
+var interval = time.Minute * 10
 
 // Init set up for external service clients (segment, k8s api)
 func (c *Component) Init() error {
@@ -35,7 +36,6 @@ func (c *Component) Init() error {
 		return nil
 	}
 
-	c.interval = c.ClusterConfig.Spec.Telemetry.Interval
 	c.stopCh = make(chan struct{})
 	c.log.Info("kube client has been init")
 	c.analyticsClient = newSegmentClient(segmentToken)
@@ -86,7 +86,7 @@ func (c *Component) Healthy() error {
 }
 
 func (c Component) run() {
-	ticker := time.NewTicker(c.interval)
+	ticker := time.NewTicker(interval)
 	for {
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
Fixes #920 

Removes the user configurable telemetry interval and uses constant 10min, which is the current default. I don't know why anyone would need to adjust it and what good it would do either way.