### PR TITLE
fixed config file path conversion to absolute

### DIFF
--- a/cmd/install/util.go
+++ b/cmd/install/util.go
@@ -34,7 +34,7 @@ func cmdFlagsToArgs(cmd *cobra.Command) []string {
 		case "stringSlice", "stringToString":
 			flagsAndVals = append(flagsAndVals, fmt.Sprintf(`--%s="%s"`, f.Name, strings.Trim(val, "[]")))
 		default:
-			if f.Name == "data-dir" || f.Name == "token-file" || f.Name == "config-file" {
+			if f.Name == "data-dir" || f.Name == "token-file" || f.Name == "config" {
 				val, _ = filepath.Abs(val)
 			}
 			flagsAndVals = append(flagsAndVals, fmt.Sprintf("--%s=%s", f.Name, val))


### PR DESCRIPTION
Fixes #927 

The name of the config parameter was incorrect changed it from `config-file` to `config`