### PR TITLE
Fix tokens link in setup docs

### DIFF
--- a/docs/k0s-multi-node.md
+++ b/docs/k0s-multi-node.md
@@ -63,7 +63,7 @@ To get a token, run the following command on one of the existing controller node
 k0s token create --role=worker
 ```
 
-The resulting output is a long [token](#tokens) string, which you can use to add a worker to the cluster.
+The resulting output is a long [token](#about-tokens) string, which you can use to add a worker to the cluster.
 
 For enhanced security, run the following command to set an expiration time for the token:
 


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>


**Issue**
Token link broken at multi-node setup guide.

**What this PR Includes**
Fixes the link :D