### PR TITLE
Configurable mode for kube proxy

### DIFF
--- a/internal/testutil/kube_client.go
+++ b/internal/testutil/kube_client.go
@@ -25,6 +25,7 @@ func NewFakeClientFactory(objects ...runtime.Object) FakeClientFactory {
 		{Group: "", Version: "v1", Resource: "nodes"}:                                         "NodeList",
 		{Group: "", Version: "v1", Resource: "configmaps"}:                                    "ConfigMapList",
 		{Group: "certificates.k8s.io", Version: "v1", Resource: "certificatesigningrequests"}: "CertificateSigningRequestList",
+		{Group: "apps", Version: "v1", Resource: "deployments"}:                               "DeploymentList",
 	}
 
 	return FakeClientFactory{

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -671,6 +671,9 @@ func (s *FootlooseSuite) createConfig() config.Config {
 		{
 			ContainerPort: uint16(s.KubeAPIExternalPort), // kube API
 		},
+		{
+			ContainerPort: uint16(6060), // pprof API
+		},
 	}
 
 	cfg := config.Config{

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -83,6 +83,8 @@ func TestDualStack(t *testing.T) {
 const k0sConfigWithAddon = `
 spec:
   network:
+    kubeProxy:
+      mode: ipvs
     provider: calico
     calico:
       mode: "bird"

--- a/pkg/apis/v1beta1/kubeproxy.go
+++ b/pkg/apis/v1beta1/kubeproxy.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1beta1
+
+import "fmt"
+
+var _ Validateable = (*KubeProxy)(nil)
+
+const (
+	ModeIptables  = "iptables"
+	ModeIPVS      = "ipvs"
+	ModeUSerspace = "userspace"
+)
+
+// KubeProxy defines the configuration for kube-proxy
+type KubeProxy struct {
+	Disabled bool
+	Mode     string
+}
+
+// DefaultKubeProxy creates the default config for kube-proxy
+func DefaultKubeProxy() *KubeProxy {
+	return &KubeProxy{
+		Disabled: false,
+		Mode:     "iptables",
+	}
+}
+
+// Validate validates kube proxy config
+func (k *KubeProxy) Validate() []error {
+	if k.Disabled {
+		return nil
+	}
+	var errors []error
+	if k.Mode != "iptables" && k.Mode != "ipvs" && k.Mode != "userspace" {
+		errors = append(errors, fmt.Errorf("unsupported mode %s for kubeProxy config", k.Mode))
+	}
+	return errors
+}

--- a/pkg/apis/v1beta1/network_test.go
+++ b/pkg/apis/v1beta1/network_test.go
@@ -157,6 +157,25 @@ spec:
 	s.False(p.Disabled)
 }
 
+func (s *NetworkSuite) TestKubeProxyDisabling() {
+	yamlData := `
+apiVersion: k0s.k0sproject.io/v1beta1
+kind: Cluster
+metadata:
+  name: foobar
+spec:
+  network:
+    kubeProxy:
+      disabled: true
+`
+
+	c, err := configFromString(yamlData, k0sVars)
+	s.NoError(err)
+	p := c.Spec.Network.KubeProxy
+
+	s.True(p.Disabled)
+}
+
 func (s *NetworkSuite) TestValidation() {
 	s.T().Run("defaults_are_valid", func(t *testing.T) {
 		n := DefaultNetwork()

--- a/pkg/applier/applier_test.go
+++ b/pkg/applier/applier_test.go
@@ -22,7 +22,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -32,6 +34,12 @@ import (
 func TestApplierAppliesAllManifestsInADirectory(t *testing.T) {
 	dir, err := ioutil.TempDir("", "applier-test-*")
 	assert.NoError(t, err)
+	templateNS := `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name:  kube-system
+`
 	template := `
 kind: ConfigMap
 apiVersion: v1
@@ -56,25 +64,60 @@ spec:
     - name: nginx
       image: nginx:1.15
 `
+
+	templateDeployment := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+       app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: docker.io/nginx:1-alpine
+        resources:
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+        ports:
+          - containerPort: 80	
+`
+	assert.NoError(t, ioutil.WriteFile(fmt.Sprintf("%s/test-ns.yaml", dir), []byte(templateNS), 0400))
 	assert.NoError(t, ioutil.WriteFile(fmt.Sprintf("%s/test.yaml", dir), []byte(template), 0400))
 	assert.NoError(t, ioutil.WriteFile(fmt.Sprintf("%s/test-pod.yaml", dir), []byte(template2), 0400))
+	assert.NoError(t, ioutil.WriteFile(fmt.Sprintf("%s/test-deploy.yaml", dir), []byte(templateDeployment), 0400))
 
 	fakes := kubeutil.NewFakeClientFactory()
-
-	a := NewApplier(dir, fakes)
-	assert.NoError(t, err)
-
+	verbs := []string{"get", "list", "delete", "create"}
 	fakes.RawDiscovery.Resources = []*metav1.APIResourceList{
 		{
 			GroupVersion: corev1.SchemeGroupVersion.String(),
 			APIResources: []metav1.APIResource{
-				{Name: "nodes", Namespaced: false, Kind: "Node"},
-				{Name: "pods", Namespaced: true, Kind: "Pod"},
-				{Name: "configmaps", Namespaced: true, Kind: "ConfigMap"},
-				{Name: "replicationcontrollers", Namespaced: true, Kind: "ReplicationController"},
+				{Name: "nodes", Namespaced: false, Kind: "Node", Verbs: verbs},
+				{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: verbs},
+				{Name: "configmaps", Namespaced: true, Kind: "ConfigMap", Verbs: verbs},
+				{Name: "namespaces", Namespaced: false, Kind: "Namespace", Verbs: verbs},
+			},
+		},
+		{
+			GroupVersion: appsv1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", Namespaced: true, Kind: "Deployment", Verbs: verbs},
 			},
 		},
 	}
+
+	a := NewApplier(dir, fakes)
+	assert.NoError(t, err)
+
 	err = a.Apply()
 	assert.NoError(t, err)
 	gv, _ := schema.ParseResourceArg("configmaps.v1.")
@@ -86,4 +129,29 @@ spec:
 	assert.NoError(t, err)
 	assert.Equal(t, "Pod", r.GetKind())
 	assert.Equal(t, "applier", r.GetLabels()["component"])
+	deployGV, _ := schema.ParseResourceArg("deployments.v1.apps")
+	_, err = a.client.Resource(*deployGV).Namespace("kube-system").Get(context.Background(), "nginx", metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	// Attempt to delete the stack with a different applier
+	a2 := NewApplier(dir, fakes)
+	assert.NoError(t, a2.Delete())
+	// Check that the resources are deleted
+	_, err = a.client.Resource(*gv).Namespace("kube-system").Get(context.Background(), "applier-test", metav1.GetOptions{})
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+
+	_, err = a.client.Resource(*podgv).Namespace("kube-system").Get(context.Background(), "applier-test", metav1.GetOptions{})
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+
+	_, err = a.client.Resource(*deployGV).Namespace("kube-system").Get(context.Background(), "nginx", metav1.GetOptions{})
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+
+	gvNS, _ := schema.ParseResourceArg("namespaces.v1.")
+	_, err = a.client.Resource(*gvNS).Get(context.Background(), "kube-system", metav1.GetOptions{})
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+
 }

--- a/pkg/applier/manager.go
+++ b/pkg/applier/manager.go
@@ -178,7 +178,7 @@ func (m *Manager) removeStack(name string) error {
 		m.log.WithField("stack", name).WithError(err).Warn("failed to stop and delete a stack applier")
 		return err
 	}
-
+	m.log.WithField("stack", name).Info("stack deleted succesfully")
 	delete(m.stacks, name)
 
 	return nil

--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -135,28 +135,6 @@ func (s *Stack) keepResource(resource *unstructured.Unstructured) {
 	s.keepResources = append(s.keepResources, resourceID)
 }
 
-func (s *Stack) getAllAccessibleNamespaces(ctx context.Context) []string {
-	var namespaces []string
-	nsGroupVersionResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
-	nsList, err := s.Client.Resource(nsGroupVersionResource).List(ctx, metav1.ListOptions{})
-	if apiErrors.IsForbidden(err) {
-		for _, resource := range s.Resources {
-			if ns := resource.GetNamespace(); ns != "" {
-				namespaces = append(namespaces, ns)
-			}
-		}
-	}
-	if err != nil {
-		return namespaces
-	}
-
-	for _, namespace := range nsList.Items {
-		namespaces = append(namespaces, namespace.GetName())
-	}
-
-	return namespaces
-}
-
 func (s *Stack) prune(ctx context.Context, mapper *restmapper.DeferredDiscoveryRESTMapper) error {
 	pruneableResources, err := s.findPruneableResources(ctx, mapper)
 	if err != nil {

--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sync"
+	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/sirupsen/logrus"
@@ -160,10 +161,15 @@ func (s *Stack) prune(ctx context.Context, mapper *restmapper.DeferredDiscoveryR
 	if err != nil {
 		return err
 	}
+	if len(pruneableResources) == 0 {
+		return nil
+	}
 
+	log.Debug("starting to delete resources, namespaced resources first")
 	for _, resource := range pruneableResources {
+		resourceID := generateResourceID(resource)
 		if resource.GetNamespace() != "" {
-			log.Debugf("deleting resource %s", resource.GetSelfLink())
+			log.Debugf("deleting resource %s", resourceID)
 			err = s.deleteResource(ctx, mapper, resource)
 			if err != nil {
 				return err
@@ -171,15 +177,16 @@ func (s *Stack) prune(ctx context.Context, mapper *restmapper.DeferredDiscoveryR
 		}
 	}
 	for _, resource := range pruneableResources {
+		resourceID := generateResourceID(resource)
 		if resource.GetNamespace() == "" {
-			log.Debugf("deleting resource %s", resource.GetSelfLink())
+			log.Debugf("deleting resource %s", resourceID)
 			err = s.deleteResource(ctx, mapper, resource)
 			if err != nil {
 				return err
 			}
 		}
 	}
-
+	log.Debug("resources pruned succesfully")
 	s.keepResources = []string{}
 
 	return nil
@@ -188,13 +195,17 @@ func (s *Stack) prune(ctx context.Context, mapper *restmapper.DeferredDiscoveryR
 // ignoredResources defines a list of resources which as ignored in prune phase
 // The reason for ignoring these are:
 // - v1:Endpoints inherit the stack label but do not have owner ref set --> each apply would prune all stack related endpoints
+// - discovery.k8s.io/v1:EndpointSlice inherit the stack label but do not have owner ref set --> each apply would prune all stack related endpointsslices
 // Defined is the form of api-group/version:kind. The core group kinds are defined as v1:<kind>
-var ignoredResources = []string{"v1:Endpoints"}
+var ignoredResources = []string{
+	"v1:Endpoints",
+	"discovery.k8s.io/v1:EndpointSlice",
+}
 
-func (s *Stack) findPruneableResources(ctx context.Context, mapper *restmapper.DeferredDiscoveryRESTMapper) ([]*unstructured.Unstructured, error) {
+func (s *Stack) findPruneableResources(ctx context.Context, mapper *restmapper.DeferredDiscoveryRESTMapper) ([]unstructured.Unstructured, error) {
 	log := logrus.WithField("stack", s.Name)
 
-	var pruneableResources []*unstructured.Unstructured
+	var pruneableResources []unstructured.Unstructured
 	apiResourceLists, err := s.Discovery.ServerPreferredResources()
 	if err != nil {
 		// Client-Go emits an error when an API service is registered but unimplemented.
@@ -235,6 +246,8 @@ func (s *Stack) findPruneableResources(ctx context.Context, mapper *restmapper.D
 		}
 	}
 
+	log.Debug("starting to find prunable resources")
+	start := time.Now()
 	wg := sync.WaitGroup{}
 	namespaces := s.getAllAccessibleNamespaces(ctx)
 	mu := sync.Mutex{} // The shield against concurrent appends for pruneable resources
@@ -252,11 +265,11 @@ func (s *Stack) findPruneableResources(ctx context.Context, mapper *restmapper.D
 	}
 	wg.Wait()
 	log.Debugf("found %d prunable resources from %d namespaces", len(pruneableResources), len(namespaces))
-
+	log.Debugf("finding prunable resources took %s", time.Since(start).String())
 	return pruneableResources, nil
 }
 
-func (s *Stack) deleteResource(ctx context.Context, mapper *restmapper.DeferredDiscoveryRESTMapper, resource *unstructured.Unstructured) error {
+func (s *Stack) deleteResource(ctx context.Context, mapper *restmapper.DeferredDiscoveryRESTMapper, resource unstructured.Unstructured) error {
 	propagationPolicy := metav1.DeletePropagationForeground
 	drClient, err := s.clientForResource(mapper, resource)
 	if err != nil {
@@ -271,7 +284,7 @@ func (s *Stack) deleteResource(ctx context.Context, mapper *restmapper.DeferredD
 	return nil
 }
 
-func (s *Stack) clientForResource(mapper *restmapper.DeferredDiscoveryRESTMapper, resource *unstructured.Unstructured) (dynamic.ResourceInterface, error) {
+func (s *Stack) clientForResource(mapper *restmapper.DeferredDiscoveryRESTMapper, resource unstructured.Unstructured) (dynamic.ResourceInterface, error) {
 	mapping, err := mapper.RESTMapping(resource.GroupVersionKind().GroupKind(), resource.GroupVersionKind().Version)
 	if err != nil {
 		return nil, fmt.Errorf("mapping error: %s", err)
@@ -287,49 +300,39 @@ func (s *Stack) clientForResource(mapper *restmapper.DeferredDiscoveryRESTMapper
 	return drClient, nil
 }
 
-func (s *Stack) findPruneableResourceForGroupVersionKind(ctx context.Context, mapper *restmapper.DeferredDiscoveryRESTMapper, groupVersionKind *schema.GroupVersionKind, namespaces []string) []*unstructured.Unstructured {
-	var pruneableResources []*unstructured.Unstructured
+func (s *Stack) findPruneableResourceForGroupVersionKind(ctx context.Context, mapper *restmapper.DeferredDiscoveryRESTMapper, groupVersionKind *schema.GroupVersionKind, namespaces []string) []unstructured.Unstructured {
 	groupKind := schema.GroupKind{
 		Group: groupVersionKind.Group,
 		Kind:  groupVersionKind.Kind,
 	}
 	mapping, _ := mapper.RESTMapping(groupKind, groupVersionKind.Version)
+	// FIXME error handling...
 	if mapping != nil {
-		if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
-			drClient := s.Client.Resource(mapping.Resource)
-			_, err := drClient.List(ctx, metav1.ListOptions{Limit: 1})
-			if err == nil {
-				// rights to fetch all namespaces at once
-				pruneableResources = append(pruneableResources, s.getPruneableResources(ctx, drClient)...)
-			} else {
-				// need to query each namespace separately
-				for _, namespace := range namespaces {
-					pruneableResources = append(pruneableResources, s.getPruneableResources(ctx, drClient.Namespace(namespace))...)
-				}
-			}
-		} else {
-			drClient := s.Client.Resource(mapping.Resource)
-			pruneableResources = append(pruneableResources, s.getPruneableResources(ctx, drClient)...)
-		}
+		// We're running this with full admin rights, we should have capability to get stuff with single call
+		drClient := s.Client.Resource(mapping.Resource)
+		return s.getPruneableResources(ctx, drClient)
 	}
 
-	return pruneableResources
+	return nil
 }
 
-func (s *Stack) getPruneableResources(ctx context.Context, drClient dynamic.ResourceInterface) []*unstructured.Unstructured {
-	var pruneableResources []*unstructured.Unstructured
+func (s *Stack) getPruneableResources(ctx context.Context, drClient dynamic.ResourceInterface) []unstructured.Unstructured {
+	var pruneableResources []unstructured.Unstructured
+	log := logrus.WithField("stack", s.Name)
 	listOpts := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", NameLabel, s.Name),
 	}
 	resourceList, err := drClient.List(ctx, listOpts)
 	if err != nil {
-		return []*unstructured.Unstructured{}
+		// FIXME why no error propagation !??!
+		return nil
 	}
 	for _, resource := range resourceList.Items {
 		// We need to filter out objects that do not actually have the stack label set
 		// There are some cases where we get "extra" results, e.g.: https://github.com/kubernetes-sigs/metrics-server/issues/604
 		if !s.isInStack(resource) && len(resource.GetOwnerReferences()) == 0 && resource.GetLabels()[NameLabel] == s.Name {
-			pruneableResources = append(pruneableResources, &resource)
+			log.Debugf("adding prunable resource: %s", generateResourceID(resource))
+			pruneableResources = append(pruneableResources, resource)
 		}
 	}
 
@@ -343,7 +346,6 @@ func (s *Stack) isInStack(resource unstructured.Unstructured) bool {
 			return true
 		}
 	}
-	logrus.WithField("stack", s.Name).Debugf("resource NOT in current stack: %s", resourceID)
 	return false
 }
 

--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -117,6 +117,7 @@ func (k *KubeProxy) getConfig() (proxyConfig, error) {
 		Image:                k.clusterConf.Spec.Images.KubeProxy.URI(),
 		PullPolicy:           k.clusterConf.Spec.Images.DefaultPullPolicy,
 		DualStack:            k.clusterConf.Spec.Network.DualStack.Enabled,
+		Mode:                 k.clusterConf.Spec.Network.KubeProxy.Mode,
 	}
 
 	return cfg, nil
@@ -128,6 +129,7 @@ type proxyConfig struct {
 	ClusterCIDR          string
 	Image                string
 	PullPolicy           string
+	Mode                 string
 }
 
 const proxyTemplate = `
@@ -225,11 +227,8 @@ data:
     {{ if .DualStack }}
     featureGates:
       IPv6DualStack: true
-    mode: "ipvs"
-    {{ else }}
-    mode: ""
     {{ end }}
-    
+    mode: "{{ .Mode }}"
     conntrack:
       maxPerCore: 0
       min: null

--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -264,13 +264,11 @@ kind: ServiceAccount
 metadata:
   name: kube-router
   namespace: kube-system
-
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kube-router
-  namespace: kube-system
 rules:
   - apiGroups:
     - ""

--- a/pkg/component/worker/localproxy.go
+++ b/pkg/component/worker/localproxy.go
@@ -1,0 +1,1 @@
+package worker

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -63,6 +63,11 @@ func (c *clientFactory) GetClient() (kubernetes.Interface, error) {
 
 	if c.restConfig == nil {
 		c.restConfig, err = clientcmd.BuildConfigFromFlags("", c.configPath)
+		// We're always running the client on the same host as the API, no need to compress
+		c.restConfig.DisableCompression = true
+		// To mitigate stack applier bursts in startup
+		c.restConfig.QPS = 40.0
+		c.restConfig.Burst = 400.0
 		if err != nil {
 			return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
 		}
@@ -89,6 +94,11 @@ func (c *clientFactory) GetDynamicClient() (dynamic.Interface, error) {
 	var err error
 	if c.restConfig == nil {
 		c.restConfig, err = clientcmd.BuildConfigFromFlags("", c.configPath)
+		// We're always running the client on the same host as the API, no need to compress
+		c.restConfig.DisableCompression = true
+		// To mitigate stack applier bursts in startup
+		c.restConfig.QPS = 40.0
+		c.restConfig.Burst = 400.0
 		if err != nil {
 			return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
 		}


### PR DESCRIPTION
**Issue**
Currently kube-proxy mode is not really configurable. There are cases when we want to make the proxy mode something else than the default `iptables`, e.g.:
- huge amount of services --> iptables is way too CPU heavy
- very limited set of kernel modules available --> we need to set it to userspace mode

Partial (the kube-proxy part) fix for #427 as this now add possibility to disable kube-proxy completely.

**What this PR Includes**

This PR makes kube proxy mode configurable and possible to disable too.

This also includes quite a few fixes for the stack delete logic as that was pretty badly broken in some cases.

