### PR TITLE
Fix kube version string to use '+' as suffix

### DIFF
--- a/embedded-bins/kubernetes/Dockerfile
+++ b/embedded-bins/kubernetes/Dockerfile
@@ -22,7 +22,7 @@ RUN \
 		export KUBE_CGO_OVERRIDES="${COMMANDS}"; \
 	fi; \
 	for cmd in $COMMANDS; do \
-		export KUBE_GIT_VERSION="v$VERSION-k0s1"; \
+		export KUBE_GIT_VERSION="v$VERSION+k0s"; \
 		make GOFLAGS="${BUILD_GO_FLAGS} -tags=${BUILD_GO_TAGS}" GOLDFLAGS="${BUILD_GO_LDFLAGS_EXTRA}" WHAT=cmd/$cmd || break;\
 	done
 


### PR DESCRIPTION


Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
In semver `-` signifies a pre-release, thus the reported Kubernetes server version is slightly wrong:
```
kubectl version
Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-13T13:28:09Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"20+", GitVersion:"v1.20.5-k0s1", GitCommit:"6b1d87acf3c8253c123756b9e61dac642678305f", GitTreeState:"clean", BuildDate:"2021-04-08T09:00:44Z", GoVersion:"go1.15.11", Compiler:"gc", Platform:"linux/amd64"}
```

**What this PR Includes**
This PR changes the k0s build kube version to use a "static" `+k0s` suffix as that's more correct from semver point of view.