### PR TITLE
Regenerate all k0s managed non-CA certs at k0s startup

### DIFF
--- a/pkg/component/controller/certificates.go
+++ b/pkg/component/controller/certificates.go
@@ -253,9 +253,7 @@ func (c *Certificates) Stop() error {
 }
 
 func kubeConfig(dest, url, caCert, clientCert, clientKey, owner string) error {
-	if util.FileExists(dest) {
-		return util.ChownFile(dest, owner, constant.CertSecureMode)
-	}
+	// We always overwrite the kubeconfigs as the certs might be regenerated at startup
 	data := struct {
 		URL        string
 		CACert     string


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Fixes #496 

**What this PR Includes**
This ensures we rotate all non-CA certs periodically.

**Testing**

The HA case has been manually tested by myself and @jasmingacic and we've found no issues in restarting controllers "randomly" and thus regenerating the certs many times. Controlplane recovers and node components continue to be operational.
