### PR TITLE
k0s reset: support for docker

### DIFF
--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -66,13 +66,6 @@ func (c *CmdOpts) reset() error {
 		logger.Fatal("k0s seems to be running! please stop k0s before reset.")
 	}
 
-	role := install.GetRoleByStagedKubelet(c.K0sVars.BinDir)
-	logrus.Debugf("detected role for cleanup: %v", role)
-	err := install.UninstallService(role)
-	if err != nil {
-		// might be that k0s was not run as a part of a service. just notify on uninstall error
-		logger.Infof("failed to uninstall k0s service: %v", err)
-	}
 	// Get Cleanup Config
 	cfg, err := cleanup.NewConfig(c.K0sVars.DataDir, c.WorkerOptions.CriSocket)
 	if err != nil {

--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -67,14 +67,11 @@ func (c *CmdOpts) reset() error {
 	}
 
 	// Get Cleanup Config
-	cfg, err := cleanup.NewConfig(c.K0sVars.DataDir, c.WorkerOptions.CriSocket)
+	cfg, err := cleanup.NewConfig(c.K0sVars, c.CfgFile, c.WorkerOptions.CriSocket)
 	if err != nil {
 		logger.Fatalf("failed to configure cleanup: %v", err)
 		return err
 	}
-
-	cfg.CfgFile = c.CfgFile
-	cfg.K0sVars = c.K0sVars
 
 	err = cfg.Cleanup()
 

--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -66,9 +66,17 @@ func (c *CmdOpts) reset() error {
 		logger.Fatal("k0s seems to be running! please stop k0s before reset.")
 	}
 
+	role := install.GetRoleByStagedKubelet(c.K0sVars.BinDir)
+	logrus.Debugf("detected role for cleanup: %v", role)
+	err := install.UninstallService(role)
+	if err != nil {
+		// might be that k0s was not run as a part of a service. just notify on uninstall error
+		logger.Infof("failed to uninstall k0s service: %v", err)
+	}
+	// Get Cleanup Config
 	cfg, err := cleanup.NewConfig(c.K0sVars.DataDir, c.WorkerOptions.CriSocket)
 	if err != nil {
-		logger.Fatal("Failed to configure cleanup: %v", err)
+		logger.Fatalf("failed to configure cleanup: %v", err)
 		return err
 	}
 

--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -45,6 +45,7 @@ func NewResetCmd() *cobra.Command {
 	}
 	cmd.SilenceUsage = true
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+	cmd.Flags().AddFlagSet(config.GetCriSocketFlag())
 	return cmd
 }
 
@@ -65,11 +66,16 @@ func (c *CmdOpts) reset() error {
 		logger.Fatal("k0s seems to be running! please stop k0s before reset.")
 	}
 
-	cfg := cleanup.NewConfig(c.K0sVars.DataDir)
+	cfg, err := cleanup.NewConfig(c.K0sVars.DataDir, c.WorkerOptions.CriSocket)
+	if err != nil {
+		logger.Fatal("Failed to configure cleanup: %v", err)
+		return err
+	}
+
 	cfg.CfgFile = c.CfgFile
 	cfg.K0sVars = c.K0sVars
 
-	err := cfg.Cleanup()
+	err = cfg.Cleanup()
 
 	logger.Info("k0s cleanup operations done. To ensure a full reset, a node reboot is recommended.")
 	return err

--- a/pkg/cleanup/cleanup_unix.go
+++ b/pkg/cleanup/cleanup_unix.go
@@ -27,12 +27,12 @@ import (
 )
 
 type Config struct {
+	cfgFile          string
 	containerd       *containerdConfig
 	containerRuntime runtime.ContainerRuntime
 	dataDir          string
+	k0sVars          constant.CfgVars
 	runDir           string
-	CfgFile          string
-	K0sVars          constant.CfgVars
 }
 
 type containerdConfig struct {
@@ -41,7 +41,7 @@ type containerdConfig struct {
 	socketPath string
 }
 
-func NewConfig(dataDir string, criSocketPath string) (*Config, error) {
+func NewConfig(k0sVars constant.CfgVars, cfgFile string, criSocketPath string) (*Config, error) {
 	runDir := "/run/k0s" // https://github.com/k0sproject/k0s/pull/591/commits/c3f932de85a0b209908ad39b817750efc4987395
 
 	var err error
@@ -51,7 +51,7 @@ func NewConfig(dataDir string, criSocketPath string) (*Config, error) {
 	if criSocketPath == "" {
 		criSocketPath = fmt.Sprintf("unix:///%s/containerd.sock", runDir)
 		containerdCfg = &containerdConfig{
-			binPath:    fmt.Sprintf("%s/%s", dataDir, "bin/containerd"),
+			binPath:    fmt.Sprintf("%s/%s", k0sVars.DataDir, "bin/containerd"),
 			socketPath: fmt.Sprintf("%s/containerd.sock", runDir),
 		}
 		runtimeType = "cri"
@@ -63,10 +63,12 @@ func NewConfig(dataDir string, criSocketPath string) (*Config, error) {
 	}
 
 	return &Config{
+		cfgFile:          cfgFile,
 		containerd:       containerdCfg,
 		containerRuntime: runtime.NewContainerRuntime(runtimeType, criSocketPath),
-		dataDir:          dataDir,
+		dataDir:          k0sVars.DataDir,
 		runDir:           runDir,
+		k0sVars:          k0sVars,
 	}, nil
 }
 

--- a/pkg/cleanup/cleanup_unix.go
+++ b/pkg/cleanup/cleanup_unix.go
@@ -73,7 +73,7 @@ func NewConfig(dataDir string, criSocketPath string) (*Config, error) {
 func (c *Config) Cleanup() error {
 	var msg []error
 	cleanupSteps := []Step{
-		&containerd{Config: c},
+		&containers{Config: c},
 		&users{Config: c},
 		&services{Config: c},
 		&directories{Config: c},

--- a/pkg/cleanup/containerd.go
+++ b/pkg/cleanup/containerd.go
@@ -113,7 +113,7 @@ func (c *containerd) stopContainerd() {
 func (c *containerd) stopAllContainers() error {
 	var msg []error
 	logrus.Debugf("trying to list all pods")
-	pods, err := c.Config.criCtl.ListPods()
+	pods, err := c.Config.containerRuntime.ListContainers()
 	if err != nil {
 		logrus.Debugf("failed at listing pods %v", err)
 		return err
@@ -129,7 +129,7 @@ func (c *containerd) stopAllContainers() error {
 
 	for _, pod := range pods {
 		logrus.Debugf("stopping container: %v", pod)
-		err := c.Config.criCtl.StopPod(pod)
+		err := c.Config.containerRuntime.StopContainer(pod)
 		if err != nil {
 			if strings.Contains(err.Error(), "443: connect: connection refused") {
 				// on a single node instance, we will see "connection refused" error. this is to be expected
@@ -142,14 +142,14 @@ func (c *containerd) stopAllContainers() error {
 				msg = append(msg, fmtError)
 			}
 		}
-		err = c.Config.criCtl.RemovePod(pod)
+		err = c.Config.containerRuntime.RemoveContainer(pod)
 		if err != nil {
 			msg = append(msg, fmt.Errorf("failed to remove pod %v: err: %v", pod, err))
 
 		}
 	}
 
-	pods, err = c.Config.criCtl.ListPods()
+	pods, err = c.Config.containerRuntime.ListContainers()
 	if err == nil && len(pods) == 0 {
 		logrus.Info("successfully removed k0s containers!")
 	}

--- a/pkg/cleanup/users.go
+++ b/pkg/cleanup/users.go
@@ -18,7 +18,7 @@ func (u *users) Name() string {
 
 // NeedsToRun detects controller users
 func (u *users) NeedsToRun() bool {
-	clusterConfig, err := config.GetYamlFromFile(u.Config.CfgFile, u.Config.K0sVars)
+	clusterConfig, err := config.GetYamlFromFile(u.Config.cfgFile, u.Config.k0sVars)
 	if err != nil {
 		return false
 	}
@@ -35,7 +35,7 @@ func (u *users) NeedsToRun() bool {
 // Run removes all controller users that are present on the host
 func (u *users) Run() error {
 	logger := logrus.New()
-	clusterConfig, err := config.GetYamlFromFile(u.Config.CfgFile, u.Config.K0sVars)
+	clusterConfig, err := config.GetYamlFromFile(u.Config.cfgFile, u.Config.k0sVars)
 	if err != nil {
 		logger.Errorf("failed to get cluster setup: %v", err)
 	}

--- a/pkg/component/worker/cri_runtime.go
+++ b/pkg/component/worker/cri_runtime.go
@@ -1,0 +1,23 @@
+package worker
+
+import (
+	"fmt"
+	"strings"
+)
+
+type RuntimeType = string
+type RuntimeSocket = string
+
+func SplitRuntimeConfig(rtConfig string) (RuntimeType, RuntimeSocket, error) {
+	runtimeConfig := strings.SplitN(rtConfig, ":", 2)
+	if len(runtimeConfig) != 2 {
+		return "", "", fmt.Errorf("cannot parse CRI socket path")
+	}
+	runtimeType := runtimeConfig[0]
+	runtimeSocket := runtimeConfig[1]
+	if runtimeType != "docker" && runtimeType != "remote" {
+		return "", "", fmt.Errorf("unknown runtime type %s, must be either of remote or docker", runtimeType)
+	}
+
+	return runtimeType, runtimeSocket, nil
+}

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -128,7 +128,7 @@ func (k *Kubelet) Run() error {
 	}
 
 	if k.CRISocket != "" {
-		rtType, rtSock, err := splitRuntimeConfig(k.CRISocket)
+		rtType, rtSock, err := SplitRuntimeConfig(k.CRISocket)
 		if err != nil {
 			return err
 		}
@@ -209,20 +209,6 @@ func (k *Kubelet) Stop() error {
 
 // Health-check interface
 func (k *Kubelet) Healthy() error { return nil }
-
-func splitRuntimeConfig(rtConfig string) (string, string, error) {
-	runtimeConfig := strings.SplitN(rtConfig, ":", 2)
-	if len(runtimeConfig) != 2 {
-		return "", "", fmt.Errorf("cannot parse CRI socket path")
-	}
-	runtimeType := runtimeConfig[0]
-	runtimeSocket := runtimeConfig[1]
-	if runtimeType != "docker" && runtimeType != "remote" {
-		return "", "", fmt.Errorf("unknown runtime type %s, must be either of remote or docker", runtimeType)
-	}
-
-	return runtimeType, runtimeSocket, nil
-}
 
 const awsMetaInformationURI = "http://169.254.169.254/latest/meta-data/local-hostname"
 

--- a/pkg/component/worker/kubelet_test.go
+++ b/pkg/component/worker/kubelet_test.go
@@ -54,7 +54,7 @@ func TestCRISocketParsing(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			criType, sock, err := splitRuntimeConfig(tc.input)
+			criType, sock, err := SplitRuntimeConfig(tc.input)
 			if tc.err {
 				require.Error(t, err)
 			} else {

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -100,11 +100,16 @@ func GetKubeCtlFlagSet() *pflag.FlagSet {
 	return flagset
 }
 
+func GetCriSocketFlag() *pflag.FlagSet {
+	flagset := &pflag.FlagSet{}
+	flagset.StringVar(&workerOpts.CriSocket, "cri-socket", "", "contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]")
+	return flagset
+}
+
 func GetWorkerFlags() *pflag.FlagSet {
 	flagset := &pflag.FlagSet{}
 
 	flagset.StringVar(&workerOpts.WorkerProfile, "profile", "default", "worker profile to use on the node")
-	flagset.StringVar(&workerOpts.CriSocket, "cri-socket", "", "contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]")
 	flagset.StringVar(&workerOpts.APIServer, "api-server", "", "HACK: api-server for the windows worker node")
 	flagset.StringVar(&workerOpts.CIDRRange, "cidr-range", "10.96.0.0/12", "HACK: cidr range for the windows worker node")
 	flagset.StringVar(&workerOpts.ClusterDNS, "cluster-dns", "10.96.0.10", "HACK: cluster dns for the windows worker node")
@@ -113,6 +118,8 @@ func GetWorkerFlags() *pflag.FlagSet {
 	flagset.StringToStringVarP(&workerOpts.CmdLogLevels, "logging", "l", DefaultLogLevels(), "Logging Levels for the different components")
 	flagset.StringSliceVarP(&workerOpts.Labels, "labels", "", []string{}, "Node labels, list of key=value pairs")
 	flagset.StringVar(&workerOpts.KubeletExtraArgs, "kubelet-extra-args", "", "extra args for kubelet")
+	flagset.AddFlagSet(GetCriSocketFlag())
+
 	return flagset
 }
 
@@ -122,9 +129,9 @@ func GetControllerFlags() *pflag.FlagSet {
 	flagset.StringVar(&workerOpts.WorkerProfile, "profile", "default", "worker profile to use on the node")
 	flagset.BoolVar(&controllerOpts.EnableWorker, "enable-worker", false, "enable worker (default false)")
 	flagset.StringVar(&workerOpts.TokenFile, "token-file", "", "Path to the file containing join-token.")
-	flagset.StringVar(&workerOpts.CriSocket, "cri-socket", "", "contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]")
 	flagset.StringToStringVarP(&workerOpts.CmdLogLevels, "logging", "l", DefaultLogLevels(), "Logging Levels for the different components")
 	flagset.BoolVar(&controllerOpts.SingleNode, "single", false, "enable single node (implies --enable-worker, default false)")
+	flagset.AddFlagSet(GetCriSocketFlag())
 
 	return flagset
 }

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -102,7 +102,7 @@ func GetKubeCtlFlagSet() *pflag.FlagSet {
 
 func GetCriSocketFlag() *pflag.FlagSet {
 	flagset := &pflag.FlagSet{}
-	flagset.StringVar(&workerOpts.CriSocket, "cri-socket", "", "contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]")
+	flagset.StringVar(&workerOpts.CriSocket, "cri-socket", "", "container runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]")
 	return flagset
 }
 

--- a/pkg/container/runtime/cri.go
+++ b/pkg/container/runtime/cri.go
@@ -1,4 +1,4 @@
-package crictl
+package runtime
 
 import (
 	"context"
@@ -9,16 +9,14 @@ import (
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
-type CriCtl struct {
-	addr string
+var _ ContainerRuntime = &CRIRuntime{}
+
+type CRIRuntime struct {
+	criSocketPath string
 }
 
-func NewCriCtl(addr string) *CriCtl {
-	return &CriCtl{addr}
-}
-
-func (c *CriCtl) ListPods() ([]string, error) {
-	client, conn, err := getRuntimeClient(c.addr)
+func (cri *CRIRuntime) ListContainers() ([]string, error) {
+	client, conn, err := getRuntimeClient(cri.criSocketPath)
 	defer closeConnection(conn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CRI runtime client: %w", err)
@@ -40,8 +38,8 @@ func (c *CriCtl) ListPods() ([]string, error) {
 	return pods, nil
 }
 
-func (c *CriCtl) RemovePod(id string) error {
-	client, conn, err := getRuntimeClient(c.addr)
+func (cri *CRIRuntime) RemoveContainer(id string) error {
+	client, conn, err := getRuntimeClient(cri.criSocketPath)
 	defer closeConnection(conn)
 	if err != nil {
 		return fmt.Errorf("failed to create CRI runtime client: %w", err)
@@ -60,8 +58,8 @@ func (c *CriCtl) RemovePod(id string) error {
 	return nil
 }
 
-func (c *CriCtl) StopPod(id string) error {
-	client, conn, err := getRuntimeClient(c.addr)
+func (cri *CRIRuntime) StopContainer(id string) error {
+	client, conn, err := getRuntimeClient(cri.criSocketPath)
 	defer closeConnection(conn)
 	if err != nil {
 		return fmt.Errorf("failed to create CRI runtime client: %w", err)

--- a/pkg/container/runtime/docker.go
+++ b/pkg/container/runtime/docker.go
@@ -1,0 +1,37 @@
+package runtime
+
+import (
+	"github.com/pkg/errors"
+	"os/exec"
+	"strings"
+)
+
+var _ ContainerRuntime = &DockerRuntime{}
+
+type DockerRuntime struct {
+	criSocketPath string
+}
+
+func (d *DockerRuntime) ListContainers() ([]string, error) {
+	out, err := exec.Command("docker", "--host", d.criSocketPath, "ps", "-a", "--filter", "name=k8s_", "-q").CombinedOutput()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list containers: output: %s, error", string(out))
+	}
+	return strings.Fields(string(out)), nil
+}
+
+func (d *DockerRuntime) RemoveContainer(id string) error {
+	out, err := exec.Command("docker", "--host", d.criSocketPath, "rm", "--volumes", id).CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to remove container %s: output: %s, error", id, string(out))
+	}
+	return nil
+}
+
+func (d *DockerRuntime) StopContainer(id string) error {
+	out, err := exec.Command("docker", "--host", d.criSocketPath, "stop", id).CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to stop running container %s: output: %s, error", id, string(out))
+	}
+	return nil
+}

--- a/pkg/container/runtime/runtime.go
+++ b/pkg/container/runtime/runtime.go
@@ -1,0 +1,14 @@
+package runtime
+
+type ContainerRuntime interface {
+	ListContainers() ([]string, error)
+	RemoveContainer(id string) error
+	StopContainer(id string) error
+}
+
+func NewContainerRuntime(runtimeType string, criSocketPath string) ContainerRuntime {
+	if runtimeType == "docker" {
+		return nil
+	}
+	return &CRIRuntime{criSocketPath}
+}

--- a/pkg/container/runtime/runtime.go
+++ b/pkg/container/runtime/runtime.go
@@ -8,7 +8,7 @@ type ContainerRuntime interface {
 
 func NewContainerRuntime(runtimeType string, criSocketPath string) ContainerRuntime {
 	if runtimeType == "docker" {
-		return nil
+		return &DockerRuntime{criSocketPath}
 	}
 	return &CRIRuntime{criSocketPath}
 }

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -96,8 +96,6 @@ func (hc *Commands) AddRepository(repoCfg k0sv1beta1.Repository) error {
 	}
 	r.CachePath = hc.helmCacheDir
 
-
-
 	if _, err := r.DownloadIndexFile(); err != nil {
 		return fmt.Errorf("can't add repository: %q is not a valid chart repository or cannot be reached: %v", "repo", err)
 	}


### PR DESCRIPTION
**Issue**
Fixes #742

**What this PR Includes**
The purpose of this PR is to support docker and CRI-compatible container runtimes by `k0s reset` command.

**Changes**
Command `reset` accepts flag to specify CRI socket:
```
k0s reset --cri-socket docker:unix:///var/run/docker.sock
```

**How to test**
```
k0s install controller --enable-worker --cri-socket docker:unix:///var/run/docker.sock
k0s start
k0s kc get pods -n kube-system
```
Wait for startup of pods in the `kube-system` namespace
```
k0s stop
k0s reset --debug --cri-socket docker:unix:///var/run/docker.sock
docker ps -aq
```
There should be no containers.