### PR TITLE
Retry controller join for transient failures

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -134,11 +134,17 @@ func joinController(tokenArg string, certRootDir string) (*token.JoinClient, err
 		return nil, fmt.Errorf("failed to create join client: %w", err)
 	}
 
-	caData, err := joinClient.GetCA()
+	var caData v1beta1.CaResponse
+	err = retry.Do(func() error {
+		caData, err = joinClient.GetCA()
+		if err != nil {
+			return fmt.Errorf("failed to sync CA: %w", err)
+		}
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to sync CA: %w", err)
+		return nil, err
 	}
-
 	return joinClient, writeCerts(caData, certRootDir)
 }
 


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Fixes #866 

**What this PR Includes**
This PR makes controller join process to retry the CA sync. With automation tools like k0sctl the controllers are joined so fast that on the initial controller the sync API might not yet be up-and-running. That'll make the underlying init system (e.g. systemd) to restart the service. The job will get done for sure, but it'll take a bit long. Testing with this fix and with k0sctl shows this shaves ~1min off from the 3+3 setup.