### PR TITLE
Change out put to output in k0s status

### DIFF
--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -76,6 +76,6 @@ func NewStatusCmd() *cobra.Command {
 		},
 	}
 	cmd.SilenceUsage = true
-	cmd.PersistentFlags().StringVarP(&output, "out", "o", "", "sets type of out put to json or yaml")
+	cmd.PersistentFlags().StringVarP(&output, "out", "o", "", "sets type of output to json or yaml")
 	return cmd
 }

--- a/docs/cli/k0s_status.md
+++ b/docs/cli/k0s_status.md
@@ -14,7 +14,7 @@ The command will return information about system init, PID, k0s role, kubeconfig
 
 ```shell
   -h, --help         help for status
-  -o, --out string   sets type of out put to json or yaml
+  -o, --out string   sets type of output to json or yaml
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

```
k0s status --help
Helper command for get general information about k0s

Usage:
  k0s status [flags]

Examples:
The command will return information about system init, PID, k0s role, kubeconfig and similar.

Flags:
  -h, --help         help for status
  -o, --out string   sets type of out put to json or yaml
```

Removes eyesore and saves a byte in size!
