### PR TITLE
Fix empty "stubfile" in k0s status

### DIFF
--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -60,10 +60,11 @@ func NewStatusCmd() *cobra.Command {
 					logrus.Fatal("k0s status must be run as root!")
 				}
 
-				if s.SysInit, s.StubFile, err = install.GetSysInit(s.Role); err != nil {
+				if s.Role, err = install.GetRoleByPID(s.Pid); err != nil {
 					return err
 				}
-				if s.Role, err = install.GetRoleByPID(s.Pid); err != nil {
+
+				if s.SysInit, s.StubFile, err = install.GetSysInit(s.Role); err != nil {
 					return err
 				}
 			} else {

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -64,7 +65,7 @@ func NewStatusCmd() *cobra.Command {
 					return err
 				}
 
-				if s.SysInit, s.StubFile, err = install.GetSysInit(s.Role); err != nil {
+				if s.SysInit, s.StubFile, err = install.GetSysInit(strings.TrimSuffix(s.Role, "+worker")); err != nil {
 					return err
 				}
 			} else {


### PR DESCRIPTION
The status command was trying to resolve a value for the "stubfile" field by using role, but role is only resolved after that, resulting in the field always being empty.

Other observations:

* There's a `String()` function that does not return a string.
* The output format is serialized into the output:
    ```yaml
    # k0s status -o yaml
    version: v1.21.1+k0s.0
    pid: 12348
    ppid: 1
    role: controller+worker
    sysinit: linux-systemd
    stubfile: ""
    output: yaml
    ```
* There's some problem in the version detection, giving `/proc/xxxx/exe: Permission denied` error in some cases (worked before reset, after reset and install doesn't seem to.)
* The term "stubfile" [seems incorrect](https://en.wikipedia.org/wiki/Stub_file).
