### PR TITLE
Update etcd to go1.16 via `embedded-bins/Makefile.variables`

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -32,7 +32,7 @@ kine_build_go_ldflags = "-w -s"
 kine_build_go_ldflags_extra = "-extldflags=-static"
 
 etcd_version = 3.4.16
-etcd_buildimage = golang:1.13-alpine
+etcd_buildimage = golang:1.16-alpine
 #etcd_build_go_tags =
 etcd_build_go_cgo_enabled = 0
 #etcd_build_go_flags =


### PR DESCRIPTION
This now matches the version that was recently updated in `embedded-bins/etcd/Dockerfile`

Signed-off-by: Shane Jarych <sjarych@mirantis.com>