### PR TITLE
getting k0s status from k0s status socket

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -39,8 +39,10 @@ import (
 	"github.com/k0sproject/k0s/pkg/certificate"
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/component/controller"
+	"github.com/k0sproject/k0s/pkg/component/status"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
+	"github.com/k0sproject/k0s/pkg/install"
 	"github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/pkg/performance"
 	"github.com/k0sproject/k0s/pkg/telemetry"
@@ -293,6 +295,24 @@ func (c *CmdOpts) startController() error {
 			),
 		)
 	}
+
+	workload := false
+	if c.SingleNode || c.EnableWorker {
+		workload = true
+	}
+
+	componentManager.Add(&status.Status{
+		StatusInformation: install.K0sStatus{
+			Pid:           os.Getpid(),
+			Role:          "controller",
+			Args:          os.Args,
+			Version:       build.Version,
+			Workloads:     workload,
+			K0sVars:       c.K0sVars,
+			ClusterConfig: c.ClusterConfig,
+		},
+		Socket: config.StatusSocket,
+	})
 
 	perfTimer.Checkpoint("starting-component-init")
 	// init components

--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -61,16 +61,15 @@ func (c *CmdOpts) reset() error {
 		logger.Fatal("this command must be run as root!")
 	}
 
-	k0sStatus, _ := install.GetPid()
-	if k0sStatus.Pid != 0 {
+	k0sStatus, _ := install.GetStatusInfo(config.StatusSocket)
+	if k0sStatus != nil && k0sStatus.Pid != 0 {
 		logger.Fatal("k0s seems to be running! please stop k0s before reset.")
 	}
 
 	// Get Cleanup Config
 	cfg, err := cleanup.NewConfig(c.K0sVars, c.CfgFile, c.WorkerOptions.CriSocket)
 	if err != nil {
-		logger.Fatalf("failed to configure cleanup: %v", err)
-		return err
+		return fmt.Errorf("failed to configure cleanup: %v", err)
 	}
 
 	err = cfg.Cleanup()

--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -76,8 +76,8 @@ func (c *CmdOpts) restore(path string) error {
 		return fmt.Errorf("this command must be run as root")
 	}
 
-	k0sStatus, _ := install.GetPid()
-	if k0sStatus.Pid != 0 {
+	k0sStatus, _ := install.GetStatusInfo(config.StatusSocket)
+	if k0sStatus != nil && k0sStatus.Pid != 0 {
 		logger.Fatal("k0s seems to be running! k0s must be down during the restore operation.")
 	}
 

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -28,9 +28,12 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/k0sproject/k0s/internal/util"
+	"github.com/k0sproject/k0s/pkg/build"
 	"github.com/k0sproject/k0s/pkg/component"
+	"github.com/k0sproject/k0s/pkg/component/status"
 	"github.com/k0sproject/k0s/pkg/component/worker"
 	"github.com/k0sproject/k0s/pkg/config"
+	"github.com/k0sproject/k0s/pkg/install"
 )
 
 type CmdOpts config.CLIOptions
@@ -139,6 +142,20 @@ func (c *CmdOpts) StartWorker() error {
 		})
 	}
 
+	if !c.SingleNode && !c.EnableWorker {
+		componentManager.Add(&status.Status{
+			StatusInformation: install.K0sStatus{
+				Pid:           os.Getpid(),
+				Role:          "worker",
+				Args:          os.Args,
+				Version:       build.Version,
+				Workloads:     true,
+				K0sVars:       c.K0sVars,
+				ClusterConfig: c.ClusterConfig,
+			},
+			Socket: config.StatusSocket,
+		})
+	}
 	// extract needed components
 	if err := componentManager.Init(); err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/magiconair/properties v1.8.1
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/go-ps v1.0.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/olekukonko/tablewriter v0.0.2
 	github.com/onsi/ginkgo v1.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -641,8 +641,6 @@ github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFW
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
-github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -31,6 +31,7 @@ check-network-vm: bin/sonobuoy
 
 TIMEOUT ?= 4m
 
+check-ctr: TIMEOUT=10m
 check-byocri: TIMEOUT=5m
 # readiness check for metric tests takes between around 5 and 6 minutes.
 check-metrics: TIMEOUT=6m

--- a/pkg/component/status/status.go
+++ b/pkg/component/status/status.go
@@ -1,0 +1,79 @@
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/k0sproject/k0s/internal/util"
+	"github.com/k0sproject/k0s/pkg/install"
+	"github.com/sirupsen/logrus"
+)
+
+type Status struct {
+	StatusInformation install.K0sStatus
+	Socket            string
+	L                 *logrus.Entry
+	httpserver        http.Server
+	listener          net.Listener
+}
+
+// Healthy dummy implementation
+func (s *Status) Healthy() error { return nil }
+
+// Init initializes component
+func (s *Status) Init() error {
+	s.L = logrus.WithFields(logrus.Fields{"component": "status"})
+
+	var err error
+	s.httpserver = http.Server{
+		Handler: &statusHandler{Status: s},
+	}
+	err = util.InitDirectory(s.StatusInformation.K0sVars.RunDir, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %w", s.Socket, err)
+	}
+
+	s.listener, err = net.Listen("unix", s.Socket)
+	if err != nil {
+		s.L.Errorf("failed to create listener %s", err)
+		return err
+	}
+	s.L.Infof("Listening address %s", s.Socket)
+
+	return nil
+}
+
+// Run runs the component
+func (s *Status) Run() error {
+	go func() {
+		if err := s.httpserver.Serve(s.listener); err != nil {
+			s.L.Errorf("failed to start status server at %s: %s", s.Socket, err)
+		}
+	}()
+	return nil
+}
+
+// Stop stops status component and removes the unix socket
+func (s *Status) Stop() error {
+	defer os.Remove(s.Socket)
+	if err := s.httpserver.Shutdown(context.TODO()); err != nil {
+		return err
+	}
+	return nil
+}
+
+type statusHandler struct {
+	Status *Status
+}
+
+// ServerHTTP implementation of handler interface
+func (sh *statusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if json.NewEncoder(w).Encode(sh.Status.StatusInformation) != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -16,6 +16,7 @@ limitations under the License.
 package config
 
 import (
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -31,6 +32,7 @@ var (
 	DataDir        string
 	Debug          bool
 	DebugListenOn  string
+	StatusSocket   string
 	K0sVars        constant.CfgVars
 	workerOpts     WorkerOptions
 	controllerOpts ControllerOptions
@@ -94,6 +96,7 @@ func GetPersistentFlagSet() *pflag.FlagSet {
 	flagset.StringVarP(&CfgFile, "config", "c", "", "config file, use '-' to read the config from stdin")
 	flagset.BoolVarP(&Debug, "debug", "d", false, "Debug logging (default: false)")
 	flagset.StringVar(&DataDir, "data-dir", "", "Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!")
+	flagset.StringVar(&StatusSocket, "status-socket", filepath.Join(K0sVars.RunDir, "status.sock"), "Full file path to the socket file.")
 	flagset.StringVar(&DebugListenOn, "debugListenOn", ":6060", "Http listenOn for Debug pprof handler")
 	return flagset
 }

--- a/pkg/install/process.go
+++ b/pkg/install/process.go
@@ -16,135 +16,55 @@ limitations under the License.
 package install
 
 import (
+	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
-	"os/exec"
-	"runtime"
-	"strings"
+	"net"
+	"net/http"
 
-	"github.com/k0sproject/k0s/internal/util"
-	"github.com/mitchellh/go-ps"
-	"gopkg.in/yaml.v2"
+	config "github.com/k0sproject/k0s/pkg/apis/v1beta1"
+	"github.com/k0sproject/k0s/pkg/constant"
 )
 
 type K0sStatus struct {
-	Version  string
-	Pid      int
-	PPid     int
-	Role     string
-	SysInit  string
-	StubFile string
-	Output   string
+	Version       string
+	Pid           int
+	PPid          int
+	Role          string
+	SysInit       string
+	StubFile      string
+	Output        string
+	Workloads     bool
+	Args          []string
+	ClusterConfig *config.ClusterConfig
+	K0sVars       constant.CfgVars
 }
 
-func GetPid() (status *K0sStatus, err error) {
-	pid, ppid, err := getProcessID()
-	if err == nil && pid != nil {
-		status = &K0sStatus{
-			Pid:  *pid,
-			PPid: *ppid,
-		}
-		return status, nil
+func GetStatusInfo(socketPath string) (status *K0sStatus, err error) {
+	status = &K0sStatus{}
+
+	httpc := http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", socketPath)
+			},
+		},
 	}
-	return &K0sStatus{}, nil
-}
 
-func getProcessID() (pid *int, ppid *int, err error) {
-	processList, err := ps.Processes()
+	response, err := httpc.Get("http://localhost")
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
+	defer response.Body.Close()
 
-	for _, p := range processList {
-		if p.Executable() == "k0s" && hasChildren(p.Pid(), processList) {
-			pid := p.Pid()
-			ppid := p.PPid()
-			return &pid, &ppid, nil
-		}
-	}
-	return nil, nil, nil
-}
-
-func hasChildren(pid int, processes []ps.Process) bool {
-	for _, p := range processes {
-		if p.PPid() == pid {
-			return true
-		}
-	}
-	return false
-}
-
-func GetRoleByPID(pid int) (role string, err error) {
-	if runtime.GOOS == "windows" {
-		return "worker", nil
-	}
-
-	var raw []byte
-	if raw, err = ioutil.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid)); err != nil {
-		return "", err
-	}
-	cmdln := string(raw)
-	if strings.Contains(cmdln, "enable-worker") || strings.Contains(cmdln, "single") {
-		return "controller+worker", nil
-	} else if strings.Contains(cmdln, "controller") {
-		return "controller", nil
-	} else if strings.Contains(cmdln, "worker") {
-		return "worker", nil
-	} else if strings.Contains(cmdln, "server") {
-		return "controller", nil
-	}
-	return "", fmt.Errorf("k0s role is not found")
-}
-
-func (s K0sStatus) GetK0sVersion() (string, error) {
-	cmd := fmt.Sprintf("/proc/%d/exe", s.Pid)
-	stdout, err := exec.Command(cmd, "version").Output()
+	responseData, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return strings.TrimSuffix(string(stdout), "\n"), nil
-}
 
-func (s K0sStatus) String() {
-	switch s.Output {
-	case "json":
-		jsn, _ := json.MarshalIndent(s, "", "   ")
-		fmt.Println(string(jsn))
-	case "yaml":
-		ym, _ := yaml.Marshal(s)
-		fmt.Println(string(ym))
-	default:
-		if s.Pid == 0 {
-			fmt.Println("K0s not running")
-			return
-		}
-
-		fmt.Println("Version:", s.Version)
-		fmt.Println("Process ID:", s.Pid)
-		fmt.Println("Parent Process ID:", s.PPid)
-		fmt.Println("Role:", s.Role)
-
-		if s.SysInit != "" {
-			fmt.Println("Init System:", s.SysInit)
-
-		}
-		if s.StubFile != "" {
-			fmt.Println("Service file:", s.StubFile)
-		}
+	err = json.Unmarshal(responseData, status)
+	if err != nil {
+		return nil, err
 	}
-}
-
-// This function attempts to find out the host role, by staged binaries
-func GetRoleByStagedKubelet(binPath string) string {
-	apiBinary := fmt.Sprintf("%s/%s", binPath, "kube-apiserver")
-	kubeletBinary := fmt.Sprintf("%s/%s", binPath, "kubelet")
-
-	if util.FileExists(apiBinary) && util.FileExists(kubeletBinary) {
-		return "controller+worker"
-	} else if util.FileExists(apiBinary) {
-		return "controller"
-	} else {
-		return "worker"
-	}
+	return status, nil
 }


### PR DESCRIPTION
This PR introduces "status" sockets to transmit information about the running process. It will surface information as follows:
```
# k0s status -o json
[
   {
      "Version": "v1.21.0+k0s.0-164-g6050cc15",
      "Pid": 1577859,
      "PPid": 0,
      "Role": "controller",
      "SysInit": "",
      "StubFile": "",
      "Output": "",
      "Workload": true,
      "Args": [
         "./k0s",
         "controller",
         "--single"
      ],
      "ClusterConfig": {
         "APIVersion": "k0s.k0sproject.io/v1beta1",
         "Kind": "Cluster",
         "Metadata": {
            "Name": "k0s"
         },
         "Spec": {
            "API": {
               "Address": "147.75.33.177",
               "Port": 6443,
               "K0sAPIPort": 9443,
               "ExternalAddress": "",
               "SANs": [
                  "147.75.33.177",
                  "10.12.18.133",
                  "172.17.0.1",
                  "10.244.0.1"
               ],
               "ExtraArgs": {}
            },
            "ControllerManager": {
               "ExtraArgs": {}
            },
            "Scheduler": {
               "ExtraArgs": {}
            },
            "Storage": {
               "Type": "kine",
               "Kine": {
                  "DataSource": "sqlite:///var/lib/k0s/db/state.db?more=rwc\u0026_journal=WAL\u0026cache=shared"
               },
               "Etcd": null
            },
            "Network": {
               "PodCIDR": "10.244.0.0/16",
               "ServiceCIDR": "10.96.0.0/12",
               "Provider": "kuberouter",
               "Calico": null,
               "KubeRouter": {
                  "MTU": 0,
                  "PeerRouterIPs": "",
                  "PeerRouterASNs": "",
                  "AutoMTU": true
               },
               "DualStack": {
                  "Enabled": false,
                  "IPv6PodCIDR": "",
                  "IPv6ServiceCIDR": ""
               },
               "KubeProxy": {
                  "Disabled": false,
                  "Mode": "iptables"
               }
            },
            "PodSecurityPolicy": {
               "DefaultPolicy": "00-k0s-privileged"
            },
            "WorkerProfiles": null,
            "Telemetry": {
               "Enabled": true
            },
            "Install": {
               "SystemUsers": {
                  "Etcd": "etcd",
                  "Kine": "kube-apiserver",
                  "Konnectivity": "konnectivity-server",
                  "KubeAPIServer": "kube-apiserver",
                  "KubeScheduler": "kube-scheduler"
               }
            },
            "Images": {
               "Konnectivity": {
                  "Image": "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent",
                  "Version": "v0.0.20"
               },
               "MetricsServer": {
                  "Image": "gcr.io/k8s-staging-metrics-server/metrics-server",
                  "Version": "v0.3.7"
               },
               "KubeProxy": {
                  "Image": "k8s.gcr.io/kube-proxy",
                  "Version": "v1.21.2"
               },
               "CoreDNS": {
                  "Image": "docker.io/coredns/coredns",
                  "Version": "1.7.0"
               },
               "Calico": {
                  "CNI": {
                     "Image": "docker.io/calico/cni",
                     "Version": "v3.18.1"
                  },
                  "Node": {
                     "Image": "docker.io/calico/node",
                     "Version": "v3.18.1"
                  },
                  "KubeControllers": {
                     "Image": "docker.io/calico/kube-controllers",
                     "Version": "v3.18.1"
                  }
               },
               "KubeRouter": {
                  "CNI": {
                     "Image": "docker.io/cloudnativelabs/kube-router",
                     "Version": "v1.2.1"
                  },
                  "CNIInstaller": {
                     "Image": "quay.io/k0sproject/cni-node",
                     "Version": "0.1.0"
                  }
               },
               "Repository": "",
               "DefaultPullPolicy": "IfNotPresent"
            },
            "Extensions": null,
            "Konnectivity": {
               "AgentPort": 8132,
               "AdminPort": 8133
            }
         }
      },
      "K0sVars": {
         "AdminKubeConfigPath": "/var/lib/k0s/pki/admin.conf",
         "BinDir": "/var/lib/k0s/bin",
         "CertRootDir": "/var/lib/k0s/pki",
         "WindowsCertRootDir": "C:\\var\\lib\\k0s\\pki",
         "DataDir": "/var/lib/k0s",
         "EtcdCertDir": "/var/lib/k0s/pki/etcd",
         "EtcdDataDir": "/var/lib/k0s/etcd",
         "KineSocketPath": "/run/k0s/kine/kine.sock:2379",
         "KonnectivitySocketDir": "/run/k0s/konnectivity-server",
         "KubeletAuthConfigPath": "/var/lib/k0s/kubelet.conf",
         "KubeletBootstrapConfigPath": "/var/lib/k0s/kubelet-bootstrap.conf",
         "KubeletVolumePluginDir": "/usr/libexec/k0s/kubelet-plugins/volume/exec",
         "ManifestsDir": "/var/lib/k0s/manifests",
         "RunDir": "/run/k0s",
         "KonnectivityKubeConfigPath": "/var/lib/k0s/pki/konnectivity.conf",
         "OCIBundleDir": "/var/lib/k0s/images",
         "DefaultStorageType": "kine",
         "HelmHome": "/var/lib/k0s/helmhome",
         "HelmRepositoryCache": "/var/lib/k0s/helmhome/cache",
         "HelmRepositoryConfig": "/var/lib/k0s/helmhome/repositories.yaml"
      }
   }
]
```

or if running without out parameter it will return:
```
# ./k0s status 
Version: v1.21.0+k0s.0-164-g6050cc15
Process ID: 1577859
Role: controller
Workloads: true
```

This PR also removes the role "controller+worker" and introduces parameters workloads so instead of having "controller+worker" it will return Role: controller and Workloads: true to indicate that the controller is started as single node.

Also what might be confusing is that json and yaml will be returned as an array. This is because we need to be able to poll status in scenarios where users are running two instances of k0s on the same host. To make this work when k0s is bootstrapped as controller it will create rundir + controller.sock and worker.sock for worker instance.
