### PR TITLE
Konnectivity 0.0.21, runc 1.0.0, use go 1.16

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -24,7 +24,7 @@ kubernetes_build_go_flags = "-v"
 kubernetes_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
 kine_version = 0.6.0
-kine_buildimage = golang:1.15-alpine
+kine_buildimage = golang:1.16-alpine
 #kine_build_go_tags =
 #kine_build_go_cgo_enabled =
 #kine_build_go_flags =

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,5 @@
-runc_version = 1.0.0-rc95
-runc_buildimage = golang:1.15-alpine
+runc_version = 1.0.0
+runc_buildimage = golang:1.16-alpine
 runc_build_go_tags = "seccomp"
 #runc_build_go_cgo_enabled =
 #runc_build_go_flags =

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -39,8 +39,8 @@ etcd_build_go_cgo_enabled = 0
 etcd_build_go_ldflags = "-w -s"
 #etcd_build_go_ldflags_extra =
 
-konnectivity_version = 0.0.20
-konnectivity_buildimage = golang:1.15-alpine
+konnectivity_version = 0.0.21
+konnectivity_buildimage = golang:1.16-alpine
 #konnectivity_build_go_tags =
 konnectivity_build_go_cgo_enabled = 0
 konnectivity_build_go_flags = "-a"

--- a/embedded-bins/kine/Dockerfile
+++ b/embedded-bins/kine/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDIMAGE=golang:1.15-alpine
+ARG BUILDIMAGE=golang:1.16-alpine
 FROM $BUILDIMAGE AS build
 
 ARG VERSION

--- a/embedded-bins/konnectivity/Dockerfile
+++ b/embedded-bins/konnectivity/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDIMAGE=golang:1.15-alpine
+ARG BUILDIMAGE=golang:1.16-alpine
 FROM $BUILDIMAGE AS build
 
 ARG VERSION

--- a/embedded-bins/runc/Dockerfile
+++ b/embedded-bins/runc/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDIMAGE=golang:1.15-alpine
+ARG BUILDIMAGE=golang:1.16-alpine
 FROM $BUILDIMAGE AS build
 
 ARG VERSION

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -55,7 +55,7 @@ const (
 	DefaultPSP = "00-k0s-privileged"
 	// Image Constants
 	KonnectivityImage                  = "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent"
-	KonnectivityImageVersion           = "v0.0.20"
+	KonnectivityImageVersion           = "v0.0.21"
 	MetricsImage                       = "gcr.io/k8s-staging-metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.3.7"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"


### PR DESCRIPTION

**What this PR Includes**

- bump connectivity to 0.0.21 (fixes build on recent MacOS with M1 chip)
- bump runs to 1.0.0
- use go 1.16 to build kine