### PR TITLE
Configurable --run-dir

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -214,7 +214,7 @@ func (c *CmdOpts) startController() error {
 	// common factory to get the admin kube client that's needed in many components
 	adminClientFactory := kubernetes.NewAdminClientFactory(c.K0sVars)
 
-	componentManager.Add(&controller.APIServer{
+	componentManager.Add(&controller.KubeAPIServer{
 		ClusterConfig:      c.ClusterConfig,
 		K0sVars:            c.K0sVars,
 		LogLevel:           c.Logging["kube-apiserver"],

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -29,6 +29,7 @@ func NewStartCmd() *cobra.Command {
 		Use:   "start",
 		Short: "Start the k0s service configured on this host. Must be run as root (or with sudo)",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			if os.Geteuid() != 0 {
 				return fmt.Errorf("this command must be run as root")
 			}
@@ -38,7 +39,6 @@ func NewStartCmd() *cobra.Command {
 			}
 			status, _ := svc.Status()
 			if status == service.StatusRunning {
-				cmd.SilenceUsage = true
 				return fmt.Errorf("already running")
 			}
 			return svc.Start()

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -29,6 +29,7 @@ func NewStopCmd() *cobra.Command {
 		Use:   "stop",
 		Short: "Stop the k0s service configured on this host. Must be run as root (or with sudo)",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			if os.Geteuid() != 0 {
 				return fmt.Errorf("this command must be run as root")
 			}
@@ -36,12 +37,7 @@ func NewStopCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			status, err := svc.Status()
-			if err != nil {
-				return err
-			}
-			if status == service.StatusStopped {
-				cmd.SilenceUsage = true
+			if status, err := svc.Status(); err != nil || status == service.StatusStopped {
 				return fmt.Errorf("already stopped")
 			}
 			return svc.Stop()

--- a/pkg/apis/v1beta1/cluster_test.go
+++ b/pkg/apis/v1beta1/cluster_test.go
@@ -33,7 +33,7 @@ func TestClusterDefaults(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, c.Metadata)
 	assert.Equal(t, "k0s", c.Metadata.Name)
-	assert.Equal(t, DefaultStorageSpec(constant.GetConfig("")), c.Spec.Storage)
+	assert.Equal(t, DefaultStorageSpec(constant.GetConfig("", "")), c.Spec.Storage)
 }
 
 func TestStorageDefaults(t *testing.T) {

--- a/pkg/apis/v1beta1/images_test.go
+++ b/pkg/apis/v1beta1/images_test.go
@@ -33,7 +33,7 @@ func getConfigYAML(t *testing.T, c *ClusterConfig) []byte {
 
 func TestImagesRepoOverrideInConfiguration(t *testing.T) {
 	t.Run("if_has_repository_not_empty_add_prefix_to_all_images", func(t *testing.T) {
-		k0sVars := constant.GetConfig("")
+		k0sVars := constant.GetConfig("", "")
 		t.Run("default_config", func(t *testing.T) {
 			cfg := DefaultClusterConfig(k0sVars)
 			cfg.Spec.Images.Repository = "my.repo"

--- a/pkg/cleanup/cleanup_unix.go
+++ b/pkg/cleanup/cleanup_unix.go
@@ -18,8 +18,9 @@ package cleanup
 
 import (
 	"fmt"
-	"github.com/k0sproject/k0s/pkg/component/worker"
 	"os/exec"
+
+	"github.com/k0sproject/k0s/pkg/component/worker"
 
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/container/runtime"
@@ -42,17 +43,15 @@ type containerdConfig struct {
 }
 
 func NewConfig(k0sVars constant.CfgVars, cfgFile string, criSocketPath string) (*Config, error) {
-	runDir := "/run/k0s" // https://github.com/k0sproject/k0s/pull/591/commits/c3f932de85a0b209908ad39b817750efc4987395
-
 	var err error
 	var containerdCfg *containerdConfig
 	var runtimeType string
 
 	if criSocketPath == "" {
-		criSocketPath = fmt.Sprintf("unix:///%s/containerd.sock", runDir)
+		criSocketPath = fmt.Sprintf("unix:///%s/containerd.sock", k0sVars.RunDir)
 		containerdCfg = &containerdConfig{
 			binPath:    fmt.Sprintf("%s/%s", k0sVars.DataDir, "bin/containerd"),
-			socketPath: fmt.Sprintf("%s/containerd.sock", runDir),
+			socketPath: fmt.Sprintf("%s/containerd.sock", k0sVars.RunDir),
 		}
 		runtimeType = "cri"
 	} else {
@@ -67,7 +66,7 @@ func NewConfig(k0sVars constant.CfgVars, cfgFile string, criSocketPath string) (
 		containerd:       containerdCfg,
 		containerRuntime: runtime.NewContainerRuntime(runtimeType, criSocketPath),
 		dataDir:          k0sVars.DataDir,
-		runDir:           runDir,
+		runDir:           k0sVars.RunDir,
 		k0sVars:          k0sVars,
 	}, nil
 }

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -34,8 +34,8 @@ import (
 	"github.com/k0sproject/k0s/pkg/supervisor"
 )
 
-// APIServer implement the component interface to run kube api
-type APIServer struct {
+// KubeAPIServer implement the component interface to run kube api
+type KubeAPIServer struct {
 	ClusterConfig      *config.ClusterConfig
 	K0sVars            constant.CfgVars
 	LogLevel           string
@@ -73,7 +73,7 @@ type egressSelectorConfig struct {
 }
 
 // Init extracts needed binaries
-func (a *APIServer) Init() error {
+func (a *KubeAPIServer) Init() error {
 	var err error
 	a.uid, err = util.GetUID(constant.ApiserverUser)
 	if err != nil {
@@ -83,7 +83,7 @@ func (a *APIServer) Init() error {
 }
 
 // Run runs kube api
-func (a *APIServer) Run() error {
+func (a *KubeAPIServer) Run() error {
 	logrus.Info("Starting kube-apiserver")
 	args := map[string]string{
 		"advertise-address":                a.ClusterConfig.Spec.API.Address,
@@ -171,7 +171,7 @@ func (a *APIServer) Run() error {
 	return a.supervisor.Supervise()
 }
 
-func (a *APIServer) writeKonnectivityConfig() error {
+func (a *KubeAPIServer) writeKonnectivityConfig() error {
 	tw := util.TemplateWriter{
 		Name:     "konnectivity",
 		Template: egressSelectorConfigTemplate,
@@ -189,12 +189,12 @@ func (a *APIServer) writeKonnectivityConfig() error {
 }
 
 // Stop stops APIServer
-func (a *APIServer) Stop() error {
+func (a *KubeAPIServer) Stop() error {
 	return a.supervisor.Stop()
 }
 
 // Health-check interface
-func (a *APIServer) Healthy() error {
+func (a *KubeAPIServer) Healthy() error {
 	// Load client cert so the api can authenitcate the request.
 	certFile := path.Join(a.K0sVars.CertRootDir, "admin.crt")
 	keyFile := path.Join(a.K0sVars.CertRootDir, "admin.key")

--- a/pkg/component/controller/calico_test.go
+++ b/pkg/component/controller/calico_test.go
@@ -17,7 +17,7 @@ func (i inMemorySaver) Save(dst string, content []byte) error {
 }
 
 func TestCalicoManifests(t *testing.T) {
-	k0sVars := constant.GetConfig("")
+	k0sVars := constant.GetConfig("", "")
 	clusterConfig := v1beta1.DefaultClusterConfig(k0sVars)
 	clusterConfig.Spec.Network.Calico = v1beta1.DefaultCalico()
 	clusterConfig.Spec.Network.Provider = "calico"

--- a/pkg/component/controller/kubeletconfig_test.go
+++ b/pkg/component/controller/kubeletconfig_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var k0sVars = constant.GetConfig("")
+var k0sVars = constant.GetConfig("", "")
 
 func Test_KubeletConfig(t *testing.T) {
 	dnsAddr := "dns.local"

--- a/pkg/component/controller/metricserver_test.go
+++ b/pkg/component/controller/metricserver_test.go
@@ -16,8 +16,8 @@ import (
 func TestGetConfigWithZeroNodes(t *testing.T) {
 	fakeFactory := testutil.NewFakeClientFactory()
 
-	clusterCfg := v1beta1.DefaultClusterConfig(constant.GetConfig(""))
-	metrics, err := NewMetricServer(clusterCfg, constant.GetConfig("/foo/bar"), fakeFactory)
+	clusterCfg := v1beta1.DefaultClusterConfig(constant.GetConfig("", ""))
+	metrics, err := NewMetricServer(clusterCfg, constant.GetConfig("/foo/bar", ""), fakeFactory)
 	require.NoError(t, err)
 	cfg, err := metrics.getConfig()
 	require.NoError(t, err)
@@ -39,8 +39,8 @@ func TestGetConfigWithSomeNodes(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	clusterCfg := v1beta1.DefaultClusterConfig(constant.GetConfig(""))
-	metrics, err := NewMetricServer(clusterCfg, constant.GetConfig("/foo/bar"), fakeFactory)
+	clusterCfg := v1beta1.DefaultClusterConfig(constant.GetConfig("", ""))
+	metrics, err := NewMetricServer(clusterCfg, constant.GetConfig("/foo/bar", ""), fakeFactory)
 	require.NoError(t, err)
 	cfg, err := metrics.getConfig()
 	require.NoError(t, err)

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -26,6 +26,7 @@ import (
 var (
 	CfgFile        string
 	DataDir        string
+	RunDir         string
 	Debug          bool
 	DebugListenOn  string
 	K0sVars        constant.CfgVars
@@ -87,6 +88,7 @@ func GetPersistentFlagSet() *pflag.FlagSet {
 	flagset.StringVarP(&CfgFile, "config", "c", "", "config file, use '-' to read the config from stdin")
 	flagset.BoolVarP(&Debug, "debug", "d", false, "Debug logging (default: false)")
 	flagset.StringVar(&DataDir, "data-dir", "", "Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!")
+	flagset.StringVar(&RunDir, "run-dir", "", "Run Directory for k0s (default: /run/k0s (root), {data-dir}/run (non-root))")
 	flagset.StringVar(&DebugListenOn, "debugListenOn", ":6060", "Http listenOn for Debug pprof handler")
 	return flagset
 }
@@ -96,6 +98,7 @@ func GetPersistentFlagSet() *pflag.FlagSet {
 func GetKubeCtlFlagSet() *pflag.FlagSet {
 	flagset := &pflag.FlagSet{}
 	flagset.StringVar(&DataDir, "data-dir", "", "Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!")
+	flagset.StringVar(&RunDir, "run-dir", "", "Run Directory for k0s (default: /run/k0s (root), {data-dir}/run (non-root))")
 	flagset.BoolVar(&Debug, "debug", false, "Debug logging (default: false)")
 	return flagset
 }
@@ -137,7 +140,7 @@ func GetControllerFlags() *pflag.FlagSet {
 }
 
 func GetCmdOpts() CLIOptions {
-	K0sVars = constant.GetConfig(DataDir)
+	K0sVars = constant.GetConfig(DataDir, RunDir)
 
 	opts := CLIOptions{
 		ControllerOptions: controllerOpts,

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -99,7 +99,7 @@ type CfgVars struct {
 }
 
 // GetConfig returns the pointer to a Config struct
-func GetConfig(dataDir string) CfgVars {
+func GetConfig(dataDir, runDir string) CfgVars {
 	if dataDir == "" {
 		switch runtime.GOOS {
 		case "windows":
@@ -112,12 +112,14 @@ func GetConfig(dataDir string) CfgVars {
 	// fetch absolute path for dataDir
 	dataDir, _ = filepath.Abs(dataDir)
 
-	var runDir string
-	if os.Geteuid() == 0 {
-		runDir = "/run/k0s"
-	} else {
-		runDir = formatPath(dataDir, "run")
+	if runDir == "" {
+		if runtime.GOOS != "windows" && os.Geteuid() == 0 {
+			runDir = "/run/k0s"
+		} else {
+			runDir = formatPath(dataDir, "run")
+		}
 	}
+
 	certDir := formatPath(dataDir, "pki")
 	winCertDir := WinDataDirDefault + "\\pki" // hacky but we need it to be windows style even on linux machine
 	helmHome := formatPath(dataDir, "helmhome")

--- a/pkg/constant/constant_windows.go
+++ b/pkg/constant/constant_windows.go
@@ -27,8 +27,6 @@ const (
 	CertRootDir = "C:\\var\\lib\\k0s\\pki"
 	// BinDir defines the location for all pki related binaries
 	BinDir = "C:\\var\\lib\\k0s\\bin"
-	// RunDir run directory
-	RunDir = "C:\\run\\k0s"
 	// ManifestsDir stack applier directory
 	ManifestsDir = "C:\\var\\lib\\k0s\\manifests"
 	// KubeletVolumePluginDir defines the location for kubelet plugins volume executables


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

A silly attempt at making the rundir settable via `--run-dir` like the data-dir.

Obviously this is still merely a torso.

- On start-up, k0s should refuse to start if a pidfile exists in the rundir and the process listed in it exists. If a pidfile that was created more then X seconds ago exists but the process does not, it should expect the previous session crashed and clean up the rundir, maybe warn about it and start normally.
- A user running a single instance should not care about rundir.
- A user running multiple instances, should be able to set a different run dir for each instance.
- Commands like `k0s status` should use the default run-dir unless `--run-dir` given.
- Pid file, socket file, etc should have a constant name under the run-dir, `k0s.pid` and `k0s-status.sock` for example. To utilize the rundir, the operator should not need to know the role of the instance beforehand. You should be able to figure out the role by doing something like `curl --unix-socket=/run/k0s.1/k0s-status.sock http://localhost/ | grep '"Role":`.

