### PR TITLE
Add utils helper to perform strict unmarshaling but ignoring errors in the masked out fields

### DIFF
--- a/internal/util/yaml.go
+++ b/internal/util/yaml.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"gopkg.in/yaml.v2"
+	"regexp"
+	"strings"
+)
+
+var fieldNamePattern = regexp.MustCompile("field ([^ ]+)")
+
+// YamlUnmarshalStrictIgnoringFields does UnmarshalStrict but ignores type errors for given fields
+func YamlUnmarshalStrictIgnoringFields(in []byte, out interface{}, ignore []string) (err error) {
+	err = yaml.UnmarshalStrict(in, out)
+	if err == nil {
+		return nil
+	}
+	errYaml, isTypeError := err.(*yaml.TypeError)
+	if !isTypeError {
+		return err
+	}
+	for _, fieldErr := range errYaml.Errors {
+		if !strings.Contains(fieldErr, "not found in type") {
+			// we have some other error, just return error message
+			return errYaml
+		}
+		match := fieldNamePattern.FindStringSubmatch(fieldErr)
+		if match == nil {
+			// again some other error
+			return errYaml
+		}
+
+		if StringSliceContains(ignore, match[1]) {
+			continue
+		}
+		// we have type error but not for the masked fields, return error
+		return errYaml
+	}
+
+	return nil
+}

--- a/internal/util/yaml_test.go
+++ b/internal/util/yaml_test.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// ClusterConfig cluster manifest
+type testConfig struct {
+	StringA string `yaml:"stringA"`
+}
+
+func TestDoNotFailOnObsoleteFields(t *testing.T) {
+	t.Run("no_error_on_masked_fields", func(t *testing.T) {
+		input := `
+stringA: stringValue
+stringB: shouldBeIgnoredAndGiveNoError
+stringC: 
+  key: value
+`
+		tgt := testConfig{}
+		err := YamlUnmarshalStrictIgnoringFields([]byte(input), &tgt, []string{"stringC", "stringB"})
+		assert.NoError(t, err)
+		assert.Equal(t, "stringValue", tgt.StringA)
+	})
+
+	t.Run("error_on_non_masked_fields", func(t *testing.T) {
+		input := `
+stringA: stringValue
+stringB: shouldGiveErrorBecauseNotMasked
+stringC: 
+  key: value
+`
+		tgt := testConfig{}
+		err := YamlUnmarshalStrictIgnoringFields([]byte(input), &tgt, []string{"stringC"})
+		assert.Error(t, err)
+	})
+}

--- a/pkg/apis/v1beta1/cluster.go
+++ b/pkg/apis/v1beta1/cluster.go
@@ -17,11 +17,11 @@ package v1beta1
 
 import (
 	"fmt"
+	"github.com/k0sproject/k0s/internal/util"
 	"io/ioutil"
 	"os"
 
 	"github.com/k0sproject/k0s/pkg/constant"
-	"gopkg.in/yaml.v2"
 )
 
 // ClusterConfig cluster manifest
@@ -149,7 +149,7 @@ func ConfigFromStdin(k0sVars constant.CfgVars) (*ClusterConfig, error) {
 
 func configFromString(yml string, k0sVars constant.CfgVars) (*ClusterConfig, error) {
 	config := &ClusterConfig{k0sVars: k0sVars}
-	err := yaml.UnmarshalStrict([]byte(yml), &config)
+	err := util.YamlUnmarshalStrictIgnoringFields([]byte(yml), &config, []string{"interval"})
 	if err != nil {
 		return config, err
 	}


### PR DESCRIPTION
Add utils helper to perform strict unmarshaling but ignoring errors in the masked out fields

Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>



**Issue**
Fixes #994 
**What this PR Includes**
Adds small helper-wrapper to call yaml.UnmarshalStrict, inspects the err if happened, and ignores error if it was related to the dropped fields.