### PR TITLE
Move `k0s-cloud-provider` logic to Annotations

### DIFF
--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -562,11 +562,30 @@ func (s *FootlooseSuite) GetNodeLabels(node string, kc *kubernetes.Clientset) (m
 	return n.Labels, nil
 }
 
+// GetNodeLabels return the labels of given node
+func (s *FootlooseSuite) GetNodeAnnotations(node string, kc *kubernetes.Clientset) (map[string]string, error) {
+	n, err := kc.CoreV1().Nodes().Get(context.TODO(), node, v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return n.Annotations, nil
+}
+
 // AddNodeLabel adds a label to the provided node.
 func (s *FootlooseSuite) AddNodeLabel(node string, kc *kubernetes.Clientset, key string, value string) (*corev1.Node, error) {
-	labelKey := fmt.Sprintf("/metadata/labels/%s", jsonpointer.Escape(key))
-	labelPatch := fmt.Sprintf(`[{"op":"add", "path":"%s", "value":"%s" }]`, labelKey, value)
-	return kc.CoreV1().Nodes().Patch(context.TODO(), node, types.JSONPatchType, []byte(labelPatch), v1.PatchOptions{})
+	return nodeValuePatchAdd(node, kc, "/metadata/labels", key, value)
+}
+
+// AddNodeAnnotation adds an annotation to the provided node.
+func (s *FootlooseSuite) AddNodeAnnotation(node string, kc *kubernetes.Clientset, key string, value string) (*corev1.Node, error) {
+	return nodeValuePatchAdd(node, kc, "/metadata/annotations", key, value)
+}
+
+// nodeValuePatchAdd patch-adds a key/value to a specific path via the Node API
+func nodeValuePatchAdd(node string, kc *kubernetes.Clientset, path string, key string, value string) (*corev1.Node, error) {
+	keyPath := fmt.Sprintf("%s/%s", path, jsonpointer.Escape(key))
+	patch := fmt.Sprintf(`[{"op":"add", "path":"%s", "value":"%s" }]`, keyPath, value)
+	return kc.CoreV1().Nodes().Patch(context.TODO(), node, types.JSONPatchType, []byte(patch), v1.PatchOptions{})
 }
 
 // WaitForKubeAPI waits until we see kube API online on given node.

--- a/pkg/k0scloudprovider/addresses.go
+++ b/pkg/k0scloudprovider/addresses.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	ExternalIPLabel = "k0sproject.io/node-ip-external"
+	ExternalIPAnnotation = "k0sproject.io/node-ip-external"
 )
 
 // AddressCollector finds addresses on a node.
@@ -79,8 +79,8 @@ func populateExternalAddress(addrs *[]v1.NodeAddress, node *v1.Node) {
 		return
 	}
 
-	// Search the nodes labels for any external IP address definitions.
-	if externalIP, ok := node.Labels[ExternalIPLabel]; ok {
+	// Search the nodes annotations for any external IP address definitions.
+	if externalIP, ok := node.Annotations[ExternalIPAnnotation]; ok {
 		*addrs = append(*addrs, v1.NodeAddress{Type: v1.NodeExternalIP, Address: externalIP})
 	}
 }

--- a/pkg/k0scloudprovider/addresses_test.go
+++ b/pkg/k0scloudprovider/addresses_test.go
@@ -123,8 +123,8 @@ var testDataPopulateExternalAddress = []populateAddressTestData{
 		name: "Equality",
 		input: &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					ExternalIPLabel: "1.2.3.4",
+				Annotations: map[string]string{
+					ExternalIPAnnotation: "1.2.3.4",
 				},
 			},
 			Status: v1.NodeStatus{
@@ -139,7 +139,7 @@ var testDataPopulateExternalAddress = []populateAddressTestData{
 		name: "Missing",
 		input: &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{},
+				Annotations: map[string]string{},
 			},
 			Status: v1.NodeStatus{
 				Addresses: []v1.NodeAddress{},


### PR DESCRIPTION
The initial implementation of `k0s-cloud-provider` relied on querying `k0sproject.io/node-ip-external` node labels.  While this was fine for IPv4 addresses, the character restriction for labels prevented the use of IPv6 addresses.

Instead of using labels, use annotations instead which are not as restrictive as labels (and should have been used in the first place)

Going forward, the `k0sproject.io/node-ip-external` annotation should be used for both IPv4/6.

Fixes: #996