### PR TITLE
Bump containerd 1.4.8 (CVE-2021-32760)

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -6,7 +6,7 @@ runc_build_go_tags = "seccomp"
 #runc_build_go_ldflags =
 runc_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
-containerd_version = 1.4.7
+containerd_version = 1.4.8
 containerd_buildimage = golang:1.15-alpine
 containerd_build_go_tags = "apparmor,selinux"
 containerd_build_shim_go_cgo_enabled = 0


### PR DESCRIPTION
Signed-off-by: Natanael Copa <ncopa@mirantis.com>


**Issue**
Fixes CVE-2021-32760

