### PR TITLE
Cherry picks for july release

### DIFF
--- a/docs/airgap-install.md
+++ b/docs/airgap-install.md
@@ -84,7 +84,7 @@ spec:
         dstDir: /var/lib/k0s/images/
         perm: 0755
   k0s:
-    version: 1.21.2+k0s.0
+    version: 1.21.3+k0s.0
 ```
 
 ## 3. Ensure pull policy in the k0s.yaml (optional)

--- a/docs/cli/k0s_controller.md
+++ b/docs/cli/k0s_controller.md
@@ -23,11 +23,14 @@ k0s controller --token-file [path_to_file]
 ### Options
 
 ```shell
-      --cri-socket string   contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]
-      --enable-worker       enable worker (default false)
-  -h, --help                help for controller
-      --profile string      worker profile to use on the node (default "default")
-      --token-file string   Path to the file containing join-token.
+      --cri-socket string                              contrainer runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]
+      --enable-worker                                  enable worker (default false)
+  -h, --help                                           help for controller
+      --profile string                                 worker profile to use on the node (default "default")
+      --token-file string                              Path to the file containing join-token.
+      --enable-k0s-cloud-provider                      enables the k0s-cloud-provider (default false)
+      --k0s-cloud-provider-port int                    the port that k0s-cloud-provider binds on (default 10258)
+      --k0s-cloud-provider-update-frequency duration   the frequency of k0s-cloud-provider node updates (default 2m0s)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -4,7 +4,7 @@ k0s builds Kubernetes components in *providerless* mode, meaning that cloud prov
 
 ## 1. Enable cloud provider support in kubelet
 
-Even when all components are built with providerless mode, you must be able to enable cloud provider mode for kubelet. To do this, run the workers with `--enable-cloud-provider=true`, to enable `--cloud-provider=external` on the kubelet process.
+Even when all components are built with providerless mode, you must be able to enable cloud provider mode for kubelet. To do this, run the workers with `--enable-cloud-provider=true`.
 
 ## 2. Deploy the cloud provider
 

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -2,14 +2,43 @@
 
 k0s builds Kubernetes components in *providerless* mode, meaning that cloud providers are not built into k0s-managed Kubernetes components. As such, you must externally configure the cloud providers to enable their support in your k0s cluster (for more information on running Kubernetes with cloud providers, refer to the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/).
 
-## 1. Enable cloud provider support in kubelet
+## External Cloud Providers
+
+### Enable cloud provider support in kubelet
 
 Even when all components are built with providerless mode, you must be able to enable cloud provider mode for kubelet. To do this, run the workers with `--enable-cloud-provider=true`.
 
-## 2. Deploy the cloud provider
+### Deploy the cloud provider
 
 The easiest way to deploy cloud provider controllers is on the k0s cluster.
 
 Use the built-in [manifest deployer](manifests.md) built into k0s to deploy your cloud provider as a k0s-managed stack. Next, just drop all required manifests into the `/var/lib/k0s/manifests/aws/` directory, and k0s will handle the deployment.
 
 **Note**: The prerequisites for the various cloud providers can vary (for example, several require that configuration files be present on all of the nodes). Refer to your chosen cloud provider's documentation as necessary.
+
+## k0s Cloud Provider
+
+Alternatively, k0s provides its own lightweight cloud provider that can
+be used to statically assign `ExternalIP` values to worker nodes via
+Kubernetes annotations.  This is beneficial for those who need to expose
+worker nodes externally via static IP assignments.
+
+To enable this functionality, add the parameter `--enable-k0s-cloud-provider=true`
+to all controllers, and `--enable-cloud-provider=true` to all workers.
+
+Adding a static IP address to a node using `kubectl`:
+
+    kubectl annotate \
+        node <node> \
+        k0sproject.io/node-ip-external=<external IP>
+
+Both IPv4 and IPv6 addresses are supported.
+
+### Defaults
+
+The default node refresh interval is `2m`, which can be overridden using
+the `--k0s-cloud-provider-update-frequency=<duration>` parameter when launching
+the controller(s).
+
+The default port that the cloud provider binds to can be overridden using the
+`--k0s-cloud-provider-port=<int>` parameter when launching the controller(s).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,7 +78,7 @@ spec:
       version: v0.3.7
     kubeproxy:
       image: k8s.gcr.io/kube-proxy
-      version: v1.21.2
+      version: v1.21.3
     coredns:
       image: docker.io/coredns/coredns
       version: 1.7.0

--- a/docs/install.md
+++ b/docs/install.md
@@ -64,7 +64,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
     ```shell
     $ sudo k0s kubectl get nodes
     NAME   STATUS   ROLES    AGE    VERSION
-    k0s    Ready    <none>   4m6s   v1.21.2-k0s1
+    k0s    Ready    <none>   4m6s   v1.21.3-k0s1
     ```
 
 ## Uninstall k0s

--- a/docs/k0s-multi-node.md
+++ b/docs/k0s-multi-node.md
@@ -24,13 +24,13 @@ The download script accepts the following environment variables:
 
 | Variable                   | Purpose                                           |
 |:---------------------------|:--------------------------------------------------|
-| `K0S_VERSION=v1.21.2+k0s.0 | Select the version of k0s to be installed         |
+| `K0S_VERSION=v1.21.3+k0s.0 | Select the version of k0s to be installed         |
 | `DEBUG=true`               | Output commands and their arguments at execution. |
 
 **Note**: If you require environment variables and use sudo, you can do:
 
 ```shell
-curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.21.2+k0s.0 sh
+curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.21.3+k0s.0 sh
 ```
 
 ### 2. Bootstrap a controller node
@@ -119,7 +119,7 @@ To get general information about your k0s instance's status:
 
 ```shell
 $ sudo k0s status
-Version: v1.21.2+k0s.0
+Version: v1.21.3+k0s.0
 Process ID: 2769
 Parent Process ID: 1
 Role: controller
@@ -134,7 +134,7 @@ Use the Kubernetes 'kubectl' command-line tool that comes with k0s binary to dep
 ```shell
 $ sudo k0s kubectl get nodes
 NAME   STATUS   ROLES    AGE    VERSION
-k0s    Ready    <none>   4m6s   v1.21.2-k0s1
+k0s    Ready    <none>   4m6s   v1.21.3-k0s1
 ```
 
 You can also access your cluster easily with [Lens](https://k8slens.dev/), simply by copying the kubeconfig and pasting it to Lens:

--- a/docs/reset.md
+++ b/docs/reset.md
@@ -50,8 +50,8 @@ k0sctl can be used to connect each node and remove all k0s-related files and pro
     INFO ==> Running phase: Prepare hosts    
     INFO ==> Running phase: Gather k0s facts 
     INFO [ssh] 13.53.43.63:22: found existing configuration 
-    INFO [ssh] 13.53.43.63:22: is running k0s controller version 1.21.2+k0s.0 
-    INFO [ssh] 13.53.218.149:22: is running k0s worker version 1.21.2+k0s.0 
+    INFO [ssh] 13.53.43.63:22: is running k0s controller version 1.21.3+k0s.0
+    INFO [ssh] 13.53.218.149:22: is running k0s worker version 1.21.3+k0s.0
     INFO [ssh] 13.53.43.63:22: checking if worker  has joined 
     INFO ==> Running phase: Reset hosts      
     INFO [ssh] 13.53.43.63:22: stopping k0s           

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -52,7 +52,7 @@ You can configure the desired cluster version in the k0sctl configuration by set
 ```yaml
 spec:
   k0s:
-    version: 1.21.2+k0s.0
+    version: 1.21.3+k0s.0
 ```
 
 If you do not specify a version, k0sctl checks online for the latest version and defaults to it.
@@ -72,7 +72,7 @@ INFO[0027] [ssh] 10.0.0.17:22: waiting for node to become ready again
 INFO[0027] [ssh] 10.0.0.17:22: upgrade successful
 INFO[0027] ==> Running phase: Disconnect from hosts
 INFO[0027] ==> Finished in 27s
-INFO[0027] k0s cluster version 1.21.2+k0s.0 is now installed
+INFO[0027] k0s cluster version 1.21.3+k0s.0 is now installed
 INFO[0027] Tip: To access the cluster you can now fetch the admin kubeconfig using:
 INFO[0027]      k0sctl kubeconfig
 ```

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -6,7 +6,7 @@ runc_build_go_tags = "seccomp"
 #runc_build_go_ldflags =
 runc_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
-containerd_version = 1.4.6
+containerd_version = 1.4.8
 containerd_buildimage = golang:1.15-alpine
 containerd_build_go_tags = "apparmor,selinux"
 containerd_build_shim_go_cgo_enabled = 0

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -39,7 +39,7 @@ etcd_build_go_cgo_enabled = 0
 etcd_build_go_ldflags = "-w -s"
 #etcd_build_go_ldflags_extra =
 
-konnectivity_version = 0.0.21
+konnectivity_version = 0.0.22
 konnectivity_buildimage = golang:1.16-alpine
 #konnectivity_build_go_tags =
 konnectivity_build_go_cgo_enabled = 0

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,4 +1,4 @@
-runc_version = 1.0.0
+runc_version = 1.0.1
 runc_buildimage = golang:1.16-alpine
 runc_build_go_tags = "seccomp"
 #runc_build_go_cgo_enabled =

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -23,7 +23,7 @@ kubernetes_build_go_flags = "-v"
 #kubernetes_build_go_ldflags =
 kubernetes_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
-kine_version = 0.6.0
+kine_version = 0.6.3
 kine_buildimage = golang:1.16-alpine
 #kine_build_go_tags =
 #kine_build_go_cgo_enabled =

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -15,7 +15,7 @@ containerd_build_shim_go_cgo_enabled = 0
 #containerd_build_go_ldflags =
 containerd_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
-kubernetes_version = 1.21.2
+kubernetes_version = 1.21.3
 kubernetes_buildimage = golang:1.16-alpine
 kubernetes_build_go_tags = "providerless"
 #kubernetes_build_go_cgo_enabled =

--- a/examples/footloose-ha-controllers/Dockerfile
+++ b/examples/footloose-ha-controllers/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/footloose/ubuntu18.04
 
 ADD k0s.service /etc/systemd/system/k0s.service
 
-RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.21.2/bin/linux/amd64/kubectl && \
+RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.21.3/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -42,7 +42,7 @@ check-customports: TIMEOUT=6m
 include Makefile.variables
 
 $(smoketests): .footloose-alpine.stamp
-	K0S_IMAGES_BUNDLE=$(realpath ../image-bundle/bundle.tar) K0S_PATH=$(realpath ../k0s) go test -count=1 -v -timeout $(TIMEOUT) github.com/k0sproject/k0s/inttest/$(subst check-,,$@)
+	K0S_IMAGES_BUNDLE="$(realpath ../image-bundle/bundle.tar)" K0S_PATH="$(realpath ../k0s)" go test -count=1 -v -timeout $(TIMEOUT) github.com/k0sproject/k0s/inttest/$(subst check-,,$@)
 
 .PHONY: clean
 clean:

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -562,11 +562,30 @@ func (s *FootlooseSuite) GetNodeLabels(node string, kc *kubernetes.Clientset) (m
 	return n.Labels, nil
 }
 
+// GetNodeLabels return the labels of given node
+func (s *FootlooseSuite) GetNodeAnnotations(node string, kc *kubernetes.Clientset) (map[string]string, error) {
+	n, err := kc.CoreV1().Nodes().Get(context.TODO(), node, v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return n.Annotations, nil
+}
+
 // AddNodeLabel adds a label to the provided node.
 func (s *FootlooseSuite) AddNodeLabel(node string, kc *kubernetes.Clientset, key string, value string) (*corev1.Node, error) {
-	labelKey := fmt.Sprintf("/metadata/labels/%s", jsonpointer.Escape(key))
-	labelPatch := fmt.Sprintf(`[{"op":"add", "path":"%s", "value":"%s" }]`, labelKey, value)
-	return kc.CoreV1().Nodes().Patch(context.TODO(), node, types.JSONPatchType, []byte(labelPatch), v1.PatchOptions{})
+	return nodeValuePatchAdd(node, kc, "/metadata/labels", key, value)
+}
+
+// AddNodeAnnotation adds an annotation to the provided node.
+func (s *FootlooseSuite) AddNodeAnnotation(node string, kc *kubernetes.Clientset, key string, value string) (*corev1.Node, error) {
+	return nodeValuePatchAdd(node, kc, "/metadata/annotations", key, value)
+}
+
+// nodeValuePatchAdd patch-adds a key/value to a specific path via the Node API
+func nodeValuePatchAdd(node string, kc *kubernetes.Clientset, path string, key string, value string) (*corev1.Node, error) {
+	keyPath := fmt.Sprintf("%s/%s", path, jsonpointer.Escape(key))
+	patch := fmt.Sprintf(`[{"op":"add", "path":"%s", "value":"%s" }]`, keyPath, value)
+	return kc.CoreV1().Nodes().Patch(context.TODO(), node, types.JSONPatchType, []byte(patch), v1.PatchOptions{})
 }
 
 // WaitForKubeAPI waits until we see kube API online on given node.

--- a/inttest/conformance/README.md
+++ b/inttest/conformance/README.md
@@ -36,14 +36,14 @@ In the same directory as your `main.tf` file, create an additional file `terrafo
 
 ```terraform
 k0s_version=v0.9.0
-k8s_version=v1.21.2
+k8s_version=v1.21.3
 onobuoy_version=0.20.0
 ```
 
 ### 2. Environment variables
 
 ```shell
-TF_VAR_k0s_version=v0.7.0-beta1 TF_VAR_sonobuoy_version=0.18.0 TF_VAR_k8s_version=v1.21.2 terraform apply
+TF_VAR_k0s_version=v0.7.0-beta1 TF_VAR_sonobuoy_version=0.18.0 TF_VAR_k8s_version=v1.21.3 terraform apply
 ```
 
 **NOTE:** By default, terraform will fetch sonobuoy version **0.20.0**. If you want to use a different version you can override this with one of the above methods.

--- a/inttest/conformance/terraform/main.tf
+++ b/inttest/conformance/terraform/main.tf
@@ -13,7 +13,7 @@ variable "sonobuoy_version" {
 }
 
 variable "k8s_version" {
-  // format: v1.21.2
+  // format: v1.21.3
   type = string
 }
 

--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13
 
-ENV KUBE_VERSION=1.21.2
+ENV KUBE_VERSION=1.21.3
 
 RUN apk add openrc openssh-server bash busybox-initscripts coreutils findutils iptables curl haproxy
 # enable syslog and sshd

--- a/inttest/sonobuoy/signetwork_test.go
+++ b/inttest/sonobuoy/signetwork_test.go
@@ -70,7 +70,7 @@ func (s *NetworkSuite) TestSigNetwork() {
 		`--e2e-focus=\[sig-network\].*\[Conformance\]`,
 		`--e2e-skip=\[Serial\]`,
 		"--e2e-parallel=y",
-		"--kube-conformance-image-version=v1.21.2",
+		"--kube-conformance-image-version=v1.21.3",
 	}
 	s.T().Log("running sonobuoy, this may take a while")
 	sonoFinished := make(chan bool)

--- a/pkg/cleanup/bridge_linux.go
+++ b/pkg/cleanup/bridge_linux.go
@@ -1,0 +1,49 @@
+package cleanup
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/vishvananda/netlink"
+)
+
+type bridge struct {
+	link netlink.Link
+}
+
+// Name returns the name of the step
+func (b *bridge) Name() string {
+	return "kube-bridge leftovers cleanup step"
+}
+
+// NeedsToRun checks if there are and kube-bridge leftovers
+func (b *bridge) NeedsToRun() bool {
+	if runtime.GOOS == "windows" {
+		return false
+	}
+	linkName := "kube-bridge"
+	lnks, err := netlink.LinkList()
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return false
+	}
+
+	for _, l := range lnks {
+		if l.Attrs().Name == linkName {
+			b.link = l
+			return true
+		}
+
+	}
+
+	return false
+}
+
+// Run removes found kube-bridge leftovers
+func (b *bridge) Run() error {
+	err := netlink.LinkDel(b.link)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/cleanup/bridge_windows.go
+++ b/pkg/cleanup/bridge_windows.go
@@ -1,0 +1,19 @@
+package cleanup
+
+type bridge struct {
+}
+
+// Name returns the name of the step
+func (b *bridge) Name() string {
+	return "kube-bridge leftovers cleanup step"
+}
+
+// NeedsToRun checks if there are and kube-bridge leftovers
+func (b *bridge) NeedsToRun() bool {
+	return false
+}
+
+// Run removes found kube-bridge leftovers
+func (b *bridge) Run() error {
+	return nil
+}

--- a/pkg/cleanup/cleanup_unix.go
+++ b/pkg/cleanup/cleanup_unix.go
@@ -18,8 +18,9 @@ package cleanup
 
 import (
 	"fmt"
-	"github.com/k0sproject/k0s/pkg/component/worker"
 	"os/exec"
+
+	"github.com/k0sproject/k0s/pkg/component/worker"
 
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/container/runtime"
@@ -80,6 +81,7 @@ func (c *Config) Cleanup() error {
 		&services{Config: c},
 		&directories{Config: c},
 		&cni{Config: c},
+		&bridge{},
 	}
 
 	for _, step := range cleanupSteps {

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -55,7 +55,7 @@ const (
 	DefaultPSP = "00-k0s-privileged"
 	// Image Constants
 	KonnectivityImage                  = "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent"
-	KonnectivityImageVersion           = "v0.0.21"
+	KonnectivityImageVersion           = "v0.0.22"
 	MetricsImage                       = "gcr.io/k8s-staging-metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.3.7"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -59,7 +59,7 @@ const (
 	MetricsImage                       = "gcr.io/k8s-staging-metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.3.7"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"
-	KubeProxyImageVersion              = "v1.21.2"
+	KubeProxyImageVersion              = "v1.21.3"
 	CoreDNSImage                       = "docker.io/coredns/coredns"
 	CoreDNSImageVersion                = "1.7.0"
 	CalicoImage                        = "docker.io/calico/cni"

--- a/pkg/k0scloudprovider/addresses.go
+++ b/pkg/k0scloudprovider/addresses.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	ExternalIPLabel = "k0sproject.io/node-ip-external"
+	ExternalIPAnnotation = "k0sproject.io/node-ip-external"
 )
 
 // AddressCollector finds addresses on a node.
@@ -79,8 +79,8 @@ func populateExternalAddress(addrs *[]v1.NodeAddress, node *v1.Node) {
 		return
 	}
 
-	// Search the nodes labels for any external IP address definitions.
-	if externalIP, ok := node.Labels[ExternalIPLabel]; ok {
+	// Search the nodes annotations for any external IP address definitions.
+	if externalIP, ok := node.Annotations[ExternalIPAnnotation]; ok {
 		*addrs = append(*addrs, v1.NodeAddress{Type: v1.NodeExternalIP, Address: externalIP})
 	}
 }

--- a/pkg/k0scloudprovider/addresses_test.go
+++ b/pkg/k0scloudprovider/addresses_test.go
@@ -123,8 +123,8 @@ var testDataPopulateExternalAddress = []populateAddressTestData{
 		name: "Equality",
 		input: &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					ExternalIPLabel: "1.2.3.4",
+				Annotations: map[string]string{
+					ExternalIPAnnotation: "1.2.3.4",
 				},
 			},
 			Status: v1.NodeStatus{
@@ -139,7 +139,7 @@ var testDataPopulateExternalAddress = []populateAddressTestData{
 		name: "Missing",
 		input: &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{},
+				Annotations: map[string]string{},
 			},
 			Status: v1.NodeStatus{
 				Addresses: []v1.NodeAddress{},


### PR DESCRIPTION
## Includes cherry-picks from `main`:
- #1006
- https://github.com/k0sproject/k0s/pull/1021
- https://github.com/k0sproject/k0s/pull/1020
- https://github.com/k0sproject/k0s/pull/1018
- https://github.com/k0sproject/k0s/pull/1005 (which fixes #996)
- https://github.com/k0sproject/k0s/pull/1009 (fix for https://github.com/k0sproject/k0sctl/issues/167)
- https://github.com/k0sproject/k0s/pull/1012
- https://github.com/k0sproject/k0s/pull/1015
- 
## Includes a diversion from `main`:
- kine 0.6.3 (main has [kine 0.7.x](https://github.com/k0sproject/k0s/commit/3341692f54c5b06485197b52372754f6a6376e67))

Diff from main:
```diff
diff --git a/embedded-bins/Makefile.variables b/embedded-bins/Makefile.variables
index 8aa565e1..bff74583 100644
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -23,7 +23,7 @@ kubernetes_build_go_flags = "-v"
 #kubernetes_build_go_ldflags =
 kubernetes_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
-kine_version = 0.7.1
+kine_version = 0.6.3
 kine_buildimage = golang:1.16-alpine
 #kine_build_go_tags =
 #kine_build_go_cgo_enabled =
```
