### PR TITLE
feat(konnectivity): add 'disabled' to allow disable konnectivity

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -219,7 +219,7 @@ func (c *CmdOpts) startController() error {
 		K0sVars:            c.K0sVars,
 		LogLevel:           c.Logging["kube-apiserver"],
 		Storage:            storageBackend,
-		EnableKonnectivity: !c.SingleNode,
+		EnableKonnectivity: !c.ClusterConfig.Spec.Konnectivity.Disabled && !c.SingleNode,
 	})
 
 	if c.ClusterConfig.Spec.API.ExternalAddress != "" {
@@ -228,7 +228,7 @@ func (c *CmdOpts) startController() error {
 			KubeClientFactory: adminClientFactory,
 		})
 	}
-	if !c.SingleNode {
+	if !c.ClusterConfig.Spec.Konnectivity.Disabled && !c.SingleNode {
 		componentManager.Add(&controller.Konnectivity{
 			ClusterConfig:     c.ClusterConfig,
 			LogLevel:          c.Logging["konnectivity-server"],

--- a/pkg/apis/v1beta1/konnectivity.go
+++ b/pkg/apis/v1beta1/konnectivity.go
@@ -20,6 +20,7 @@ var _ Validateable = (*KonnectivitySpec)(nil)
 
 // KonnectivitySpec ...
 type KonnectivitySpec struct {
+	Disabled  bool  `yaml:"disabled,omitempty"`
 	AgentPort int64 `yaml:"agentPort,omitempty"`
 	AdminPort int64 `yaml:"adminPort,omitempty"`
 }


### PR DESCRIPTION
add 'disabled' to allow disable konnectivity

Signed-off-by: mritd <mritd@linux.com>

**What this PR Includes**

In some cases, we don't need the konnectivity service; 
this PR adds a 'disabled' option to disable the konnectivity service.