### PR TITLE
Add spec.api.bindAddress configuration

### DIFF
--- a/cmd/controller/certificates.go
+++ b/cmd/controller/certificates.go
@@ -83,7 +83,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 		return fmt.Errorf("failed to read ca cert: %w", err)
 	}
 	c.CACert = string(cert)
-	kubeConfigAPIUrl := fmt.Sprintf("https://localhost:%d", c.ClusterSpec.API.Port)
+	kubeConfigAPIUrl := fmt.Sprintf("https://%s:%d", c.ClusterSpec.API.APIServerAddress(), c.ClusterSpec.API.Port)
 	eg.Go(func() error {
 		// Front proxy CA
 		if err := c.CertManager.EnsureCA("front-proxy-ca", "kubernetes-front-proxy-ca"); err != nil {

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -162,6 +162,7 @@ func (c *CmdOpts) startController(ctx context.Context) error {
 	}
 
 	logrus.Infof("using api address: %s", c.NodeConfig.Spec.API.Address)
+	logrus.Infof("using api bind-address: %s", c.NodeConfig.Spec.API.BindAddress)
 	logrus.Infof("using listen port: %d", c.NodeConfig.Spec.API.Port)
 	logrus.Infof("using sans: %s", c.NodeConfig.Spec.API.SANs)
 	dnsAddress, err := c.NodeConfig.Spec.Network.DNSAddress()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,7 @@ spec:
   api:
     address: 192.168.68.104
     port: 6443
+    bindAddress: 0.0.0.0
     k0sApiPort: 9443
     externalAddress: my-lb-address.example.com
     sans:
@@ -125,7 +126,8 @@ spec:
 | Element           | Description                                                                                                                                                                                                                 |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `externalAddress` | The loadbalancer address (for k0s controllers running behind a loadbalancer). Configures all cluster components to connect to this address and also configures this address for use  when joining new nodes to the cluster. |
-| `address`         | Local address on which to bind an API. Also serves as one of the addresses pushed on the k0s create service certificate on the API. Defaults to first non-local address found on the node.                                  |
+| `address`         | Local address on which to bind an API. Also serves as one of the addresses pushed on the k0s create service certificate on the API. Defaults to first non-local address found on the node.                                 |
+| `bindAddress`     | Local address on which to bind the kube-apiserver. Defaults to 0.0.0.0.    |
 | `sans`            | List of additional addresses to push to API servers serving the certificate.                                                                                                                                                |
 | `extraArgs`       | Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process.                                                                                                                          |
 | `port`¹           | Custom port for kube-api server to listen on (default: 6443)                                                                                                                                                                |

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/api.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/api.go
@@ -56,6 +56,7 @@ func DefaultAPISpec() *APISpec {
 	return &APISpec{
 		Port:                   6443,
 		K0sAPIPort:             9443,
+		BindAddress:            "0.0.0.0",
 		SANs:                   addresses,
 		Address:                publicAddress,
 		ExtraArgs:              make(map[string]string),
@@ -98,6 +99,20 @@ func (a *APISpec) getExternalURIForPort(port int) string {
 	return fmt.Sprintf("https://%s:%d", addr, port)
 }
 
+// APIServerAddress returns the address the API is listening on
+func (a *APISpec) APIServerAddress() string {
+	return a.getAPIServerAddress(a.BindAddress)
+}
+
+func (a *APISpec) getAPIServerAddress(address string) string {
+	switch address {
+	case "0.0.0.0":
+		return "localhost"
+	default:
+		return address
+	}
+}
+
 // Sans return the given SANS plus all local adresses and externalAddress if given
 func (a *APISpec) Sans() []string {
 	sans, _ := iface.AllAddresses()
@@ -126,6 +141,10 @@ func (a *APISpec) Validate() []error {
 
 	if !govalidator.IsIP(a.Address) {
 		errors = append(errors, fmt.Errorf("spec.api.address: %q is not IP address", a.Address))
+	}
+
+	if !govalidator.IsIP(a.BindAddress) {
+		errors = append(errors, fmt.Errorf("spec.api.bindAddress: %q is not IP address", a.BindAddress))
 	}
 
 	return errors

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/api.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/api.go
@@ -32,6 +32,9 @@ type APISpec struct {
 	// Local address on which to bind an API
 	Address string `json:"address"`
 
+	// Local address on which to bind the kube-apiserver. Defaults to 0.0.0.0.
+	BindAddress string `json:"bindAddress,omitempty"`
+
 	// The loadbalancer address (for k0s controllers running behind a loadbalancer)
 	ExternalAddress string `json:"externalAddress,omitempty"`
 	// TunneledNetworkingMode indicates if we access to KAS through konnectivity tunnel

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/api.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/api.go
@@ -108,18 +108,14 @@ func (a *APISpec) APIServerAddress() string {
 }
 
 func (a *APISpec) getAPIServerAddress(address string) string {
-	switch address {
-	case "0.0.0.0":
-		return "localhost"
-	default:
-		return address
-	}
+	return address
 }
 
 // Sans return the given SANS plus all local adresses and externalAddress if given
 func (a *APISpec) Sans() []string {
 	sans, _ := iface.AllAddresses()
 	sans = append(sans, a.Address)
+	sans = append(sans, a.BindAddress)
 	sans = append(sans, a.SANs...)
 	if a.ExternalAddress != "" {
 		sans = append(sans, a.ExternalAddress)

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/api_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/api_test.go
@@ -36,6 +36,7 @@ func (s *APISuite) TestValidation() {
 	s.T().Run("accepts_ipv6_as_address", func(t *testing.T) {
 		a := APISpec{
 			Address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+			BindAddress: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
 		}
 
 		s.Nil(a.Validate())
@@ -45,6 +46,7 @@ func (s *APISuite) TestValidation() {
 	s.T().Run("invalid_api_address", func(t *testing.T) {
 		a := APISpec{
 			Address: "somehting.that.is.not.valid//(())",
+			BindAddress: "0.0.0.0",
 		}
 
 		errors := a.Validate()
@@ -56,6 +58,7 @@ func (s *APISuite) TestValidation() {
 	s.T().Run("invalid_sans_address", func(t *testing.T) {
 		a := APISpec{
 			Address: "1.2.3.4",
+			BindAddress: "0.0.0.0",
 			SANs: []string{
 				"somehting.that.is.not.valid//(())",
 			},
@@ -65,6 +68,18 @@ func (s *APISuite) TestValidation() {
 		s.NotNil(errors)
 		s.Len(errors, 1)
 		s.Contains(errors[0].Error(), "is not a valid address for sans")
+	})
+
+	s.T().Run("invalid_api_bind_address", func(t *testing.T) {
+		a := APISpec{
+			Address: "1.2.3.4",
+			BindAddress: "somehting.that.is.not.valid//(())",
+		}
+
+		errors := a.Validate()
+		s.NotNil(errors)
+		s.Len(errors, 1)
+		s.Contains(errors[0].Error(), "is not IP address")
 	})
 }
 

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -95,6 +95,7 @@ func (a *APIServer) Run(_ context.Context) error {
 	logrus.Info("Starting kube-apiserver")
 	args := stringmap.StringMap{
 		"advertise-address":                a.ClusterConfig.Spec.API.Address,
+		"bind-address":                     a.ClusterConfig.Spec.API.BindAddress,
 		"secure-port":                      fmt.Sprintf("%d", a.ClusterConfig.Spec.API.Port),
 		"authorization-mode":               "Node,RBAC",
 		"client-ca-file":                   path.Join(a.K0sVars.CertRootDir, "ca.crt"),
@@ -223,7 +224,7 @@ func (a *APIServer) Healthy() error {
 		TLSClientConfig: tlsConfig,
 	}
 	client := &http.Client{Transport: tr}
-	resp, err := client.Get(fmt.Sprintf("https://localhost:%d/readyz?verbose", a.ClusterConfig.Spec.API.Port))
+	resp, err := client.Get(fmt.Sprintf("https://%s:%d/readyz?verbose", a.ClusterConfig.Spec.API.APIServerAddress(), a.ClusterConfig.Spec.API.Port))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Should a new `bindAddress` option be created and change documentation for the existing `address` option, or should the existing `address` option's behavior be changed to match the existing documentation?

The later I can see causing some issues with existing setups, `bindAddress` is probably the safest route. Currently the default for `bindAddress` is "0.0.0.0", which is the default kube-api-server uses if the `--bind-address` flag isn't used.

**Issue**
Fixes #957

**What this PR Includes**
Adds the ability to define a `bindAddress` for the kube-api-server.