### PR TITLE
Updated extensions structure in docs

### DIFF
--- a/docs/helm-charts.md
+++ b/docs/helm-charts.md
@@ -1,6 +1,6 @@
 # Helm Charts
 
-Defining your extensions as Helm charts is one of two methods you can use to run k0s with your preferred extensions (the other being through the use of [Manifest Deployer](manifests.md).
+Defining your extensions as Helm charts is one of two methods you can use to run k0s with your preferred extensions (the other being through the use of [Manifest Deployer](manifests.md)).
 
 k0s supports two methods for deploying applications using Helm charts:
 

--- a/docs/manifests.md
+++ b/docs/manifests.md
@@ -1,6 +1,6 @@
 # Manifest Deployer
 
-Included with k0s, Manifest Deployer is one of two methods you can use to run k0s with your preferred extensions (the other being by [defining your extensions as Helm charts](helm-charts.md).
+Included with k0s, Manifest Deployer is one of two methods you can use to run k0s with your preferred extensions (the other being by defining your extensions as [Helm charts](helm-charts.md)).
 
 ## Overview
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,18 +31,17 @@ nav:
       - Networking (CNI):                 networking.md
       - Runtime (CRI):                    runtime.md
       - Storage (CSI):                    storage.md
+      - Manifest Deployer:                manifests.md
+      - Helm Charts:                      helm-charts.md
       - Cloud Providers:                  cloud-providers.md
       - IPv4/IPv6 Dual-Stack:             dual-stack.md
       - Control Plane High Availability:  high-availability.md
       - Shell Completion:                 shell-completion.md
       - User Management:                  user-management.md
   - Extensions:
-      - Manifest Deployer:                manifests.md
-      - Helm Charts:                      helm-charts.md
-      - Examples:
-          - Traefik Ingress Controller:   examples/traefik-ingress.md
-          - Ambassador Gateway:           examples/ambassador-ingress.md
-          - Ceph Storage with Rook:       examples/rook-ceph.md
+      - Traefik Ingress Controller:       examples/traefik-ingress.md
+      - Ambassador Gateway:               examples/ambassador-ingress.md
+      - Ceph Storage with Rook:           examples/rook-ceph.md
   - Troubleshooting:
       - FAQ:                              FAQ.md
       - Common Pitfalls:                  troubleshooting.md


### PR DESCRIPTION
**What this PR Includes**

- Previously the extension examples were difficult to find in the docs. To solve this, they were moved from level 3 to level 2.
- Manifest Deployer and Helm chart pages were moved to the Usage section to make room for extension examples.
- Few minor changes/corrections.

Signed-off-by: mviitanen <mviitanen@mirantis.com>
