### PR TITLE
Bundle statically built iptables

### DIFF
--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -7,7 +7,7 @@ TARGET_OS ?= linux
 export TARGET_OS
 
 bindir = staging/${TARGET_OS}/bin
-posix_bins = runc kubelet containerd containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2 kube-apiserver kube-scheduler kube-controller-manager etcd kine konnectivity-server
+posix_bins = runc kubelet containerd containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2 kube-apiserver kube-scheduler kube-controller-manager etcd kine konnectivity-server xtables-legacy-multi
 windows_bins = kubelet.exe kube-proxy.exe
 buildmode = docker
 
@@ -53,6 +53,7 @@ $(bindir)/etcd: .container.etcd
 $(bindir)/kine: .container.kine
 $(bindir)/konnectivity-server: .container.konnectivity
 $(bindir)/kubelet $(bindir)/kube-apiserver $(bindir)/kube-scheduler $(bindir)/kube-controller-manager: .container.kubernetes
+$(bindir)/xtables-legacy-multi: .container.iptables
 
 $(bindir)/kubelet.exe $(bindir)/kube-proxy.exe: .container.kubernetes.windows
 

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -46,3 +46,6 @@ konnectivity_build_go_cgo_enabled = 0
 konnectivity_build_go_flags = "-a"
 konnectivity_build_go_ldflags = "-w -s"
 konnectivity_build_go_ldflags_extra = "-extldflags=-static"
+
+iptables_version = 1.8.7
+iptables_buildimage = alpine:3.14

--- a/embedded-bins/iptables/Dockerfile
+++ b/embedded-bins/iptables/Dockerfile
@@ -1,0 +1,23 @@
+ARG BUILDIMAGE=alpine:3.14
+FROM $BUILDIMAGE AS build
+
+ARG VERSION
+RUN apk add build-base git file curl \
+	linux-headers pkgconf libnftnl-dev bison flex
+
+RUN curl -L https://www.netfilter.org/projects/iptables/files/iptables-$VERSION.tar.bz2 \
+	| tar -C / -jx
+
+RUN cd /iptables-$VERSION && CFLAGS="-Os" ./configure --sysconfdir=/etc --disable-shared --disable-nftables --without-kernel --disable-devel
+
+RUN make -j$(nproc) -C /iptables-$VERSION LDFLAGS=-all-static
+RUN make -j$(nproc) -C /iptables-$VERSION install
+
+RUN strip /usr/local/sbin/xtables-legacy-multi
+RUN scanelf -Rn /usr/local && file /usr/local/sbin/*
+
+FROM scratch
+COPY --from=build /usr/local/sbin/xtables-legacy-multi \
+	/bin/xtables-legacy-multi
+
+CMD ["/bin/xtables-legacy-multi"]

--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.13
 
 ENV KUBE_VERSION=1.21.3
 
-RUN apk add openrc openssh-server bash busybox-initscripts coreutils findutils iptables curl haproxy
+RUN apk add openrc openssh-server bash busybox-initscripts coreutils findutils curl haproxy
 # enable syslog and sshd
 RUN rc-update add cgroups boot
 RUN rc-update add syslog boot


### PR DESCRIPTION
**Issue**
Partially fixes #271

**What this PR Includes**
Bundles statically built iptables with needed symlinks. 

With this PR there will be no external dependencies with kubernetes 1.22.