### PR TITLE
Add documentation of configuring environment variables

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,24 @@
+# Environment variables
+
+`k0s install` does not support environment variables.
+Setting environment variable for a component used by k0s depends on used init system.
+
+## SystemD
+
+Create a drop-in directory and add config file with a desired environment variable:
+
+```shell
+mkdir -p /etc/systemd/system/k0scontroller.service.d
+tee -a /etc/systemd/system/k0scontroller.service.d/http-proxy.conf <<EOT
+[Service]
+Environment=HTTP_PROXY=192.168.33.10:3128
+EOT
+```
+
+## OpenRC
+
+Export desired environment variable overriding service configuration in /etc/conf.d directory:
+
+```shell
+echo 'export HTTP_PROXY="192.168.33.10:3128"' > /etc/conf.d/k0scontroller
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
       - Control Plane High Availability:  high-availability.md
       - Shell Completion:                 shell-completion.md
       - User Management:                  user-management.md
+      - Configuration of Environment Variables: environment-variables.md
   - Extensions:
       - Traefik Ingress Controller:       examples/traefik-ingress.md
       - Ambassador Gateway:               examples/ambassador-ingress.md


### PR DESCRIPTION
**Issue**
Fixes #754 

**What this PR Includes**
Simple documentation how to configure environment variable for components used by k0s on systems with SystemD and OpenRC.

**How to test**
[Here](https://github.com/jewertow/k0s-sandbox/tree/master/cluster-behind-a-proxy) is a sandbox environment with k0s behind a forward proxy where containerd has configured `HTTP_PROXY` in accordance with this documentation.