### PR TITLE
Bump konnectivity to 0.0.24

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -39,7 +39,7 @@ etcd_build_go_cgo_enabled = 0
 etcd_build_go_ldflags = "-w -s"
 #etcd_build_go_ldflags_extra =
 
-konnectivity_version = 0.0.22
+konnectivity_version = 0.0.24
 konnectivity_buildimage = golang:1.16-alpine
 #konnectivity_build_go_tags =
 konnectivity_build_go_cgo_enabled = 0

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -55,7 +55,7 @@ const (
 	DefaultPSP = "00-k0s-privileged"
 	// Image Constants
 	KonnectivityImage                  = "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent"
-	KonnectivityImageVersion           = "v0.0.22"
+	KonnectivityImageVersion           = "v0.0.24"
 	MetricsImage                       = "gcr.io/k8s-staging-metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.5.0"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"


### PR DESCRIPTION
Signed-off-by: Natanael Copa <ncopa@mirantis.com>

**What this PR Includes**

Update konnectivity to 0.0.24