### PR TITLE
Use Go 1.16 in nightly network test

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -21,6 +21,11 @@ jobs:
       run:
         working-directory: ./inttest/terraform/test-cluster
     steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+        id: go
       - name: Get PR Reference
         env:
           INPUT_PRNUMBER: ${{ github.event.inputs.prNumber }}


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>


**Issue**
Network test used default GH runner Go version which is bit outdated and causes some failures

**What this PR Includes**
Bump up the Golang version for nightly network test