### PR TITLE
Replace uses of deprecated ioutil

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -20,9 +20,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -149,12 +149,12 @@ func (c *CmdOpts) etcdHandler() http.Handler {
 		}
 
 		etcdCaCertPath, etcdCaCertKey := filepath.Join(c.K0sVars.EtcdCertDir, "ca.crt"), filepath.Join(c.K0sVars.EtcdCertDir, "ca.key")
-		etcdCACert, err := ioutil.ReadFile(etcdCaCertPath)
+		etcdCACert, err := os.ReadFile(etcdCaCertPath)
 		if err != nil {
 			sendError(err, resp)
 			return
 		}
-		etcdCAKey, err := ioutil.ReadFile(etcdCaCertKey)
+		etcdCAKey, err := os.ReadFile(etcdCaCertKey)
 
 		if err != nil {
 			sendError(err, resp)
@@ -241,27 +241,27 @@ func (c *CmdOpts) caHandler() http.Handler {
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 
 		caResp := v1beta1.CaResponse{}
-		key, err := ioutil.ReadFile(path.Join(c.K0sVars.CertRootDir, "ca.key"))
+		key, err := os.ReadFile(path.Join(c.K0sVars.CertRootDir, "ca.key"))
 		if err != nil {
 			sendError(err, resp)
 			return
 		}
 		caResp.Key = key
-		crt, err := ioutil.ReadFile(path.Join(c.K0sVars.CertRootDir, "ca.crt"))
+		crt, err := os.ReadFile(path.Join(c.K0sVars.CertRootDir, "ca.crt"))
 		if err != nil {
 			sendError(err, resp)
 			return
 		}
 		caResp.Cert = crt
 
-		saKey, err := ioutil.ReadFile(path.Join(c.K0sVars.CertRootDir, "sa.key"))
+		saKey, err := os.ReadFile(path.Join(c.K0sVars.CertRootDir, "sa.key"))
 		if err != nil {
 			sendError(err, resp)
 			return
 		}
 		caResp.SAKey = saKey
 
-		saPub, err := ioutil.ReadFile(path.Join(c.K0sVars.CertRootDir, "sa.pub"))
+		saPub, err := os.ReadFile(path.Join(c.K0sVars.CertRootDir, "sa.pub"))
 		if err != nil {
 			sendError(err, resp)
 			return

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path"
@@ -72,7 +71,7 @@ func NewControllerCmd() *cobra.Command {
 				return fmt.Errorf("you can only pass one token argument either as a CLI argument 'k0s controller [join-token]' or as a flag 'k0s controller --token-file [path]'")
 			}
 			if len(c.TokenFile) > 0 {
-				bytes, err := ioutil.ReadFile(c.TokenFile)
+				bytes, err := os.ReadFile(c.TokenFile)
 				if err != nil {
 					return err
 				}
@@ -122,7 +121,7 @@ func writeCerts(caData v1beta1.CaResponse, certRootDir string) error {
 		{path: filepath.Join(certRootDir, "sa.key"), data: caData.SAKey, mode: constant.CertSecureMode},
 		{path: filepath.Join(certRootDir, "sa.pub"), data: caData.SAPub, mode: constant.CertMode},
 	} {
-		err := ioutil.WriteFile(f.path, f.data, f.mode)
+		err := os.WriteFile(f.path, f.data, f.mode)
 		if err != nil {
 			return fmt.Errorf("failed to write %s: %w", f.path, err)
 		}

--- a/cmd/kubeconfig/admin.go
+++ b/cmd/kubeconfig/admin.go
@@ -17,7 +17,6 @@ package kubeconfig
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -38,7 +37,7 @@ func kubeConfigAdminCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := CmdOpts(config.GetCmdOpts())
 			if util.FileExists(c.K0sVars.AdminKubeConfigPath) {
-				content, err := ioutil.ReadFile(c.K0sVars.AdminKubeConfigPath)
+				content, err := os.ReadFile(c.K0sVars.AdminKubeConfigPath)
 				if err != nil {
 					log.Fatal(err)
 				}

--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -20,13 +20,13 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"html/template"
+	"os"
+	"path"
+
 	"github.com/cloudflare/cfssl/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"html/template"
-	"io/ioutil"
-	"os"
-	"path"
 
 	"github.com/k0sproject/k0s/pkg/certificate"
 	"github.com/k0sproject/k0s/pkg/config"
@@ -84,7 +84,7 @@ Note: A certificate once signed cannot be revoked for a particular user`,
 			if err != nil {
 				return fmt.Errorf("failed to fetch cluster's API Address: %w", err)
 			}
-			caCert, err := ioutil.ReadFile(path.Join(c.K0sVars.CertRootDir, "ca.crt"))
+			caCert, err := os.ReadFile(path.Join(c.K0sVars.CertRootDir, "ca.crt"))
 			if err != nil {
 				return fmt.Errorf("failed to read cluster ca certificate: %w, check if the control plane is initialized on this node", err)
 			}

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -18,7 +18,6 @@ package worker
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"runtime"
@@ -61,7 +60,7 @@ func NewWorkerCmd() *cobra.Command {
 			}
 
 			if len(c.TokenFile) > 0 {
-				bytes, err := ioutil.ReadFile(c.TokenFile)
+				bytes, err := os.ReadFile(c.TokenFile)
 				if err != nil {
 					return err
 				}

--- a/hack/gen-bindata/main.go
+++ b/hack/gen-bindata/main.go
@@ -23,7 +23,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -50,12 +49,12 @@ func compressFiles(prefix string) []fileInfo {
 	// compress the files
 	var wg sync.WaitGroup
 	for _, dir := range flag.Args() {
-		files, err := ioutil.ReadDir(dir)
+		files, err := os.ReadDir(dir)
 		if err != nil {
 			log.Fatal(err)
 		}
 		for _, f := range files {
-			tmpf, err := ioutil.TempFile("", f.Name())
+			tmpf, err := os.CreateTemp("", f.Name())
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/internal/util/dir.go
+++ b/internal/util/dir.go
@@ -17,7 +17,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -33,7 +32,7 @@ func GetAllDirs(base string) ([]string, error) {
 	if !IsDirectory(base) {
 		return dirs, fmt.Errorf("%s is not a directory", base)
 	}
-	fileInfos, err := ioutil.ReadDir(base)
+	fileInfos, err := os.ReadDir(base)
 	if err != nil {
 		return dirs, err
 	}

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -18,11 +18,11 @@ package util
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
+
+	"github.com/sirupsen/logrus"
 )
 
 // FileExists checks if a file exists and is not a directory before we
@@ -97,12 +97,12 @@ func FileCopy(src, dst string) error {
 		return fmt.Errorf("%s is not a regular file", src)
 	}
 
-	input, err := ioutil.ReadFile(src)
+	input, err := os.ReadFile(src)
 	if err != nil {
 		return fmt.Errorf("error reading source file (%v): %v", src, err)
 	}
 
-	err = ioutil.WriteFile(dst, input, sourceFileStat.Mode())
+	err = os.WriteFile(dst, input, sourceFileStat.Mode())
 	if err != nil {
 		return fmt.Errorf("error writing destination file (%v): %v", dst, err)
 	}

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -88,7 +87,7 @@ func (s *FootlooseSuite) SetupSuite() {
 	if s.KonnectivityAgentPort == 0 {
 		s.KonnectivityAgentPort = 8132
 	}
-	dir, err := ioutil.TempDir("", "footloose-keys")
+	dir, err := os.MkdirTemp("", "footloose-keys")
 	if err != nil {
 		s.T().Logf("ERROR: failed to load footloose config: %s", err.Error())
 		s.T().FailNow()
@@ -191,7 +190,7 @@ func (s *FootlooseSuite) TearDownSuite() {
 			s.T().Logf("failed to cat logs on machine %s: %s", m.Hostname(), err)
 		}
 		logPath := path.Join("/tmp", fmt.Sprintf("%s.log", m.Hostname()))
-		if err := ioutil.WriteFile(logPath, []byte(log), 0700); err != nil {
+		if err := os.WriteFile(logPath, []byte(log), 0700); err != nil {
 			s.T().Logf("failed to save logs from machine %s: %s", m.Hostname(), err)
 		}
 
@@ -206,7 +205,7 @@ func (s *FootlooseSuite) TearDownSuite() {
 			return
 		}
 		filename := path.Join(os.TempDir(), util.RandomString(8)+"-footloose.yaml")
-		err = ioutil.WriteFile(filename, footlooseYaml, 0700)
+		err = os.WriteFile(filename, footlooseYaml, 0700)
 		if err != nil {
 			s.T().Logf("failed to write footloose yaml: %s", err.Error())
 			return

--- a/inttest/common/ssh.go
+++ b/inttest/common/ssh.go
@@ -17,11 +17,11 @@ package common
 
 import (
 	"fmt"
-	"github.com/mitchellh/go-homedir"
-	"golang.org/x/crypto/ssh"
-	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/mitchellh/go-homedir"
+	"golang.org/x/crypto/ssh"
 )
 
 // SSHConnection describes an SSH connection
@@ -100,7 +100,7 @@ func loadExternalFile(path string) ([]byte, error) {
 		return []byte{}, err
 	}
 
-	filedata, err := ioutil.ReadFile(realpath)
+	filedata, err := os.ReadFile(realpath)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/inttest/sonobuoy/signetwork_test.go
+++ b/inttest/sonobuoy/signetwork_test.go
@@ -17,7 +17,6 @@ package sonobuoy
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -152,7 +151,7 @@ func (s *NetworkSuite) retrieveResults() (Result, error) {
 }
 
 func (s *NetworkSuite) dumpKubeConfig() string {
-	dir, err := ioutil.TempDir("", "sig-network-kubeconfig-")
+	dir, err := os.MkdirTemp("", "sig-network-kubeconfig-")
 	s.NoError(err)
 	ssh, err := s.SSH(s.ControllerIP)
 	s.NoError(err)

--- a/pkg/apis/v1beta1/cluster.go
+++ b/pkg/apis/v1beta1/cluster.go
@@ -17,9 +17,10 @@ package v1beta1
 
 import (
 	"fmt"
-	"github.com/k0sproject/k0s/internal/util"
-	"io/ioutil"
+	"io"
 	"os"
+
+	"github.com/k0sproject/k0s/internal/util"
 
 	"github.com/k0sproject/k0s/pkg/constant"
 )
@@ -129,7 +130,7 @@ func validateSpecs(v Validateable) []error {
 
 // ConfigFromFile ...
 func ConfigFromFile(filename string, k0sVars constant.CfgVars) (*ClusterConfig, error) {
-	buf, err := ioutil.ReadFile(filename)
+	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file at %s: %w", filename, err)
 	}
@@ -139,7 +140,7 @@ func ConfigFromFile(filename string, k0sVars constant.CfgVars) (*ClusterConfig, 
 
 // ConfigFromStdin tries to read k0s.yaml config from stdin
 func ConfigFromStdin(k0sVars constant.CfgVars) (*ClusterConfig, error) {
-	input, err := ioutil.ReadAll(os.Stdin)
+	input, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return nil, fmt.Errorf("can't read configration from stdin: %v", err)
 	}

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -18,7 +18,7 @@ package applier
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -143,7 +143,7 @@ func (a *Applier) parseFiles(files []string) ([]*unstructured.Unstructured, erro
 	var resources []*unstructured.Unstructured
 	for _, file := range files {
 		// TODO Probably better to pass in the file stream into decoder and not to read it fully to mem first
-		source, err := ioutil.ReadFile(file)
+		source, err := os.ReadFile(file)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/applier/applier_test.go
+++ b/pkg/applier/applier_test.go
@@ -18,7 +18,7 @@ package applier
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +32,7 @@ import (
 )
 
 func TestApplierAppliesAllManifestsInADirectory(t *testing.T) {
-	dir, err := ioutil.TempDir("", "applier-test-*")
+	dir, err := os.MkdirTemp("", "applier-test-*")
 	assert.NoError(t, err)
 	templateNS := `
 apiVersion: v1
@@ -88,12 +88,12 @@ spec:
             memory: "64Mi"
             cpu: "100m"
         ports:
-          - containerPort: 80	
+          - containerPort: 80
 `
-	assert.NoError(t, ioutil.WriteFile(fmt.Sprintf("%s/test-ns.yaml", dir), []byte(templateNS), 0400))
-	assert.NoError(t, ioutil.WriteFile(fmt.Sprintf("%s/test.yaml", dir), []byte(template), 0400))
-	assert.NoError(t, ioutil.WriteFile(fmt.Sprintf("%s/test-pod.yaml", dir), []byte(template2), 0400))
-	assert.NoError(t, ioutil.WriteFile(fmt.Sprintf("%s/test-deploy.yaml", dir), []byte(templateDeployment), 0400))
+	assert.NoError(t, os.WriteFile(fmt.Sprintf("%s/test-ns.yaml", dir), []byte(templateNS), 0400))
+	assert.NoError(t, os.WriteFile(fmt.Sprintf("%s/test.yaml", dir), []byte(template), 0400))
+	assert.NoError(t, os.WriteFile(fmt.Sprintf("%s/test-pod.yaml", dir), []byte(template2), 0400))
+	assert.NoError(t, os.WriteFile(fmt.Sprintf("%s/test-deploy.yaml", dir), []byte(templateDeployment), 0400))
 
 	fakes := kubeutil.NewFakeClientFactory()
 	verbs := []string{"get", "list", "delete", "create"}

--- a/pkg/backup/manager.go
+++ b/pkg/backup/manager.go
@@ -20,7 +20,6 @@ package backup
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -164,7 +163,7 @@ func (bm Manager) getConfigForRestore(k0sVars constant.CfgVars) (*v1beta1.Cluste
 
 // NewBackupManager builds new manager
 func NewBackupManager() (*Manager, error) {
-	tmpDir, err := ioutil.TempDir("", "k0s-backup")
+	tmpDir, err := os.MkdirTemp("", "k0s-backup")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary directory: %v", err)
 	}

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -81,12 +80,12 @@ func (m *Manager) EnsureCA(name, cn string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(keyFile, key, constant.CertSecureMode)
+	err = os.WriteFile(keyFile, key, constant.CertSecureMode)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(certFile, cert, constant.CertMode)
+	err = os.WriteFile(certFile, cert, constant.CertMode)
 	if err != nil {
 		return err
 	}
@@ -146,11 +145,11 @@ func (m *Manager) EnsureCertificate(certReq Request, ownerName string) (Certific
 			Key:  string(key),
 			Cert: string(cert),
 		}
-		err = ioutil.WriteFile(keyFile, key, constant.CertSecureMode)
+		err = os.WriteFile(keyFile, key, constant.CertSecureMode)
 		if err != nil {
 			return Certificate{}, err
 		}
-		err = ioutil.WriteFile(certFile, cert, constant.CertMode)
+		err = os.WriteFile(certFile, cert, constant.CertMode)
 		if err != nil {
 			return Certificate{}, err
 		}
@@ -171,11 +170,11 @@ func (m *Manager) EnsureCertificate(certReq Request, ownerName string) (Certific
 	_ = os.Chown(keyFile, uid, -1)
 	_ = os.Chown(certFile, uid, -1)
 
-	cert, err := ioutil.ReadFile(certFile)
+	cert, err := os.ReadFile(certFile)
 	if err != nil {
 		return Certificate{}, fmt.Errorf("failed to read ca cert %s for %s: %w", certFile, certReq.Name, err)
 	}
-	key, err := ioutil.ReadFile(keyFile)
+	key, err := os.ReadFile(keyFile)
 	if err != nil {
 		return Certificate{}, fmt.Errorf("failed to read ca key %s for %s: %w", keyFile, certReq.Name, err)
 	}

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -19,8 +19,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"path"
 	"strings"
 
@@ -203,7 +204,7 @@ func (a *APIServer) Healthy() error {
 		return err
 	}
 	// Load CA cert
-	caCert, err := ioutil.ReadFile(path.Join(a.K0sVars.CertRootDir, "ca.crt"))
+	caCert, err := os.ReadFile(path.Join(a.K0sVars.CertRootDir, "ca.crt"))
 	if err != nil {
 		return err
 	}
@@ -224,7 +225,7 @@ func (a *APIServer) Healthy() error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err == nil {
 			logrus.Debugf("api server readyz output:\n %s", string(body))
 		}

--- a/pkg/component/controller/certificates.go
+++ b/pkg/component/controller/certificates.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -81,7 +80,7 @@ func (c *Certificates) Init() error {
 
 	// We need CA cert loaded to generate client configs
 	logrus.Debugf("CA key and cert exists, loading")
-	cert, err := ioutil.ReadFile(caCertPath)
+	cert, err := os.ReadFile(caCertPath)
 	if err != nil {
 		return fmt.Errorf("failed to read ca cert: %w", err)
 	}

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -18,7 +18,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -104,12 +103,12 @@ func (e *Etcd) syncEtcdConfig(peerURL, etcdCaCert, etcdCaCertKey string) ([]stri
 	if util.FileExists(etcdCaCert) && util.FileExists(etcdCaCertKey) {
 		logrus.Warnf("etcd ca certs already exists, not gonna overwrite. If you wish to re-sync them, delete the existing ones.")
 	} else {
-		err = ioutil.WriteFile(etcdCaCertKey, etcdResponse.CA.Key, constant.CertSecureMode)
+		err = os.WriteFile(etcdCaCertKey, etcdResponse.CA.Key, constant.CertSecureMode)
 		if err != nil {
 			return nil, err
 		}
 
-		err = ioutil.WriteFile(etcdCaCert, etcdResponse.CA.Cert, constant.CertSecureMode)
+		err = os.WriteFile(etcdCaCert, etcdResponse.CA.Cert, constant.CertSecureMode)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/component/controller/kubeletconfig.go
+++ b/pkg/component/controller/kubeletconfig.go
@@ -18,11 +18,11 @@ package controller
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path"
 	"path/filepath"
 
 	"io"
-	"io/ioutil"
 
 	"github.com/imdario/mergo"
 	"github.com/sirupsen/logrus"
@@ -126,7 +126,7 @@ func (k *KubeletConfig) save(data []byte) error {
 	}
 
 	filePath := filepath.Join(kubeletDir, "kubelet-config.yaml")
-	if err := ioutil.WriteFile(filePath, data, constant.CertMode); err != nil {
+	if err := os.WriteFile(filePath, data, constant.CertMode); err != nil {
 		return fmt.Errorf("can't write kubelet configuration config map: %v", err)
 	}
 	return nil
@@ -235,7 +235,7 @@ metadata:
   name: {{.Name}}
   namespace: kube-system
 data:
-  kubelet: | 
+  kubelet: |
 {{ .KubeletConfigYAML | nindent 4 }}
 `
 
@@ -248,7 +248,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
-  resourceNames: 
+  resourceNames:
 {{- range .ConfigMapNames }}
     - "{{ . -}}"
 {{ end }}

--- a/pkg/component/controller/manifests.go
+++ b/pkg/component/controller/manifests.go
@@ -18,7 +18,7 @@ package controller
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -35,7 +35,7 @@ type FsManifestsSaver struct {
 // Save saves given manifest under the given path
 func (f FsManifestsSaver) Save(dst string, content []byte) error {
 	target := filepath.Join(f.dir, dst)
-	if err := ioutil.WriteFile(target, content, constant.ManifestsDirMode); err != nil {
+	if err := os.WriteFile(target, content, constant.ManifestsDirMode); err != nil {
 		return fmt.Errorf("can't write manifest %s: %v", target, err)
 	}
 	logrus.WithField("component", "manifest-saver").Debugf("succesfully wrote %s", target)

--- a/pkg/component/worker/calico_installer_windows.go
+++ b/pkg/component/worker/calico_installer_windows.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -35,7 +35,7 @@ func (c CalicoInstaller) Init() error {
 		return fmt.Errorf("can't create CalicoWindows dir: %v", err)
 	}
 
-	if err := ioutil.WriteFile(path, []byte(installCalicoPowershell), 777); err != nil {
+	if err := os.WriteFile(path, []byte(installCalicoPowershell), 777); err != nil {
 		return fmt.Errorf("can't unpack calico installer: %v", err)
 	}
 
@@ -82,11 +82,11 @@ func (c CalicoInstaller) SaveKubeConfig(path string) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected response status: %s", resp.Status)
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("can't read response body: %v", err)
 	}
-	if err := ioutil.WriteFile(path, b, 0700); err != nil {
+	if err := os.WriteFile(path, b, 0700); err != nil {
 		return fmt.Errorf("can't save kubeconfig for calico: %v", err)
 	}
 	posh := NewPowershell()
@@ -243,7 +243,7 @@ function GetCalicoKubeConfig()
       [parameter(Mandatory=$false)] $SecretName = "calico-node",
       [parameter(Mandatory=$false)] $KubeConfigPath = "C:\\var\\lib\\k0s\\kubelet-bootstrap.conf"
     )
-	Move-Item -Path C:\\calico-kube-config -Destination C:\\CalicoWindows\calico-kube-config 
+	Move-Item -Path C:\\calico-kube-config -Destination C:\\CalicoWindows\calico-kube-config
 }
 
 
@@ -319,7 +319,7 @@ if ($platform -EQ "ec2") {
 
     $calicoNs = GetCalicoNamespace
     GetCalicoKubeConfig -CalicoNamespace $calicoNs
-    $Backend = GetBackendType 
+    $Backend = GetBackendType
 
     Write-Host "Backend networking is $Backend"
     if ($Backend -EQ "bgp") {

--- a/pkg/component/worker/kernelsetup_linux.go
+++ b/pkg/component/worker/kernelsetup_linux.go
@@ -19,7 +19,7 @@ limitations under the License.
 package worker
 
 import (
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path"
 	"strings"
@@ -31,7 +31,7 @@ import (
 
 // check if kernel has overlay fs
 func hasFilesystem(filesystem string) bool {
-	data, err := ioutil.ReadFile("/proc/filesystems")
+	data, err := os.ReadFile("/proc/filesystems")
 	if err != nil {
 		return false
 	}
@@ -53,7 +53,7 @@ func modprobe(module string) {
 
 func enableSysCtl(entry string) {
 	file := path.Join("/proc", "sys", entry)
-	err := ioutil.WriteFile(file, []byte("1"), 0644)
+	err := os.WriteFile(file, []byte("1"), 0644)
 	if err != nil {
 		logrus.Warnf("Failed to enable %s: %s", file, err.Error())
 	}

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -17,7 +17,7 @@ package worker
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -240,7 +240,7 @@ func getNodeName() (string, error) {
 		return os.Hostname()
 	}
 	defer resp.Body.Close()
-	h, err := ioutil.ReadAll(resp.Body)
+	h, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("can't read aws hostname: %v", err)
 	}

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -3,15 +3,15 @@ package worker
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
 	"github.com/avast/retry-go"
 	"github.com/containerd/containerd"
 	"github.com/k0sproject/k0s/internal/util"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/sirupsen/logrus"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"time"
 )
 
 // OCIBundleReconciler tries to import OCI bundle into the running containerd instance
@@ -33,7 +33,7 @@ func (a *OCIBundleReconciler) Init() error {
 }
 
 func (a *OCIBundleReconciler) Run() error {
-	files, err := ioutil.ReadDir(a.k0sVars.OCIBundleDir)
+	files, err := os.ReadDir(a.k0sVars.OCIBundleDir)
 	if err != nil {
 		return fmt.Errorf("can't read bundles directory")
 	}

--- a/pkg/component/worker/utils.go
+++ b/pkg/component/worker/utils.go
@@ -2,7 +2,7 @@ package worker
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 
 	"k8s.io/client-go/tools/clientcmd"
@@ -28,12 +28,12 @@ func HandleKubeletBootstrapToken(encodedToken string, k0sVars constant.CfgVars) 
 		if err := util.InitDirectory(k0sVars.CertRootDir, constant.CertRootDirMode); err != nil {
 			return fmt.Errorf("failed to initialize directory '%s': %w", k0sVars.CertRootDir, err)
 		}
-		err = ioutil.WriteFile(kubeletCAPath, clientCfg.Clusters["k0s"].CertificateAuthorityData, constant.CertMode)
+		err = os.WriteFile(kubeletCAPath, clientCfg.Clusters["k0s"].CertificateAuthorityData, constant.CertMode)
 		if err != nil {
 			return fmt.Errorf("failed to write ca client cert: %w", err)
 		}
 	}
-	err = ioutil.WriteFile(k0sVars.KubeletBootstrapConfigPath, kubeconfig, constant.CertSecureMode)
+	err = os.WriteFile(k0sVars.KubeletBootstrapConfigPath, kubeconfig, constant.CertSecureMode)
 	if err != nil {
 		return fmt.Errorf("failed writing kubelet bootstrap auth config: %w", err)
 	}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -2,7 +2,6 @@ package helm
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,7 +68,7 @@ func (hc *Commands) AddRepository(repoCfg k0sv1beta1.Repository) error {
 		return fmt.Errorf("can't add repository to %s: %v", hc.repoFile, err)
 	}
 
-	b, err := ioutil.ReadFile(hc.repoFile)
+	b, err := os.ReadFile(hc.repoFile)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("can't add repository to %s: %v", hc.repoFile, err)
 	}

--- a/pkg/install/process.go
+++ b/pkg/install/process.go
@@ -18,7 +18,7 @@ package install
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 
@@ -57,7 +57,7 @@ func GetStatusInfo(socketPath string) (status *K0sStatus, err error) {
 	}
 	defer response.Body.Close()
 
-	responseData, err := ioutil.ReadAll(response.Body)
+	responseData, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -17,7 +17,6 @@ package supervisor
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -60,7 +59,7 @@ func (s *Supervisor) processWaitQuit() bool {
 	}()
 
 	pidbuf := []byte(strconv.Itoa(s.cmd.Process.Pid) + "\n")
-	err := ioutil.WriteFile(s.PidFile, pidbuf, constant.PidFileMode)
+	err := os.WriteFile(s.PidFile, pidbuf, constant.PidFileMode)
 	if err != nil {
 		s.log.Warnf("Failed to write file %s: %v", s.PidFile, err)
 	}

--- a/pkg/token/joinclient.go
+++ b/pkg/token/joinclient.go
@@ -18,7 +18,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -88,7 +88,7 @@ func (j *JoinClient) GetCA() (v1beta1.CaResponse, error) {
 	if resp.Body == nil {
 		return caData, fmt.Errorf("response body is nil")
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return caData, err
 	}
@@ -130,7 +130,7 @@ func (j *JoinClient) JoinEtcd(peerAddress string) (v1beta1.EtcdResponse, error) 
 		return etcdResponse, fmt.Errorf("unexpected response status when trying to join etcd cluster: %s", resp.Status)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return etcdResponse, err
 	}

--- a/pkg/token/kubeconfig.go
+++ b/pkg/token/kubeconfig.go
@@ -20,7 +20,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -58,7 +58,7 @@ users:
 
 func CreateKubeletBootstrapConfig(clusterConfig *config.ClusterConfig, k0sVars constant.CfgVars, role string, expiry time.Duration) (string, error) {
 	crtFile := filepath.Join(k0sVars.CertRootDir, "ca.crt")
-	caCert, err := ioutil.ReadFile(crtFile)
+	caCert, err := os.ReadFile(crtFile)
 	if err != nil {
 		return "", fmt.Errorf("failed to read cluster ca certificate from %s: %w. check if the control plane is initialized on this node", crtFile, err)
 	}


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Replaces uses of ioutil with the suggested replacements at https://golang.org/doc/go1.16#ioutil
