### PR TITLE
Fix iptables symlink on upgrades (#1074)

### DIFF
--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -77,7 +77,12 @@ func (k *Kubelet) Init() error {
 
 	if runtime.GOOS == "linux" {
 		for _, symlink := range []string{"iptables-save", "iptables-restore", "ip6tables", "ip6tables-save", "ip6tables-restore"} {
-			err := os.Symlink("xtables-legacy-multi", filepath.Join(k.K0sVars.BinDir, symlink))
+			symlinkPath := filepath.Join(k.K0sVars.BinDir, symlink)
+
+			// remove if it exist and ignore error if it doesn't
+			_ = os.Remove(symlinkPath)
+
+			err := os.Symlink("xtables-legacy-multi", symlinkPath)
 			if err != nil {
 				return fmt.Errorf("failed to create symlink %s: %w", symlink, err)
 			}


### PR DESCRIPTION
The iptables' symlinks may exist when we upgrade k0s. Update the symlink
instead of exit with error.

Fixes https://github.com/k0sproject/k0s/issues/1074

Signed-off-by: Natanael Copa <ncopa@mirantis.com>


**Issue**
Fixes #1074

**What this PR Includes**
Prevent k0s exit with error due to pre-existing iptbales symlinks on upgrades.
