### PR TITLE
Allow user to overwrite ANY flags with 'extraArgs'

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -865,6 +865,43 @@ jobs:
           path: |
             /tmp/*.log
 
+  smoketest-extraargs:
+    name: Smoke test for extra args for kube components
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+        id: go
+      - name: Get PR Reference and Set Cache Name
+        run: |
+          PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
+          echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Cache compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0s
+          key: build-${{env.cachePrefix}}
+
+      - name: Run smoke test for kube extra-args
+        run: make -C inttest check-extraargs
+
+      - name: Collect test logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            /tmp/*.log
+
+
   smoketest-arm:
     name: Smoke test on arm64
     runs-on: [self-hosted,linux,arm64]

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -17,5 +17,6 @@ smoketests := \
 	check-airgap \
 	check-k0scloudprovider \
 	check-cli \
-	check-disabledcomponents
+	check-disabledcomponents \
+	check-extraargs
 

--- a/inttest/extraargs/extraargs_test.go
+++ b/inttest/extraargs/extraargs_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2021 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package extraargs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ExtraArgsSuite struct {
+	common.FootlooseSuite
+}
+
+func (s *ExtraArgsSuite) TestK0sGetsUp() {
+	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfig)
+	s.NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
+
+	s.NoError(s.RunWorkers())
+
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	s.NoError(err)
+
+	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
+	s.NoError(err)
+
+	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
+		Limit: 100,
+	})
+	s.NoError(err)
+
+	podCount := len(pods.Items)
+
+	s.T().Logf("found %d pods in kube-system", podCount)
+	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+
+	s.T().Log("waiting to see kube-router pods ready")
+	s.NoError(common.WaitForKubeRouterReady(kc), "kube-router did not start")
+
+}
+
+func TestExtraArgsSuite(t *testing.T) {
+	s :=
+		ExtraArgsSuite{
+			common.FootlooseSuite{
+				ControllerCount: 1,
+				WorkerCount:     1,
+			},
+		}
+	suite.Run(t, &s)
+}
+
+const k0sConfig = `
+spec:
+  api:
+    extraArgs:
+      disable-admission-plugins: PodSecurityPolicy
+      enable-admission-plugins: NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,PodSecurity,Priority,DefaultTolerationSeconds,DefaultStorageClass,StorageObjectInUseProtection,PersistentVolumeClaimResize,RuntimeClass,CertificateApproval,CertificateSigning,CertificateSubjectRestriction,DefaultIngressClass,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota
+`

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -128,8 +128,8 @@ func (a *APIServer) Run() error {
 	args["api-audiences"] = strings.Join(apiAudiences, ",")
 
 	for name, value := range a.ClusterConfig.Spec.API.ExtraArgs {
-		if args[name] != "" && name != "profiling" {
-			return fmt.Errorf("cannot override apiserver flag: %s", name)
+		if args[name] != "" {
+			logrus.Warnf("overriding apiserver flag with user provided value: %s", name)
 		}
 		args[name] = value
 	}

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -89,8 +89,8 @@ func (a *Manager) Run() error {
 	}
 
 	for name, value := range a.ClusterConfig.Spec.ControllerManager.ExtraArgs {
-		if args[name] != "" && name != "profiling" {
-			return fmt.Errorf("cannot override kube-controller-manager flag: %s", name)
+		if args[name] != "" {
+			logrus.Warnf("overriding kube-controller-manager flag with user provided value: %s", name)
 		}
 		args[name] = value
 	}

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -62,8 +62,8 @@ func (a *Scheduler) Run() error {
 		"v":                         a.LogLevel,
 	}
 	for name, value := range a.ClusterConfig.Spec.Scheduler.ExtraArgs {
-		if args[name] != "" && name != "profiling" {
-			return fmt.Errorf("cannot override kube-scheduler flag: %s", name)
+		if args[name] != "" {
+			logrus.Warnf("overriding kube-scheduler flag with user provided value: %s", name)
 		}
 		args[name] = value
 	}


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>


**Issue**
Fixes #1104 

**What this PR Includes**
Currently k0s will error out if user tries to overwrite any flags k0s itself sets for kube-apiserver, controller-manager or scheduler. This PR makes k0s to "just" warn about that and still allows user to do the expected.

The most obvious case #1087 is now also tested as smoke test.