### PR TITLE
Update pause image version and improve air-gap test

### DIFF
--- a/inttest/airgap/airgap_test.go
+++ b/inttest/airgap/airgap_test.go
@@ -34,11 +34,21 @@ spec:
     default_pull_policy: Never
 `
 
+const etcHosts = `
+127.0.0.8 docker.io
+127.0.0.8 gcr.io
+127.0.0.8 k8s.gcr.io
+127.0.0.8 us.gcr.io
+127.0.0.8 quay.io
+`
+
 type AirgapSuite struct {
 	common.FootlooseSuite
 }
 
 func (s *AirgapSuite) TestK0sGetsUp() {
+	s.AppendFile(s.ControllerNode(0), "/etc/hosts", etcHosts)
+	s.AppendFile(s.WorkerNode(0), "/etc/hosts", etcHosts)
 	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfig)
 	s.NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
 	s.NoError(s.RunWorkers(`--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args="--address=0.0.0.0 --event-burst=10 --image-gc-high-threshold=100"`))

--- a/inttest/common/filetools.go
+++ b/inttest/common/filetools.go
@@ -23,3 +23,14 @@ func (s *FootlooseSuite) PutFile(node, path, content string) {
 
 	s.Require().NoError(err)
 }
+
+// AppendFile appends content to file on given node
+func (s *FootlooseSuite) AppendFile(node, path, content string) {
+	ssh, err := s.SSH(node)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+	// TODO: send data via pipe instead, so we can write data with single quotes '
+	_, err = ssh.ExecWithOutput(fmt.Sprintf("echo '%s' >> %s", content, path))
+
+	s.Require().NoError(err)
+}

--- a/pkg/constant/constant_posix.go
+++ b/pkg/constant/constant_posix.go
@@ -26,7 +26,7 @@ const (
 	KubeletVolumePluginDir         = "/usr/libexec/k0s/kubelet-plugins/volume/exec"
 	KineSocket                     = "kine/kine.sock:2379"
 	KubePauseContainerImage        = "k8s.gcr.io/pause"
-	KubePauseContainerImageVersion = "3.2"
+	KubePauseContainerImageVersion = "3.5"
 )
 
 func formatPath(dir string, file string) string {


### PR DESCRIPTION

**What this PR Includes**
In k8s `1.22`, `pause` image is updated to `3.5` (https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md)

Add some fake entries in `/etc/hosts` of air-gap test to ensure any missing image is not available to download so as to expose the issue in the test.

Signed-off-by: Xinfeng Liu <xinfeng.liu@gmail.com>
