### PR TITLE
improve flag parser for --kubelet-extra-args

### DIFF
--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -24,7 +24,7 @@ import (
 // Split splits arbitrary set of flags into StringMap struct
 func Split(input string) stringmap.StringMap {
 	mArgs := stringmap.StringMap{}
-	args := strings.Split(input, " ")
+	args := strings.Fields(input)
 	for _, a := range args {
 		av := strings.SplitN(a, "=", 2)
 		if len(av) < 1 {

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -39,7 +39,7 @@ func (s *BasicSuite) TestK0sGetsUp() {
 
 	token, err := s.GetJoinToken("worker", dataDirOpt)
 	s.NoError(err)
-	s.NoError(s.RunWorkersWithToken(token, `--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args="--address=0.0.0.0 --event-burst=10"`))
+	s.NoError(s.RunWorkersWithToken(token, `--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args=" --address=0.0.0.0  --event-burst=10"`))
 
 	kc, err := s.KubeClient(s.ControllerNode(0), dataDirOpt)
 	s.NoError(err)


### PR DESCRIPTION

**What this PR Includes**
Currently if the input of `--kubelet-extra-args` contains extra white spaces, the kubelet will not accept the flags and fail to start. 

This PR uses `strings.Fields(input)` instead of `strings.Split(input, " ")`. `strings.Fields(input)` can trim leading/training white spaces and remove duplicated white spaces in the middle of the string.

Signed-off-by: Xinfeng Liu <xinfeng.liu@gmail.com>
