### PR TITLE
Prettify config YAML validation errors

### DIFF
--- a/pkg/apis/v1beta1/calico.go
+++ b/pkg/apis/v1beta1/calico.go
@@ -58,8 +58,8 @@ func (c *Calico) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	c.IPAutodetectionMethod = ""
 	c.IPv6AutodetectionMethod = ""
 
-	type ycalico Calico
-	yc := (*ycalico)(c)
+	type calico Calico
+	yc := (*calico)(c)
 	if err := unmarshal(yc); err != nil {
 		return err
 	}

--- a/pkg/apis/v1beta1/cluster.go
+++ b/pkg/apis/v1beta1/cluster.go
@@ -181,8 +181,8 @@ func (c *ClusterConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	c.Spec = DefaultClusterSpec(c.k0sVars)
 
-	type yclusterconfig ClusterConfig
-	yc := (*yclusterconfig)(c)
+	type config ClusterConfig
+	yc := (*config)(c)
 
 	if err := unmarshal(yc); err != nil {
 		return err

--- a/pkg/apis/v1beta1/images.go
+++ b/pkg/apis/v1beta1/images.go
@@ -48,8 +48,8 @@ type ClusterImages struct {
 }
 
 func (ci *ClusterImages) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	type wrapper ClusterImages
-	imagesWrapper := (*wrapper)(ci)
+	type images ClusterImages
+	imagesWrapper := (*images)(ci)
 	if err := unmarshal(imagesWrapper); err != nil {
 		return err
 	}

--- a/pkg/apis/v1beta1/network.go
+++ b/pkg/apis/v1beta1/network.go
@@ -134,8 +134,8 @@ func (n *Network) InternalAPIAddresses() ([]string, error) {
 func (n *Network) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	n.Provider = "calico"
 
-	type ynetwork Network
-	yc := (*ynetwork)(n)
+	type network Network
+	yc := (*network)(n)
 
 	if err := unmarshal(yc); err != nil {
 		return err

--- a/pkg/apis/v1beta1/storage.go
+++ b/pkg/apis/v1beta1/storage.go
@@ -84,8 +84,8 @@ func (s *StorageSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	s.Type = EtcdStorageType
 	s.Etcd = DefaultEtcdConfig()
 
-	type ystorageconfig StorageSpec
-	yc := (*ystorageconfig)(s)
+	type storage StorageSpec
+	yc := (*storage)(s)
 
 	if err := unmarshal(yc); err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Replaces the type name in `type yclusterconfig ClusterConfig` yaml unmarshal trickery with a type name that at least vaguely points to a key in the actual configuration. The intermediary type name is displayed in the error message, so this will beautify some of the validation errors.
 
Before:
```
$ k0s validate config --config /etc/k0s/k0s.yaml # btw, maybe the validate config subcommand should take the fn as positional arg
yaml: unmarshal errors:
  line 62: cannot unmarshal !!seq into v1beta1.ystorageconfig
```

After:
```
$ k0s validate config --config /etc/k0s/k0s.yaml
yaml: unmarshal errors:
  line 62: cannot unmarshal !!seq into v1beta1.storage
```
