### PR TITLE
Bump kubernetes to 1.22.2 (CVE-2021-25741)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,7 +78,7 @@ spec:
       version: v0.3.7
     kubeproxy:
       image: k8s.gcr.io/kube-proxy
-      version: v1.22.1
+      version: v1.22.2
     coredns:
       image: docker.io/coredns/coredns
       version: 1.7.0

--- a/docs/install.md
+++ b/docs/install.md
@@ -64,7 +64,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
     ```shell
     $ sudo k0s kubectl get nodes
     NAME   STATUS   ROLES    AGE    VERSION
-    k0s    Ready    <none>   4m6s   v1.22.1-k0s1
+    k0s    Ready    <none>   4m6s   v1.22.2-k0s1
     ```
 
 ## Uninstall k0s

--- a/docs/k0s-multi-node.md
+++ b/docs/k0s-multi-node.md
@@ -24,13 +24,13 @@ The download script accepts the following environment variables:
 
 | Variable                   | Purpose                                           |
 |:---------------------------|:--------------------------------------------------|
-| `K0S_VERSION=v1.22.1+k0s.0 | Select the version of k0s to be installed         |
+| `K0S_VERSION=v1.22.2+k0s.0 | Select the version of k0s to be installed         |
 | `DEBUG=true`               | Output commands and their arguments at execution. |
 
 **Note**: If you require environment variables and use sudo, you can do:
 
 ```shell
-curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.22.1+k0s.0 sh
+curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.22.2+k0s.0 sh
 ```
 
 ### 2. Bootstrap a controller node
@@ -119,7 +119,7 @@ To get general information about your k0s instance's status:
 
 ```shell
 $ sudo k0s status
-Version: v1.22.1+k0s.0
+Version: v1.22.2+k0s.0
 Process ID: 2769
 Parent Process ID: 1
 Role: controller
@@ -134,7 +134,7 @@ Use the Kubernetes 'kubectl' command-line tool that comes with k0s binary to dep
 ```shell
 $ sudo k0s kubectl get nodes
 NAME   STATUS   ROLES    AGE    VERSION
-k0s    Ready    <none>   4m6s   v1.22.1-k0s1
+k0s    Ready    <none>   4m6s   v1.22.2-k0s1
 ```
 
 You can also access your cluster easily with [Lens](https://k8slens.dev/), simply by copying the kubeconfig and pasting it to Lens:

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -15,7 +15,7 @@ containerd_build_shim_go_cgo_enabled = 0
 #containerd_build_go_ldflags =
 containerd_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
-kubernetes_version = 1.22.1
+kubernetes_version = 1.22.2
 kubernetes_buildimage = golang:1.16-alpine
 kubernetes_build_go_tags = "providerless"
 #kubernetes_build_go_cgo_enabled =

--- a/examples/footloose-ha-controllers/Dockerfile
+++ b/examples/footloose-ha-controllers/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/footloose/ubuntu18.04
 
 ADD k0s.service /etc/systemd/system/k0s.service
 
-RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.1/bin/linux/amd64/kubectl && \
+RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.2/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf

--- a/inttest/conformance/README.md
+++ b/inttest/conformance/README.md
@@ -35,15 +35,15 @@ In order to run the conformance test, you will need to set the tested k0s versio
 In the same directory as your `main.tf` file, create an additional file `terraform.tfvars` with the following input:
 
 ```terraform
-k0s_version=v1.22.1+k0s.0
-k8s_version=v1.22.1
+k0s_version=v1.22.2+k0s.0
+k8s_version=v1.22.2
 sonobuoy_version=0.53.2
 ```
 
 ### 2. Environment variables
 
 ```shell
-TF_VAR_k0s_version=v1.22.1+k0s.0 TF_VAR_sonobuoy_version=0.20.0 TF_VAR_k8s_version=v1.22.1 terraform apply
+TF_VAR_k0s_version=v1.22.2+k0s.0 TF_VAR_sonobuoy_version=0.20.0 TF_VAR_k8s_version=v1.22.2 terraform apply
 ```
 
 **NOTE:** By default, terraform will fetch sonobuoy version **0.53.2**. If you want to use a different version you can override this with one of the above methods.

--- a/inttest/conformance/terraform/main.tf
+++ b/inttest/conformance/terraform/main.tf
@@ -13,7 +13,7 @@ variable "sonobuoy_version" {
 }
 
 variable "k8s_version" {
-  // format: v1.22.1
+  // format: v1.22.2
   type = string
 }
 

--- a/inttest/sonobuoy/signetwork_test.go
+++ b/inttest/sonobuoy/signetwork_test.go
@@ -69,7 +69,7 @@ func (s *NetworkSuite) TestSigNetwork() {
 		`--e2e-focus=\[sig-network\].*\[Conformance\]`,
 		`--e2e-skip=\[Serial\]`,
 		"--e2e-parallel=y",
-		"--kube-conformance-image-version=v1.22.1",
+		"--kube-conformance-image-version=v1.22.2",
 	}
 	s.T().Log("running sonobuoy, this may take a while")
 	sonoFinished := make(chan bool)

--- a/pkg/constant/constant_posix.go
+++ b/pkg/constant/constant_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -59,7 +59,7 @@ const (
 	MetricsImage                       = "gcr.io/k8s-staging-metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.5.0"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"
-	KubeProxyImageVersion              = "v1.22.1"
+	KubeProxyImageVersion              = "v1.22.2"
 	CoreDNSImage                       = "docker.io/coredns/coredns"
 	CoreDNSImageVersion                = "1.7.0"
 	CalicoImage                        = "docker.io/calico/cni"

--- a/pkg/supervisor/detachattr.go
+++ b/pkg/supervisor/detachattr.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/telemetry/sysinfo_linux.go
+++ b/pkg/telemetry/sysinfo_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package telemetry


### PR DESCRIPTION
Fixes:
- CVE-2021-25741: Symlink Exchange Can Allow Host Filesystem Access
  https://groups.google.com/g/kubernetes-announce/c/-e9OlTcED5E

Also run gofmt to please linter