### PR TITLE
Cherry picks for release 1.22.2

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,7 +78,7 @@ spec:
       version: v0.3.7
     kubeproxy:
       image: k8s.gcr.io/kube-proxy
-      version: v1.22.1
+      version: v1.22.2
     coredns:
       image: docker.io/coredns/coredns
       version: 1.7.0

--- a/docs/install.md
+++ b/docs/install.md
@@ -64,7 +64,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
     ```shell
     $ sudo k0s kubectl get nodes
     NAME   STATUS   ROLES    AGE    VERSION
-    k0s    Ready    <none>   4m6s   v1.22.1-k0s1
+    k0s    Ready    <none>   4m6s   v1.22.2-k0s1
     ```
 
 ## Uninstall k0s

--- a/docs/k0s-multi-node.md
+++ b/docs/k0s-multi-node.md
@@ -24,13 +24,13 @@ The download script accepts the following environment variables:
 
 | Variable                   | Purpose                                           |
 |:---------------------------|:--------------------------------------------------|
-| `K0S_VERSION=v1.22.1+k0s.0 | Select the version of k0s to be installed         |
+| `K0S_VERSION=v1.22.2+k0s.0 | Select the version of k0s to be installed         |
 | `DEBUG=true`               | Output commands and their arguments at execution. |
 
 **Note**: If you require environment variables and use sudo, you can do:
 
 ```shell
-curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.22.1+k0s.0 sh
+curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.22.2+k0s.0 sh
 ```
 
 ### 2. Bootstrap a controller node
@@ -119,7 +119,7 @@ To get general information about your k0s instance's status:
 
 ```shell
 $ sudo k0s status
-Version: v1.22.1+k0s.0
+Version: v1.22.2+k0s.0
 Process ID: 2769
 Parent Process ID: 1
 Role: controller
@@ -134,7 +134,7 @@ Use the Kubernetes 'kubectl' command-line tool that comes with k0s binary to dep
 ```shell
 $ sudo k0s kubectl get nodes
 NAME   STATUS   ROLES    AGE    VERSION
-k0s    Ready    <none>   4m6s   v1.22.1-k0s1
+k0s    Ready    <none>   4m6s   v1.22.2-k0s1
 ```
 
 You can also access your cluster easily with [Lens](https://k8slens.dev/), simply by copying the kubeconfig and pasting it to Lens:

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -15,7 +15,7 @@ containerd_build_shim_go_cgo_enabled = 0
 #containerd_build_go_ldflags =
 containerd_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
-kubernetes_version = 1.22.1
+kubernetes_version = 1.22.2
 kubernetes_buildimage = golang:1.16-alpine
 kubernetes_build_go_tags = "providerless"
 #kubernetes_build_go_cgo_enabled =

--- a/examples/footloose-ha-controllers/Dockerfile
+++ b/examples/footloose-ha-controllers/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/footloose/ubuntu18.04
 
 ADD k0s.service /etc/systemd/system/k0s.service
 
-RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.1/bin/linux/amd64/kubectl && \
+RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.2/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -24,7 +24,7 @@ import (
 // Split splits arbitrary set of flags into StringMap struct
 func Split(input string) stringmap.StringMap {
 	mArgs := stringmap.StringMap{}
-	args := strings.Split(input, " ")
+	args := strings.Fields(input)
 	for _, a := range args {
 		av := strings.SplitN(a, "=", 2)
 		if len(av) < 1 {

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -39,7 +39,7 @@ func (s *BasicSuite) TestK0sGetsUp() {
 
 	token, err := s.GetJoinToken("worker", dataDirOpt)
 	s.NoError(err)
-	s.NoError(s.RunWorkersWithToken(token, `--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args="--address=0.0.0.0 --event-burst=10"`))
+	s.NoError(s.RunWorkersWithToken(token, `--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args=" --address=0.0.0.0  --event-burst=10"`))
 
 	kc, err := s.KubeClient(s.ControllerNode(0), dataDirOpt)
 	s.NoError(err)

--- a/inttest/conformance/README.md
+++ b/inttest/conformance/README.md
@@ -35,15 +35,15 @@ In order to run the conformance test, you will need to set the tested k0s versio
 In the same directory as your `main.tf` file, create an additional file `terraform.tfvars` with the following input:
 
 ```terraform
-k0s_version=v1.22.1+k0s.0
-k8s_version=v1.22.1
+k0s_version=v1.22.2+k0s.0
+k8s_version=v1.22.2
 sonobuoy_version=0.53.2
 ```
 
 ### 2. Environment variables
 
 ```shell
-TF_VAR_k0s_version=v1.22.1+k0s.0 TF_VAR_sonobuoy_version=0.20.0 TF_VAR_k8s_version=v1.22.1 terraform apply
+TF_VAR_k0s_version=v1.22.2+k0s.0 TF_VAR_sonobuoy_version=0.20.0 TF_VAR_k8s_version=v1.22.2 terraform apply
 ```
 
 **NOTE:** By default, terraform will fetch sonobuoy version **0.53.2**. If you want to use a different version you can override this with one of the above methods.

--- a/inttest/conformance/README.md
+++ b/inttest/conformance/README.md
@@ -35,18 +35,18 @@ In order to run the conformance test, you will need to set the tested k0s versio
 In the same directory as your `main.tf` file, create an additional file `terraform.tfvars` with the following input:
 
 ```terraform
-k0s_version=v0.9.0
+k0s_version=v1.22.1+k0s.0
 k8s_version=v1.22.1
-onobuoy_version=0.20.0
+sonobuoy_version=0.53.2
 ```
 
 ### 2. Environment variables
 
 ```shell
-TF_VAR_k0s_version=v0.7.0-beta1 TF_VAR_sonobuoy_version=0.18.0 TF_VAR_k8s_version=v1.22.1 terraform apply
+TF_VAR_k0s_version=v1.22.1+k0s.0 TF_VAR_sonobuoy_version=0.20.0 TF_VAR_k8s_version=v1.22.1 terraform apply
 ```
 
-**NOTE:** By default, terraform will fetch sonobuoy version **0.20.0**. If you want to use a different version you can override this with one of the above methods.
+**NOTE:** By default, terraform will fetch sonobuoy version **0.53.2**. If you want to use a different version you can override this with one of the above methods.
 
 ## Fetching Sonobuoy's results
 
@@ -56,25 +56,24 @@ Once provisioning of the cluster finishes you can get the results by SSH'ing int
 $ ssh -i .terraform/modules/k0s-sonobuoy/inttest/terraform/test-cluster/aws_private.pem ubuntu@[controller_ip]
 
 ubuntu@controller-0:~$ export KUBECONFIG=/var/lib/k0s/pki/admin.conf
-ubuntu@controller-0:~$ sonobuoy status
-         PLUGIN     STATUS   RESULT   COUNT
-            e2e    running                1
-   systemd-logs   complete                2
-   systemd-logs    running                1
+ubuntu@controller-0:~$ sudo --preserve-env=KUBECONFIG sonobuoy status
+         PLUGIN     STATUS   RESULT   COUNT               PROGRESS
+            e2e    running                1   128/346 (0 failures)
+   systemd-logs   complete                3
 
-Sonobuoy is still running. Runs can take up to 60 minutes.
+Sonobuoy is still running. Runs can take 60 minutes or more depending on cluster and plugin configuration.
 ```
 
 Once sonobuoy finishes to retieve results run following command on the cluster host:
 
 ```shell
-result=$(sonobuoy retrieve)
+result=$(sudo --preserve-env=KUBECONFIG sonobuoy retrieve)
 ```
 
 Analyze results:
 
 ```shell
-$ sonobuoy results $results
+$ sudo --preserve-env=KUBECONFIG sonobuoy results $results
 Plugin: systemd-logs
 Status: passed
 Total: 3

--- a/inttest/conformance/terraform/main.tf
+++ b/inttest/conformance/terraform/main.tf
@@ -9,7 +9,7 @@ variable "k0s_version" {
 
 variable "sonobuoy_version" {
   type    = string
-  default = "0.20.0"
+  default = "0.53.2"
 }
 
 variable "k8s_version" {

--- a/inttest/conformance/terraform/main.tf
+++ b/inttest/conformance/terraform/main.tf
@@ -13,7 +13,7 @@ variable "sonobuoy_version" {
 }
 
 variable "k8s_version" {
-  // format: v1.22.1
+  // format: v1.22.2
   type = string
 }
 

--- a/inttest/sonobuoy/signetwork_test.go
+++ b/inttest/sonobuoy/signetwork_test.go
@@ -69,7 +69,7 @@ func (s *NetworkSuite) TestSigNetwork() {
 		`--e2e-focus=\[sig-network\].*\[Conformance\]`,
 		`--e2e-skip=\[Serial\]`,
 		"--e2e-parallel=y",
-		"--kube-conformance-image-version=v1.22.1",
+		"--kube-conformance-image-version=v1.22.2",
 	}
 	s.T().Log("running sonobuoy, this may take a while")
 	sonoFinished := make(chan bool)

--- a/pkg/constant/constant_posix.go
+++ b/pkg/constant/constant_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -59,7 +59,7 @@ const (
 	MetricsImage                       = "gcr.io/k8s-staging-metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.5.0"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"
-	KubeProxyImageVersion              = "v1.22.1"
+	KubeProxyImageVersion              = "v1.22.2"
 	CoreDNSImage                       = "docker.io/coredns/coredns"
 	CoreDNSImageVersion                = "1.7.0"
 	CalicoImage                        = "docker.io/calico/cni"

--- a/pkg/supervisor/detachattr.go
+++ b/pkg/supervisor/detachattr.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/telemetry/sysinfo_linux.go
+++ b/pkg/telemetry/sysinfo_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package telemetry


### PR DESCRIPTION
Cherry picks from `main` to `release-1.22` branch for release 1.22.2.

**What this PR Includes**

- Bump sonobuoy to 0.53.2
- update conformance test readme
- improve flag parser for inttest
- bump kuberentes to 1.22.2  (CVE-2021-25741)
- Fix go formatting with gofmt
