### PR TITLE
Skip pushing latest docs from 1.21 release branch

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -57,5 +57,4 @@ jobs:
       - name: mkdocs deploy new release
         if: contains(github.ref, 'refs/tags/v') && !github.event.release.prerelease # (don't generate for pre-releases)
         run: |
-          mike deploy --push --update-aliases ${{ steps.get_version.outputs.VERSION }} latest
-          mike set-default --push ${{ steps.get_version.outputs.VERSION }}
+          mike deploy --push


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
Currently all tags will create a "release" also in docs site and push the latest tag (from time point of view) as the "latest". This will make docs.k0sproject.io to redirect to this "latest" which is wrong.

**What this PR Includes**
This PR drop the "latest" aliasing completely from 1.21 release branch.