### PR TITLE
docs: missing --become when listing etcd members

### DIFF
--- a/docs/examples/ansible-playbook.md
+++ b/docs/examples/ansible-playbook.md
@@ -210,7 +210,7 @@ k0s-7   NotReady   <none>   21s   v1.20.1-k0s1   192.168.64.61   <none>        U
 **Note**: The first three control plane nodes will not display, as the control plane is fully isolated. To check on the distributed etcd cluster, you can use ssh to securely log a controller node, or you can run the following ad-hoc command:
 
 ```shell
-$ ansible k0s-1 -a "k0s etcd member-list -c /etc/k0s/k0s.yaml" -i inventory/multipass/inventory.yml | tail -1 | jq
+$ ansible k0s-1 --become -a "k0s etcd member-list -c /etc/k0s/k0s.yaml" -i inventory/multipass/inventory.yml | tail -1 | jq
 {
   "level": "info",
   "members": {


### PR DESCRIPTION
Without this, an error is return complaining about file permissions:
```
...
open /var/lib/k0s/pki/apiserver-etcd-client.key: permission denied
...
```
**What this PR Includes**
Fixes incorrect docs about listing etcd members