### PR TITLE
Component specific environment setting

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -2,9 +2,13 @@
 
 `k0s install` does not support environment variables.
 
-Setting environment variables for components used by k0s depends on the used init system. The environment variables set in `k0scontroller` or `k0sworker` service will be inherited by k0s components, such as `etcd`, `containerd`, etc.
+Setting environment variables for components used by k0s depends on the used init system. The environment variables set in `k0scontroller` or `k0sworker` service will be inherited by k0s components, such as `etcd`, `containerd`, `konnectivity`, etc.
 
-Component specific environment variables can be set in `k0scontroller` or `k0sworker` service. For example: `CONTAINERD_HTTPS_PROXY` will be converted to `HTTPS_PROXY` in the `containerd` process while other components are not affected.
+Component specific environment variables can be set in `k0scontroller` or `k0sworker` service. For example: for `CONTAINERD_HTTPS_PROXY`, the prefix `CONTAINERD_` will be stripped and converted to `HTTPS_PROXY` in the `containerd` process.
+
+For those components having env prefix convention such as `ETCD_xxx`, they are handled specially, i.e. the prefix will not be stripped. For example, `ETCD_MAX_WALS` will still be `ETCD_MAX_WALS` in etcd process.
+
+The proxy envs `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` are always overridden by component specific environment variables, so `ETCD_HTTPS_PROXY` will still be converted to `HTTPS_PROXY` in etcd process.
 
 ## SystemD
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,7 +1,10 @@
 # Environment variables
 
 `k0s install` does not support environment variables.
-Setting environment variable for a component used by k0s depends on used init system.
+
+Setting environment variables for components used by k0s depends on the used init system. The environment variables set in `k0scontroller` or `k0sworker` service will be inherited by k0s components, such as `etcd`, `containerd`, etc.
+
+Component specific environment variables can be set in `k0scontroller` or `k0sworker` service. For example: `CONTAINERD_HTTPS_PROXY` will be converted to `HTTPS_PROXY` in the `containerd` process while other components are not affected.
 
 ## SystemD
 

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -187,13 +187,14 @@ func (e *Etcd) Run() error {
 	logrus.Infof("starting etcd with args: %v", args)
 
 	e.supervisor = supervisor.Supervisor{
-		Name:    "etcd",
-		BinPath: assets.BinPath("etcd", e.K0sVars.BinDir),
-		RunDir:  e.K0sVars.RunDir,
-		DataDir: e.K0sVars.DataDir,
-		Args:    args.ToArgs(),
-		UID:     e.uid,
-		GID:     e.gid,
+		Name:          "etcd",
+		BinPath:       assets.BinPath("etcd", e.K0sVars.BinDir),
+		RunDir:        e.K0sVars.RunDir,
+		DataDir:       e.K0sVars.DataDir,
+		Args:          args.ToArgs(),
+		UID:           e.uid,
+		GID:           e.gid,
+		KeepEnvPrefix: true,
 	}
 
 	return e.supervisor.Supervise()

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -112,7 +113,7 @@ func (s *Supervisor) Supervise() error {
 		for {
 			s.cmd = exec.Command(s.BinPath, s.Args...)
 			s.cmd.Dir = s.DataDir
-			s.cmd.Env = getEnv(s.DataDir)
+			s.cmd.Env = getEnv(s.DataDir, s.Name)
 
 			// detach from the process group so children don't
 			// get signals sent directly to parent.
@@ -169,13 +170,35 @@ func (s *Supervisor) Stop() error {
 	return nil
 }
 
-// Modifies the current processes env so that we inject k0s embedded bins into path
-func getEnv(dataDir string) []string {
+// Prepare the env for exec:
+// - handle component specific env
+// - inject k0s embedded bins into path
+func getEnv(dataDir, component string) []string {
 	env := os.Environ()
-	for i, e := range env {
-		if strings.HasPrefix(e, "PATH=") {
-			env[i] = fmt.Sprintf("PATH=%s:%s", path.Join(dataDir, "bin"), os.Getenv("PATH"))
+	componentPrefix := fmt.Sprintf("%s_", strings.ToUpper(component))
+
+	// put the component specific env vars in the front.
+	sort.Slice(env, func(i, j int) bool { return strings.HasPrefix(env[i], componentPrefix) })
+
+	overrides := map[string]struct{}{}
+	i := 0
+	for _, e := range env {
+		kv := strings.SplitN(e, "=", 2)
+		k, v := kv[0], kv[1]
+		// if there is already a correspondent component specific env, skip it.
+		if _, ok := overrides[k]; ok {
+			continue
 		}
+		if strings.HasPrefix(k, componentPrefix) {
+			k = strings.TrimPrefix(k, componentPrefix)
+			overrides[k] = struct{}{}
+		}
+		env[i] = fmt.Sprintf("%s=%s", k, v)
+		if k == "PATH" {
+			env[i] = fmt.Sprintf("PATH=%s:%s", path.Join(dataDir, "bin"), v)
+		}
+		i++
 	}
-	return env
+
+	return env[:i]
 }

--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -75,14 +75,25 @@ func TestGetEnv(t *testing.T) {
 	os.Setenv("FOO_k3", "foo_v3")
 	os.Setenv("k4", "v4")
 	os.Setenv("FOO_k2", "foo_v2")
+	os.Setenv("FOO_HTTPS_PROXY", "a.b.c:1080")
+	os.Setenv("HTTPS_PROXY", "1.2.3.4:8888")
 	os.Setenv("k1", "v1")
 	os.Setenv("FOO_PATH", "/usr/local/bin")
-	env := getEnv("/var/lib/k0s", "foo")
+
+	env := getEnv("/var/lib/k0s", "foo", false)
 	sort.Strings(env)
-	expected := "[PATH=/var/lib/k0s/bin:/usr/local/bin k1=v1 k2=foo_v2 k3=foo_v3 k4=v4]"
+	expected := "[HTTPS_PROXY=a.b.c:1080 PATH=/var/lib/k0s/bin:/usr/local/bin k1=v1 k2=foo_v2 k3=foo_v3 k4=v4]"
 	actual := fmt.Sprintf("%s", env)
 	if actual != expected {
-		t.Errorf("Failed in env processing, expected: %q, actual: %q", expected, actual)
+		t.Errorf("Failed in env processing with keepEnvPrefix=false, expected: %q, actual: %q", expected, actual)
+	}
+
+	env = getEnv("/var/lib/k0s", "foo", true)
+	sort.Strings(env)
+	expected = "[FOO_PATH=/usr/local/bin FOO_k2=foo_v2 FOO_k3=foo_v3 HTTPS_PROXY=a.b.c:1080 PATH=/var/lib/k0s/bin:/bin k1=v1 k2=v2 k3=v3 k4=v4]"
+	actual = fmt.Sprintf("%s", env)
+	if actual != expected {
+		t.Errorf("Failed in env processing with keepEnvPrefix=true, expected: %q, actual: %q", expected, actual)
 	}
 
 	//restore environment vars


### PR DESCRIPTION

**Issue**
Fixes #1125

**What this PR Includes**
User can specify component specific environment variables such as `CONTAINERD_HTTPS_PROXY` in k0s service, in this example, `HTTPS_PROXY` environment variable will be set with the value of `CONTAINERD_HTTPS_PROXY` in containerd process.

Signed-off-by: Xinfeng Liu <xinfeng.liu@gmail.com>