### PR TITLE
Konnectivity dockerfile fix

### DIFF
--- a/embedded-bins/konnectivity/Dockerfile
+++ b/embedded-bins/konnectivity/Dockerfile
@@ -8,7 +8,7 @@ ARG BUILD_GO_FLAGS
 ARG BUILD_GO_LDFLAGS
 ARG BUILD_GO_LDFLAGS_EXTRA
 
-RUN apk add build-base git make
+RUN apk add build-base git make protoc
 
 RUN git clone -b v$VERSION --depth=1 https://github.com/kubernetes-sigs/apiserver-network-proxy.git /apiserver-network-proxy
 WORKDIR /apiserver-network-proxy


### PR DESCRIPTION
**What this PR Includes**
The PR fixes docker build error:
```
#9 38.66 make: protoc: No such file or directory
```

Konnectivity's readme says:
> Proto definitions are compiled with protoc. Please ensure you have protoc installed (Instructions) and the proto-gen-go library at the appropriate version.

https://github.com/kubernetes-sigs/apiserver-network-proxy#protoc


Full log:
```
docker build -t k0sbuild.docker-image.konnectivity \
                --build-arg VERSION=0.0.24 \
                --build-arg BUILDIMAGE=golang:1.16-alpine \
                --build-arg BUILD_GO_TAGS= \
                --build-arg BUILD_GO_CGO_ENABLED=0 \
                --build-arg BUILD_SHIM_GO_CGO_ENABLED= \
                --build-arg BUILD_GO_FLAGS="-a" \
                --build-arg BUILD_GO_LDFLAGS="-w -s" \
                --build-arg BUILD_GO_LDFLAGS_EXTRA="-extldflags=-static" \
                -f konnectivity/Dockerfile .
[+] Building 39.3s (9/10)                                                                                                                                                                                 
 => [internal] load build definition from Dockerfile                                                                                                                                                 0.0s
 => => transferring dockerfile: 904B                                                                                                                                                                 0.0s
 => [internal] load .dockerignore                                                                                                                                                                    0.0s
 => => transferring context: 34B                                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/golang:1.16-alpine                                                                                                                                0.2s
 => [build 1/6] FROM docker.io/library/golang:1.16-alpine@sha256:69d613a986635e0ee3f1b351131fa689b0dd3570ef9cab8e619a5f1fb939ec56                                                                    0.0s
 => CACHED [build 2/6] RUN apk add build-base git make                                                                                                                                               0.0s
 => CACHED [build 3/6] RUN git clone -b v0.0.24 --depth=1 https://github.com/kubernetes-sigs/apiserver-network-proxy.git /apiserver-network-proxy                                                    0.0s
 => CACHED [build 4/6] WORKDIR /apiserver-network-proxy                                                                                                                                              0.0s
 => CACHED [build 5/6] RUN go version                                                                                                                                                                0.0s
 => ERROR [build 6/6] RUN GO111MODULE=on go get github.com/golang/mock/mockgen@v1.4.4 &&     make gen &&     CGO_ENABLED=0     GOOS=linux     go build         -a         -tags=""         -ldflag  39.0s
------                                                                                                                                                                                                    
 > [build 6/6] RUN GO111MODULE=on go get github.com/golang/mock/mockgen@v1.4.4 &&     make gen &&     CGO_ENABLED=0     GOOS=linux     go build         -a         -tags=""         -ldflags="-w -s -extldflags=-static"         -o bin/proxy-server cmd/server/main.go:                                                                                                                                            
#9 3.051 go: downloading github.com/golang/mock v1.4.4
#9 3.180 go: downloading golang.org/x/tools v0.0.0-20210106214847-113979e3529a
#9 4.545 go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
#9 4.545 go: downloading golang.org/x/mod v0.3.0
#9 6.958 go mod download
#9 38.66 mkdir -p /go/src
#9 38.66 protoc -I . proto/agent/agent.proto --go_out=plugins=grpc:/go/src
#9 38.66 make: protoc: No such file or directory
#9 38.66 make: *** [Makefile:110: proto/agent/agent.pb.go] Error 127
------
executor failed running [/bin/sh -c GO111MODULE=on go get github.com/golang/mock/mockgen@v1.4.4 &&     make gen &&     CGO_ENABLED=${BUILD_GO_CGO_ENABLED}     GOOS=linux     go build         ${BUILD_GO_FLAGS}         -tags="${BUILD_GO_TAGS}"         -ldflags="${BUILD_GO_LDFLAGS} ${BUILD_GO_LDFLAGS_EXTRA}"         -o bin/proxy-server cmd/server/main.go]: exit code: 2
make[1]: *** [.docker-image.konnectivity.stamp] Error 1
make: *** [.bins.linux.stamp] Error 2

```