### PR TITLE
Context propagation

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -279,7 +279,7 @@ We need to validate:
 - that we find a secret with the ID
 - that the token matches whats inside the secret
 */
-func (c *CmdOpts) isValidToken(token string, role string) bool {
+func (c *CmdOpts) isValidToken(ctx context.Context, token string, role string) bool {
 	parts := strings.Split(token, ".")
 	logrus.Debugf("token parts: %v", parts)
 	if len(parts) != 2 {
@@ -287,7 +287,7 @@ func (c *CmdOpts) isValidToken(token string, role string) bool {
 	}
 
 	secretName := fmt.Sprintf("bootstrap-token-%s", parts[0])
-	secret, err := c.KubeClient.CoreV1().Secrets("kube-system").Get(context.TODO(), secretName, v1.GetOptions{})
+	secret, err := c.KubeClient.CoreV1().Secrets("kube-system").Get(ctx, secretName, v1.GetOptions{})
 	if err != nil {
 		logrus.Errorf("failed to get bootstrap token: %s", err.Error())
 		return false
@@ -316,7 +316,7 @@ func (c *CmdOpts) authMiddleware(next http.Handler, role string) http.Handler {
 		parts := strings.Split(auth, "Bearer ")
 		if len(parts) == 2 {
 			token := parts[1]
-			if !c.isValidToken(token, role) {
+			if !c.isValidToken(r.Context(), token, role) {
 				sendError(fmt.Errorf("go away"), w, http.StatusUnauthorized)
 				return
 			}

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -261,7 +261,7 @@ func (c *CmdOpts) startController(ctx context.Context) error {
 
 	// Set up signal handling. Use buffered channel so we dont miss
 	// signals during startup
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
 	perfTimer.Checkpoint("starting-node-components")

--- a/cmd/token/create.go
+++ b/cmd/token/create.go
@@ -61,7 +61,7 @@ k0s token create --role worker --expiry 10m  //sets expiration time to 10 minute
 			}, func(err error) bool {
 				return waitCreate
 			}, func() error {
-				bootstrapConfig, err = token.CreateKubeletBootstrapConfig(cfg, c.K0sVars, createTokenRole, expiry)
+				bootstrapConfig, err = token.CreateKubeletBootstrapConfig(cmd.Context(), cfg, c.K0sVars, createTokenRole, expiry)
 
 				return err
 			})

--- a/cmd/token/invalidate.go
+++ b/cmd/token/invalidate.go
@@ -40,7 +40,7 @@ func tokenInvalidateCmd() *cobra.Command {
 			}
 
 			for _, id := range args {
-				err := manager.Remove(id)
+				err := manager.Remove(cmd.Context(), id)
 				if err != nil {
 					return err
 				}

--- a/cmd/token/list.go
+++ b/cmd/token/list.go
@@ -41,7 +41,7 @@ func tokenListCmd() *cobra.Command {
 				return err
 			}
 
-			tokens, err := manager.List(listTokenRole)
+			tokens, err := manager.List(cmd.Context(), listTokenRole)
 			if err != nil {
 				return err
 			}

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -68,7 +68,7 @@ func NewWorkerCmd() *cobra.Command {
 				c.TokenArg = string(bytes)
 			}
 			cmd.SilenceUsage = true
-			return c.StartWorker()
+			return c.StartWorker(cmd.Context())
 		},
 	}
 
@@ -79,7 +79,7 @@ func NewWorkerCmd() *cobra.Command {
 }
 
 // StartWorker starts the worker components based on the CmdOpts config
-func (c *CmdOpts) StartWorker() error {
+func (c *CmdOpts) StartWorker(ctx context.Context) error {
 
 	worker.KernelSetup()
 	if c.TokenArg == "" && !file.Exists(c.K0sVars.KubeletAuthConfigPath) {
@@ -103,18 +103,18 @@ func (c *CmdOpts) StartWorker() error {
 		return fmt.Errorf("windows worker needs to have external CRI")
 	}
 	if c.CriSocket == "" {
-		componentManager.Add(&worker.ContainerD{
+		componentManager.Add(ctx, &worker.ContainerD{
 			LogLevel: c.Logging["containerd"],
 			K0sVars:  c.K0sVars,
 		})
 	}
 
-	componentManager.Add(worker.NewOCIBundleReconciler(c.K0sVars))
+	componentManager.Add(ctx, worker.NewOCIBundleReconciler(c.K0sVars))
 	if c.WorkerProfile == "default" && runtime.GOOS == "windows" {
 		c.WorkerProfile = "default-windows"
 	}
 
-	componentManager.Add(&worker.Kubelet{
+	componentManager.Add(ctx, &worker.Kubelet{
 		CRISocket:           c.CriSocket,
 		EnableCloudProvider: c.CloudProvider,
 		K0sVars:             c.K0sVars,
@@ -129,12 +129,12 @@ func (c *CmdOpts) StartWorker() error {
 		if c.TokenArg == "" {
 			return fmt.Errorf("no join-token given, which is required for windows bootstrap")
 		}
-		componentManager.Add(&worker.KubeProxy{
+		componentManager.Add(ctx, &worker.KubeProxy{
 			K0sVars:   c.K0sVars,
 			LogLevel:  c.Logging["kube-proxy"],
 			CIDRRange: c.CIDRRange,
 		})
-		componentManager.Add(&worker.CalicoInstaller{
+		componentManager.Add(ctx, &worker.CalicoInstaller{
 			Token:      c.TokenArg,
 			APIAddress: c.APIServer,
 			CIDRRange:  c.CIDRRange,
@@ -143,7 +143,7 @@ func (c *CmdOpts) StartWorker() error {
 	}
 
 	if !c.SingleNode && !c.EnableWorker {
-		componentManager.Add(&status.Status{
+		componentManager.Add(ctx, &status.Status{
 			StatusInformation: install.K0sStatus{
 				Pid:           os.Getpid(),
 				Role:          "worker",

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -164,7 +164,7 @@ func (c *CmdOpts) StartWorker(ctx context.Context) error {
 	worker.KernelSetup()
 
 	// Set up signal handling
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
 	err = componentManager.Start(ctx)

--- a/pkg/applier/manager.go
+++ b/pkg/applier/manager.go
@@ -73,7 +73,7 @@ func (m *Manager) Init() error {
 }
 
 // Run runs the Manager
-func (m *Manager) Run() error {
+func (m *Manager) Run(_ context.Context) error {
 	return nil
 }
 

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -21,7 +21,6 @@ import (
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 )
 
-
 // Component defines the interface each managed component implements
 type Component interface {
 	Init() error

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -15,12 +15,17 @@ limitations under the License.
 */
 package component
 
-import "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+import (
+	"context"
+
+	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+)
+
 
 // Component defines the interface each managed component implements
 type Component interface {
 	Init() error
-	Run() error
+	Run(context.Context) error
 	Stop() error
 	Healthy() error
 }
@@ -28,5 +33,5 @@ type Component interface {
 // ReconcilerComponent defines the component interface that is reconciled based
 // on changes on the global config CR object changes
 type ReconcilerComponent interface {
-	Reconcile(*v1beta1.ClusterConfig) error
+	Reconcile(context.Context, *v1beta1.ClusterConfig) error
 }

--- a/pkg/component/controller/apiendpointreconciler_test.go
+++ b/pkg/component/controller/apiendpointreconciler_test.go
@@ -52,7 +52,7 @@ func TestBasicReconcilerWithNoLeader(t *testing.T) {
 
 	assert.NoError(t, r.Init())
 
-	assert.NoError(t, r.reconcileEndpoints())
+	assert.NoError(t, r.reconcileEndpoints(context.Background()))
 	client, err := fakeFactory.GetClient()
 	assert.NoError(t, err)
 	_, err = client.CoreV1().Endpoints("default").Get(context.TODO(), "kubernetes", v1.GetOptions{})
@@ -78,7 +78,7 @@ func TestBasicReconcilerWithNoExistingEndpoint(t *testing.T) {
 
 	assert.NoError(t, r.Init())
 
-	assert.NoError(t, r.reconcileEndpoints())
+	assert.NoError(t, r.reconcileEndpoints(context.Background()))
 	verifyEndpointAddresses(t, expectedAddresses, fakeFactory)
 }
 
@@ -113,7 +113,7 @@ func TestBasicReconcilerWithEmptyEndpointSubset(t *testing.T) {
 
 	assert.NoError(t, r.Init())
 
-	assert.NoError(t, r.reconcileEndpoints())
+	assert.NoError(t, r.reconcileEndpoints(context.Background()))
 	verifyEndpointAddresses(t, expectedAddresses, fakeFactory)
 }
 
@@ -155,7 +155,7 @@ func TestReconcilerWithNoNeedForUpdate(t *testing.T) {
 
 	assert.NoError(t, r.Init())
 
-	assert.NoError(t, r.reconcileEndpoints())
+	assert.NoError(t, r.reconcileEndpoints(context.Background()))
 	e := verifyEndpointAddresses(t, expectedAddresses, fakeFactory)
 	assert.Equal(t, "bar", e.ObjectMeta.Annotations["foo"])
 }

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -16,6 +16,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -85,7 +86,7 @@ func (a *APIServer) Init() error {
 }
 
 // Run runs kube api
-func (a *APIServer) Run() error {
+func (a *APIServer) Run(_ context.Context) error {
 	logrus.Info("Starting kube-apiserver")
 	args := map[string]string{
 		"advertise-address":                a.ClusterConfig.Spec.API.Address,

--- a/pkg/component/controller/calico.go
+++ b/pkg/component/controller/calico.go
@@ -17,6 +17,7 @@ package controller
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -92,7 +93,7 @@ func (c *Calico) Init() error {
 }
 
 // Run nothing really running, all logic based on reactive reconcile
-func (c *Calico) Run() error {
+func (c *Calico) Run(_ context.Context) error {
 	return nil
 }
 
@@ -209,7 +210,7 @@ func (c *Calico) Stop() error {
 }
 
 // Reconcile detects changes in configuration and applies them to the component
-func (c *Calico) Reconcile(cfg *v1beta1.ClusterConfig) error {
+func (c *Calico) Reconcile(_ context.Context, cfg *v1beta1.ClusterConfig) error {
 	c.log.Debug("reconcile method called for: Calico")
 	if cfg.Spec.Network.Provider != "calico" {
 		return nil

--- a/pkg/component/controller/calico_test.go
+++ b/pkg/component/controller/calico_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"testing"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
@@ -28,7 +29,7 @@ func TestCalicoManifests(t *testing.T) {
 		crdSaver := inMemorySaver{}
 		calico, err := NewCalico(k0sVars, crdSaver, saver)
 		require.NoError(t, err)
-		require.NoError(t, calico.Run())
+		require.NoError(t, calico.Run(context.Background()))
 		require.NoError(t, calico.Stop())
 
 		for k := range crdSaver {

--- a/pkg/component/controller/certificates.go
+++ b/pkg/component/controller/certificates.go
@@ -237,7 +237,7 @@ func (c *Certificates) Init() error {
 }
 
 // Run does nothing, the cert component only needs to be initialized
-func (c *Certificates) Run() error {
+func (c *Certificates) Run(_ context.Context) error {
 	return nil
 }
 

--- a/pkg/component/controller/clusterConfig.go
+++ b/pkg/component/controller/clusterConfig.go
@@ -69,7 +69,7 @@ func (r *ClusterConfigReconciler) Init() error {
 	return nil
 }
 
-func (r *ClusterConfigReconciler) Run() error {
+func (r *ClusterConfigReconciler) Run(ctx context.Context) error {
 
 	c, err := cfgClient.NewForConfig(r.kubeConfig)
 	if err != nil {
@@ -90,7 +90,7 @@ func (r *ClusterConfigReconciler) Run() error {
 		for {
 			select {
 			case <-ticker.C:
-				err := r.Reconcile()
+				err := r.Reconcile(ctx)
 				if err != nil {
 					r.log.Warnf("cluster-config reconciliation failed: %s", err.Error())
 				}
@@ -117,8 +117,8 @@ func (r *ClusterConfigReconciler) Run() error {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
-func (r *ClusterConfigReconciler) Reconcile() error {
-	clusterConfig, err := r.configClient.Get(context.Background(), "k0s", getOpts)
+func (r *ClusterConfigReconciler) Reconcile(ctx context.Context) error {
+	clusterConfig, err := r.configClient.Get(ctx, "k0s", getOpts)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// ClusterConfig CR cannot be found, which means we can create it
@@ -140,7 +140,7 @@ func (r *ClusterConfigReconciler) Reconcile() error {
 		if len(errors) > 0 {
 			err = fmt.Errorf("failed to validate config: %v", errors)
 		} else {
-			err = r.ComponentManager.Reconcile(clusterConfig)
+			err = r.ComponentManager.Reconcile(ctx, clusterConfig)
 			// "store" the version even when errors so we don't reconcile in a loop with the same broken config
 			r.lastReconciledConfigVersion = clusterConfig.ResourceVersion
 		}

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -16,6 +16,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -73,10 +74,10 @@ func (a *Manager) Init() error {
 }
 
 // Run runs kube Manager
-func (a *Manager) Run() error { return nil }
+func (a *Manager) Run(_ context.Context) error { return nil }
 
 // Reconcile detects changes in configuration and applies them to the component
-func (a *Manager) Reconcile(clusterConfig *v1beta1.ClusterConfig) error {
+func (a *Manager) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterConfig) error {
 	logger := logrus.WithField("component", "kube-controller-manager")
 	logger.Info("Starting reconcile")
 	ccmAuthConf := filepath.Join(a.K0sVars.CertRootDir, "ccm.conf")

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -286,8 +286,8 @@ func (c *CoreDNS) Init() error {
 }
 
 // Run runs the CoreDNS reconciler component
-func (c *CoreDNS) Run() error {
-	c.stopCtx, c.stopFunc = context.WithCancel(context.Background())
+func (c *CoreDNS) Run(ctx context.Context) error {
+	c.stopCtx, c.stopFunc = context.WithCancel(ctx)
 
 	go func() {
 		ticker := time.NewTicker(10 * time.Second)
@@ -299,7 +299,7 @@ func (c *CoreDNS) Run() error {
 					// We cannot figure out the full config without having the last known cluster config from CR
 					continue
 				}
-				err := c.Reconcile(c.lastKnownClusterConfig)
+				err := c.Reconcile(c.stopCtx, c.lastKnownClusterConfig)
 				if err != nil {
 					c.log.Warnf("failed to reconcile coredns based on node count: %v", err)
 				}
@@ -313,13 +313,13 @@ func (c *CoreDNS) Run() error {
 	return nil
 }
 
-func (c *CoreDNS) getConfig(clusterConfig *v1beta1.ClusterConfig) (coreDNSConfig, error) {
+func (c *CoreDNS) getConfig(ctx context.Context, clusterConfig *v1beta1.ClusterConfig) (coreDNSConfig, error) {
 	dns, err := clusterConfig.Spec.Network.DNSAddress()
 	if err != nil {
 		return coreDNSConfig{}, err
 	}
 
-	nodes, err := c.client.CoreV1().Nodes().List(context.TODO(), v1.ListOptions{})
+	nodes, err := c.client.CoreV1().Nodes().List(ctx, v1.ListOptions{})
 	if err != nil {
 		return coreDNSConfig{}, err
 	}
@@ -358,9 +358,9 @@ func (c *CoreDNS) Stop() error {
 }
 
 // Reconcile detects changes in configuration and applies them to the component
-func (c *CoreDNS) Reconcile(clusterConfig *v1beta1.ClusterConfig) error {
+func (c *CoreDNS) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterConfig) error {
 	logrus.Debug("reconcile method called for: CoreDNS")
-	cfg, err := c.getConfig(clusterConfig)
+	cfg, err := c.getConfig(ctx, clusterConfig)
 	if err != nil {
 		return fmt.Errorf("error calculating coredns configs: %v. will retry", err)
 	}

--- a/pkg/component/controller/crd.go
+++ b/pkg/component/controller/crd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/k0sproject/k0s/pkg/component"
@@ -47,7 +48,7 @@ func (c CRD) Init() error {
 }
 
 // Run unpacks manifests from bindata
-func (c CRD) Run() error {
+func (c CRD) Run(_ context.Context) error {
 	for _, bundle := range bundles {
 		crds, err := static.AssetDir(fmt.Sprintf("manifests/%s/CustomResourceDefinition", bundle))
 		if err != nil {

--- a/pkg/component/controller/csrapprover_test.go
+++ b/pkg/component/controller/csrapprover_test.go
@@ -72,7 +72,7 @@ func TestBasicCRSApprover(t *testing.T) {
 	c := NewCSRApprover(config, &DummyLeaderElector{Leader: true}, fakeFactory)
 
 	assert.NoError(t, c.Init())
-	assert.NoError(t, c.approveCSR())
+	assert.NoError(t, c.approveCSR(ctx))
 
 	csr, err := client.CertificatesV1().CertificateSigningRequests().Get(ctx, newCsr.Name, metav1.GetOptions{})
 	assert.NoError(t, err)

--- a/pkg/component/controller/defaultpsp.go
+++ b/pkg/component/controller/defaultpsp.go
@@ -74,7 +74,7 @@ func (d *DefaultPSP) Stop() error {
 }
 
 // Reconcile detects changes in configuration and applies them to the component
-func (d *DefaultPSP) Reconcile(clusterConfig *v1beta1.ClusterConfig) error {
+func (d *DefaultPSP) Reconcile(_ctx context.Context, clusterConfig *v1beta1.ClusterConfig) error {
 	log := logrus.WithField("component", "DefaultPSP")
 	log.Debug("reconcile method called for: DefaultPSP")
 	if d.previousPolicy == clusterConfig.Spec.PodSecurityPolicy.DefaultPolicy {

--- a/pkg/component/controller/defaultpsp.go
+++ b/pkg/component/controller/defaultpsp.go
@@ -16,6 +16,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -63,7 +64,7 @@ func (d *DefaultPSP) Init() error {
 }
 
 // Run reconciles the k0s default PSP rules
-func (d *DefaultPSP) Run() error {
+func (d *DefaultPSP) Run(_ context.Context) error {
 	return nil
 }
 

--- a/pkg/component/controller/dummyleaderelector.go
+++ b/pkg/component/controller/dummyleaderelector.go
@@ -15,6 +15,8 @@ limitations under the License.
 */
 package controller
 
+import "context"
+
 type DummyLeaderElector struct {
 	Leader    bool
 	callbacks []func()
@@ -32,7 +34,7 @@ func (l *DummyLeaderElector) AddAcquiredLeaseCallback(fn func()) {
 
 func (l *DummyLeaderElector) AddLostLeaseCallback(func()) {}
 
-func (l *DummyLeaderElector) Run() error {
+func (l *DummyLeaderElector) Run(_ context.Context) error {
 	if !l.Leader {
 		return nil
 	}

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -125,7 +125,7 @@ func (e *Etcd) syncEtcdConfig(peerURL, etcdCaCert, etcdCaCertKey string) ([]stri
 }
 
 // Run runs etcd
-func (e *Etcd) Run() error {
+func (e *Etcd) Run(ctx context.Context) error {
 	etcdCaCert := filepath.Join(e.K0sVars.EtcdCertDir, "ca.crt")
 	etcdCaCertKey := filepath.Join(e.K0sVars.EtcdCertDir, "ca.key")
 	etcdServerCert := filepath.Join(e.K0sVars.EtcdCertDir, "server.crt")
@@ -174,7 +174,7 @@ func (e *Etcd) Run() error {
 		args["--initial-cluster-state"] = "existing"
 	}
 
-	if err := e.setupCerts(); err != nil {
+	if err := e.setupCerts(ctx); err != nil {
 		return fmt.Errorf("failed to create etcd certs: %w", err)
 	}
 
@@ -211,7 +211,7 @@ func (e *Etcd) Reconcile() error {
 	return nil
 }
 
-func (e *Etcd) setupCerts() error {
+func (e *Etcd) setupCerts(ctx context.Context) error {
 	etcdCaCert := filepath.Join(e.K0sVars.EtcdCertDir, "ca.crt")
 	etcdCaCertKey := filepath.Join(e.K0sVars.EtcdCertDir, "ca.key")
 
@@ -219,7 +219,7 @@ func (e *Etcd) setupCerts() error {
 		return fmt.Errorf("failed to create etcd ca: %w", err)
 	}
 
-	eg, _ := errgroup.WithContext(context.Background())
+	eg, _ := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
 		// etcd client cert

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -219,7 +219,7 @@ func (e *Etcd) setupCerts(ctx context.Context) error {
 		return fmt.Errorf("failed to create etcd ca: %w", err)
 	}
 
-	eg, _ := errgroup.WithContext(ctx)
+	var eg errgroup.Group
 
 	eg.Go(func() error {
 		// etcd client cert

--- a/pkg/component/controller/k0sLease.go
+++ b/pkg/component/controller/k0sLease.go
@@ -30,8 +30,8 @@ func (l *K0sLease) Init() error {
 }
 
 // Run runs the leader elector to keep the lease object up-to-date.
-func (l *K0sLease) Run() error {
-	l.cancelCtx, l.cancelFunc = context.WithCancel(context.Background())
+func (l *K0sLease) Run(ctx context.Context) error {
+	l.cancelCtx, l.cancelFunc = context.WithCancel(ctx)
 	log := logrus.WithFields(logrus.Fields{"component": "controllerlease"})
 	client, err := l.KubeClientFactory.GetClient()
 	if err != nil {

--- a/pkg/component/controller/k0sLease.go
+++ b/pkg/component/controller/k0sLease.go
@@ -19,7 +19,6 @@ type K0sLease struct {
 	ClusterConfig     *v1beta1.ClusterConfig
 	KubeClientFactory kubeutil.ClientFactoryInterface
 
-	cancelCtx   context.Context
 	cancelFunc  context.CancelFunc
 	leaseCancel context.CancelFunc
 }
@@ -31,7 +30,7 @@ func (l *K0sLease) Init() error {
 
 // Run runs the leader elector to keep the lease object up-to-date.
 func (l *K0sLease) Run(ctx context.Context) error {
-	l.cancelCtx, l.cancelFunc = context.WithCancel(ctx)
+	ctx, l.cancelFunc = context.WithCancel(ctx)
 	log := logrus.WithFields(logrus.Fields{"component": "controllerlease"})
 	client, err := l.KubeClientFactory.GetClient()
 	if err != nil {
@@ -63,7 +62,7 @@ func (l *K0sLease) Run(ctx context.Context) error {
 				log.Info("acquired leader lease")
 			case <-events.LostLease:
 				log.Error("lost leader lease, this should not really happen!?!?!?")
-			case <-l.cancelCtx.Done():
+			case <-ctx.Done():
 				return
 			}
 		}

--- a/pkg/component/controller/k0scloudprovider.go
+++ b/pkg/component/controller/k0scloudprovider.go
@@ -16,6 +16,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"time"
 
 	"github.com/k0sproject/k0s/pkg/component"
@@ -67,7 +68,7 @@ func (c *k0sCloudProvider) Init() error {
 
 // Run will create a k0s-cloud-provider command, and run it on a goroutine.
 // Failures to create this command will be returned as an error.
-func (c *k0sCloudProvider) Run() error {
+func (c *k0sCloudProvider) Run(_ context.Context) error {
 	command, err := c.commandBuilder()
 	if err != nil {
 		return err

--- a/pkg/component/controller/k0scloudprovider_test.go
+++ b/pkg/component/controller/k0scloudprovider_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -74,7 +75,7 @@ func (suite *K0sCloudProviderSuite) TestInit() {
 // `Stop()`, without worrying about what was actually running.
 func (suite *K0sCloudProviderSuite) TestRunStop() {
 	assert.Nil(suite.T(), suite.ccp.Init())
-	assert.Nil(suite.T(), suite.ccp.Run())
+	assert.Nil(suite.T(), suite.ccp.Run(context.Background()))
 
 	// Ensures that the stopping mechanism actually closes the stop channel.
 	assert.Nil(suite.T(), suite.ccp.Stop())

--- a/pkg/component/controller/k0scontrolapi.go
+++ b/pkg/component/controller/k0scontrolapi.go
@@ -16,6 +16,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -39,7 +40,7 @@ func (m *K0SControlAPI) Init() error {
 }
 
 // Run runs k0s control api as separate process
-func (m *K0SControlAPI) Run() error {
+func (m *K0SControlAPI) Run(_ context.Context) error {
 	// TODO: Make the api process to use some other user
 
 	selfExe, err := os.Executable()

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -16,6 +16,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -81,7 +82,7 @@ func (k *Kine) Init() error {
 }
 
 // Run runs kine
-func (k *Kine) Run() error {
+func (k *Kine) Run(_ context.Context) error {
 	logrus.Info("Starting kine")
 	logrus.Debugf("datasource: %s", k.Config.DataSource)
 

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -87,11 +87,11 @@ func (k *Konnectivity) Init() error {
 }
 
 // Run ..
-func (k *Konnectivity) Run() error {
+func (k *Konnectivity) Run(ctx context.Context) error {
 	// Buffered chan to send updates for the count of servers
 	k.serverCountChan = make(chan int, 1)
 
-	k.stopCtx, k.stopFunc = context.WithCancel(context.Background())
+	k.stopCtx, k.stopFunc = context.WithCancel(ctx)
 
 	go k.runServer()
 
@@ -99,7 +99,7 @@ func (k *Konnectivity) Run() error {
 }
 
 // Reconcile detects changes in configuration and applies them to the component
-func (k *Konnectivity) Reconcile(clusterCfg *v1beta1.ClusterConfig) error {
+func (k *Konnectivity) Reconcile(ctx context.Context, clusterCfg *v1beta1.ClusterConfig) error {
 	k.clusterConfig = clusterCfg
 	if k.NodeConfig.Spec.API.ExternalAddress != "" {
 		go k.runLeaseCounter()

--- a/pkg/component/controller/kubeletconfig.go
+++ b/pkg/component/controller/kubeletconfig.go
@@ -74,13 +74,13 @@ func (k *KubeletConfig) Stop() error {
 }
 
 // Run dumps the needed manifest objects
-func (k *KubeletConfig) Run() error {
+func (k *KubeletConfig) Run(_ context.Context) error {
 
 	return nil
 }
 
 // Reconcile detects changes in configuration and applies them to the component
-func (k *KubeletConfig) Reconcile(clusterSpec *v1beta1.ClusterConfig) error {
+func (k *KubeletConfig) Reconcile(_ context.Context, clusterSpec *v1beta1.ClusterConfig) error {
 	k.log.Debug("reconcile method called for: KubeletConfig")
 	// Check if we actually need to reconcile anything
 	defaultProfilesExist, err := k.defaultProfilesExist()

--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -16,6 +16,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"os"
 	"path"
 	"path/filepath"
@@ -66,10 +67,10 @@ func (k *KubeProxy) Init() error {
 }
 
 // Run runs the kube-proxy reconciler
-func (k *KubeProxy) Run() error { return nil }
+func (k *KubeProxy) Run(_ context.Context) error { return nil }
 
 // Reconcile detects changes in configuration and applies them to the component
-func (k *KubeProxy) Reconcile(clusterConfig *v1beta1.ClusterConfig) error {
+func (k *KubeProxy) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterConfig) error {
 	if clusterConfig.Spec.Network.KubeProxy.Disabled {
 		return os.RemoveAll(k.manifestDir)
 	}

--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -18,6 +18,7 @@ package controller
 import (
 	"bytes"
 	"fmt"
+	"context"
 
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
@@ -69,7 +70,7 @@ func (k *KubeRouter) Healthy() error { return nil }
 func (k *KubeRouter) Stop() error { return nil }
 
 // Reconcile detects changes in configuration and applies them to the component
-func (k *KubeRouter) Reconcile(clusterConfig *v1beta1.ClusterConfig) error {
+func (k *KubeRouter) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterConfig) error {
 	logrus.Debug("reconcile method called for: KubeRouter")
 	if clusterConfig.Spec.Network.Provider != constant.CNIProviderKubeRouter {
 		return nil
@@ -115,7 +116,7 @@ func (k *KubeRouter) Reconcile(clusterConfig *v1beta1.ClusterConfig) error {
 }
 
 // Run runs the kube-router reconciler
-func (k *KubeRouter) Run() error {
+func (k *KubeRouter) Run(_ context.Context) error {
 	k.log.Info("starting to dump manifests")
 
 	return nil

--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -17,8 +17,8 @@ package controller
 
 import (
 	"bytes"
-	"fmt"
 	"context"
+	"fmt"
 
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"

--- a/pkg/component/controller/kuberouter_test.go
+++ b/pkg/component/controller/kuberouter_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -28,7 +29,7 @@ func TestKubeRouterConfig(t *testing.T) {
 	saver := inMemorySaver{}
 	kr, err := NewKubeRouter(k0sVars, saver)
 	require.NoError(t, err)
-	require.NoError(t, kr.Reconcile(cfg))
+	require.NoError(t, kr.Reconcile(context.Background(), cfg))
 	require.NoError(t, kr.Stop())
 
 	manifestData, foundRaw := saver["kube-router.yaml"]
@@ -60,7 +61,7 @@ func TestKubeRouterDefaultManifests(t *testing.T) {
 	saver := inMemorySaver{}
 	kr, err := NewKubeRouter(k0sVars, saver)
 	require.NoError(t, err)
-	require.NoError(t, kr.Reconcile(cfg))
+	require.NoError(t, kr.Reconcile(context.Background(), cfg))
 	require.NoError(t, kr.Stop())
 
 	manifestData, foundRaw := saver["kube-router.yaml"]

--- a/pkg/component/controller/leaderelector.go
+++ b/pkg/component/controller/leaderelector.go
@@ -62,7 +62,7 @@ func (l *leaderElector) Init() error {
 	return nil
 }
 
-func (l *leaderElector) Run() error {
+func (l *leaderElector) Run(_ context.Context) error {
 	client, err := l.kubeClientFactory.GetClient()
 	if err != nil {
 		return fmt.Errorf("can't create kubernetes rest client for lease pool: %v", err)

--- a/pkg/component/controller/metricserver_test.go
+++ b/pkg/component/controller/metricserver_test.go
@@ -16,11 +16,12 @@ var cfg = v1beta1.DefaultClusterConfig("")
 
 func TestGetConfigWithZeroNodes(t *testing.T) {
 	fakeFactory := testutil.NewFakeClientFactory()
+	ctx := context.Background()
 
 	metrics, err := NewMetricServer(k0sVars, fakeFactory)
 	require.NoError(t, err)
-	require.NoError(t, metrics.Reconcile(cfg))
-	cfg, err := metrics.getConfig()
+	require.NoError(t, metrics.Reconcile(ctx, cfg))
+	cfg, err := metrics.getConfig(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "10m", cfg.CPURequest)
 	require.Equal(t, "30M", cfg.MEMRequest)
@@ -29,6 +30,7 @@ func TestGetConfigWithZeroNodes(t *testing.T) {
 func TestGetConfigWithSomeNodes(t *testing.T) {
 	fakeFactory := testutil.NewFakeClientFactory()
 	fakeClient, _ := fakeFactory.GetClient()
+	ctx := context.Background()
 
 	for i := 1; i <= 100; i++ {
 		n := &corev1.Node{
@@ -42,8 +44,8 @@ func TestGetConfigWithSomeNodes(t *testing.T) {
 
 	metrics, err := NewMetricServer(k0sVars, fakeFactory)
 	require.NoError(t, err)
-	require.NoError(t, metrics.Reconcile(cfg))
-	cfg, err := metrics.getConfig()
+	require.NoError(t, metrics.Reconcile(ctx, cfg))
+	cfg, err := metrics.getConfig(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "100m", cfg.CPURequest)
 	require.Equal(t, "300M", cfg.MEMRequest)

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -16,6 +16,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
@@ -54,7 +55,7 @@ func (a *Scheduler) Init() error {
 }
 
 // Run runs kube scheduler
-func (a *Scheduler) Run() error {
+func (a *Scheduler) Run(_ context.Context) error {
 	return nil
 }
 
@@ -67,7 +68,7 @@ func (a *Scheduler) Stop() error {
 }
 
 // Reconcile detects changes in configuration and applies them to the component
-func (a *Scheduler) Reconcile(clusterConfig *v1beta1.ClusterConfig) error {
+func (a *Scheduler) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterConfig) error {
 	logrus.Debug("reconcile method called for: Scheduler")
 
 	logrus.Info("Starting kube-scheduler")

--- a/pkg/component/controller/systemrbac.go
+++ b/pkg/component/controller/systemrbac.go
@@ -16,6 +16,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -44,7 +45,7 @@ func (s *SystemRBAC) Init() error {
 }
 
 // Run reconciles the k0s related system RBAC rules
-func (s *SystemRBAC) Run() error {
+func (s *SystemRBAC) Run(_ context.Context) error {
 	rbacDir := path.Join(s.manifestDir, "bootstraprbac")
 	err := dir.Init(rbacDir, constant.ManifestsDirMode)
 	if err != nil {

--- a/pkg/component/manager.go
+++ b/pkg/component/manager.go
@@ -45,10 +45,10 @@ func NewManager() *Manager {
 }
 
 // Add adds a component to the manager
-func (m *Manager) Add(component Component) {
+func (m *Manager) Add(ctx context.Context, component Component) {
 	m.Components = append(m.Components, component)
 	if isReconcileComponent(component) && m.lastReconciledConfig != nil {
-		if err := m.reconcileComponent(context.TODO(), component, m.lastReconciledConfig); err != nil {
+		if err := m.reconcileComponent(ctx, component, m.lastReconciledConfig); err != nil {
 			logrus.Warnf("component reconciler failed: %v", err)
 		}
 	}

--- a/pkg/component/manager.go
+++ b/pkg/component/manager.go
@@ -48,7 +48,7 @@ func NewManager() *Manager {
 func (m *Manager) Add(component Component) {
 	m.Components = append(m.Components, component)
 	if isReconcileComponent(component) && m.lastReconciledConfig != nil {
-		if err := m.reconcileComponent(component, m.lastReconciledConfig); err != nil {
+		if err := m.reconcileComponent(context.TODO(), component, m.lastReconciledConfig); err != nil {
 			logrus.Warnf("component reconciler failed: %v", err)
 		}
 	}
@@ -89,7 +89,7 @@ func (m *Manager) Start(ctx context.Context) error {
 		compName := reflect.TypeOf(comp).Elem().Name()
 		perfTimer.Checkpoint(fmt.Sprintf("running-%s", compName))
 		logrus.Infof("starting %v", compName)
-		if err := comp.Run(); err != nil {
+		if err := comp.Run(ctx); err != nil {
 			return err
 		}
 		perfTimer.Checkpoint(fmt.Sprintf("running-%s-done", compName))
@@ -133,12 +133,12 @@ func (r ReconcileError) Error() string {
 }
 
 // Reconcile reconciles all managed components
-func (m *Manager) Reconcile(cfg *v1beta1.ClusterConfig) error {
+func (m *Manager) Reconcile(ctx context.Context, cfg *v1beta1.ClusterConfig) error {
 	errors := make([]error, 0)
 	var ret error
 	logrus.Infof("starting component reconciling for %d components", len(m.Components))
 	for _, component := range m.Components {
-		if err := m.reconcileComponent(component, cfg); err != nil {
+		if err := m.reconcileComponent(ctx, component, cfg); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -152,7 +152,7 @@ func (m *Manager) Reconcile(cfg *v1beta1.ClusterConfig) error {
 	return ret
 }
 
-func (m *Manager) reconcileComponent(component Component, cfg *v1beta1.ClusterConfig) error {
+func (m *Manager) reconcileComponent(ctx context.Context, component Component, cfg *v1beta1.ClusterConfig) error {
 	clusterComponent, ok := component.(ReconcilerComponent)
 	compName := reflect.TypeOf(component).String()
 	if !ok {
@@ -160,7 +160,7 @@ func (m *Manager) reconcileComponent(component Component, cfg *v1beta1.ClusterCo
 		return nil
 	}
 	logrus.Infof("starting to reconcile %s", compName)
-	if err := clusterComponent.Reconcile(cfg); err != nil {
+	if err := clusterComponent.Reconcile(ctx, cfg); err != nil {
 		logrus.Errorf("failed to reconcile component %s: %s", compName, err.Error())
 		return err
 	}

--- a/pkg/component/status/status.go
+++ b/pkg/component/status/status.go
@@ -48,7 +48,7 @@ func (s *Status) Init() error {
 }
 
 // Run runs the component
-func (s *Status) Run() error {
+func (s *Status) Run(_ context.Context) error {
 	go func() {
 		if err := s.httpserver.Serve(s.listener); err != nil {
 			s.L.Errorf("failed to start status server at %s: %s", s.Socket, err)

--- a/pkg/component/worker/calico_installer_windows.go
+++ b/pkg/component/worker/calico_installer_windows.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -93,7 +94,7 @@ func (c CalicoInstaller) SaveKubeConfig(path string) error {
 	return posh.execute(fmt.Sprintf("C:\\bootstrap.ps1 -ServiceCidr \"%s\" -DNSServerIPs \"%s\"", c.CIDRRange, c.ClusterDNS))
 }
 
-func (c CalicoInstaller) Run() error {
+func (c CalicoInstaller) Run(_ context.Context) error {
 	return nil
 }
 

--- a/pkg/component/worker/containerd.go
+++ b/pkg/component/worker/containerd.go
@@ -16,6 +16,7 @@ limitations under the License.
 package worker
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -61,7 +62,7 @@ func (c *ContainerD) Init() error {
 }
 
 // Run runs containerD
-func (c *ContainerD) Run() error {
+func (c *ContainerD) Run(_ context.Context) error {
 	logrus.Info("Starting containerD")
 
 	if err := c.setupConfig(); err != nil {

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -16,6 +16,7 @@ limitations under the License.
 package worker
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -102,7 +103,7 @@ func (k *Kubelet) Init() error {
 }
 
 // Run runs kubelet
-func (k *Kubelet) Run() error {
+func (k *Kubelet) Run(ctx context.Context) error {
 	cmd := "kubelet"
 
 	kubeletConfigData := kubeletConfig{
@@ -136,7 +137,7 @@ func (k *Kubelet) Run() error {
 	}
 
 	if runtime.GOOS == "windows" {
-		node, err := getNodeName()
+		node, err := getNodeName(ctx)
 		if err != nil {
 			return fmt.Errorf("can't get hostname: %v", err)
 		}
@@ -201,7 +202,7 @@ func (k *Kubelet) Run() error {
 	}
 
 	err := retry.Do(func() error {
-		kubeletconfig, err := k.KubeletConfigClient.Get(k.Profile)
+		kubeletconfig, err := k.KubeletConfigClient.Get(ctx, k.Profile)
 		if err != nil {
 			logrus.Warnf("failed to get initial kubelet config with join token: %s", err.Error())
 			return err
@@ -244,11 +245,12 @@ func (k *Kubelet) Healthy() error { return nil }
 
 const awsMetaInformationURI = "http://169.254.169.254/latest/meta-data/local-hostname"
 
-func getNodeName() (string, error) {
+func getNodeName(ctx context.Context) (string, error) {
 	req, err := http.NewRequest("GET", awsMetaInformationURI, nil)
 	if err != nil {
 		return "", err
 	}
+	req = req.WithContext(ctx)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return os.Hostname()

--- a/pkg/component/worker/kubeletconfigclient.go
+++ b/pkg/component/worker/kubeletconfigclient.go
@@ -43,9 +43,9 @@ func NewKubeletConfigClient(kubeconfigPath string) (*KubeletConfigClient, error)
 }
 
 // Get reads the config from kube api
-func (k *KubeletConfigClient) Get(profile string) (string, error) {
+func (k *KubeletConfigClient) Get(ctx context.Context, profile string) (string, error) {
 	cmName := fmt.Sprintf("kubelet-config-%s-%s", profile, constant.KubernetesMajorMinorVersion)
-	cm, err := k.kubeClient.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), cmName, v1.GetOptions{})
+	cm, err := k.kubeClient.CoreV1().ConfigMaps("kube-system").Get(ctx, cmName, v1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to get kubelet config from API: %w", err)
 	}

--- a/pkg/component/worker/kubeproxy_windows.go
+++ b/pkg/component/worker/kubeproxy_windows.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -22,8 +23,8 @@ func (k KubeProxy) Init() error {
 	return assets.Stage(k.K0sVars.BinDir, "kube-proxy.exe", constant.BinDirMode)
 }
 
-func (k KubeProxy) Run() error {
-	node, err := getNodeName()
+func (k KubeProxy) Run(ctx context.Context) error {
+	node, err := getNodeName(ctx)
 	if err != nil {
 		return fmt.Errorf("can't get hostname: %v", err)
 	}

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -32,7 +32,7 @@ func (a *OCIBundleReconciler) Init() error {
 	return dir.Init(a.k0sVars.OCIBundleDir, constant.ManifestsDirMode)
 }
 
-func (a *OCIBundleReconciler) Run() error {
+func (a *OCIBundleReconciler) Run(ctx context.Context) error {
 	files, err := os.ReadDir(a.k0sVars.OCIBundleDir)
 	if err != nil {
 		return fmt.Errorf("can't read bundles directory")
@@ -48,7 +48,7 @@ func (a *OCIBundleReconciler) Run() error {
 			logrus.WithError(err).Errorf("can't connect to containerd socket %s", sock)
 			return err
 		}
-		_, err := client.ListImages(context.Background())
+		_, err := client.ListImages(ctx)
 		if err != nil {
 			logrus.WithError(err).Errorf("can't use containerd client")
 			return err
@@ -61,7 +61,7 @@ func (a *OCIBundleReconciler) Run() error {
 	defer client.Close()
 
 	for _, file := range files {
-		if err := a.unpackBundle(client, a.k0sVars.OCIBundleDir+"/"+file.Name()); err != nil {
+		if err := a.unpackBundle(ctx, client, a.k0sVars.OCIBundleDir+"/"+file.Name()); err != nil {
 			logrus.WithError(err).Errorf("can't unpack bundle %s", file.Name())
 			return fmt.Errorf("can't unpack bundle %s: %w", file.Name(), err)
 		}
@@ -69,13 +69,13 @@ func (a *OCIBundleReconciler) Run() error {
 	return nil
 }
 
-func (a OCIBundleReconciler) unpackBundle(client *containerd.Client, bundlePath string) error {
+func (a OCIBundleReconciler) unpackBundle(ctx context.Context, client *containerd.Client, bundlePath string) error {
 	r, err := os.Open(bundlePath)
 	if err != nil {
 		return fmt.Errorf("can't open bundle file %s: %v", bundlePath, err)
 	}
 	defer r.Close()
-	images, err := client.Import(context.Background(), r)
+	images, err := client.Import(ctx, r)
 	if err != nil {
 		return fmt.Errorf("can't import bundle: %v", err)
 	}

--- a/pkg/component/worker/stubs.go
+++ b/pkg/component/worker/stubs.go
@@ -3,7 +3,11 @@
 
 package worker
 
-import "github.com/k0sproject/k0s/pkg/constant"
+import (
+	"context"
+
+	"github.com/k0sproject/k0s/pkg/constant"
+)
 
 type CalicoInstaller struct {
 	Token      string
@@ -16,7 +20,7 @@ func (c CalicoInstaller) Init() error {
 	panic("stub component is used: CalicoInstaller")
 }
 
-func (c CalicoInstaller) Run() error {
+func (c CalicoInstaller) Run(_ context.Context) error {
 	panic("stub component is used: CalicoInstaller")
 }
 
@@ -42,7 +46,7 @@ func (k KubeProxy) Init() error {
 	panic("stub component is used: KubeProxy")
 }
 
-func (k KubeProxy) Run() error {
+func (k KubeProxy) Run(_ context.Context) error {
 	panic("stub component is used: KubeProxy")
 }
 

--- a/pkg/telemetry/component.go
+++ b/pkg/telemetry/component.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"context"
 	"time"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
@@ -57,7 +58,7 @@ func (c *Component) retrieveKubeClient(ch chan struct{}) {
 }
 
 // Run runs work cycle
-func (c *Component) Run() error {
+func (c *Component) Run(_ context.Context) error {
 	return nil
 }
 
@@ -77,7 +78,7 @@ func (c *Component) Stop() error {
 }
 
 // Reconcile detects changes in configuration and applies them to the component
-func (c *Component) Reconcile(clusterCfg *v1beta1.ClusterConfig) error {
+func (c *Component) Reconcile(_ context.Context, clusterCfg *v1beta1.ClusterConfig) error {
 	logrus.Debug("reconcile method called for: Telemetry")
 	if !clusterCfg.Spec.Telemetry.Enabled {
 		return c.Stop()

--- a/pkg/token/kubeconfig.go
+++ b/pkg/token/kubeconfig.go
@@ -17,6 +17,7 @@ package token
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"html/template"
@@ -54,7 +55,7 @@ users:
     token: {{.Token}}
 `))
 
-func CreateKubeletBootstrapConfig(nodeConfig *v1beta1.ClusterConfig, k0sVars constant.CfgVars, role string, expiry time.Duration) (string, error) {
+func CreateKubeletBootstrapConfig(ctx context.Context, nodeConfig *v1beta1.ClusterConfig, k0sVars constant.CfgVars, role string, expiry time.Duration) (string, error) {
 	crtFile := filepath.Join(k0sVars.CertRootDir, "ca.crt")
 	caCert, err := os.ReadFile(crtFile)
 	if err != nil {
@@ -64,7 +65,7 @@ func CreateKubeletBootstrapConfig(nodeConfig *v1beta1.ClusterConfig, k0sVars con
 	if err != nil {
 		return "", err
 	}
-	tokenString, err := manager.Create(expiry, role)
+	tokenString, err := manager.Create(ctx, expiry, role)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/token/manager.go
+++ b/pkg/token/manager.go
@@ -58,7 +58,7 @@ type Manager struct {
 }
 
 // Create creates a new bootstrap token
-func (m *Manager) Create(valid time.Duration, role string) (string, error) {
+func (m *Manager) Create(ctx context.Context, valid time.Duration, role string) (string, error) {
 	tokenID := random.String(6)
 	tokenSecret := random.String(16)
 
@@ -98,7 +98,7 @@ func (m *Manager) Create(valid time.Duration, role string) (string, error) {
 		StringData: data,
 	}
 
-	_, err := m.client.CoreV1().Secrets("kube-system").Create(context.TODO(), secret, metav1.CreateOptions{})
+	_, err := m.client.CoreV1().Secrets("kube-system").Create(ctx, secret, metav1.CreateOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -107,8 +107,8 @@ func (m *Manager) Create(valid time.Duration, role string) (string, error) {
 }
 
 // List returns all the join tokens for given role. If role == "" then it returns all join tokens
-func (m *Manager) List(role string) ([]Token, error) {
-	tokenList, err := m.client.CoreV1().Secrets("kube-system").List(context.TODO(), metav1.ListOptions{
+func (m *Manager) List(ctx context.Context, role string) ([]Token, error) {
+	tokenList, err := m.client.CoreV1().Secrets("kube-system").List(ctx, metav1.ListOptions{
 		FieldSelector: "type=bootstrap.kubernetes.io/token",
 	})
 	if err != nil {
@@ -132,8 +132,8 @@ func (m *Manager) List(role string) ([]Token, error) {
 	return tokens, nil
 }
 
-func (m *Manager) Remove(tokenID string) error {
-	err := m.client.CoreV1().Secrets("kube-system").Delete(context.TODO(), fmt.Sprintf("bootstrap-token-%s", tokenID), metav1.DeleteOptions{})
+func (m *Manager) Remove(ctx context.Context, tokenID string) error {
+	err := m.client.CoreV1().Secrets("kube-system").Delete(ctx, fmt.Sprintf("bootstrap-token-%s", tokenID), metav1.DeleteOptions{})
 	if errors.IsNotFound(err) {
 		return nil
 	}


### PR DESCRIPTION
**Issue**
Fixes #917

**What this PR Includes**
- Context propagation instead of `context.TODO()` usage.
- `signal.NotifyContext ` is used instead of `signal.Notify` for signal handling.