### PR TITLE
increase golint timeout and rename workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Go build
+name: Go lint
 on:
   push:
     branches:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # options for analysis running
 run:
 
-  timeout: 5m
+  timeout: 8m
 
   skip-dirs-use-default: false
   skip-dirs:


### PR DESCRIPTION
Signed-off-by: Xinfeng Liu <xinfeng.liu@gmail.com>


**What this PR Includes**
Currently golint workflow often fails due to 5m timeout. This PR increase golint timeout and rename the workflow for better readability. 