### PR TITLE
Fix check-unit on MacOS

### DIFF
--- a/pkg/cleanup/bridge_darwin.go
+++ b/pkg/cleanup/bridge_darwin.go
@@ -1,0 +1,1 @@
+bridge_windows.go

--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -28,8 +28,9 @@ func TestSupervisor(t *testing.T) {
 			shouldFail: false,
 			proc: Supervisor{
 				Name:    "supervisor-test-fail",
-				BinPath: "/bin/false",
+				BinPath: "/bin/sh",
 				RunDir:  ".",
+				Args:	[]string{"-c", "false"},
 			},
 		},
 		SupervisorTest{


### PR DESCRIPTION
**What this PR Includes**
Fixes so we can run `make check-unit` on MacOS.