### PR TITLE
Fix return status for config validation

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -16,8 +16,6 @@ limitations under the License.
 package validate
 
 import (
-	"fmt"
-
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/spf13/cobra"
 )
@@ -43,11 +41,10 @@ func validateConfigCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := CmdOpts(config.GetCmdOpts())
 			_, err := config.GetNodeConfig(c.CfgFile, c.K0sVars)
-			if err != nil {
-				fmt.Println(err)
-			}
-			return nil
+			return err
 		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 
 	// append flags


### PR DESCRIPTION
Exit with failure when config validation fails.

Enable SilenceErrors so we don't print error message twice.

Enable SilenceUsage so we don't print usage on validation errors.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

