### PR TITLE
Mention that git tags should be annotated in release docs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ We try to follow the practice of releasing often. That allows us to have smaller
 
 ## Creating a release
 
-Creating a release happens via Github Actions by creating a git tag. Tag creation triggers the release workflow which will do most of the heavy-lifting:
+Creating a release happens via Github Actions by creating an [annotated](https://git-scm.com/book/en/v2/Git-Basics-Tagging#_creating_tags) git tag. Tag creation triggers the release workflow which will do most of the heavy-lifting:
 
 - Create the actual release in [releases](https://github.com/k0sproject/k0s/releases/)
 - Build `k0s` binary on both AMD64 and ARM64 architectures


### PR DESCRIPTION
**What this PR Includes**
Update release doc to mention that git tags should be annotated.

Annotated tags will make the release date in github to use the date of
the tag. Lightweigt tags will use the date of the commit the tag points
to. Using annotated tags makes it possible to set the date of the tag so
correct tag is shown as "latest" in github.

