### PR TITLE
Allow enabling dual-stack when kube-proxy is disabled

### DIFF
--- a/pkg/apis/k0s.k0sproject.io/v1beta1/network.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/network.go
@@ -81,7 +81,7 @@ func (n *Network) Validate() []error {
 		if err != nil {
 			errors = append(errors, fmt.Errorf("invalid service IPv6 CIDR %s", n.DualStack.IPv6ServiceCIDR))
 		}
-		if n.KubeProxy.Mode != ModeIPVS {
+		if !n.KubeProxy.Disabled && n.KubeProxy.Mode != ModeIPVS {
 			errors = append(errors, fmt.Errorf("dual-stack requires kube-proxy in ipvs mode"))
 		}
 	}

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/network_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/network_test.go
@@ -268,6 +268,21 @@ func (s *NetworkSuite) TestValidation() {
 		s.Len(errors, 1)
 		s.Contains(errors[0].Error(), "dual-stack requires kube-proxy in ipvs mode")
 	})
+
+	s.T().Run("valid_proxy_disabled_for_dualstack", func(t *testing.T) {
+		n := DefaultNetwork()
+		n.Calico = DefaultCalico()
+		n.Calico.Mode = "bird"
+		n.DualStack = DefaultDualStack()
+		n.DualStack.Enabled = true
+		n.KubeProxy.Disabled = true
+		n.KubeProxy.Mode = "iptables"
+		n.DualStack.IPv6PodCIDR = "fd00::/108"
+		n.DualStack.IPv6ServiceCIDR = "fd01::/108"
+
+		errors := n.Validate()
+		s.Nil(errors)
+	})
 }
 
 func TestNetworkSuite(t *testing.T) {


### PR DESCRIPTION
**Issue**
Fixes #1183

**What this PR Includes**
Corrects a logic error that invalidates dual-stack based on kube-proxy mode, even when kube-proxy is disabled.