### PR TITLE
Calico `overlay` should be `Never` instead of `None`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,7 +141,7 @@ spec:
 | Element   | Description           |
 |-----------|---------------------------|
 | `mode`      | `vxlan` (default) or `ipip`|
-| `overlay`   | Overlay mode: `Always` (default), `CrossSubnet` or `None` (requires `mode=vxlan` to disable calico overlay-network).
+| `overlay`   | Overlay mode: `Always` (default), `CrossSubnet` or `Never` (requires `mode=vxlan` to disable calico overlay-network).
 | `vxlanPort`      | The UDP port for VXLAN (default: `4789`).|
 | `vxlanVNI`      | The virtual network ID for VXLAN (default: `4096`).|
 | `mtu`      | MTU for overlay network (default: `0`, which causes Calico to detect optimal MTU during bootstrap).|


### PR DESCRIPTION
A small fix to the calico config docs.

Setting up a k0s cluster with calico and want to run without overlay, using `None` here causes calico-node to exit with unknown config value.