### PR TITLE
Use k8s version from embedded-bins for conformance tests

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -100,7 +100,6 @@ jobs:
 
       - name: Check Network
         run: |
-          export K8S_VERSION="v1.22.2"
           make check-network-vm
         working-directory: ./inttest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,15 +339,7 @@ jobs:
       - name: Deploy k0s to Hosts
         run: ./deploy-k0s.sh
 
-      - name: Set Outputs
-        id: vars
-        env:
-          K0S_VER: ${{ needs.release.outputs.tag_name }}
-        run: echo ::set-output name=k8s_version::$(echo ${K0S_VER} | sed 's/\+.*//')
-
       - name: Run Full Conformance Check
-        env:
-          K8S_VERSION: ${{ steps.vars.outputs.k8s_version }}
         run: |
           make check-conformance
         working-directory: ./inttest

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -8,6 +8,8 @@ curl = curl -L --silent
 
 bins = bin/sonobuoy
 
+include ../embedded-bins/Makefile.variables
+
 .PHONY: all
 all: $(bins) .footloose-alpine.stamp
 
@@ -27,11 +29,11 @@ check-network: bin/sonobuoy .footloose-alpine.stamp
 
 check-network-vm: bin/sonobuoy
 	K0S_PATH=$(realpath ../k0s) SONOBUOY_PATH=$(realpath bin/sonobuoy) \
-		go test -count=1 -v -timeout 30m github.com/k0sproject/k0s/inttest/sonobuoy/ -run ^TestVMNetworkSuite -kubernetes-version=$(K8S_VERSION)
+		go test -count=1 -v -timeout 30m github.com/k0sproject/k0s/inttest/sonobuoy/ -run ^TestVMNetworkSuite -kubernetes-version=v$(kubernetes_version)
 
 check-conformance: bin/sonobuoy
 	K0S_PATH=$(realpath ../k0s) SONOBUOY_PATH=$(realpath bin/sonobuoy) \
-		go test -count=1 -v -timeout 240m github.com/k0sproject/k0s/inttest/sonobuoy/ -run ^TestConformanceSuite -kubernetes-version=$(K8S_VERSION)
+		go test -count=1 -v -timeout 240m github.com/k0sproject/k0s/inttest/sonobuoy/ -run ^TestConformanceSuite -kubernetes-version=v$(kubernetes_version)
 TIMEOUT ?= 4m
 
 check-ctr: TIMEOUT=10m


### PR DESCRIPTION
We can not simply strip out the `+k0s.*` from the release tag to
calculate the kubernetes version. This is because we use version from
both kuberentes and k0s so when we tag k0s release candidates we set -rc
suffix to the kubernets version part of the string, not to the +k0s
part, because that is not valid semver.

To avoid confusion of kubernetes version release candidates and k0s
version release candidate we do not use the release tag at all to find
kubernetes version. Instead we re-use the kubernetes_version set in
embedded-bins/Makefile.variables, which always will be correct.

While at it, we also remove a hardcoded K8S_VERSION for the network
conformance test.

Fixes commit 6ad33ed56426 (Add CNCF conformance test)

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

---
name: Pull Request
about: Create a Pull Request
title: ''
labels: ''
assignees: ''

---

**Issue**
Fixes #{ issue number }

**What this PR Includes**
A short description of what this PR does.