### PR TITLE
Remove unused command-line flags from some sub-commands

### DIFF
--- a/cmd/airgap/airgap.go
+++ b/cmd/airgap/airgap.go
@@ -17,8 +17,6 @@ package airgap
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/k0sproject/k0s/pkg/config"
 )
 
 func NewAirgapCmd() *cobra.Command {
@@ -29,6 +27,5 @@ func NewAirgapCmd() *cobra.Command {
 
 	cmd.SilenceUsage = true
 	cmd.AddCommand(NewAirgapListImagesCmd())
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	return cmd
 }

--- a/cmd/airgap/listimages.go
+++ b/cmd/airgap/listimages.go
@@ -33,9 +33,11 @@ func NewAirgapListImagesCmd() *cobra.Command {
 		Short:   "List image names and version needed for air-gap install",
 		Example: `k0s airgap list-images`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// we don't need warning messages in case of default config
-			logrus.SetLevel(logrus.ErrorLevel)
 			c := CmdOpts(config.GetCmdOpts())
+			if !c.Debug {
+				// we don't need warning messages in case of default config
+				logrus.SetLevel(logrus.ErrorLevel)
+			}
 			cfg, err := config.GetYamlFromFile(c.CfgFile, c.K0sVars)
 			if err != nil {
 				return err
@@ -47,6 +49,6 @@ func NewAirgapListImagesCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+	cmd.PersistentFlags().AddFlagSet(config.GetDebugFlagSet())
 	return cmd
 }

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -99,9 +99,9 @@ func NewControllerCmd() *cobra.Command {
 	}
 
 	// append flags
-	cmd.Flags().AddFlagSet(config.GetPersistentFlagSet())
-	cmd.PersistentFlags().AddFlagSet(config.GetControllerFlags())
-	cmd.PersistentFlags().AddFlagSet(config.GetWorkerFlags())
+	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+	cmd.Flags().AddFlagSet(config.GetControllerFlags())
+	cmd.Flags().AddFlagSet(config.GetWorkerFlags())
 	return cmd
 }
 

--- a/cmd/etcd/etcd.go
+++ b/cmd/etcd/etcd.go
@@ -16,11 +16,8 @@ limitations under the License.
 package etcd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
-	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/config"
 )
 
@@ -30,22 +27,9 @@ func NewEtcdCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "etcd",
 		Short: "Manage etcd cluster",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			c := CmdOpts(config.GetCmdOpts())
-			cfg, err := config.GetNodeConfig(c.CfgFile, c.K0sVars)
-			if err != nil {
-				return err
-			}
-			c.ClusterConfig = cfg
-			if c.ClusterConfig.Spec.Storage.Type != v1beta1.EtcdStorageType {
-				return fmt.Errorf("wrong storage type: %s", c.ClusterConfig.Spec.Storage.Type)
-			}
-			return nil
-		},
 	}
 	cmd.SilenceUsage = true
 	cmd.AddCommand(etcdLeaveCmd())
 	cmd.AddCommand(etcdListCmd())
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	return cmd
 }

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -38,7 +38,6 @@ func NewInstallCmd() *cobra.Command {
 
 	cmd.AddCommand(installControllerCmd())
 	cmd.AddCommand(installWorkerCmd())
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	return cmd
 }
 

--- a/cmd/install/worker.go
+++ b/cmd/install/worker.go
@@ -48,8 +48,11 @@ Windows flags like "--api-server", "--cidr-range" and "--cluster-dns" will be ig
 		PreRunE: preRunValidateConfig,
 	}
 	// append flags
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
-	cmd.PersistentFlags().AddFlagSet(config.GetWorkerFlags())
+	cmd.PersistentFlags().AddFlagSet(config.GetDebugFlagSet())
+	cmd.PersistentFlags().AddFlagSet(config.GetDataDirFlagSet())
+	cmd.PersistentFlags().AddFlagSet(config.GetStatusSocketFlagSet())
+
+	cmd.Flags().AddFlagSet(config.GetWorkerFlags())
 
 	return cmd
 }

--- a/cmd/kubeconfig/kubeconfig.go
+++ b/cmd/kubeconfig/kubeconfig.go
@@ -33,6 +33,5 @@ func NewKubeConfigCmd() *cobra.Command {
 	cmd.SilenceUsage = true
 	cmd.AddCommand(kubeconfigCreateCmd())
 	cmd.AddCommand(kubeConfigAdminCmd())
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	return cmd
 }

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -43,6 +43,5 @@ func NewTokenCmd() *cobra.Command {
 	cmd.AddCommand(tokenCreateCmd())
 	cmd.AddCommand(tokenListCmd())
 	cmd.AddCommand(tokenInvalidateCmd())
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	return cmd
 }

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -73,8 +73,11 @@ func NewWorkerCmd() *cobra.Command {
 	}
 
 	// append flags
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
-	cmd.PersistentFlags().AddFlagSet(config.GetWorkerFlags())
+	cmd.PersistentFlags().AddFlagSet(config.GetDebugFlagSet())
+	cmd.PersistentFlags().AddFlagSet(config.GetDataDirFlagSet())
+	cmd.PersistentFlags().AddFlagSet(config.GetStatusSocketFlagSet())
+
+	cmd.Flags().AddFlagSet(config.GetWorkerFlags())
 	return cmd
 }
 

--- a/inttest/customports/customports_test.go
+++ b/inttest/customports/customports_test.go
@@ -109,7 +109,7 @@ func (ds *Suite) TestControllerJoinsWithCustomPort() {
 
 	token, err = ds.GetJoinToken("worker", "", "--config=/tmp/k0s.yaml")
 	ds.Require().NoError(err)
-	ds.Require().NoError(ds.RunWorkersWithToken("/var/lib/k0s", token, `--config="/tmp/k0s.yaml"`))
+	ds.Require().NoError(ds.RunWorkersWithToken("/var/lib/k0s", token))
 
 	kc, err := ds.KubeClient("controller0", "")
 	ds.Require().NoError(err)

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -98,13 +98,37 @@ func DefaultLogLevels() map[string]string {
 	}
 }
 
-func GetPersistentFlagSet() *pflag.FlagSet {
+func GetConfigurationFlagSet() *pflag.FlagSet {
 	flagset := &pflag.FlagSet{}
 	flagset.StringVarP(&CfgFile, "config", "c", "", "config file, use '-' to read the config from stdin")
+	return flagset
+}
+
+func GetDebugFlagSet() *pflag.FlagSet {
+	flagset := &pflag.FlagSet{}
 	flagset.BoolVarP(&Debug, "debug", "d", false, "Debug logging (default: false)")
-	flagset.StringVar(&DataDir, "data-dir", "", "Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!")
-	flagset.StringVar(&StatusSocket, "status-socket", filepath.Join(K0sVars.RunDir, "status.sock"), "Full file path to the socket file.")
 	flagset.StringVar(&DebugListenOn, "debugListenOn", ":6060", "Http listenOn for Debug pprof handler")
+	return flagset
+}
+
+func GetDataDirFlagSet() *pflag.FlagSet {
+	flagset := &pflag.FlagSet{}
+	flagset.StringVar(&DataDir, "data-dir", "", "Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!")
+	return flagset
+}
+
+func GetStatusSocketFlagSet() *pflag.FlagSet {
+	flagset := &pflag.FlagSet{}
+	flagset.StringVar(&StatusSocket, "status-socket", filepath.Join(K0sVars.RunDir, "status.sock"), "Full file path to the socket file.")
+	return flagset
+}
+
+func GetPersistentFlagSet() *pflag.FlagSet {
+	flagset := &pflag.FlagSet{}
+	flagset.AddFlagSet(GetConfigurationFlagSet())
+	flagset.AddFlagSet(GetDebugFlagSet())
+	flagset.AddFlagSet(GetDataDirFlagSet())
+	flagset.AddFlagSet(GetStatusSocketFlagSet())
 	return flagset
 }
 


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Fixes #1222 

Removes the `--config` flag from worker commands. Also tries to clean up flags in other commands (odd choices between PersistentFlags and Flags, having flags in "subcategory" no-op commands like `k0s token`)

TODO: 
- Unsure about the `etcd` "mid"-command having flags and a run-block that seemingly never executes.
