### PR TITLE
Backport sonobuoy-0.53.2 for release-1.21 branch

### DIFF
--- a/inttest/conformance/terraform/main.tf
+++ b/inttest/conformance/terraform/main.tf
@@ -9,7 +9,7 @@ variable "k0s_version" {
 
 variable "sonobuoy_version" {
   type    = string
-  default = "0.20.0"
+  default = "0.53.2"
 }
 
 variable "k8s_version" {


### PR DESCRIPTION
**What this PR Includes**
cherrpy-pick the sonobuoy update for the release-1.21 branch. We will maintain this branch for some more time so it might be nice to have an updated sonobuoy.