### PR TITLE
Remove mentions of "helper command" from command help

### DIFF
--- a/cmd/install/controller.go
+++ b/cmd/install/controller.go
@@ -24,13 +24,13 @@ import (
 func installControllerCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "controller",
-		Short:   "Helper command for setting up k0s as controller node on a brand-new system. Must be run as root (or with sudo)",
+		Short:   "Install k0s controller on a brand-new system. Must be run as root (or with sudo)",
 		Aliases: []string{"server"},
-		Example: `All default values of controller command will be passed to the service stub unless overriden. 
+		Example: `All default values of controller command will be passed to the service stub unless overriden.
 
-With controller subcommand you can setup a single node cluster by running:
+With the controller subcommand you can setup a single node cluster by running:
 
-	k0s install controller --enable-worker
+	k0s install controller --single
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := CmdOpts(config.GetCmdOpts())

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -33,7 +33,7 @@ type CmdOpts config.CLIOptions
 func NewInstallCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
-		Short: "Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)",
+		Short: "Install k0s on a brand-new system. Must be run as root (or with sudo)",
 	}
 
 	cmd.AddCommand(installControllerCmd())

--- a/cmd/install/worker.go
+++ b/cmd/install/worker.go
@@ -24,8 +24,8 @@ import (
 func installWorkerCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "worker",
-		Short: "Helper command for setting up k0s as a worker node on a brand-new system. Must be run as root (or with sudo)",
-		Example: `Worker subcommand allows you to pass in all available worker parameters. 
+		Short: "Install k0s worker on a brand-new system. Must be run as root (or with sudo)",
+		Example: `Worker subcommand allows you to pass in all available worker parameters.
 All default values of worker command will be passed to the service stub unless overriden.
 
 Windows flags like "--api-server", "--cidr-range" and "--cluster-dns" will be ignored since install command doesn't yet support Windows services`,

--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -33,7 +33,7 @@ type CmdOpts config.CLIOptions
 func NewResetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reset",
-		Short: "Helper command for uninstalling k0s. Must be run as root (or with sudo)",
+		Short: "Uninstall k0s. Must be run as root (or with sudo)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if runtime.GOOS == "windows" {
 				return fmt.Errorf("currently not supported on windows")

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -37,7 +37,7 @@ var (
 func NewStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "status",
-		Short:   "Helper command for get general information about k0s",
+		Short:   "Get k0s instance status information",
 		Example: `The command will return information about system init, PID, k0s role, kubeconfig and similar.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -25,7 +25,7 @@ type CmdOpts config.CLIOptions
 func NewValidateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validate",
-		Short: "Helper command for validating the config file",
+		Short: "Validation related sub-commands",
 	}
 	cmd.AddCommand(validateConfigCmd())
 	cmd.SilenceUsage = true
@@ -35,7 +35,7 @@ func NewValidateCmd() *cobra.Command {
 func validateConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
-		Short: "Helper command for validating the config file",
+		Short: "Validate k0s configuration",
 		Long: `Example:
    k0s validate config --config path_to_config.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/cli/k0s.md
+++ b/docs/cli/k0s.md
@@ -25,12 +25,12 @@ k0s - The zero friction Kubernetes - https://k0sproject.io
 * [k0s default-config](k0s_default-config.md) - Output the default k0s configuration yaml to stdout
 * [k0s docs](k0s_docs.md) - Generate Markdown docs for the k0s binary
 * [k0s etcd](k0s_etcd.md) - Manage etcd cluster
-* [k0s install](k0s_install.md) - Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)
+* [k0s install](k0s_install.md) - Install k0s on a brand-new system. Must be run as root (or with sudo)
 * [k0s start](k0s_stop.md) - Start the k0s service after it has been installed using `k0s install`. Must be run as root (or with sudo)
 * [k0s stop](k0s_stop.md) - Stop the k0s service after it has been installed using `k0s install`. Must be run as root (or with sudo)
 * [k0s kubeconfig](k0s_kubeconfig.md) - Create a kubeconfig file for a specified user
-* [k0s status](k0s_status.md) - Helper command for get general information about k0s
+* [k0s status](k0s_status.md) - Get k0s instance status information
 * [k0s token](k0s_token.md) - Manage join tokens
-* [k0s validate](k0s_validate.md) - Helper command for validating the config file
+* [k0s validate](k0s_validate.md) - Validation related sub-commands
 * [k0s version](k0s_version.md) - Print the k0s version
 * [k0s worker](k0s_worker.md) - Run worker

--- a/docs/cli/k0s_install.md
+++ b/docs/cli/k0s_install.md
@@ -1,6 +1,6 @@
 ## k0s install
 
-Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo).
+Install k0s on a brand-new system. Must be run as root (or with sudo).
 
 ### Options
 
@@ -21,7 +21,7 @@ Helper command for setting up k0s on a brand-new system. Must be run as root (or
 ### SEE ALSO
 
 * [k0s](k0s.md) - k0s - Zero Friction Kubernetes
-* [k0s install controller](k0s_install_controller.md) - Helper command for setting up k0s as controller node on a brand-new system. Must be run as root (or with sudo)
-* [k0s install worker](k0s_install_worker.md) - Helper command for setting up k0s as a worker node on a brand-new system. Must be run as root (or with sudo)
+* [k0s install controller](k0s_install_controller.md) - Install k0s controller on a brand-new system. Must be run as root (or with sudo)
+* [k0s install worker](k0s_install_worker.md) - Install k0s worker on a brand-new system. Must be run as root (or with sudo)
 * [k0s start](k0s_stop.md) - Start the k0s service after it has been installed using `k0s install`. Must be run as root (or with sudo)
 * [k0s stop](k0s_stop.md) - Stop the k0s service after it has been installed using `k0s install`. Must be run as root (or with sudo)

--- a/docs/cli/k0s_install_controller.md
+++ b/docs/cli/k0s_install_controller.md
@@ -1,6 +1,6 @@
 ## k0s install controller
 
-Helper command for setting up k0s as controller node on a brand-new system. Must be run as root (or with sudo)
+Install k0s controller on a brand-new system. Must be run as root (or with sudo)
 
 ```shell
 k0s install controller [flags]
@@ -10,10 +10,10 @@ k0s install controller [flags]
 
 All default values of controller command will be passed to the service stub unless overriden.
 
-With controller subcommand you can setup a single node cluster by running:
+With the controller subcommand you can setup a single node cluster by running:
 
 ```shell
-sudo k0s install controller --enable-worker
+sudo k0s install controller --single
 ```
 
 ### Options
@@ -38,4 +38,4 @@ sudo k0s install controller --enable-worker
 
 ### SEE ALSO
 
-* [k0s install](k0s_install.md) - Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)
+* [k0s install](k0s_install.md) - Install k0s on a brand-new system. Must be run as root (or with sudo)

--- a/docs/cli/k0s_install_worker.md
+++ b/docs/cli/k0s_install_worker.md
@@ -1,6 +1,6 @@
 ## k0s install worker
 
-Helper command for setting up k0s as a worker node on a brand-new system. Must be run as root (or with sudo)
+Install k0s worker on a brand-new system. Must be run as root (or with sudo)
 
 ```shell
 k0s install worker [flags]
@@ -39,4 +39,4 @@ Windows flags like "--api-server", "--cidr-range" and "--cluster-dns" will be ig
 
 ### SEE ALSO
 
-* [k0s install](k0s_install.md) - Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)
+* [k0s install](k0s_install.md) - Install k0s on a brand-new system. Must be run as root (or with sudo)

--- a/docs/cli/k0s_start.md
+++ b/docs/cli/k0s_start.md
@@ -17,6 +17,6 @@ Start the k0s service after it has been installed using `k0s install`. Must be r
 ### SEE ALSO
 
 * [k0s stop](k0s_stop.md) - Stop the k0s service after it has been installed using `k0s install`. Must be run as root (or with sudo)
-* [k0s install](k0s_install.md) - Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)
-* [k0s install controller](k0s_install_controller.md) - Helper command for setting up k0s as controller node on a brand-new system. Must be run as root (or with sudo)
-* [k0s install worker](k0s_install_worker.md) - Helper command for setting up k0s as a worker node on a brand-new system. Must be run as root (or with sudo)
+* [k0s install](k0s_install.md) - Install k0s on a brand-new system. Must be run as root (or with sudo)
+* [k0s install controller](k0s_install_controller.md) - Install k0s controller on a brand-new system. Must be run as root (or with sudo)
+* [k0s install worker](k0s_install_worker.md) - Install k0s worker on a brand-new system. Must be run as root (or with sudo)

--- a/docs/cli/k0s_status.md
+++ b/docs/cli/k0s_status.md
@@ -1,6 +1,6 @@
 ## k0s status
 
-Helper command for get general information about k0s
+Get k0s instance status information
 
 ```shell
 k0s status [flags]

--- a/docs/cli/k0s_stop.md
+++ b/docs/cli/k0s_stop.md
@@ -17,6 +17,6 @@ Stop the k0s service after it has been installed using `k0s install`. Must be ru
 ### SEE ALSO
 
 * [k0s start](k0s_stop.md) - Start the k0s service after it has been installed using `k0s install`. Must be run as root (or with sudo)
-* [k0s install](k0s_install.md) - Helper command for setting up k0s on a brand-new system. Must be run as root (or with sudo)
-* [k0s install controller](k0s_install_controller.md) - Helper command for setting up k0s as controller node on a brand-new system. Must be run as root (or with sudo)
-* [k0s install worker](k0s_install_worker.md) - Helper command for setting up k0s as a worker node on a brand-new system. Must be run as root (or with sudo)
+* [k0s install](k0s_install.md) - Install k0s on a brand-new system. Must be run as root (or with sudo)
+* [k0s install controller](k0s_install_controller.md) - Install k0s controller on a brand-new system. Must be run as root (or with sudo)
+* [k0s install worker](k0s_install_worker.md) - Install k0s worker on a brand-new system. Must be run as root (or with sudo)

--- a/docs/cli/k0s_validate.md
+++ b/docs/cli/k0s_validate.md
@@ -1,6 +1,6 @@
 ## k0s validate
 
-Helper command for validating the config file
+Validation related sub-commands
 
 ### Options
 
@@ -21,4 +21,4 @@ Helper command for validating the config file
 ### SEE ALSO
 
 * [k0s](k0s.md) - k0s - Zero Friction Kubernetes
-* [k0s validate config](k0s_validate_config.md) - Helper command for validating the config file
+* [k0s validate config](k0s_validate_config.md) - Validate k0s configuration

--- a/docs/cli/k0s_validate_config.md
+++ b/docs/cli/k0s_validate_config.md
@@ -1,6 +1,6 @@
 ## k0s validate config
 
-Helper command for validating the config file
+Validate k0s configuration
 
 ```shell
 k0s validate config [flags]
@@ -30,4 +30,4 @@ k0s validate config [flags]
 
 ### SEE ALSO
 
-* [k0s validate](k0s_validate.md) - Helper command for validating the config file
+* [k0s validate](k0s_validate.md) - Validation related sub-commands


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Rewords the command descriptions where they call themselves "helper commands".
