### PR TITLE
Give validation errors on unknown config fields

### DIFF
--- a/internal/pkg/strictyaml/strictyaml.go
+++ b/internal/pkg/strictyaml/strictyaml.go
@@ -10,7 +10,7 @@ import (
 // var fieldNamePattern = regexp.MustCompile("field ([^ ]+)")
 
 // YamlUnmarshalStrictIgnoringFields does UnmarshalStrict but ignores type errors for given fields
-func YamlUnmarshalStrictIgnoringFields(in []byte, out interface{}, ignore []string) (err error) {
+func YamlUnmarshalStrictIgnoringFields(in []byte, out interface{}, ignore ...string) (err error) {
 	err = yaml.UnmarshalStrict(in, out)
 	if err != nil {
 		// parse errors for unknown field errors

--- a/internal/pkg/strictyaml/strictyaml_test.go
+++ b/internal/pkg/strictyaml/strictyaml_test.go
@@ -20,7 +20,7 @@ stringC:
   key: value
 `
 		tgt := testConfig{}
-		err := YamlUnmarshalStrictIgnoringFields([]byte(input), &tgt, []string{"stringC", "stringB"})
+		err := YamlUnmarshalStrictIgnoringFields([]byte(input), &tgt, "stringC", "stringB")
 		assert.NoError(t, err)
 		assert.Equal(t, "stringValue", tgt.StringA)
 	})
@@ -33,7 +33,7 @@ stringC:
   key: value
 `
 		tgt := testConfig{}
-		err := YamlUnmarshalStrictIgnoringFields([]byte(input), &tgt, []string{"stringC"})
+		err := YamlUnmarshalStrictIgnoringFields([]byte(input), &tgt, "stringC")
 		assert.Error(t, err)
 	})
 
@@ -41,11 +41,11 @@ stringC:
 		input := `
 	stringA: stringValue
 stringB: shouldGiveErrorBecauseNotMasked
-stringC: 
+stringC:
   key: value
 `
 		tgt := testConfig{}
-		err := YamlUnmarshalStrictIgnoringFields([]byte(input), &tgt, []string{""})
+		err := YamlUnmarshalStrictIgnoringFields([]byte(input), &tgt)
 		assert.Error(t, err)
 	})
 }

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
@@ -16,6 +16,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -183,7 +184,7 @@ func ConfigFromStdin(dataDir string) (*ClusterConfig, error) {
 
 func ConfigFromString(yml string, dataDir string) (*ClusterConfig, error) {
 	config := DefaultClusterConfig(dataDir)
-	err := strictyaml.YamlUnmarshalStrictIgnoringFields([]byte(yml), config, []string{"interval"})
+	err := strictyaml.YamlUnmarshalStrictIgnoringFields([]byte(yml), config, "interval")
 	if err != nil {
 		return config, err
 	}
@@ -218,10 +219,10 @@ func (c *ClusterConfig) UnmarshalJSON(data []byte) error {
 	type config ClusterConfig
 	jc := (*config)(c)
 
-	if err := json.Unmarshal(data, jc); err != nil {
-		return err
-	}
-	return nil
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+
+	return decoder.Decode(jc)
 }
 
 // DefaultClusterSpec default settings

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types_test.go
@@ -31,6 +31,15 @@ func TestClusterDefaults(t *testing.T) {
 	assert.Equal(t, DefaultStorageSpec(dataDir), c.Spec.Storage)
 }
 
+func TestUnknownFieldValidation(t *testing.T) {
+	_, err := ConfigFromString(`
+apiVersion: k0s.k0sproject.io/v1beta1
+kind: ClusterConfig
+unknown: 1`, dataDir)
+
+	assert.Error(t, err)
+}
+
 func TestStorageDefaults(t *testing.T) {
 	yamlData := `
 apiVersion: k0s.k0sproject.io/v1beta1
@@ -167,8 +176,7 @@ metadata:
   name: foobar
 spec:
   workerProfiles:
-  - profile_XXX:
-    name: profile_XXX
+  - name: profile_XXX
     values:
       authentication:
         anonymous:
@@ -176,8 +184,7 @@ spec:
         webhook:
           cacheTTL: 2m0s
           enabled: true
-  - profile_YYY:
-    name: profile_YYY
+  - name: profile_YYY
     values:
       apiVersion: v2
       authentication:


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

As mentioned in https://github.com/k0sproject/k0s/issues/1237#issuecomment-958726392 - the unknown field validation has not been working as intended since the move to https://sigs.k8s.io/yaml

Seems what breaks it is the `UnmarshalJSON` function which runs  basic `json.Unmarshal`, which will lose the strictness. This PR makes it use the `DisallowUnknownFields` JSON decoder option.