### PR TITLE
Add SingleNode: true/false to k0s status output

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -235,18 +235,14 @@ func (c *CmdOpts) startController(ctx context.Context) error {
 		)
 	}
 
-	workload := false
-	if c.SingleNode || c.EnableWorker {
-		workload = true
-	}
-
 	c.NodeComponents.Add(ctx, &status.Status{
 		StatusInformation: install.K0sStatus{
 			Pid:           os.Getpid(),
 			Role:          "controller",
 			Args:          os.Args,
 			Version:       build.Version,
-			Workloads:     workload,
+			Workloads:     c.SingleNode || c.EnableWorker,
+			SingleNode:    c.SingleNode,
 			K0sVars:       c.K0sVars,
 			ClusterConfig: c.NodeConfig,
 		},

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -78,6 +78,7 @@ func printStatus(status *install.K0sStatus, output string) {
 		fmt.Println("Process ID:", status.Pid)
 		fmt.Println("Role:", status.Role)
 		fmt.Println("Workloads:", status.Workloads)
+		fmt.Println("SingleNode:", status.SingleNode)
 
 		if status.SysInit != "" {
 			fmt.Println("Init System:", status.SysInit)

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -151,6 +151,7 @@ func (c *CmdOpts) StartWorker(ctx context.Context) error {
 				Args:          os.Args,
 				Version:       build.Version,
 				Workloads:     true,
+				SingleNode:    false,
 				K0sVars:       c.K0sVars,
 				ClusterConfig: c.ClusterConfig,
 			},

--- a/pkg/install/process.go
+++ b/pkg/install/process.go
@@ -35,6 +35,7 @@ type K0sStatus struct {
 	StubFile      string
 	Output        string
 	Workloads     bool
+	SingleNode    bool
 	Args          []string
 	ClusterConfig *config.ClusterConfig
 	K0sVars       constant.CfgVars


### PR DESCRIPTION
Fixes #1236 

Adds `SingleNode: true/false` to `k0s status` output.

--

Signed-off-by: Kimmo Lehto <klehto@mirantis.com>
