### PR TITLE
Version bumps

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,7 +73,7 @@ spec:
   images:
     konnectivity:
       image: k8s.gcr.io/kas-network-proxy/proxy-agent
-      version: v0.0.24
+      version: v0.0.25
     metricsserver:
       image: k8s.gcr.io/metrics-server/metrics-server
       version: v0.5.0

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -39,7 +39,7 @@ etcd_build_go_cgo_enabled = 0
 etcd_build_go_ldflags = "-w -s"
 #etcd_build_go_ldflags_extra =
 
-konnectivity_version = 0.0.24
+konnectivity_version = 0.0.25
 konnectivity_buildimage = golang:1.16-alpine
 #konnectivity_build_go_tags =
 konnectivity_build_go_cgo_enabled = 0

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -88,7 +88,7 @@ const (
 	CalicoNodeImage                    = "quay.io/calico/node"
 	KubeControllerImage                = "quay.io/calico/kube-controllers"
 	KubeRouterCNIImage                 = "docker.io/cloudnativelabs/kube-router"
-	KubeRouterCNIImageVersion          = "v1.3.1"
+	KubeRouterCNIImageVersion          = "v1.3.2"
 	KubeRouterCNIInstallerImage        = "quay.io/k0sproject/cni-node"
 	KubeRouterCNIInstallerImageVersion = "0.1.0"
 

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -76,7 +76,7 @@ const (
 	DefaultPSP = "00-k0s-privileged"
 	// Image Constants
 	KonnectivityImage                  = "k8s.gcr.io/kas-network-proxy/proxy-agent"
-	KonnectivityImageVersion           = "v0.0.24"
+	KonnectivityImageVersion           = "v0.0.25"
 	MetricsImage                       = "k8s.gcr.io/metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.5.0"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"


### PR DESCRIPTION
**Issue**
~Fixes #1200~

**What this PR Includes**
- bump kube router to 1.3.2
- bump konnectivity to 0.0.25
- ~bump calico to 3.20.2~