### PR TITLE
Add a CR validator for API config

### DIFF
--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
@@ -282,6 +282,16 @@ func (c *ClusterConfig) Validate() []error {
 	return errors
 }
 
+// CRValidator is used to make sure a config CR is created with correct values
+func (c *ClusterConfig) CRValidator() *ClusterConfig {
+	copy := c.DeepCopy()
+	copy.ClusterName = "k0s"
+	copy.ObjectMeta.Name = "k0s"
+	copy.ObjectMeta.Namespace = "kube-system"
+
+	return copy
+}
+
 // validateSpecs invokes validator Validate function
 func validateSpecs(v Validateable) []error {
 	return v.Validate()

--- a/pkg/component/controller/clusterConfig.go
+++ b/pkg/component/controller/clusterConfig.go
@@ -106,7 +106,6 @@ func (r *ClusterConfigReconciler) Run(ctx context.Context) error {
 			}
 			return true, nil
 		})
-
 		if err != nil {
 			return fmt.Errorf("not able to get or create the cluster config: %v", err)
 		}
@@ -202,7 +201,7 @@ func (r *ClusterConfigReconciler) reportStatus(config *v1beta1.ClusterConfig, re
 func (r *ClusterConfigReconciler) copyRunningConfigToCR(baseCtx context.Context) (*v1beta1.ClusterConfig, error) {
 	ctx, cancel := context.WithTimeout(baseCtx, 5*time.Second)
 	defer cancel()
-	clusterWideConfig := config.ClusterConfigMinusNodeConfig(r.YamlConfig).StripDefaults()
+	clusterWideConfig := config.ClusterConfigMinusNodeConfig(r.YamlConfig).StripDefaults().CRValidator()
 	clusterConfig, err := r.configClient.Create(ctx, clusterWideConfig, cOpts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Karen Almog <kalmog@mirantis.com>

**What this PR Includes**
When the config reconciler creates the config custom resource, CRValidator will validate the the created object has the right fields the k0s expects for this object.