### PR TITLE
Update the `haproxy` example docs to not change the default mode.

### DIFF
--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -22,30 +22,34 @@ The load balancer can be implemented in many different ways and k0s doesn't have
 
 ### Example configuration: HAProxy
 
-Change the default mode to tcp under the 'defaults' section of haproxy.cfg.
-
 Add the following lines to the end of the haproxy.cfg:
 
 ```txt
 frontend kubeAPI
     bind :6443
+    mode tcp
     default_backend kubeAPI_backend
 frontend konnectivity
     bind :8132
+    mode tcp
     default_backend konnectivity_backend
 frontend controllerJoinAPI
     bind :9443
+    mode tcp
     default_backend controllerJoinAPI_backend
 
 backend kubeAPI_backend
+    mode tcp
     server k0s-controller1 <ip-address1>:6443 check check-ssl verify none
     server k0s-controller2 <ip-address2>:6443 check check-ssl verify none
     server k0s-controller3 <ip-address3>:6443 check check-ssl verify none
 backend konnectivity_backend
+    mode tcp
     server k0s-controller1 <ip-address1>:8132 check check-ssl verify none
     server k0s-controller2 <ip-address2>:8132 check check-ssl verify none
     server k0s-controller3 <ip-address3>:8132 check check-ssl verify none
 backend controllerJoinAPI_backend
+    mode tcp
     server k0s-controller1 <ip-address1>:9443 check check-ssl verify none
     server k0s-controller2 <ip-address2>:9443 check check-ssl verify none
     server k0s-controller3 <ip-address3>:9443 check check-ssl verify none


### PR DESCRIPTION
This changes the example `/etc/haproxy/haproxy.cfg` configuration to not change
the default mode (http), but to explicitly override it in our frontend/backend
configurations.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>