### PR TITLE
Enable the use of kubectl plugins in "k0s kubectl" subcommand

### DIFF
--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -16,7 +16,11 @@ limitations under the License.
 package kubectl
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
+	"runtime"
+	"syscall"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -28,6 +32,42 @@ import (
 
 type CmdOpts config.CLIOptions
 
+type kubectlPluginHandler struct{}
+
+func (h *kubectlPluginHandler) Lookup(filename string) (string, bool) {
+	path, err := exec.LookPath(fmt.Sprintf("kubectl-%s", filename))
+	if err != nil || path == "" {
+		return "", false
+	}
+	return path, true
+}
+
+// adapted from kubectl.DefaultPluginHandler
+func (h *kubectlPluginHandler) Execute(executablePath string, cmdArgs, environment []string) error {
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		if exe, err := os.Executable(); err == nil {
+			logrus.Warnf("kubectl not found in $PATH. many kubectl plugins try to run 'kubectl'. you can use k0s as a replacement by creating a symlink, for example: `sudo ln -s \"%s\" /usr/local/bin/kubectl`", exe)
+		}
+	}
+
+	// Windows does not support exec syscall.
+	if runtime.GOOS == "windows" {
+		cmd := exec.Command(executablePath, cmdArgs...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+		cmd.Env = environment
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+		os.Exit(0)
+	}
+
+	// invoke cmd binary relaying the environment and args given
+	// append executablePath to cmdArgs, as execve will make first argument the "binary name".
+	return syscall.Exec(executablePath, append([]string{executablePath}, cmdArgs...), environment)
+}
+
 func NewK0sKubectlCmd() *cobra.Command {
 	args := kubectl.KubectlOptions{
 		IOStreams: genericclioptions.IOStreams{
@@ -35,6 +75,8 @@ func NewK0sKubectlCmd() *cobra.Command {
 			Out:    os.Stdout,
 			ErrOut: os.Stderr,
 		},
+		Arguments:     os.Args,
+		PluginHandler: &kubectlPluginHandler{},
 	}
 	cmd := kubectl.NewKubectlCommand(args)
 	cmd.Aliases = []string{"kc"}
@@ -55,8 +97,7 @@ func NewK0sKubectlCmd() *cobra.Command {
 			}
 		}
 		c := CmdOpts(config.GetCmdOpts())
-		kubenv := os.Getenv("KUBECONFIG")
-		if kubenv == "" {
+		if os.Getenv("KUBECONFIG") == "" {
 			// Verify we can read the config before pushing it to env
 			file, err := os.OpenFile(c.K0sVars.AdminKubeConfigPath, os.O_RDONLY, 0600)
 			if err != nil {
@@ -66,7 +107,22 @@ func NewK0sKubectlCmd() *cobra.Command {
 			defer file.Close()
 			os.Setenv("KUBECONFIG", c.K0sVars.AdminKubeConfigPath)
 		}
+
 		return originalPreRunE(cmd, args)
 	}
+
+	originalRun := cmd.Run
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		if len(args) > 0 {
+			if err := kubectl.HandlePluginCommand(&kubectlPluginHandler{}, args); err != nil {
+				// note: the plugin exec will replace the k0s process and exit on it's own,
+				// the error here is a failure to exec, not the error-exit of the plugin.
+				logrus.Fatalf("kubectl plugin handler failed: %v", err)
+			}
+		}
+
+		originalRun(cmd, args)
+	}
+
 	return cmd
 }

--- a/inttest/multicontroller/multicontroller_test.go
+++ b/inttest/multicontroller/multicontroller_test.go
@@ -77,6 +77,8 @@ func TestMultiControllerSuite(t *testing.T) {
 }
 
 const k0sConfigWithMultiController = `
+apiVersion: k0s.k0sproject.io/v1beta1
+kind: ClusterConfig
 spec:
   api:
     externalAddress: %s


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Fixes #1264 : The plugin handler was not being initialized in `NewKubectlCommand` - this has now been fixed.

With #1299 in place, this can now be actually usable as a kubectl drop-in replacement even when using plugins. It will warn if there's no `kubectl` in the `$PATH` and hints how to create a symlink to work around that.
