### PR TITLE
Cherry-picks for 1.22.4+k0s.0 release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://help.github.com/articles/about-codeowners/
 
-* @k0sproject/k0s-core
+* @k0sproject/k0s-maintainers

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,7 +79,7 @@ spec:
       version: v0.5.0
     kubeproxy:
       image: k8s.gcr.io/kube-proxy
-      version: v1.22.3
+      version: v1.22.4
     coredns:
       image: k8s.gcr.io/coredns/coredns
       version: v1.7.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,7 +73,7 @@ spec:
   images:
     konnectivity:
       image: k8s.gcr.io/kas-network-proxy/proxy-agent
-      version: v0.0.24
+      version: v0.0.25
     metricsserver:
       image: k8s.gcr.io/metrics-server/metrics-server
       version: v0.5.0

--- a/docs/dynamic-configuration.md
+++ b/docs/dynamic-configuration.md
@@ -2,7 +2,7 @@
 
 k0s comes with the option to enable dynamic configuration for cluster level components. This covers all the components other than etcd (or sqlite) and the Kubernetes api-server. This option enables k0s configuration directly via Kubernetes API as opposed to using a configuration file for all cluster configuration.
 
-This feature has to be separately enabled for all controllers using `k0s controller --enable-dynamic-config`.
+This feature has to be enabled for every controller in the cluster using the `--enable-dynamic-config` flag in `k0s controller` or `k0s install controller` commands. Having both types of controllers in the same cluster will cause a conflict.
 
 ## Dynamic vs. static configuration
 

--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -22,30 +22,34 @@ The load balancer can be implemented in many different ways and k0s doesn't have
 
 ### Example configuration: HAProxy
 
-Change the default mode to tcp under the 'defaults' section of haproxy.cfg.
-
 Add the following lines to the end of the haproxy.cfg:
 
 ```txt
 frontend kubeAPI
     bind :6443
+    mode tcp
     default_backend kubeAPI_backend
 frontend konnectivity
     bind :8132
+    mode tcp
     default_backend konnectivity_backend
 frontend controllerJoinAPI
     bind :9443
+    mode tcp
     default_backend controllerJoinAPI_backend
 
 backend kubeAPI_backend
+    mode tcp
     server k0s-controller1 <ip-address1>:6443 check check-ssl verify none
     server k0s-controller2 <ip-address2>:6443 check check-ssl verify none
     server k0s-controller3 <ip-address3>:6443 check check-ssl verify none
 backend konnectivity_backend
+    mode tcp
     server k0s-controller1 <ip-address1>:8132 check check-ssl verify none
     server k0s-controller2 <ip-address2>:8132 check check-ssl verify none
     server k0s-controller3 <ip-address3>:8132 check check-ssl verify none
 backend controllerJoinAPI_backend
+    mode tcp
     server k0s-controller1 <ip-address1>:9443 check check-ssl verify none
     server k0s-controller2 <ip-address2>:9443 check check-ssl verify none
     server k0s-controller3 <ip-address3>:9443 check check-ssl verify none

--- a/docs/install.md
+++ b/docs/install.md
@@ -48,7 +48,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
 
     ```shell
     $ sudo k0s status
-    Version: v1.22.2+k0s.1
+    Version: v1.22.4+k0s.1
     Process ID: 436
     Role: controller
     Workloads: true
@@ -64,7 +64,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
     ```shell
     $ sudo k0s kubectl get nodes
     NAME   STATUS   ROLES    AGE    VERSION
-    k0s    Ready    <none>   4m6s   v1.22.3-k0s1
+    k0s    Ready    <none>   4m6s   v1.22.4-k0s1
     ```
 
 ## Uninstall k0s

--- a/docs/k0s-multi-node.md
+++ b/docs/k0s-multi-node.md
@@ -24,13 +24,13 @@ The download script accepts the following environment variables:
 
 | Variable                   | Purpose                                           |
 |:---------------------------|:--------------------------------------------------|
-| `K0S_VERSION=v1.22.3+k0s.0 | Select the version of k0s to be installed         |
+| `K0S_VERSION=v1.22.4+k0s.0 | Select the version of k0s to be installed         |
 | `DEBUG=true`               | Output commands and their arguments at execution. |
 
 **Note**: If you require environment variables and use sudo, you can do:
 
 ```shell
-curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.22.3+k0s.0 sh
+curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.22.4+k0s.0 sh
 ```
 
 ### 2. Bootstrap a controller node
@@ -123,7 +123,7 @@ To get general information about your k0s instance's status:
 
 ```shell
 $ sudo k0s status
-Version: v1.22.3+k0s.0
+Version: v1.22.4+k0s.0
 Process ID: 2769
 Parent Process ID: 1
 Role: controller
@@ -138,7 +138,7 @@ Use the Kubernetes 'kubectl' command-line tool that comes with k0s binary to dep
 ```shell
 $ sudo k0s kubectl get nodes
 NAME   STATUS   ROLES    AGE    VERSION
-k0s    Ready    <none>   4m6s   v1.22.3-k0s1
+k0s    Ready    <none>   4m6s   v1.22.4-k0s1
 ```
 
 You can also access your cluster easily with [Lens](https://k8slens.dev/), simply by copying the kubeconfig and pasting it to Lens:

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -12,6 +12,6 @@ The biggest new k0s features will typically only be delivered on top of the late
 
 The k0s version string consists of the Kubernetes version and the k0s version. For example:
 
-- v1.22.3+k0s.0
+- v1.22.4+k0s.0
 
-The Kubernetes version (1.22.3) is the first part, and the last part (k0s.0) reflects the k0s version, which is built on top of the certain Kubernetes version.
+The Kubernetes version (1.22.4) is the first part, and the last part (k0s.0) reflects the k0s version, which is built on top of the certain Kubernetes version.

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -15,7 +15,7 @@ containerd_build_shim_go_cgo_enabled = 0
 #containerd_build_go_ldflags =
 containerd_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
-kubernetes_version = 1.22.3
+kubernetes_version = 1.22.4
 kubernetes_buildimage = golang:1.16-alpine
 kubernetes_build_go_tags = "providerless"
 #kubernetes_build_go_cgo_enabled =

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -23,7 +23,7 @@ kubernetes_build_go_flags = "-v"
 #kubernetes_build_go_ldflags =
 kubernetes_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
-kine_version = 0.7.1
+kine_version = 0.7.3
 kine_buildimage = golang:1.16-alpine
 #kine_build_go_tags =
 #kine_build_go_cgo_enabled =

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -39,7 +39,7 @@ etcd_build_go_cgo_enabled = 0
 etcd_build_go_ldflags = "-w -s"
 #etcd_build_go_ldflags_extra =
 
-konnectivity_version = 0.0.24
+konnectivity_version = 0.0.25
 konnectivity_buildimage = golang:1.16-alpine
 #konnectivity_build_go_tags =
 konnectivity_build_go_cgo_enabled = 0

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -6,7 +6,7 @@ runc_build_go_tags = "seccomp"
 #runc_build_go_ldflags =
 runc_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
-containerd_version = 1.5.7
+containerd_version = 1.5.8
 containerd_buildimage = golang:1.16-alpine
 containerd_build_go_tags = "apparmor,selinux"
 containerd_build_shim_go_cgo_enabled = 0

--- a/examples/footloose-ha-controllers/Dockerfile
+++ b/examples/footloose-ha-controllers/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/footloose/ubuntu18.04
 
 ADD k0s.service /etc/systemd/system/k0s.service
 
-RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.3/bin/linux/amd64/kubectl && \
+RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.4/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.16
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
-	github.com/Microsoft/hcsshim v0.8.21
+	github.com/Microsoft/hcsshim v0.8.23
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
 	github.com/avast/retry-go v2.6.0+incompatible
 	github.com/cloudflare/cfssl v1.4.1
-	github.com/containerd/containerd v1.5.7
+	github.com/containerd/containerd v1.5.8
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/docker/libnetwork v0.8.0-dev.2.0.20201031180254-535ef365dc1d
 	github.com/evanphx/json-patch v4.11.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/Microsoft/hcsshim v0.8.14/go.mod h1:NtVKoYxQuTLx6gEq0L96c9Ju4JbRJ4nY2
 github.com/Microsoft/hcsshim v0.8.15/go.mod h1:x38A4YbHbdxJtc0sF6oIz+RG0npwSCAvn69iY6URG00=
 github.com/Microsoft/hcsshim v0.8.16/go.mod h1:o5/SZqmR7x9JNKsW3pu+nqHm0MF8vbA+VxGOoXdC600=
 github.com/Microsoft/hcsshim v0.8.18/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
-github.com/Microsoft/hcsshim v0.8.21 h1:btRfUDThBE5IKcvI8O8jOiIkujUsAMBSRsYDYmEi6oM=
-github.com/Microsoft/hcsshim v0.8.21/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
+github.com/Microsoft/hcsshim v0.8.23 h1:47MSwtKGXet80aIn+7h4YI6fwPmwIghAnsx2aOUrG2M=
+github.com/Microsoft/hcsshim v0.8.23/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01nnU2M8jKDg=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -167,6 +167,7 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembj
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20180118203423-deb3ae2ef261/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
@@ -238,6 +239,7 @@ github.com/containerd/containerd v1.3.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMX
 github.com/containerd/containerd v1.4.0-beta.2.0.20200729163537-40b22ef07410/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.4.3/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.4.9/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.5.0-beta.1/go.mod h1:5HfvG1V2FsKesEGQ17k5/T7V960Tmcumvqn8Mc+pCYQ=
 github.com/containerd/containerd v1.5.0-beta.3/go.mod h1:/wr9AVtEM7x9c+n0+stptlo/uBBoBORwEx6ardVcmKU=
 github.com/containerd/containerd v1.5.0-beta.4/go.mod h1:GmdgZd2zA2GYIBZ0w09ZvgqEq8EfBp/m3lcVZIvPHhI=
@@ -245,8 +247,8 @@ github.com/containerd/containerd v1.5.0-rc.0/go.mod h1:V/IXoMqNGgBlabz3tHD2TWDoT
 github.com/containerd/containerd v1.5.1/go.mod h1:0DOxVqwDy2iZvrZp2JUx/E+hS0UNTVn7dJnIOwtYR4g=
 github.com/containerd/containerd v1.5.2/go.mod h1:0DOxVqwDy2iZvrZp2JUx/E+hS0UNTVn7dJnIOwtYR4g=
 github.com/containerd/containerd v1.5.4/go.mod h1:sx18RgvW6ABJ4iYUw7Q5x7bgFOAB9B6G7+yO0XBc4zw=
-github.com/containerd/containerd v1.5.7 h1:rQyoYtj4KddB3bxG6SAqd4+08gePNyJjRqvOIfV3rkM=
-github.com/containerd/containerd v1.5.7/go.mod h1:gyvv6+ugqY25TiXxcZC3L5yOeYgEw0QMhscqVp1AR9c=
+github.com/containerd/containerd v1.5.8 h1:NmkCC1/QxyZFBny8JogwLpOy2f+VEbO/f6bV2Mqtwuw=
+github.com/containerd/containerd v1.5.8/go.mod h1:YdFSv5bTFLpG2HIYmfqDpSYYTDX+mc5qtSuYx1YUb/s=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc h1:TP+534wVlf61smEIq1nwLLAjQVEK2EADoW3CX9AuT+8=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=

--- a/internal/pkg/file/file.go
+++ b/internal/pkg/file/file.go
@@ -18,7 +18,6 @@ package file
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -93,7 +92,7 @@ func Copy(src, dst string) error {
 }
 
 func WriteTmpFile(data string, prefix string) (path string, err error) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%v-", prefix))
+	tmpFile, err := os.CreateTemp("", prefix)
 	if err != nil {
 		return "", fmt.Errorf("cannot create temporary file: %v", err)
 	}

--- a/internal/pkg/strictyaml/strictyaml.go
+++ b/internal/pkg/strictyaml/strictyaml.go
@@ -10,7 +10,7 @@ import (
 // var fieldNamePattern = regexp.MustCompile("field ([^ ]+)")
 
 // YamlUnmarshalStrictIgnoringFields does UnmarshalStrict but ignores type errors for given fields
-func YamlUnmarshalStrictIgnoringFields(in []byte, out interface{}, ignore []string) (err error) {
+func YamlUnmarshalStrictIgnoringFields(in []byte, out interface{}, ignore ...string) (err error) {
 	err = yaml.UnmarshalStrict(in, out)
 	if err != nil {
 		// parse errors for unknown field errors

--- a/internal/pkg/strictyaml/strictyaml_test.go
+++ b/internal/pkg/strictyaml/strictyaml_test.go
@@ -20,7 +20,7 @@ stringC:
   key: value
 `
 		tgt := testConfig{}
-		err := YamlUnmarshalStrictIgnoringFields([]byte(input), &tgt, []string{"stringC", "stringB"})
+		err := YamlUnmarshalStrictIgnoringFields([]byte(input), &tgt, "stringC", "stringB")
 		assert.NoError(t, err)
 		assert.Equal(t, "stringValue", tgt.StringA)
 	})
@@ -33,7 +33,7 @@ stringC:
   key: value
 `
 		tgt := testConfig{}
-		err := YamlUnmarshalStrictIgnoringFields([]byte(input), &tgt, []string{"stringC"})
+		err := YamlUnmarshalStrictIgnoringFields([]byte(input), &tgt, "stringC")
 		assert.Error(t, err)
 	})
 
@@ -41,11 +41,11 @@ stringC:
 		input := `
 	stringA: stringValue
 stringB: shouldGiveErrorBecauseNotMasked
-stringC: 
+stringC:
   key: value
 `
 		tgt := testConfig{}
-		err := YamlUnmarshalStrictIgnoringFields([]byte(input), &tgt, []string{""})
+		err := YamlUnmarshalStrictIgnoringFields([]byte(input), &tgt)
 		assert.Error(t, err)
 	})
 }

--- a/inttest/conformance/README.md
+++ b/inttest/conformance/README.md
@@ -35,15 +35,15 @@ In order to run the conformance test, you will need to set the tested k0s versio
 In the same directory as your `main.tf` file, create an additional file `terraform.tfvars` with the following input:
 
 ```terraform
-k0s_version=v1.22.3+k0s.0
-k8s_version=v1.22.3
+k0s_version=v1.22.4+k0s.0
+k8s_version=v1.22.4
 sonobuoy_version=0.53.2
 ```
 
 ### 2. Environment variables
 
 ```shell
-TF_VAR_k0s_version=v1.22.3+k0s.0 TF_VAR_sonobuoy_version=0.20.0 TF_VAR_k8s_version=v1.22.3 terraform apply
+TF_VAR_k0s_version=v1.22.4+k0s.0 TF_VAR_sonobuoy_version=0.20.0 TF_VAR_k8s_version=v1.22.4 terraform apply
 ```
 
 **NOTE:** By default, terraform will fetch sonobuoy version **0.53.2**. If you want to use a different version you can override this with one of the above methods.

--- a/inttest/upgrade/upgrade_test.go
+++ b/inttest/upgrade/upgrade_test.go
@@ -32,7 +32,7 @@ type UpgradeSuite struct {
 	common.FootlooseSuite
 }
 
-const previousVersion = "v1.22.2+k0s.1"
+const previousVersion = "v1.22.3+k0s.0"
 
 func (s *UpgradeSuite) TestK0sGetsUp() {
 

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
@@ -16,6 +16,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -183,7 +184,7 @@ func ConfigFromStdin(dataDir string) (*ClusterConfig, error) {
 
 func ConfigFromString(yml string, dataDir string) (*ClusterConfig, error) {
 	config := DefaultClusterConfig(dataDir)
-	err := strictyaml.YamlUnmarshalStrictIgnoringFields([]byte(yml), config, []string{"interval"})
+	err := strictyaml.YamlUnmarshalStrictIgnoringFields([]byte(yml), config, "interval")
 	if err != nil {
 		return config, err
 	}
@@ -218,10 +219,10 @@ func (c *ClusterConfig) UnmarshalJSON(data []byte) error {
 	type config ClusterConfig
 	jc := (*config)(c)
 
-	if err := json.Unmarshal(data, jc); err != nil {
-		return err
-	}
-	return nil
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+
+	return decoder.Decode(jc)
 }
 
 // DefaultClusterSpec default settings

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
@@ -282,6 +282,16 @@ func (c *ClusterConfig) Validate() []error {
 	return errors
 }
 
+// CRValidator is used to make sure a config CR is created with correct values
+func (c *ClusterConfig) CRValidator() *ClusterConfig {
+	copy := c.DeepCopy()
+	copy.ClusterName = "k0s"
+	copy.ObjectMeta.Name = "k0s"
+	copy.ObjectMeta.Namespace = "kube-system"
+
+	return copy
+}
+
 // validateSpecs invokes validator Validate function
 func validateSpecs(v Validateable) []error {
 	return v.Validate()

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types_test.go
@@ -31,6 +31,15 @@ func TestClusterDefaults(t *testing.T) {
 	assert.Equal(t, DefaultStorageSpec(dataDir), c.Spec.Storage)
 }
 
+func TestUnknownFieldValidation(t *testing.T) {
+	_, err := ConfigFromString(`
+apiVersion: k0s.k0sproject.io/v1beta1
+kind: ClusterConfig
+unknown: 1`, dataDir)
+
+	assert.Error(t, err)
+}
+
 func TestStorageDefaults(t *testing.T) {
 	yamlData := `
 apiVersion: k0s.k0sproject.io/v1beta1
@@ -167,8 +176,7 @@ metadata:
   name: foobar
 spec:
   workerProfiles:
-  - profile_XXX:
-    name: profile_XXX
+  - name: profile_XXX
     values:
       authentication:
         anonymous:
@@ -176,8 +184,7 @@ spec:
         webhook:
           cacheTTL: 2m0s
           enabled: true
-  - profile_YYY:
-    name: profile_YYY
+  - name: profile_YYY
     values:
       apiVersion: v2
       authentication:

--- a/pkg/cleanup/cni.go
+++ b/pkg/cleanup/cni.go
@@ -26,7 +26,7 @@ func (c *cni) Run() error {
 		"/etc/cni/net.d/10-kuberouter.conflist",
 	}
 	for _, f := range files {
-		if err := os.Remove(f); !errors.Is(err, fs.ErrNotExist) {
+		if err := os.Remove(f); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			logrus.Debug("failed to remove", f, err)
 			msg = append(msg, err)
 		}

--- a/pkg/component/controller/clusterConfig.go
+++ b/pkg/component/controller/clusterConfig.go
@@ -106,7 +106,6 @@ func (r *ClusterConfigReconciler) Run(ctx context.Context) error {
 			}
 			return true, nil
 		})
-
 		if err != nil {
 			return fmt.Errorf("not able to get or create the cluster config: %v", err)
 		}
@@ -202,7 +201,7 @@ func (r *ClusterConfigReconciler) reportStatus(config *v1beta1.ClusterConfig, re
 func (r *ClusterConfigReconciler) copyRunningConfigToCR(baseCtx context.Context) (*v1beta1.ClusterConfig, error) {
 	ctx, cancel := context.WithTimeout(baseCtx, 5*time.Second)
 	defer cancel()
-	clusterWideConfig := config.ClusterConfigMinusNodeConfig(r.YamlConfig).StripDefaults()
+	clusterWideConfig := config.ClusterConfigMinusNodeConfig(r.YamlConfig).StripDefaults().CRValidator()
 	clusterConfig, err := r.configClient.Create(ctx, clusterWideConfig, cOpts)
 	if err != nil {
 		return nil, err

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -80,7 +80,7 @@ const (
 	MetricsImage                       = "k8s.gcr.io/metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.5.0"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"
-	KubeProxyImageVersion              = "v1.22.3"
+	KubeProxyImageVersion              = "v1.22.4"
 	CoreDNSImage                       = "k8s.gcr.io/coredns/coredns"
 	CoreDNSImageVersion                = "v1.7.0"
 	CalicoImage                        = "quay.io/calico/cni"

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -88,7 +88,7 @@ const (
 	CalicoNodeImage                    = "quay.io/calico/node"
 	KubeControllerImage                = "quay.io/calico/kube-controllers"
 	KubeRouterCNIImage                 = "docker.io/cloudnativelabs/kube-router"
-	KubeRouterCNIImageVersion          = "v1.3.1"
+	KubeRouterCNIImageVersion          = "v1.3.2"
 	KubeRouterCNIInstallerImage        = "quay.io/k0sproject/cni-node"
 	KubeRouterCNIInstallerImageVersion = "0.1.0"
 

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -76,7 +76,7 @@ const (
 	DefaultPSP = "00-k0s-privileged"
 	// Image Constants
 	KonnectivityImage                  = "k8s.gcr.io/kas-network-proxy/proxy-agent"
-	KonnectivityImageVersion           = "v0.0.24"
+	KonnectivityImageVersion           = "v0.0.25"
 	MetricsImage                       = "k8s.gcr.io/metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.5.0"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"


### PR DESCRIPTION
**What this PR Includes**
Sync up release-1.22 with main

- Bump kubernetes to 1.22.4
- Bump kine to 0.7.3
- Bump containerd 1.5.8 (CVE-2021-41190)
- reset: fix cleanup of cni
- Docs: Add emphasis on enabling the dynamic config on every controller (#1259)
- Update the `haproxy` example docs to not change the default mode.
- Bump konnectivity to 0.0.25
- Bump kube-router to 1.3.2
- Change codeowners file
- Give validation errors on unknown config fields (#1246)
- Add a CR validator for API config
- Replace ioutil.TempFile with os.CreateTemp (#1244)
