### PR TITLE
Remove labels used by kubernetes addon-manager

### DIFF
--- a/pkg/component/controller/defaultpsp.go
+++ b/pkg/component/controller/defaultpsp.go
@@ -109,7 +109,6 @@ metadata:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
 spec:
   privileged: true
   allowPrivilegeEscalation: true
@@ -139,7 +138,6 @@ metadata:
   name: k0s:podsecuritypolicy:privileged
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
   - policy

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -291,7 +291,6 @@ metadata:
   name: system:konnectivity-server
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -308,7 +307,6 @@ metadata:
   namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
 ---
 apiVersion: apps/v1
 # Alternatively, you can deploy the agents as Deployments. It is not necessary
@@ -316,7 +314,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    addonmanager.kubernetes.io/mode: Reconcile
     k8s-app: konnectivity-agent
   namespace: kube-system
   name: konnectivity-agent


### PR DESCRIPTION
Signed-off-by: uesyn <suemura@zlab.co.jp>

`addonmanager.kubernetes.io/mode` label is used by kubernetres official [addon-manager](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/addon-manager).
If we deploy addon-manager in kubernetes cluster built by k0s, konnectivity and default psp will be pruned unintentionally, because these manifests have `addonmanager.kubernetes.io/mode=Reconcile` label.

This PR is needed to be deploy addon-manager safely in cluster built by k0s.
As far as I have checked, these labels are not used by k0s, so I think we can remove this label.

**Issue**
None

**What this PR Includes**
Remove labels used by kubernetes addon-manager from konnectivity and default psp, because of deploying kubernetes addon-manager safely.