### PR TITLE
Fix konnectivity build image

### DIFF
--- a/embedded-bins/konnectivity/Dockerfile
+++ b/embedded-bins/konnectivity/Dockerfile
@@ -8,12 +8,12 @@ ARG BUILD_GO_FLAGS
 ARG BUILD_GO_LDFLAGS
 ARG BUILD_GO_LDFLAGS_EXTRA
 
-RUN apk add build-base git make
+RUN apk add build-base git make protoc
 
 RUN git clone -b v$VERSION --depth=1 https://github.com/kubernetes-sigs/apiserver-network-proxy.git /apiserver-network-proxy
 WORKDIR /apiserver-network-proxy
 RUN go version
-RUN GO111MODULE=on go get github.com/golang/mock/mockgen@v1.4.4 && \
+RUN GO111MODULE=on go get github.com/golang/mock/mockgen@v1.4.4 github.com/golang/protobuf/protoc-gen-go@v1.4.3 && \
     make gen && \
     CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
     GOOS=linux \


### PR DESCRIPTION
This change fixes k0s build at least on my mac. 

Before:

```
#9 42.84 make: protoc: No such file or directory
#9 42.84 make: *** [Makefile:106: konnectivity-client/proto/client/client.pb.go] Error 127
```

After `apk add protoc`:

```
protoc-gen-go: No such file or directory
```

Finally, after `go get github.com/golang/protobuf/protoc-gen-go@v1.4.3`:

```
...
...
...
cat k0s.code bindata_linux > k0s.tmp \
		&& rm -f k0s.code \
		&& chmod +x k0s.tmp \
		&& mv k0s.tmp k0s

# scp k0s linux:tmp/
# ssh linux "chmod +x tmp/k0s && tmp/k0s" 
Usage: ...
```
