### PR TITLE
Support IPv6 only mode

### DIFF
--- a/internal/pkg/iface/iface.go
+++ b/internal/pkg/iface/iface.go
@@ -34,7 +34,7 @@ func AllAddresses() ([]string, error) {
 	for _, a := range addrs {
 		// check the address type and skip if loopback
 		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-			if ipnet.IP.To4() != nil {
+			if ipnet.IP.To4() != nil || ipnet.IP.To16() != nil {
 				addresses = append(addresses, ipnet.IP.String())
 			}
 		}
@@ -45,12 +45,14 @@ func AllAddresses() ([]string, error) {
 	return addresses, nil
 }
 
-// FirstPublicAddress return the first found non-local address that's not part of pod network
+// FirstPublicAddress return the first found non-local IPv4 address that's not part of pod network
+// if any interface does not have any IPv4 address then return the first found non-local IPv6 address
 func FirstPublicAddress() (string, error) {
 	ifs, err := net.Interfaces()
 	if err != nil {
 		return "127.0.0.1", fmt.Errorf("failed to list network interfaces: %w", err)
 	}
+	ipv6addr := ""
 	for _, i := range ifs {
 		if i.Name == "vxlan.calico" {
 			// Skip calico interface
@@ -64,11 +66,17 @@ func FirstPublicAddress() (string, error) {
 		for _, a := range addresses {
 			// check the address type and skip if loopback
 			if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-				if ipnet.IP.To4() != nil && !ipnet.IP.IsLoopback() {
+				if ipnet.IP.To4() != nil {
 					return ipnet.IP.String(), nil
+				}
+				if ipnet.IP.To16() != nil && ipv6addr == "" {
+					ipv6addr = ipnet.IP.String()
 				}
 			}
 		}
+	}
+	if ipv6addr != "" {
+		return ipv6addr, nil
 	}
 
 	logrus.Warn("failed to find any non-local, non podnetwork addresses on host, defaulting public address to 127.0.0.1")

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/network.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/network.go
@@ -97,6 +97,10 @@ func (n *Network) DNSAddress() (string, error) {
 	}
 
 	address := ipnet.IP.To4()
+	if IsIPv6String(ipnet.IP.String()) {
+		address = ipnet.IP.To16()
+	}
+
 	prefixlen, _ := ipnet.Mask.Size()
 	if prefixlen < 29 {
 		address[3] = address[3] + 10


### PR DESCRIPTION
**Issue**
Parly solves  #773

**What this PR Includes**
This start solving IPv6 only support. On this PR focus is add just enough logic to support k0s on vcluster https://www.vcluster.com/docs/operator/other-distributions#k0s with IPv6 only mode added by https://github.com/loft-sh/vcluster/pull/209

Without these changes that scenario crashed to error:
```
time="2021-11-28 20:33:54" level=info msg="using sans: [10.6.86.119]"
panic: runtime error: index out of range [3] with length 0

goroutine 1 [running]:
github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1.(*Network).DNSAddress(0xc0003db110, 0x4, 0x33d43d9, 0xe, 0xc000b48e10)
        /go/src/github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1/network.go:104 +0x3b0
github.com/k0sproject/k0s/cmd/controller.(*CmdOpts).startController(0xc000b49868, 0x3a39310, 0xc0000d8000, 0x0, 0x0)
        /go/src/github.com/k0sproject/k0s/cmd/controller/controller.go:146 +0x5ea
github.com/k0sproject/k0s/cmd/controller.NewControllerCmd.func1(0xc0003ef180, 0xc0005e11d0, 0x0, 0x3, 0x0, 0x0)
        /go/src/github.com/k0sproject/k0s/cmd/controller/controller.go:97 +0x39a
github.com/spf13/cobra.(*Command).execute(0xc0003ef180, 0xc0005e11a0, 0x3, 0x3, 0xc0003ef180, 0xc0005e11a0)
        /gocache/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0xc0003ee000, 0x407905, 0xc0000b6058, 0x2b1cd90)
        /gocache/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
        /gocache/mod/github.com/spf13/cobra@v1.2.1/command.go:902
github.com/k0sproject/k0s/cmd.Execute()
        /go/src/github.com/k0sproject/k0s/cmd/root.go:206 +0x2a
main.main()
        /go/src/github.com/k0sproject/k0s/main.go:40 +0x25
```