### PR TITLE
Run bundled kubectl and ctr when k0s started via matching symlink

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ package main
 import (
 	_ "net/http/pprof"
 	"os"
+	"path"
+	"strings"
 
 	"github.com/k0sproject/k0s/cmd"
 	"github.com/sirupsen/logrus"
@@ -37,5 +39,12 @@ func init() {
 }
 
 func main() {
+	// Make embedded commands work through symlinks such as /usr/local/bin/kubectl (or k0s-kubectl)
+	progN := strings.TrimPrefix(path.Base(os.Args[0]), "k0s-")
+	switch progN {
+	case "kubectl", "ctr":
+		os.Args = append([]string{"k0s", progN}, os.Args[1:]...)
+	}
+
 	cmd.Execute()
 }


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Runs the embedded kubectl or ctr commands when k0s is started as `kubectl` or `ctr` or `k0s-kubectl` or `k0s-ctr`, for example when running via symlink:

```shell
$ ln -s /usr/local/bin/k0s /usr/local/bin/kubectl
$ kubectl --help
kubectl controls the Kubernetes cluster manager.

 Find more information at: https://kubernetes.io/docs/reference/kubectl/overview/

Aliases:
kubectl, kc

Basic Commands (Beginner):
  create        Create a resource from a file or from stdin
....
....
```

`k0s install` could maybe install those symlinks, maybe `k0s install symlinks`.
