### PR TITLE
Fix some errors being reported twice

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -201,10 +201,7 @@ func (c *cliOpts) buildConfig() error {
 }
 
 func Execute() {
-	// just a hack to trick linter which requires to check for errors
-	// cobra itself already prints out all errors that happen in subcommands
-	err := NewRootCmd().Execute()
-	if err != nil {
-		log.Fatal(err)
+	if err := NewRootCmd().Execute(); err != nil {
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Fixes #1298 

Before:

```shell
$ ./k0s kubetl
Error: unknown command "kubetl" for "k0s"

Did you mean this?
	kubectl

Run 'k0s --help' for usage.
2021-12-01 12:58:04.932909 I | unknown command "kubetl" for "k0s"

Did you mean this?
	kubectl

After:

```shell
$ ./k0s kubetl
Error: unknown command "kubetl" for "k0s"

Did you mean this?
	kubectl

Run 'k0s --help' for usage.
```

I think this mostly happens when the `Did you mean` triggers.
