### PR TITLE
Avoid CI rebuild for unit tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,6 +79,14 @@ jobs:
       - name: Docker Layer Caching
         uses: satackey/action-docker-layer-caching@v0.0.11
 
+      - name: Docker volumes cache
+        uses: actions/cache@v2
+        with:
+          path: /var/lib/docker/volumes/
+          key: ${{ runner.os }}-docker-volumes
+          restore-keys: |
+            ${{ runner.os }}-docker-volumes
+
       - name: Build
         run: make build
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,9 +58,9 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             %LocalAppData%\go-build
-            key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-            restore-keys: |
-              ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Bindata cache
         uses: actions/cache@v2
@@ -116,9 +116,9 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             %LocalAppData%\go-build
-            key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-            restore-keys: |
-              ${{ runner.os }}-go-win-
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-win-
 
       - name: Bindata cache
         uses: actions/cache@v2
@@ -130,7 +130,6 @@ jobs:
             bindata_windows
             pkg/assets/zz_generated_offsets_windows.go
             embedded-bins/Makefile.variables
-
           key: ${{ runner.os }}-embedded-bins-win-${{ hashFiles('**/embedded-bins/**/*') }}
           restore-keys: |
             ${{ runner.os }}-embedded-bins-win-
@@ -192,9 +191,9 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             %LocalAppData%\go-build
-            key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-            restore-keys: |
-              ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Bindata cache
         uses: actions/cache@v2
@@ -256,9 +255,9 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             %LocalAppData%\go-build
-            key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-            restore-keys: |
-              ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Bindata cache
         uses: actions/cache@v2
@@ -347,9 +346,9 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             %LocalAppData%\go-build
-            key: ${{ runner.os }}-go-arm-${{ hashFiles('**/go.sum') }}
-            restore-keys: |
-              ${{ runner.os }}-go-arm-
+          key: ${{ runner.os }}-go-arm-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-arm-
 
       - name: Bindata cache
         uses: actions/cache@v2
@@ -401,9 +400,9 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             %LocalAppData%\go-build
-            key: ${{ runner.os }}-go-armv7-${{ hashFiles('**/go.sum') }}
-            restore-keys: |
-              ${{ runner.os }}-go-armv7-
+          key: ${{ runner.os }}-go-armv7-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-armv7-
 
       - name: Bindata cache
         uses: actions/cache@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,7 +53,11 @@ jobs:
       - uses: actions/cache@v2
         name: Go modules cache
         with:
-          path: ~/go/pkg/mod
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          %LocalAppData%\go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
@@ -68,10 +72,9 @@ jobs:
             bindata_linux
             pkg/assets/zz_generated_offsets_linux.go
             embedded-bins/Makefile.variables
-
           key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}
           restore-keys: |
-            ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}
+            ${{ runner.os }}-embedded-bins-
 
       - name: Build
         run: make build
@@ -108,7 +111,11 @@ jobs:
       - uses: actions/cache@v2
         name: Go modules cache
         with:
-          path: ~/go/pkg/mod
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          %LocalAppData%\go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-win-
@@ -126,7 +133,7 @@ jobs:
 
           key: ${{ runner.os }}-embedded-bins-win-${{ hashFiles('**/embedded-bins/**/*') }}
           restore-keys: |
-            ${{ runner.os }}-embedded-bins-win-${{ hashFiles('**/embedded-bins/**/*') }}
+            ${{ runner.os }}-embedded-bins-win-
 
       - name: Build
         run: make k0s.exe
@@ -177,6 +184,32 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
+      - uses: actions/cache@v2
+        name: Go modules cache
+        with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          %LocalAppData%\go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Bindata cache
+        uses: actions/cache@v2
+        id: generated-bindata
+        with:
+          path: |
+            .bins.linux.stamp
+            embedded-bins/staging/linux/bin/
+            bindata_linux
+            pkg/assets/zz_generated_offsets_linux.go
+            embedded-bins/Makefile.variables
+          key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}
+          restore-keys: |
+            ${{ runner.os }}-embedded-bins-
+
       - name: Cache compiled binary for smoke testing
         uses: actions/cache@v2
         id: restore-compiled-binary
@@ -214,6 +247,32 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
+
+      - uses: actions/cache@v2
+        name: Go modules cache
+        with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          %LocalAppData%\go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Bindata cache
+        uses: actions/cache@v2
+        id: generated-bindata
+        with:
+          path: |
+            .bins.linux.stamp
+            embedded-bins/staging/linux/bin/
+            bindata_linux
+            pkg/assets/zz_generated_offsets_linux.go
+            embedded-bins/Makefile.variables
+          key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}
+          restore-keys: |
+            ${{ runner.os }}-embedded-bins-
 
       - name: Cache compiled binary for smoke testing
         uses: actions/cache@v2
@@ -283,10 +342,15 @@ jobs:
       - uses: actions/cache@v2
         name: Go modules cache
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          %LocalAppData%\go-build
+          key: ${{ runner.os }}-go-arm-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-go-arm-
+
       - name: Bindata cache
         uses: actions/cache@v2
         id: generated-bindata
@@ -297,9 +361,10 @@ jobs:
             bindata_linux
             pkg/assets/zz_generated_offsets_linux.go
             embedded-bins/Makefile.variables
-          key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-arm64
+          key: ${{ runner.os }}-embedded-bins-arm-${{ hashFiles('**/embedded-bins/**/*') }}
           restore-keys: |
-            ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-arm64
+            ${{ runner.os }}-embedded-bins-arm-
+
       - name: Build
         run: make build
 
@@ -313,6 +378,7 @@ jobs:
           name: ${{ env.cachePrefix }}-logs-check-basic-arm-${{ github.run_number }}
           path: |
             /tmp/*.log
+
   smoketest-armv7:
     name: Smoke test on armv7
     runs-on: [self-hosted,linux,arm,lxc]
@@ -330,10 +396,15 @@ jobs:
       - uses: actions/cache@v2
         name: Go modules cache
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          %LocalAppData%\go-build
+          key: ${{ runner.os }}-go-armv7-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-go-armv7-
+
       - name: Bindata cache
         uses: actions/cache@v2
         id: generated-bindata
@@ -344,9 +415,10 @@ jobs:
             bindata_linux
             pkg/assets/zz_generated_offsets_linux.go
             embedded-bins/Makefile.variables
-          key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-armv7
+          key: ${{ runner.os }}-embedded-bins-armv7-${{ hashFiles('**/embedded-bins/**/*') }}
           restore-keys: |
-            ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}-armv7
+            ${{ runner.os }}-embedded-bins-armv7-
+
       - name: Build
         run: make build
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -76,6 +76,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-embedded-bins-
 
+      - name: Docker Layer Caching
+        uses: satackey/action-docker-layer-caching@v0.0.11
+
       - name: Build
         run: make build
 
@@ -133,6 +136,9 @@ jobs:
           key: ${{ runner.os }}-embedded-bins-win-${{ hashFiles('**/embedded-bins/**/*') }}
           restore-keys: |
             ${{ runner.os }}-embedded-bins-win-
+
+      - name: Docker Layer Caching
+        uses: satackey/action-docker-layer-caching@v0.0.11
 
       - name: Build
         run: make k0s.exe
@@ -281,22 +287,6 @@ jobs:
             k0s
           key: build-${{env.cachePrefix}}
 
-          # We need the bindata cache too so the makefile targets and deps work properly
-      - name: Bindata cache
-        uses: actions/cache@v2
-        id: generated-bindata
-        with:
-          path: |
-            .bins.linux.stamp
-            embedded-bins/staging/linux/bin/
-            bindata_linux
-            pkg/assets/zz_generated_offsets_linux.go
-            embedded-bins/Makefile.variables
-
-          key: ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}
-          restore-keys: |
-            ${{ runner.os }}-embedded-bins-${{ hashFiles('**/embedded-bins/**/*') }}
-
       - name: Cache images bundle
         uses: actions/cache@v2
         id: restore-bundle
@@ -364,6 +354,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-embedded-bins-arm-
 
+      - name: Docker Layer Caching
+        uses: satackey/action-docker-layer-caching@v0.0.11
+
       - name: Build
         run: make build
 
@@ -417,6 +410,9 @@ jobs:
           key: ${{ runner.os }}-embedded-bins-armv7-${{ hashFiles('**/embedded-bins/**/*') }}
           restore-keys: |
             ${{ runner.os }}-embedded-bins-armv7-
+
+      - name: Docker Layer Caching
+        uses: satackey/action-docker-layer-caching@v0.0.11
 
       - name: Build
         run: make build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,6 +58,7 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             %LocalAppData%\go-build
+            k0sbuild.gocache
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
@@ -78,14 +79,6 @@ jobs:
 
       - name: Docker Layer Caching
         uses: satackey/action-docker-layer-caching@v0.0.11
-
-      - name: Docker volumes cache
-        uses: actions/cache@v2
-        with:
-          path: /var/lib/docker/volumes/
-          key: ${{ runner.os }}-docker-volumes
-          restore-keys: |
-            ${{ runner.os }}-docker-volumes
 
       - name: Build
         run: make build
@@ -127,6 +120,7 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             %LocalAppData%\go-build
+            k0sbuild.gocache
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-win-
@@ -205,6 +199,7 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             %LocalAppData%\go-build
+            k0sbuild.gocache
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
@@ -269,6 +264,7 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             %LocalAppData%\go-build
+            k0sbuild.gocache
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
@@ -344,6 +340,7 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             %LocalAppData%\go-build
+            k0sbuild.gocache
           key: ${{ runner.os }}-go-arm-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-arm-
@@ -401,6 +398,7 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             %LocalAppData%\go-build
+            k0sbuild.gocache
           key: ${{ runner.os }}-go-armv7-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-armv7-

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,14 +53,14 @@ jobs:
       - uses: actions/cache@v2
         name: Go modules cache
         with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            %LocalAppData%\go-build
+            key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+            restore-keys: |
+              ${{ runner.os }}-go-
 
       - name: Bindata cache
         uses: actions/cache@v2
@@ -111,14 +111,14 @@ jobs:
       - uses: actions/cache@v2
         name: Go modules cache
         with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-win-
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            %LocalAppData%\go-build
+            key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+            restore-keys: |
+              ${{ runner.os }}-go-win-
 
       - name: Bindata cache
         uses: actions/cache@v2
@@ -187,14 +187,14 @@ jobs:
       - uses: actions/cache@v2
         name: Go modules cache
         with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            %LocalAppData%\go-build
+            key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+            restore-keys: |
+              ${{ runner.os }}-go-
 
       - name: Bindata cache
         uses: actions/cache@v2
@@ -251,14 +251,14 @@ jobs:
       - uses: actions/cache@v2
         name: Go modules cache
         with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            %LocalAppData%\go-build
+            key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+            restore-keys: |
+              ${{ runner.os }}-go-
 
       - name: Bindata cache
         uses: actions/cache@v2
@@ -342,14 +342,14 @@ jobs:
       - uses: actions/cache@v2
         name: Go modules cache
         with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-          key: ${{ runner.os }}-go-arm-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-arm-
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            %LocalAppData%\go-build
+            key: ${{ runner.os }}-go-arm-${{ hashFiles('**/go.sum') }}
+            restore-keys: |
+              ${{ runner.os }}-go-arm-
 
       - name: Bindata cache
         uses: actions/cache@v2
@@ -396,14 +396,14 @@ jobs:
       - uses: actions/cache@v2
         name: Go modules cache
         with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-          key: ${{ runner.os }}-go-armv7-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-armv7-
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            %LocalAppData%\go-build
+            key: ${{ runner.os }}-go-armv7-${{ hashFiles('**/go.sum') }}
+            restore-keys: |
+              ${{ runner.os }}-go-armv7-
 
       - name: Bindata cache
         uses: actions/cache@v2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,12 +40,24 @@ jobs:
     if: github.ref != 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        name: Go modules cache
+        with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          %LocalAppData%\go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: codegen
         run: |
           make -j$(nproc) pkg/assets/zz_generated_offsets_linux.go static/gen_manifests.go
         env:
           EMBEDDED_BINS_BUILDMODE: none
-
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,14 +44,14 @@ jobs:
       - uses: actions/cache@v2
         name: Go modules cache
         with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            %LocalAppData%\go-build
+            key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+            restore-keys: |
+              ${{ runner.os }}-go-
 
       - name: codegen
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -49,9 +49,9 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             %LocalAppData%\go-build
-            key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-            restore-keys: |
-              ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: codegen
         run: |

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,8 @@ k0s.exe: TARGET_OS = windows
 k0s.exe: BUILD_GO_CGO_ENABLED = 0
 k0s.exe: GOLANG_IMAGE = golang:1.16-alpine
 k0s.exe: pkg/assets/zz_generated_offsets_windows.go
-k0s.exe: .k0sbuild.gocache
+k0s.exe: .k0sbuild.docker-image.k0s
+k0s.exe: k0sbuild.gocache
 
 k0s.exe k0s: static/gen_manifests.go
 


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Fixes #1297 by tweaking the module/bindata cache settings.
