### PR TITLE
Fix generate-APIClient Makefile target

### DIFF
--- a/hack/client-gen/boilerplate.go.txt
+++ b/hack/client-gen/boilerplate.go.txt
@@ -1,0 +1,15 @@
+/*
+Copyright 2021 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Before:

```
$ make generate-APIClient
client-gen: command not found
# install it manually
$ make generate-APIClient
F1203 09:45:22.778165   55500 client_generator.go:322] Failed loading boilerplate: open /Users/user/Projects/go/src/k8s.io/code-generator/hack/boilerplate.go.txt: no such file or directory
```

After: 

works, includes boilerplate with k0s-authors copyright, installs client-gen if not found.
