### PR TITLE
Remove lxc tag from arm32 runner

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -327,6 +327,11 @@ jobs:
       #   with:
       #     go-version: ${{ env.GO_VERSION }}
       #   id: go
+      - name: Install GoLang for ARMHF
+        run: "echo $HOME/.local/go/bin >> $GITHUB_PATH; rm -rf $HOME/.local/go && mkdir -p $HOME/.local/go && curl --silent -L https://golang.org/dl/$(curl --silent -L 'https://golang.org/VERSION?m=text').linux-armv6l.tar.gz | tar -C $HOME/.local -xz"
+      - name: Go Version
+        run: go version
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -318,7 +318,7 @@ jobs:
             /tmp/*.log
   smoketest-armv7:
     name: Smoke test on armv7
-    runs-on: [self-hosted,linux,arm,lxc]
+    runs-on: [self-hosted,linux,arm]
     steps:
       # We cannot rely on this as it's not working on arm, see https://github.com/actions/setup-go/issues/106
       # Instead we must have proper golang version setup at system level.


### PR DESCRIPTION
The new arm32 runner is a virtual machine, and does not have the 'lxc'
tag.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

