### PR TITLE
footloose inttests: allow overriding k0s path

### DIFF
--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -52,6 +52,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+var defaultK0sBinPath = "/usr/bin/k0s"
+
 // FootlooseSuite defines all the common stuff we need to be able to run k0s testing on footloose
 type FootlooseSuite struct {
 	suite.Suite
@@ -88,9 +90,6 @@ func (s *FootlooseSuite) SetupSuite() {
 	}
 	if s.KonnectivityAgentPort == 0 {
 		s.KonnectivityAgentPort = 8132
-	}
-	if s.K0sFullPath == "" {
-		s.K0sFullPath = "/usr/bin/k0s"
 	}
 
 	dir, err := os.MkdirTemp("", "footloose-keys")
@@ -728,6 +727,10 @@ func (s *FootlooseSuite) createConfig() config.Config {
 		s.FailNow("K0S_PATH env needs to be set to k0s binary")
 	}
 
+	if s.K0sFullPath == "" {
+		s.K0sFullPath = defaultK0sBinPath
+	}
+
 	volumes := []config.Volume{
 		{
 			Type:        "bind",
@@ -737,7 +740,7 @@ func (s *FootlooseSuite) createConfig() config.Config {
 		{
 			Type:        "bind",
 			Source:      binPath,
-			Destination: "/usr/bin/k0s",
+			Destination: s.K0sFullPath,
 		},
 		{
 			Type:        "volume",

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -59,12 +59,13 @@ type FootlooseSuite struct {
 	Cluster *cluster.Cluster
 
 	ControllerCount       int
-	WorkerCount           int
-	KubeAPIExternalPort   int
 	K0sAPIExternalPort    int
-	KonnectivityAgentPort int
+	K0sFullPath           string
 	KonnectivityAdminPort int
+	KonnectivityAgentPort int
+	KubeAPIExternalPort   int
 	WithLB                bool
+	WorkerCount           int
 
 	ExtraVolumes  []config.Volume
 	tearDownTimer *time.Timer
@@ -88,6 +89,10 @@ func (s *FootlooseSuite) SetupSuite() {
 	if s.KonnectivityAgentPort == 0 {
 		s.KonnectivityAgentPort = 8132
 	}
+	if s.K0sFullPath == "" {
+		s.K0sFullPath = "/usr/bin/k0s"
+	}
+
 	dir, err := os.MkdirTemp("", "footloose-keys")
 	if err != nil {
 		s.T().Logf("ERROR: failed to load footloose config: %s", err.Error())
@@ -97,7 +102,6 @@ func (s *FootlooseSuite) SetupSuite() {
 	s.footlooseConfig = s.createConfig()
 
 	suiteCluster, err := cluster.New(s.footlooseConfig)
-
 	if err != nil {
 		s.T().Logf("ERROR: failed to load footloose config: %s", err.Error())
 		s.T().FailNow()
@@ -165,7 +169,6 @@ func (s *FootlooseSuite) waitForSSH() {
 	}
 
 	err := g.Wait()
-
 	if err != nil {
 		s.FailNowf("failed to ssh one or many nodes: %s", err.Error())
 		s.T().FailNow()
@@ -243,7 +246,6 @@ func (s *FootlooseSuite) TearDownSuite() {
 		}
 
 	}
-
 }
 
 const keepAfterTestsEnv = "K0S_KEEP_AFTER_TESTS"
@@ -272,7 +274,6 @@ func getDataDirOpt(args []string) string {
 }
 
 func (s *FootlooseSuite) startHAProxy() {
-
 	addresses := s.getControllersIPAddresses()
 	ssh, err := s.SSH("lb0")
 	s.Require().NoError(err)
@@ -383,7 +384,7 @@ func (s *FootlooseSuite) InitController(idx int, k0sArgs ...string) error {
 	}
 	defer ssh.Disconnect()
 	// Allow any arch for etcd in smokes
-	startCmd := fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=%s nohup k0s controller --debug %s >/tmp/k0s-controller.log 2>&1 &", runtime.GOARCH, strings.Join(k0sArgs, " "))
+	startCmd := fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=%s nohup %s controller --debug %s >/tmp/k0s-controller.log 2>&1 &", runtime.GOARCH, s.K0sFullPath, strings.Join(k0sArgs, " "))
 	_, err = ssh.ExecWithOutput(startCmd)
 	if err != nil {
 		s.T().Logf("failed to execute '%s' on %s", startCmd, controllerNode)
@@ -399,12 +400,11 @@ func (s *FootlooseSuite) GetJoinToken(role string, extraArgs ...string) (string,
 	controllerNode := s.ControllerNode(0)
 	s.Contains([]string{"controller", "worker"}, role, "Bad role")
 	ssh, err := s.SSH(controllerNode)
-
 	if err != nil {
 		return "", err
 	}
 	defer ssh.Disconnect()
-	token, err := ssh.ExecWithOutput(fmt.Sprintf("k0s token create --role=%s %s", role, strings.Join(extraArgs, " ")))
+	token, err := ssh.ExecWithOutput(fmt.Sprintf("%s token create --role=%s %s", s.K0sFullPath, role, strings.Join(extraArgs, " ")))
 	if err != nil {
 		return "", fmt.Errorf("can't get join token: %v", err)
 	}
@@ -413,7 +413,6 @@ func (s *FootlooseSuite) GetJoinToken(role string, extraArgs ...string) (string,
 
 	token = outputParts[len(outputParts)-1]
 	return token, nil
-
 }
 
 // RunWorkers joins all the workers to the cluster
@@ -432,7 +431,7 @@ func (s *FootlooseSuite) RunWorkersWithToken(token string, args ...string) error
 	if token == "" {
 		return fmt.Errorf("got empty token for worker join")
 	}
-	workerCommand := fmt.Sprintf(`nohup k0s --debug worker %s "%s" >/tmp/k0s-worker.log 2>&1 &`, strings.Join(args, " "), token)
+	workerCommand := fmt.Sprintf(`nohup %s --debug worker %s "%s" >/tmp/k0s-worker.log 2>&1 &`, s.K0sFullPath, strings.Join(args, " "), token)
 
 	for i := 0; i < s.WorkerCount; i++ {
 		sshWorker, err := s.SSH(s.WorkerNode(i))
@@ -495,7 +494,8 @@ func (s *FootlooseSuite) StopController(name string) error {
 	s.Require().NoError(err)
 	defer ssh.Disconnect()
 	s.T().Log("killing k0s")
-	_, err = ssh.ExecWithOutput(`kill $(pidof k0s | tr " " "\n" | sort -n | head -n1) && while pidof k0s; do sleep 0.1s; done`)
+	stopCommand := fmt.Sprintf("kill $(pidof %s | tr \" \" \"\\n\" | sort -n | head -n1) && while pidof %s; do sleep 0.1s; done", s.K0sFullPath, s.K0sFullPath)
+	_, err = ssh.ExecWithOutput(stopCommand)
 	return err
 }
 
@@ -503,7 +503,8 @@ func (s *FootlooseSuite) Reset(name string) error {
 	ssh, err := s.SSH(name)
 	s.NoError(err)
 	defer ssh.Disconnect()
-	_, err = ssh.ExecWithOutput("k0s reset --debug")
+	resetCommand := fmt.Sprintf("%s reset --debug", s.K0sFullPath)
+	_, err = ssh.ExecWithOutput(resetCommand)
 	return err
 }
 
@@ -519,7 +520,7 @@ func (s *FootlooseSuite) GetKubeClientConfig(node string, k0sKubeconfigArgs ...s
 	}
 	defer ssh.Disconnect()
 
-	kubeConfigCmd := fmt.Sprintf("k0s kubeconfig admin %s", strings.Join(k0sKubeconfigArgs, " "))
+	kubeConfigCmd := fmt.Sprintf("%s kubeconfig admin %s", s.K0sFullPath, strings.Join(k0sKubeconfigArgs, " "))
 	kubeConf, err := ssh.ExecWithOutput(kubeConfigCmd)
 	if err != nil {
 		return nil, err
@@ -532,7 +533,6 @@ func (s *FootlooseSuite) GetKubeClientConfig(node string, k0sKubeconfigArgs ...s
 		return nil, fmt.Errorf("can't parse port value `%s`: %w", cfg.Clusters["local"].Server, err)
 	}
 	port, err := strconv.ParseInt(hostURL.Port(), 10, 32)
-
 	if err != nil {
 		return nil, fmt.Errorf("can't parse port value `%s`: %w", hostURL.Port(), err)
 	}
@@ -556,7 +556,7 @@ func (s *FootlooseSuite) GetKubeConfig(node string, k0sKubeconfigArgs ...string)
 	}
 	defer ssh.Disconnect()
 
-	kubeConfigCmd := fmt.Sprintf("k0s kubeconfig admin %s", strings.Join(k0sKubeconfigArgs, " "))
+	kubeConfigCmd := fmt.Sprintf("%s kubeconfig admin %s", s.K0sFullPath, strings.Join(k0sKubeconfigArgs, " "))
 	kubeConf, err := ssh.ExecWithOutput(kubeConfigCmd)
 	if err != nil {
 		return nil, err
@@ -569,7 +569,6 @@ func (s *FootlooseSuite) GetKubeConfig(node string, k0sKubeconfigArgs ...string)
 		return nil, fmt.Errorf("can't parse port value `%s`: %w", cfg.Host, err)
 	}
 	port, err := strconv.ParseInt(hostURL.Port(), 10, 32)
-
 	if err != nil {
 		return nil, fmt.Errorf("can't parse port value `%s`: %w", hostURL.Port(), err)
 	}
@@ -697,7 +696,6 @@ func (s *FootlooseSuite) WaitJoinAPI(node string) error {
 		s.T().Logf("join api up-and-running")
 
 		return true, nil
-
 	})
 }
 

--- a/inttest/upgrade/upgrade_test.go
+++ b/inttest/upgrade/upgrade_test.go
@@ -76,6 +76,9 @@ func (s *UpgradeSuite) TestK0sGetsUp() {
 
 	s.Require().NoError(g.Wait())
 
+	// use the oldVersion k0s for footloose operations
+	s.K0sFullPath = "/usr/local/bin/k0s"
+
 	s.Require().NoError(s.WaitForKubeAPI(s.ControllerNode(0)))
 	token, err := s.GetJoinToken("worker")
 	s.NoError(err)
@@ -135,7 +138,7 @@ func (s *UpgradeSuite) TestK0sGetsUp() {
 				return err
 			}
 			defer ssh.Disconnect()
-			_, err = ssh.ExecWithOutput("rm /usr/local/bin/k0s && cp /usr/bin/k0s /usr/local/bin/k0s")
+			_, err = ssh.ExecWithOutput("rm /usr/local/bin/k0s && cp /usr/bin/k0s.new /usr/local/bin/k0s")
 			if err != nil {
 				return err
 			}
@@ -154,7 +157,7 @@ func (s *UpgradeSuite) TestK0sGetsUp() {
 				return err
 			}
 			defer ssh.Disconnect()
-			_, err = ssh.ExecWithOutput("rm /usr/local/bin/k0s && cp /usr/bin/k0s /usr/local/bin/k0s")
+			_, err = ssh.ExecWithOutput("rm /usr/local/bin/k0s && cp /usr/bin/k0s.new /usr/local/bin/k0s")
 			if err != nil {
 				return err
 			}
@@ -180,7 +183,7 @@ func TestUpgradeSuite(t *testing.T) {
 		common.FootlooseSuite{
 			ControllerCount: 1,
 			WorkerCount:     2,
-			K0sFullPath:     "/usr/local/bin/k0s",
+			K0sFullPath:     "/usr/bin/k0s.new",
 		},
 	}
 	suite.Run(t, &s)

--- a/inttest/upgrade/upgrade_test.go
+++ b/inttest/upgrade/upgrade_test.go
@@ -35,7 +35,6 @@ type UpgradeSuite struct {
 const previousVersion = "v1.22.3+k0s.0"
 
 func (s *UpgradeSuite) TestK0sGetsUp() {
-
 	dlCommand := fmt.Sprintf("curl -sSfL https://get.k0s.sh | K0S_VERSION=%s sh", previousVersion)
 	g := errgroup.Group{}
 	g.Go(func() error {
@@ -174,7 +173,6 @@ func (s *UpgradeSuite) TestK0sGetsUp() {
 
 	err = s.WaitForNodeReady(s.WorkerNode(1), kc)
 	s.NoError(err)
-
 }
 
 func TestUpgradeSuite(t *testing.T) {
@@ -182,6 +180,7 @@ func TestUpgradeSuite(t *testing.T) {
 		common.FootlooseSuite{
 			ControllerCount: 1,
 			WorkerCount:     2,
+			K0sFullPath:     "/usr/local/bin/k0s",
 		},
 	}
 	suite.Run(t, &s)


### PR DESCRIPTION
Signed-off-by: Karen Almog <kalmog@mirantis.com>

**Issue**
Fixes #1312 

**What this PR Includes**
This PR allows to override the default running k0s path inside our footloose VMs for smoke tests. It is mainly needed for the check-upgrade smoke test, since in that test we have two k0s binaries on the same VM. The change here allows us to finely-configure which binary exactly we want to run at any given moment (instead of relying on the internal footloose $PATH var).