### PR TITLE
make dual-stack configuration available to node configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -205,6 +205,7 @@ func GetNodeConfig(cfgPath string, k0sVars constant.CfgVars) (*v1beta1.ClusterCo
 		},
 		Network: &v1beta1.Network{
 			ServiceCIDR: cfg.Spec.Network.ServiceCIDR,
+			DualStack:   cfg.Spec.Network.DualStack,
 		},
 		Install: cfg.Spec.Install,
 	}


### PR DESCRIPTION
**Issue**
Fixes #1319

**What this PR Includes**
Makes the dual-stack configuration object available to the node configuration.
This is needed because the api server builds its command line flags from the node configuration:
- https://github.com/k0sproject/k0s/blob/6bba715ee130edf278593ec7f5e686054a6dd92b/cmd/controller/controller.go#L122
- https://github.com/k0sproject/k0s/blob/6bba715ee130edf278593ec7f5e686054a6dd92b/cmd/controller/controller.go#L177
- https://github.com/k0sproject/k0s/blob/6bba715ee130edf278593ec7f5e686054a6dd92b/pkg/component/controller/apiserver.go#L105
- https://github.com/k0sproject/k0s/blob/6bba715ee130edf278593ec7f5e686054a6dd92b/pkg/apis/k0s.k0sproject.io/v1beta1/network.go#L165

I didn't write a regression/integration test for this though.
