### PR TITLE
Add ephemeral env variable for the konnectivity-agent

### DIFF
--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -343,7 +343,6 @@ backend admin
 {{ end }}
 
 backend agent
-balance source
 {{ range $addr := .IPAddresses }}
 	server {{ $addr }} {{ $addr }}:{{ $OUT.KonnectivityAgentPort }}
 {{ end }}


### PR DESCRIPTION
Add ephemeral env variable to have konnectivit-agent restarted on each change of the server count to avoid relying on the connection management in the konnectivity-agent code

Also some minor context related refactoring, to drop using context as field (argument context derived from the same parent context)

Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>
