### PR TITLE
drop unused check-install in the smoketests target

### DIFF
--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -8,7 +8,6 @@ smoketests := \
 	check-customports \
 	check-dualstack \
 	check-hacontrolplane \
-	check-install \
 	check-kine \
 	check-metrics \
 	check-multicontroller \


### PR DESCRIPTION
We don't have that suite anymore

Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>

