### PR TITLE
Send log Trace..Info to stdout and Warn..Fatal to stderr

### DIFF
--- a/cmd/airgap/listimages.go
+++ b/cmd/airgap/listimages.go
@@ -33,8 +33,7 @@ func NewAirgapListImagesCmd() *cobra.Command {
 		Short:   "List image names and version needed for air-gap install",
 		Example: `k0s airgap list-images`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// we don't need warning messages in case of default config
-			logrus.SetLevel(logrus.ErrorLevel)
+			logrus.SetLevel(logrus.WarnLevel)
 			c := CmdOpts(config.GetCmdOpts())
 			cfg, err := config.GetYamlFromFile(c.CfgFile, c.K0sVars)
 			if err != nil {

--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -59,15 +59,10 @@ func NewBackupCmd() *cobra.Command {
 }
 
 func (c *CmdOpts) backup() error {
-	logger := logrus.New()
-	textFormatter := new(logrus.TextFormatter)
-	textFormatter.ForceColors = true
-	textFormatter.DisableTimestamp = true
-
-	logger.SetFormatter(textFormatter)
+	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
 
 	if os.Geteuid() != 0 {
-		logger.Fatal("this command must be run as root!")
+		logrus.Fatal("this command must be run as root!")
 	}
 
 	if !dir.IsDirectory(savePath) {

--- a/cmd/etcd/list.go
+++ b/cmd/etcd/list.go
@@ -41,11 +41,10 @@ func etcdListCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("can't list etcd cluster members: %v", err)
 			}
-			l := logrus.New()
-			l.SetFormatter(&logrus.JSONFormatter{})
 
-			l.WithField("members", members).
-				Info("done")
+			logrus.SetFormatter(&logrus.JSONFormatter{})
+			logrus.WithField("members", members).Info("done")
+
 			return nil
 		},
 	}

--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -136,7 +136,7 @@ Note: A certificate once signed cannot be revoked for a particular user`,
 
 func (c *CmdOpts) getAPIURL() (string, error) {
 	// Disable logrus
-	logrus.SetLevel(logrus.FatalLevel)
+	logrus.SetLevel(logrus.WarnLevel)
 
 	cfg, err := config.GetNodeConfig(c.CfgFile, c.K0sVars)
 	if err != nil {

--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -50,19 +50,15 @@ func NewResetCmd() *cobra.Command {
 }
 
 func (c *CmdOpts) reset() error {
-	logger := logrus.New()
-	textFormatter := new(logrus.TextFormatter)
-	textFormatter.DisableTimestamp = true
-
-	logger.SetFormatter(textFormatter)
+	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
 
 	if os.Geteuid() != 0 {
-		logger.Fatal("this command must be run as root!")
+		logrus.Fatal("this command must be run as root!")
 	}
 
 	k0sStatus, _ := install.GetStatusInfo(config.StatusSocket)
 	if k0sStatus != nil && k0sStatus.Pid != 0 {
-		logger.Fatal("k0s seems to be running! please stop k0s before reset.")
+		logrus.Fatal("k0s seems to be running! please stop k0s before reset.")
 	}
 
 	// Get Cleanup Config
@@ -73,7 +69,7 @@ func (c *CmdOpts) reset() error {
 
 	err = cfg.Cleanup()
 
-	logger.Info("k0s cleanup operations done. To ensure a full reset, a node reboot is recommended.")
+	logrus.Info("k0s cleanup operations done. To ensure a full reset, a node reboot is recommended.")
 	return err
 }
 

--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -61,12 +61,7 @@ func NewRestoreCmd() *cobra.Command {
 }
 
 func (c *CmdOpts) restore(path string) error {
-	logger := logrus.New()
-	textFormatter := new(logrus.TextFormatter)
-	textFormatter.ForceColors = true
-	textFormatter.DisableTimestamp = true
-
-	logger.SetFormatter(textFormatter)
+	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
 
 	if os.Geteuid() != 0 {
 		return fmt.Errorf("this command must be run as root")
@@ -74,7 +69,7 @@ func (c *CmdOpts) restore(path string) error {
 
 	k0sStatus, _ := install.GetStatusInfo(config.StatusSocket)
 	if k0sStatus != nil && k0sStatus.Pid != 0 {
-		logger.Fatal("k0s seems to be running! k0s must be down during the restore operation.")
+		logrus.Fatal("k0s seems to be running! k0s must be down during the restore operation.")
 	}
 
 	if !file.Exists(path) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,6 +132,7 @@ func newDefaultConfigCmd() *cobra.Command {
 		Use:   "default-config",
 		Short: "Output the default k0s configuration yaml to stdout",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			logrus.SetLevel(logrus.ErrorLevel)
 			c := cliOpts(config.GetCmdOpts())
 			if err := c.buildConfig(); err != nil {
 				return err

--- a/cmd/token/create.go
+++ b/cmd/token/create.go
@@ -40,7 +40,7 @@ k0s token create --role worker --expiry 10m  //sets expiration time to 10 minute
 		PreRunE: checkCreateTokenRole,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Disable logrus for token commands
-			logrus.SetLevel(logrus.FatalLevel)
+			logrus.SetLevel(logrus.WarnLevel)
 			c := CmdOpts(config.GetCmdOpts())
 			cfg, err := config.GetNodeConfig(c.CfgFile, c.K0sVars)
 			if err != nil {

--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -67,7 +67,7 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 	err = s.WaitForKubeAPI(s.ControllerNode(0))
 	s.Require().NoError(err)
 
-	output, err := ssh.ExecWithOutput("k0s kubectl get namespaces -o json")
+	output, err := ssh.ExecWithOutput("k0s kubectl get namespaces -o json 2>/dev/null")
 	s.Require().NoError(err)
 
 	namespaces := &K8sNamespaces{}

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -420,7 +420,7 @@ func (s *FootlooseSuite) GetJoinToken(role string, extraArgs ...string) (string,
 		return "", err
 	}
 	defer ssh.Disconnect()
-	token, err := ssh.ExecWithOutput(fmt.Sprintf("%s token create --role=%s %s", s.K0sFullPath, role, strings.Join(extraArgs, " ")))
+	token, err := ssh.ExecWithOutput(fmt.Sprintf("%s token create --role=%s %s 2>/dev/null", s.K0sFullPath, role, strings.Join(extraArgs, " ")))
 	if err != nil {
 		return "", fmt.Errorf("can't get join token: %v", err)
 	}
@@ -536,7 +536,7 @@ func (s *FootlooseSuite) GetKubeClientConfig(node string, k0sKubeconfigArgs ...s
 	}
 	defer ssh.Disconnect()
 
-	kubeConfigCmd := fmt.Sprintf("%s kubeconfig admin %s", s.K0sFullPath, strings.Join(k0sKubeconfigArgs, " "))
+	kubeConfigCmd := fmt.Sprintf("%s kubeconfig admin %s 2>/dev/null", s.K0sFullPath, strings.Join(k0sKubeconfigArgs, " "))
 	kubeConf, err := ssh.ExecWithOutput(kubeConfigCmd)
 	if err != nil {
 		return nil, err
@@ -572,7 +572,7 @@ func (s *FootlooseSuite) GetKubeConfig(node string, k0sKubeconfigArgs ...string)
 	}
 	defer ssh.Disconnect()
 
-	kubeConfigCmd := fmt.Sprintf("%s kubeconfig admin %s", s.K0sFullPath, strings.Join(k0sKubeconfigArgs, " "))
+	kubeConfigCmd := fmt.Sprintf("%s kubeconfig admin %s 2>/dev/null", s.K0sFullPath, strings.Join(k0sKubeconfigArgs, " "))
 	kubeConf, err := ssh.ExecWithOutput(kubeConfigCmd)
 	if err != nil {
 		return nil, err

--- a/inttest/ctr/ctr_test.go
+++ b/inttest/ctr/ctr_test.go
@@ -49,7 +49,7 @@ func (s *CtrSuite) TestK0sCtrCommand() {
 	err = s.WaitForNodeReady(s.ControllerNode(0), kc)
 	s.NoError(err)
 
-	output, err := ssh.ExecWithOutput("k0s ctr namespaces list")
+	output, err := ssh.ExecWithOutput("k0s ctr namespaces list 2>/dev/null")
 	s.Require().NoError(err)
 
 	flatOutput := removeRedundantSpaces(output)

--- a/inttest/hacontrolplane/hacontrolplane_test.go
+++ b/inttest/hacontrolplane/hacontrolplane_test.go
@@ -38,8 +38,8 @@ func (s *HAControlplaneSuite) getMembers(fromControllerIdx int) map[string]strin
 	sshCon, err := s.SSH(s.ControllerNode(fromControllerIdx))
 	s.NoError(err)
 	defer sshCon.Disconnect()
-	output, err := sshCon.ExecWithOutput("k0s etcd member-list")
-	output = lastLine(output)
+	output, err := sshCon.ExecWithOutput("k0s etcd member-list 2>/dev/null")
+	s.T().Logf("k0s etcd member-list output: %s", output)
 	s.NoError(err)
 
 	members := struct {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"io"
 	_ "net/http/pprof"
 	"os"
 	"path"
@@ -23,13 +24,32 @@ import (
 
 	"github.com/k0sproject/k0s/cmd"
 	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/writer"
 )
 
 //go:generate make generate-bindata
 
 func init() {
+	logrus.SetOutput(io.Discard) // Send all logs to nowhere by default
 
-	logrus.SetOutput(os.Stdout)
+	logrus.AddHook(&writer.Hook{ // Send logs with level higher than warning to stderr
+		Writer: os.Stderr,
+		LogLevels: []logrus.Level{
+			logrus.PanicLevel,
+			logrus.FatalLevel,
+			logrus.ErrorLevel,
+			logrus.WarnLevel,
+		},
+	})
+	logrus.AddHook(&writer.Hook{ // Send info, debug and trace logs to stdout
+		Writer: os.Stdout,
+		LogLevels: []logrus.Level{
+			logrus.InfoLevel,
+			logrus.DebugLevel,
+			logrus.TraceLevel,
+		},
+	})
+
 	logrus.SetLevel(logrus.InfoLevel)
 
 	customFormatter := new(logrus.TextFormatter)

--- a/pkg/backup/config.go
+++ b/pkg/backup/config.go
@@ -32,7 +32,7 @@ func (c configurationStep) Name() string {
 func (c configurationStep) Backup() (StepResult, error) {
 	_, err := os.Stat(c.path)
 	if os.IsNotExist(err) {
-		logrus.Info("default k0s.yaml is used, do not back it up")
+		logrus.Warn("default k0s.yaml is used, do not back it up")
 		return StepResult{}, nil
 	}
 	if err != nil {

--- a/pkg/cleanup/users.go
+++ b/pkg/cleanup/users.go
@@ -17,15 +17,14 @@ func (u *users) Name() string {
 
 // Run removes all controller users that are present on the host
 func (u *users) Run() error {
-	logger := logrus.New()
 	cfg, err := config.GetNodeConfig(u.Config.cfgFile, u.Config.k0sVars)
 	if err != nil {
-		logger.Errorf("failed to get cluster setup: %v", err)
+		logrus.Errorf("failed to get cluster setup: %v", err)
 		return nil
 	}
 	if err := install.DeleteControllerUsers(cfg); err != nil {
 		// don't fail, just notify on delete error
-		logger.Infof("failed to delete controller users: %v", err)
+		logrus.Warnf("failed to delete controller users: %v", err)
 	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,7 +63,7 @@ func getConfigFromAPI(kubeConfig string) (*v1beta1.ClusterConfig, error) {
 func GetFullConfig(cfgPath string, k0sVars constant.CfgVars) (clusterConfig *v1beta1.ClusterConfig, err error) {
 	if cfgPath == "" {
 		// no config file exists, using defaults
-		logrus.Info("no config file given, using defaults")
+		logrus.Warn("no config file given, using defaults")
 	}
 	cfg, err := ValidateYaml(cfgPath, k0sVars)
 	if err != nil {
@@ -106,7 +106,7 @@ func configRequest(kubeConfig string) (clusterConfig *v1beta1.ClusterConfig, err
 func GetYamlFromFile(cfgPath string, k0sVars constant.CfgVars) (clusterConfig *v1beta1.ClusterConfig, err error) {
 	if cfgPath == "" {
 		// no config file exists, using defaults
-		logrus.Info("no config file given, using defaults")
+		logrus.Warn("no config file given, using defaults")
 	}
 	cfg, err := ValidateYaml(cfgPath, k0sVars)
 	if err != nil {

--- a/pkg/leaderelection/lease_pool.go
+++ b/pkg/leaderelection/lease_pool.go
@@ -116,7 +116,7 @@ func WithNamespace(namespace string) LeaseOpt {
 func NewLeasePool(client kubernetes.Interface, name string, opts ...LeaseOpt) (*LeasePool, error) {
 
 	leaseConfig := LeaseConfiguration{
-		log:           logrus.NewEntry(logrus.New()),
+		log:           logrus.NewEntry(logrus.StandardLogger()),
 		duration:      60 * time.Second,
 		renewDeadline: 15 * time.Second,
 		retryPeriod:   5 * time.Second,


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Complementary to #1247 to solve a couple of my own comments.

Splits logging to output all the harmless messages to STDOUT and all the suspicious messages (warn, error, fatal, panic) to STDERR. This will make commands like `k0s airgap list-images` and `default-config` work nice with redirecting.

```
$ k0s airgap list-images > images.txt
[WARN] 01:02:03 no config file given, using defaults
$ cat images.txt
foofoo:123
foobar:345
```

