### PR TITLE
Output logs to stderr, default log level to Warn, add global verbose flag

### DIFF
--- a/cmd/airgap/listimages.go
+++ b/cmd/airgap/listimages.go
@@ -18,7 +18,6 @@ package airgap
 import (
 	"fmt"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/k0sproject/k0s/pkg/airgap"
@@ -33,8 +32,6 @@ func NewAirgapListImagesCmd() *cobra.Command {
 		Short:   "List image names and version needed for air-gap install",
 		Example: `k0s airgap list-images`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// we don't need warning messages in case of default config
-			logrus.SetLevel(logrus.ErrorLevel)
 			c := CmdOpts(config.GetCmdOpts())
 			cfg, err := config.GetYamlFromFile(c.CfgFile, c.K0sVars)
 			if err != nil {

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -59,6 +59,9 @@ func NewAPICmd() *cobra.Command {
 		Use:   "api",
 		Short: "Run the controller api",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			logrus.SetLevel(logrus.InfoLevel)
+			logrus.SetOutput(os.Stdout)
+
 			c := CmdOpts(config.GetCmdOpts())
 			cfg, err := config.GetNodeConfig(c.CfgFile, c.K0sVars)
 			if err != nil {

--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -59,15 +59,8 @@ func NewBackupCmd() *cobra.Command {
 }
 
 func (c *CmdOpts) backup() error {
-	logger := logrus.New()
-	textFormatter := new(logrus.TextFormatter)
-	textFormatter.ForceColors = true
-	textFormatter.DisableTimestamp = true
-
-	logger.SetFormatter(textFormatter)
-
 	if os.Geteuid() != 0 {
-		logger.Fatal("this command must be run as root!")
+		logrus.Fatal("this command must be run as root!")
 	}
 
 	if !dir.IsDirectory(savePath) {

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -67,6 +67,9 @@ func NewControllerCmd() *cobra.Command {
 	$ k0s controller --token-file [path_to_file]
 	Note: Token can be passed either as a CLI argument or as a flag`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			logrus.SetLevel(logrus.InfoLevel)
+			logrus.SetOutput(os.Stdout)
+
 			c := CmdOpts(config.GetCmdOpts())
 			if len(args) > 0 {
 				c.TokenArg = args[0]

--- a/cmd/etcd/list.go
+++ b/cmd/etcd/list.go
@@ -17,9 +17,10 @@ package etcd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/k0sproject/k0s/pkg/config"
@@ -41,12 +42,7 @@ func etcdListCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("can't list etcd cluster members: %v", err)
 			}
-			l := logrus.New()
-			l.SetFormatter(&logrus.JSONFormatter{})
-
-			l.WithField("members", members).
-				Info("done")
-			return nil
+			return json.NewEncoder(os.Stdout).Encode(map[string]interface{}{"members": members})
 		},
 	}
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())

--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -136,7 +136,7 @@ Note: A certificate once signed cannot be revoked for a particular user`,
 
 func (c *CmdOpts) getAPIURL() (string, error) {
 	// Disable logrus
-	logrus.SetLevel(logrus.FatalLevel)
+	logrus.SetLevel(logrus.WarnLevel)
 
 	cfg, err := config.GetNodeConfig(c.CfgFile, c.K0sVars)
 	if err != nil {

--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -50,19 +50,13 @@ func NewResetCmd() *cobra.Command {
 }
 
 func (c *CmdOpts) reset() error {
-	logger := logrus.New()
-	textFormatter := new(logrus.TextFormatter)
-	textFormatter.DisableTimestamp = true
-
-	logger.SetFormatter(textFormatter)
-
 	if os.Geteuid() != 0 {
-		logger.Fatal("this command must be run as root!")
+		logrus.Fatal("this command must be run as root!")
 	}
 
 	k0sStatus, _ := install.GetStatusInfo(config.StatusSocket)
 	if k0sStatus != nil && k0sStatus.Pid != 0 {
-		logger.Fatal("k0s seems to be running! please stop k0s before reset.")
+		logrus.Fatal("k0s seems to be running! please stop k0s before reset.")
 	}
 
 	// Get Cleanup Config
@@ -72,8 +66,9 @@ func (c *CmdOpts) reset() error {
 	}
 
 	err = cfg.Cleanup()
+	logrus.Info("k0s cleanup operations done.")
+	logrus.Warn("To ensure a full reset, a node reboot is recommended.")
 
-	logger.Info("k0s cleanup operations done. To ensure a full reset, a node reboot is recommended.")
 	return err
 }
 

--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -61,20 +61,13 @@ func NewRestoreCmd() *cobra.Command {
 }
 
 func (c *CmdOpts) restore(path string) error {
-	logger := logrus.New()
-	textFormatter := new(logrus.TextFormatter)
-	textFormatter.ForceColors = true
-	textFormatter.DisableTimestamp = true
-
-	logger.SetFormatter(textFormatter)
-
 	if os.Geteuid() != 0 {
 		return fmt.Errorf("this command must be run as root")
 	}
 
 	k0sStatus, _ := install.GetStatusInfo(config.StatusSocket)
 	if k0sStatus != nil && k0sStatus.Pid != 0 {
-		logger.Fatal("k0s seems to be running! k0s must be down during the restore operation.")
+		logrus.Fatal("k0s seems to be running! k0s must be down during the restore operation.")
 	}
 
 	if !file.Exists(path) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,11 @@ func NewRootCmd() *cobra.Command {
 		Short: "k0s - Zero Friction Kubernetes",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			c := cliOpts(config.GetCmdOpts())
+
+			if c.Verbose {
+				logrus.SetLevel(logrus.InfoLevel)
+			}
+
 			// set DEBUG from env, or from command flag
 			if viper.GetString("debug") != "" || c.Debug {
 				logrus.SetLevel(logrus.DebugLevel)
@@ -132,6 +137,7 @@ func newDefaultConfigCmd() *cobra.Command {
 		Use:   "default-config",
 		Short: "Output the default k0s configuration yaml to stdout",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			logrus.SetLevel(logrus.ErrorLevel)
 			c := cliOpts(config.GetCmdOpts())
 			if err := c.buildConfig(); err != nil {
 				return err

--- a/cmd/token/create.go
+++ b/cmd/token/create.go
@@ -40,7 +40,7 @@ k0s token create --role worker --expiry 10m  //sets expiration time to 10 minute
 		PreRunE: checkCreateTokenRole,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Disable logrus for token commands
-			logrus.SetLevel(logrus.FatalLevel)
+			logrus.SetLevel(logrus.WarnLevel)
 			c := CmdOpts(config.GetCmdOpts())
 			cfg, err := config.GetNodeConfig(c.CfgFile, c.K0sVars)
 			if err != nil {

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -50,6 +50,9 @@ func NewWorkerCmd() *cobra.Command {
 	$ k0s worker --token-file [path_to_file]
 	Note: Token can be passed either as a CLI argument or as a flag`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			logrus.SetLevel(logrus.InfoLevel)
+			logrus.SetOutput(os.Stdout)
+
 			c := CmdOpts(config.GetCmdOpts())
 			if len(args) > 0 {
 				c.TokenArg = args[0]

--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -67,7 +67,7 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 	err = s.WaitForKubeAPI(s.ControllerNode(0))
 	s.Require().NoError(err)
 
-	output, err := ssh.ExecWithOutput("k0s kubectl get namespaces -o json")
+	output, err := ssh.ExecWithOutput("k0s kubectl get namespaces -o json 2>/dev/null")
 	s.Require().NoError(err)
 
 	namespaces := &K8sNamespaces{}

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -419,7 +419,7 @@ func (s *FootlooseSuite) GetJoinToken(role string, extraArgs ...string) (string,
 		return "", err
 	}
 	defer ssh.Disconnect()
-	token, err := ssh.ExecWithOutput(fmt.Sprintf("%s token create --role=%s %s", s.K0sFullPath, role, strings.Join(extraArgs, " ")))
+	token, err := ssh.ExecWithOutput(fmt.Sprintf("%s token create --role=%s %s 2>/dev/null", s.K0sFullPath, role, strings.Join(extraArgs, " ")))
 	if err != nil {
 		return "", fmt.Errorf("can't get join token: %v", err)
 	}
@@ -535,7 +535,7 @@ func (s *FootlooseSuite) GetKubeClientConfig(node string, k0sKubeconfigArgs ...s
 	}
 	defer ssh.Disconnect()
 
-	kubeConfigCmd := fmt.Sprintf("%s kubeconfig admin %s", s.K0sFullPath, strings.Join(k0sKubeconfigArgs, " "))
+	kubeConfigCmd := fmt.Sprintf("%s kubeconfig admin %s 2>/dev/null", s.K0sFullPath, strings.Join(k0sKubeconfigArgs, " "))
 	kubeConf, err := ssh.ExecWithOutput(kubeConfigCmd)
 	if err != nil {
 		return nil, err
@@ -571,7 +571,7 @@ func (s *FootlooseSuite) GetKubeConfig(node string, k0sKubeconfigArgs ...string)
 	}
 	defer ssh.Disconnect()
 
-	kubeConfigCmd := fmt.Sprintf("%s kubeconfig admin %s", s.K0sFullPath, strings.Join(k0sKubeconfigArgs, " "))
+	kubeConfigCmd := fmt.Sprintf("%s kubeconfig admin %s 2>/dev/null", s.K0sFullPath, strings.Join(k0sKubeconfigArgs, " "))
 	kubeConf, err := ssh.ExecWithOutput(kubeConfigCmd)
 	if err != nil {
 		return nil, err

--- a/inttest/ctr/ctr_test.go
+++ b/inttest/ctr/ctr_test.go
@@ -49,7 +49,7 @@ func (s *CtrSuite) TestK0sCtrCommand() {
 	err = s.WaitForNodeReady(s.ControllerNode(0), kc)
 	s.NoError(err)
 
-	output, err := ssh.ExecWithOutput("k0s ctr namespaces list")
+	output, err := ssh.ExecWithOutput("k0s ctr namespaces list 2>/dev/null")
 	s.Require().NoError(err)
 
 	flatOutput := removeRedundantSpaces(output)

--- a/inttest/hacontrolplane/hacontrolplane_test.go
+++ b/inttest/hacontrolplane/hacontrolplane_test.go
@@ -38,8 +38,8 @@ func (s *HAControlplaneSuite) getMembers(fromControllerIdx int) map[string]strin
 	sshCon, err := s.SSH(s.ControllerNode(fromControllerIdx))
 	s.NoError(err)
 	defer sshCon.Disconnect()
-	output, err := sshCon.ExecWithOutput("k0s etcd member-list")
-	output = lastLine(output)
+	output, err := sshCon.ExecWithOutput("k0s etcd member-list 2>/dev/null")
+	s.T().Logf("k0s etcd member-list output: %s", output)
 	s.NoError(err)
 
 	members := struct {

--- a/main.go
+++ b/main.go
@@ -28,10 +28,8 @@ import (
 //go:generate make generate-bindata
 
 func init() {
-
-	logrus.SetOutput(os.Stdout)
-	logrus.SetLevel(logrus.InfoLevel)
-
+	logrus.SetOutput(os.Stderr)
+	logrus.SetLevel(logrus.WarnLevel)
 	customFormatter := new(logrus.TextFormatter)
 	customFormatter.TimestampFormat = "2006-01-02 15:04:05"
 	customFormatter.FullTimestamp = true

--- a/pkg/backup/config.go
+++ b/pkg/backup/config.go
@@ -32,7 +32,7 @@ func (c configurationStep) Name() string {
 func (c configurationStep) Backup() (StepResult, error) {
 	_, err := os.Stat(c.path)
 	if os.IsNotExist(err) {
-		logrus.Info("default k0s.yaml is used, do not back it up")
+		logrus.Warn("default k0s.yaml is used, do not back it up")
 		return StepResult{}, nil
 	}
 	if err != nil {
@@ -45,7 +45,7 @@ func (c configurationStep) Restore(restoreFrom, restoreTo string) error {
 	objectPathInArchive := path.Join(restoreFrom, "k0s.yaml")
 
 	if !file.Exists(objectPathInArchive) {
-		logrus.Infof("%s does not exist in the backup file", objectPathInArchive)
+		logrus.Debugf("%s does not exist in the backup file", objectPathInArchive)
 		return nil
 	}
 	logrus.Infof("Previously used k0s.yaml saved under the data directory `%s`", restoreTo)

--- a/pkg/backup/filesystem.go
+++ b/pkg/backup/filesystem.go
@@ -26,7 +26,7 @@ func (d FileSystemStep) Name() string {
 func (d FileSystemStep) Backup() (StepResult, error) {
 	s, err := os.Stat(d.path)
 	if os.IsNotExist(err) {
-		logrus.Infof("Path `%s` does not exist, skipping...", d.path)
+		logrus.Debugf("Path `%s` does not exist, skipping...", d.path)
 		return StepResult{}, nil
 	}
 	if err != nil {
@@ -58,7 +58,7 @@ func (d FileSystemStep) Restore(restoreFrom, restoreTo string) error {
 	objectPathInRestored := path.Join(restoreTo, childName)
 	stat, err := os.Stat(objectPathInArchive)
 	if os.IsNotExist(err) {
-		logrus.Infof("Path `%s` not found in the archive, skipping...", objectPathInArchive)
+		logrus.Debugf("Path `%s` not found in the archive, skipping...", objectPathInArchive)
 		return nil
 	}
 	logrus.Infof("restoring from `%s` to `%s`", objectPathInArchive, objectPathInRestored)

--- a/pkg/cleanup/users.go
+++ b/pkg/cleanup/users.go
@@ -17,15 +17,14 @@ func (u *users) Name() string {
 
 // Run removes all controller users that are present on the host
 func (u *users) Run() error {
-	logger := logrus.New()
 	cfg, err := config.GetNodeConfig(u.Config.cfgFile, u.Config.k0sVars)
 	if err != nil {
-		logger.Errorf("failed to get cluster setup: %v", err)
+		logrus.Errorf("failed to get cluster setup: %v", err)
 		return nil
 	}
 	if err := install.DeleteControllerUsers(cfg); err != nil {
 		// don't fail, just notify on delete error
-		logger.Infof("failed to delete controller users: %v", err)
+		logrus.Warnf("failed to delete controller users: %v", err)
 	}
 	return nil
 }

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -90,7 +90,7 @@ func (e *Etcd) syncEtcdConfig(peerURL, etcdCaCert, etcdCaCertKey string) ([]stri
 	var etcdResponse v1beta1.EtcdResponse
 	var err error
 	for i := 0; i < 20; i++ {
-		logrus.Infof("trying to sync etcd config")
+		logrus.Debugf("trying to sync etcd config")
 		etcdResponse, err = e.JoinClient.JoinEtcd(peerURL)
 		if err == nil {
 			break
@@ -101,7 +101,7 @@ func (e *Etcd) syncEtcdConfig(peerURL, etcdCaCert, etcdCaCertKey string) ([]stri
 		return nil, err
 	}
 
-	logrus.Infof("got cluster info: %v", etcdResponse.InitialCluster)
+	logrus.Debugf("got cluster info: %v", etcdResponse.InitialCluster)
 	// Write etcd ca cert&key
 	if file.Exists(etcdCaCert) && file.Exists(etcdCaCertKey) {
 		logrus.Warnf("etcd ca certs already exists, not gonna overwrite. If you wish to re-sync them, delete the existing ones.")
@@ -184,7 +184,7 @@ func (e *Etcd) Run(ctx context.Context) error {
 		args["--auth-token"] = auth
 	}
 
-	logrus.Infof("starting etcd with args: %v", args)
+	logrus.Debugf("starting etcd with args: %v", args)
 
 	e.supervisor = supervisor.Supervisor{
 		Name:          "etcd",

--- a/pkg/component/worker/calico_installer_windows.go
+++ b/pkg/component/worker/calico_installer_windows.go
@@ -140,7 +140,7 @@ func getSourceVip() (string, error) {
 	err := retry.Do(func() error {
 		ep, err := hcsshim.GetHNSEndpointByName("Calico_ep")
 		if err != nil {
-			logrus.WithError(err).Warning("can't get Calico_ep endpoint")
+			logrus.WithError(err).Warn("can't get Calico_ep endpoint")
 			return err
 		}
 		vip = ep.IPAddress.String()

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -192,7 +192,7 @@ func (k *Kubelet) Run(ctx context.Context) error {
 		args.Merge(extras)
 	}
 
-	logrus.Infof("starting kubelet with args: %v", args)
+	logrus.Debugf("starting kubelet with args: %v", args)
 	k.supervisor = supervisor.Supervisor{
 		Name:    cmd,
 		BinPath: assets.BinPath(cmd, k.K0sVars.BinDir),

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -37,6 +37,7 @@ var (
 	StatusSocket   string
 	K0sVars        constant.CfgVars
 	workerOpts     WorkerOptions
+	Verbose        bool
 	controllerOpts ControllerOptions
 )
 
@@ -54,6 +55,7 @@ type CLIOptions struct {
 	K0sVars          constant.CfgVars
 	KubeClient       k8s.Interface
 	Logging          map[string]string // merged outcome of default log levels and cmdLoglevels
+	Verbose          bool
 }
 
 // Shared controller cli flags
@@ -102,6 +104,7 @@ func GetPersistentFlagSet() *pflag.FlagSet {
 	flagset := &pflag.FlagSet{}
 	flagset.StringVarP(&CfgFile, "config", "c", "", "config file, use '-' to read the config from stdin")
 	flagset.BoolVarP(&Debug, "debug", "d", false, "Debug logging (default: false)")
+	flagset.BoolVarP(&Verbose, "verbose", "v", false, "Verbose logging (default: false)")
 	flagset.StringVar(&DataDir, "data-dir", "", "Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!")
 	flagset.StringVar(&StatusSocket, "status-socket", filepath.Join(K0sVars.RunDir, "status.sock"), "Full file path to the socket file.")
 	flagset.StringVar(&DebugListenOn, "debugListenOn", ":6060", "Http listenOn for Debug pprof handler")
@@ -185,6 +188,7 @@ func GetCmdOpts() CLIOptions {
 
 		CfgFile:          CfgFile,
 		Debug:            Debug,
+		Verbose:          Verbose,
 		DefaultLogLevels: DefaultLogLevels(),
 		K0sVars:          K0sVars,
 		DebugListenOn:    DebugListenOn,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,7 +63,7 @@ func getConfigFromAPI(kubeConfig string) (*v1beta1.ClusterConfig, error) {
 func GetFullConfig(cfgPath string, k0sVars constant.CfgVars) (clusterConfig *v1beta1.ClusterConfig, err error) {
 	if cfgPath == "" {
 		// no config file exists, using defaults
-		logrus.Info("no config file given, using defaults")
+		logrus.Warn("no config file given, using defaults")
 	}
 	cfg, err := ValidateYaml(cfgPath, k0sVars)
 	if err != nil {
@@ -106,7 +106,7 @@ func configRequest(kubeConfig string) (clusterConfig *v1beta1.ClusterConfig, err
 func GetYamlFromFile(cfgPath string, k0sVars constant.CfgVars) (clusterConfig *v1beta1.ClusterConfig, err error) {
 	if cfgPath == "" {
 		// no config file exists, using defaults
-		logrus.Info("no config file given, using defaults")
+		logrus.Warn("no config file given, using defaults")
 	}
 	cfg, err := ValidateYaml(cfgPath, k0sVars)
 	if err != nil {

--- a/pkg/install/service.go
+++ b/pkg/install/service.go
@@ -99,7 +99,7 @@ func EnsureService(args []string) error {
 	svcConfig.Dependencies = deps
 	svcConfig.Arguments = args
 
-	logrus.Info("Installing k0s service")
+	logrus.Infof("Installing %s service", svcConfig.Name)
 	err = s.Install()
 	if err != nil {
 		return fmt.Errorf("failed to install service: %v", err)

--- a/pkg/leaderelection/lease_pool.go
+++ b/pkg/leaderelection/lease_pool.go
@@ -116,7 +116,7 @@ func WithNamespace(namespace string) LeaseOpt {
 func NewLeasePool(client kubernetes.Interface, name string, opts ...LeaseOpt) (*LeasePool, error) {
 
 	leaseConfig := LeaseConfiguration{
-		log:           logrus.NewEntry(logrus.New()),
+		log:           logrus.NewEntry(logrus.StandardLogger()),
 		duration:      60 * time.Second,
 		renewDeadline: 15 * time.Second,
 		retryPeriod:   5 * time.Second,


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Closes #1325 (alternative)

* Changes default output level to WARN
* All logging goes to stderr
* Adds `--verbose|-v` for displaying progress information (aka, change loglevel to INFO)
* Changes the log level of several messages to make them more or less visible
* Changes the way `k0s etcd member-list` outputs the json.
* Output of `k0s controller`, `k0s worker` and `k0s api` is by default INFO level and goes to stdout (because they stay in the foreground)
* The stderr of some smoke-test commands is redirected to /dev/null because `ExecWithOutput` includes output from both streams.

Rationale:

* Almost all of our output is actually not "output"/"payload", but progress information and it should not be included with the output when redirecting or piping.
* None of our INFO level messages seem to contain important information / "payloads", those are always displayed via `fmt.Print`. 
* Warnings and errors belong to stderr, not stdout.

