### PR TITLE
Fix `APIEndpointReconciler.needsUpdate` boolean negation

### DIFF
--- a/pkg/component/controller/apiendpointreconciler.go
+++ b/pkg/component/controller/apiendpointreconciler.go
@@ -206,7 +206,7 @@ func (a *APIEndpointReconciler) createEndpoint(ctx context.Context, addresses []
 func needsUpdate(newAddresses []string, ep *corev1.Endpoints) bool {
 	currentAddresses := endpointAddressesToStrings(ep.Subsets[0].Addresses)
 	sort.Strings(currentAddresses)
-	return reflect.DeepEqual(currentAddresses, newAddresses)
+	return !reflect.DeepEqual(currentAddresses, newAddresses)
 }
 
 func endpointAddressesToStrings(eps []corev1.EndpointAddress) []string {


### PR DESCRIPTION
The `needsUpdate` uses reflect.DeepEqual to check if the endpoint addresses need updating or not.
But as the function usage is a "negate" pattern, we need to negate that result. :facepalm:

Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

**Issue**
The `APIEndpointReconciler` was not poperly updating the `kubernetes` service endpoint if the DNS records change.

**What this PR Includes**
Fix the negation so the endpoints get properly updated.