### PR TITLE
Fix k0s logo url in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-![k0s logo](img/k0s-logo-full-color.svg)
+![k0s logo](img/k0s-logo-full-color-light.svg)
 
 [k0s](https://k0sproject.io/) is an all-inclusive Kubernetes distribution, which is configured with all of the features needed to build a Kubernetes cluster and packaged as a single binary for ease of use.
 


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

The link got broken as the file was renamed. No light/dark-mode switching in docs yet.
