### PR TITLE
YAML validation fixes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -163,6 +163,7 @@ jobs:
           - check-extraargs
           - check-configchange
           - check-upgrade
+          - check-psp
           # skipped, originally titled "Smoke-test for network":
           # - check-etcd
 

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -19,5 +19,6 @@ smoketests := \
 	check-disabledcomponents \
 	check-extraargs \
 	check-configchange \
-	check-upgrade
+	check-upgrade \
+	check-psp
 

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -595,6 +595,43 @@ func (s *FootlooseSuite) GetKubeConfig(node string, k0sKubeconfigArgs ...string)
 	return cfg, nil
 }
 
+// CreateUserAndGetKubeClientConfig creates user and returns the kubeconfig as clientcmdapi.Config struct so it can be
+// used and loaded with clientsets directly
+func (s *FootlooseSuite) CreateUserAndGetKubeClientConfig(node string, username string, k0sKubeconfigArgs ...string) (*rest.Config, error) {
+	machine, err := s.MachineForName(node)
+	if err != nil {
+		return nil, err
+	}
+	ssh, err := s.SSH(node)
+	if err != nil {
+		return nil, err
+	}
+	defer ssh.Disconnect()
+
+	kubeConfigCmd := fmt.Sprintf("%s kubeconfig create %s %s", s.K0sFullPath, username, strings.Join(k0sKubeconfigArgs, " "))
+	kubeConf, err := ssh.ExecWithOutput(kubeConfigCmd)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeConf))
+	s.Require().NoError(err)
+
+	hostURL, err := url.Parse(cfg.Host)
+	if err != nil {
+		return nil, fmt.Errorf("can't parse port value `%s`: %w", cfg.Host, err)
+	}
+	port, err := strconv.ParseInt(hostURL.Port(), 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("can't parse port value `%s`: %w", hostURL.Port(), err)
+	}
+	hostPort, err := machine.HostPort(int(port))
+	if err != nil {
+		return nil, fmt.Errorf("footloose machine has to have %d port mapped: %w", port, err)
+	}
+	cfg.Host = fmt.Sprintf("localhost:%d", hostPort)
+	return cfg, nil
+}
+
 // KubeClient return kube client by loading the admin access config from given node
 func (s *FootlooseSuite) KubeClient(node string, k0sKubeconfigArgs ...string) (*kubernetes.Clientset, error) {
 	cfg, err := s.GetKubeConfig(node, k0sKubeconfigArgs...)
@@ -630,7 +667,26 @@ func (s *FootlooseSuite) GetNodeLabels(node string, kc *kubernetes.Clientset) (m
 	if err != nil {
 		return nil, err
 	}
+
 	return n.Labels, nil
+}
+
+// WaitForNodeLabel waits for label be assigned to the node
+func (s *FootlooseSuite) WaitForNodeLabel(kc *kubernetes.Clientset, node, labelKey, labelValue string) error {
+	return wait.PollImmediate(100*time.Millisecond, 5*time.Minute, func() (done bool, err error) {
+		labels, err := s.GetNodeLabels(node, kc)
+		if err != nil {
+			return false, nil
+		}
+
+		for k, v := range labels {
+			if labelKey == k && labelValue == v {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
 }
 
 // GetNodeLabels return the labels of given node

--- a/inttest/psp/psp_test.go
+++ b/inttest/psp/psp_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2021 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package psp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/k0sproject/k0s/inttest/common"
+)
+
+type PSPSuite struct {
+	common.FootlooseSuite
+}
+
+func (s *PSPSuite) TestK0sGetsUp() {
+	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfigWithRestrictedPSP)
+	s.NoError(s.InitController(0, "--config=/tmp/k0s.yaml", "--enable-worker"))
+
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	s.NoError(err)
+
+	err = s.WaitForNodeReady(s.ControllerNode(0), kc)
+	s.NoError(err)
+
+	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
+		Limit: 100,
+	})
+	s.NoError(err)
+
+	podCount := len(pods.Items)
+
+	s.T().Logf("found %d pods in kube-system", podCount)
+	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+
+	ukc, err := s.UserKubeClient(s.ControllerNode(0))
+	s.NoError(err)
+
+	s.PutFile(s.ControllerNode(0), "/tmp/role.yaml", k0sTestUserRoleBinding)
+
+	ssh, err := s.SSH(s.ControllerNode(0))
+	s.NoError(err)
+	defer ssh.Disconnect()
+
+	_, err = ssh.ExecWithOutput(fmt.Sprintf("%s kubectl apply -f /tmp/role.yaml", s.K0sFullPath))
+	s.NoError(err)
+
+	s.T().Run("successfully_deploy_non-priveleged_pod", func(t *testing.T) {
+		nonPrivelegedPodReq := &corev1.Pod{
+			TypeMeta:   v1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+			ObjectMeta: v1.ObjectMeta{Name: "test-pod-non-privileged"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "pause", Image: "k8s.gcr.io/pause"}},
+			},
+		}
+
+		_, err = ukc.CoreV1().Pods("default").Create(context.TODO(), nonPrivelegedPodReq, v1.CreateOptions{})
+		s.NoError(err)
+	})
+
+	s.T().Run("returns_error_for_priveleged_pod", func(t *testing.T) {
+		privelegedPodReq := &corev1.Pod{
+			TypeMeta:   v1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+			ObjectMeta: v1.ObjectMeta{Name: "test-pod-privileged"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "pause",
+						Image: "k8s.gcr.io/pause",
+						SecurityContext: &corev1.SecurityContext{
+							Privileged: boolptr(true),
+						},
+					},
+				},
+			},
+		}
+
+		_, err = ukc.CoreV1().Pods("default").Create(context.TODO(), privelegedPodReq, v1.CreateOptions{})
+		// Should return and error:
+		// pods "test-pod-privileged" is forbidden: PodSecurityPolicy: unable to admit pod: [spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed]
+		s.Error(err)
+	})
+
+	s.T().Run("returns_error_for_run_as_root", func(t *testing.T) {
+		privelegedPodReq := &corev1.Pod{
+			TypeMeta:   v1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+			ObjectMeta: v1.ObjectMeta{Name: "test-pod-privileged"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "pause",
+						Image: "k8s.gcr.io/pause",
+						SecurityContext: &corev1.SecurityContext{
+							RunAsUser: int64ptr(0),
+						},
+					},
+				},
+			},
+		}
+
+		_, err = ukc.CoreV1().Pods("default").Create(context.TODO(), privelegedPodReq, v1.CreateOptions{})
+		// Should return and error:
+		// pods "test-pod-privileged" is forbidden: PodSecurityPolicy: unable to admit pod: [spec.containers[0].securityContext.runAsUser: Invalid value: 0: running with the root UID is forbidden]
+		s.Error(err)
+	})
+}
+
+func TestPSPSuite(t *testing.T) {
+	s := PSPSuite{
+		common.FootlooseSuite{
+			ControllerCount: 1,
+		},
+	}
+	suite.Run(t, &s)
+}
+
+const k0sConfigWithRestrictedPSP = `
+spec:
+  podSecurityPolicy:
+    defaultPolicy: 99-k0s-restricted
+`
+
+const k0sTestUserRoleBinding = `
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-rolebinding
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: edit 
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: User
+  name: test
+  apiGroup: rbac.authorization.k8s.io
+`
+
+// KubeClient return kube client by loading the admin access config from given node
+func (s *PSPSuite) UserKubeClient(node string, k0sKubeconfigArgs ...string) (*kubernetes.Clientset, error) {
+	cfg, err := s.CreateUserAndGetKubeClientConfig(node, "test", k0sKubeconfigArgs...)
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(cfg)
+}
+
+func boolptr(b bool) *bool {
+	return &b
+}
+
+func int64ptr(i int64) *int64 {
+	return &i
+}

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -141,13 +141,16 @@ spec:
         beta.kubernetes.io/os: linux
       # Prefer running coredns replicas on different nodes
       affinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          topologyKey: "kubernetes.io/hostname"
-          labelSelector:
-            matchExpressions:
-            - key: k8s-app
-              operator: In
-              values: ['kube-dns']
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchExpressions:
+                - key: k8s-app
+                  operator: In
+                  values: ['kube-dns']
       containers:
       - name: coredns
         image: {{ .Image }}

--- a/pkg/component/controller/defaultpsp.go
+++ b/pkg/component/controller/defaultpsp.go
@@ -193,11 +193,7 @@ spec:
   runAsUser:
     rule: 'MustRunAsNonRoot'
   seLinux:
-    rule: 'MustRunAs'
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
+    rule: 'RunAsAny'
   supplementalGroups:
     rule: 'MustRunAs'
     ranges:

--- a/pkg/component/controller/defaultpsp.go
+++ b/pkg/component/controller/defaultpsp.go
@@ -193,9 +193,13 @@ spec:
   runAsUser:
     rule: 'MustRunAsNonRoot'
   seLinux:
-    rule: 'RunAsNonRoot'
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
   supplementalGroups:
-    rule: 'RunAsNonRoot'
+    rule: 'MustRunAs'
     ranges:
       # Forbid adding the root group.
       - min: 1
@@ -207,15 +211,6 @@ spec:
   - 'persistentVolumeClaim'
   - 'projected'
   - 'secret'
-  hostNetwork: false
-  runAsUser:
-    rule: 'RunAsAny'
-  seLinux:
-    rule: 'RunAsAny'
-  supplementalGroups:
-    rule: 'RunAsAny'
-  fsGroup:
-    rule: 'RunAsAny'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/pkg/component/controller/metricserver.go
+++ b/pkg/component/controller/metricserver.go
@@ -154,6 +154,7 @@ metadata:
   name: metrics-server
   namespace: kube-system
 spec:
+  replicas: 1
   selector:
     matchLabels:
       k8s-app: metrics-server


### PR DESCRIPTION
Signed-off-by: Alexey Makhov <amakhov@mirantis.com>

**Issue**
Fixes #1230

**What this PR Includes**
Fixes some YAML validation errors described in the issue #1230.
Fixes `99-k0s-restricted` PodSecurityPolicy. Currently, it allows everything except privileged mode.

```
$ kubectl get psp
Warning: policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
NAME                PRIV    CAPS   SELINUX    RUNASUSER   FSGROUP    SUPGROUP   READONLYROOTFS   VOLUMES
00-k0s-privileged   true    *      RunAsAny   RunAsAny    RunAsAny   RunAsAny   false            *
99-k0s-restricted   false          RunAsAny   RunAsAny    RunAsAny   RunAsAny   false            configMap,downwardAPI,emptyDir,persistentVolumeClaim,projected,secret
```