### PR TITLE
Arm release cherry-pick

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,7 +237,7 @@ jobs:
 
   armv7:
     needs: release
-    runs-on: [self-hosted,linux,arm,lxc]
+    runs-on: [self-hosted,linux,arm]
     env:
       SEGMENT_TOKEN: ${{ secrets.SEGMENT_WRITE_KEY_PROD }}
       EULA_NOTICE: ${{ secrets.EULA_NOTICE }}


### PR DESCRIPTION
The armv7 lxc github runner was replaced with an armv7 VM. Do not
require lxc tag to build armv7 releases.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

cherry-pick to release-1.22