### PR TITLE
Fix k0s kubeconfig admin command usage hint

### DIFF
--- a/cmd/kubeconfig/admin.go
+++ b/cmd/kubeconfig/admin.go
@@ -28,13 +28,13 @@ import (
 
 func kubeConfigAdminCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "admin [command]",
+		Use:   "admin",
 		Short: "Display Admin's Kubeconfig file",
 		Long:  "Print kubeconfig for the Admin user to stdout",
 		Example: `	$ k0s kubeconfig admin > ~/.kube/config
 	$ export KUBECONFIG=~/.kube/config
 	$ kubectl get nodes`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			c := CmdOpts(config.GetCmdOpts())
 			if file.Exists(c.K0sVars.AdminKubeConfigPath) {
 				content, err := os.ReadFile(c.K0sVars.AdminKubeConfigPath)

--- a/docs/cli/k0s_kubeconfig_admin.md
+++ b/docs/cli/k0s_kubeconfig_admin.md
@@ -7,7 +7,7 @@ Display Admin's Kubeconfig file
 Print kubeconfig for the Admin user to stdout
 
 ```shell
-k0s kubeconfig admin [command] [flags]
+k0s kubeconfig admin [flags]
 ```
 
 ### Examples


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Before:

```shell
$ k0s kubeconfig admin --help
Usage:
  k0s kubeconfig admin [command] [flags]
```

After:

```shell
$ k0s kubeconfig admin --help
Usage:
  k0s kubeconfig admin [flags]
```

The command does not take any "command" argument.
