### PR TITLE
Hide global flags added by embedded kubectl

### DIFF
--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	kubectl "k8s.io/kubectl/pkg/cmd"
 
@@ -29,6 +30,9 @@ import (
 type CmdOpts config.CLIOptions
 
 func NewK0sKubectlCmd() *cobra.Command {
+	_ = pflag.CommandLine.MarkHidden("log-flush-frequency")
+	_ = pflag.CommandLine.MarkHidden("version")
+
 	args := kubectl.KubectlOptions{
 		IOStreams: genericclioptions.IOStreams{
 			In:     os.Stdin,
@@ -37,6 +41,7 @@ func NewK0sKubectlCmd() *cobra.Command {
 		},
 	}
 	cmd := kubectl.NewKubectlCommand(args)
+
 	cmd.Aliases = []string{"kc"}
 	// Get handle on the original kubectl prerun so we can call it later
 	originalPreRunE := cmd.PersistentPreRunE
@@ -66,6 +71,7 @@ func NewK0sKubectlCmd() *cobra.Command {
 			defer file.Close()
 			os.Setenv("KUBECONFIG", c.K0sVars.AdminKubeConfigPath)
 		}
+
 		return originalPreRunE(cmd, args)
 	}
 	return cmd


### PR DESCRIPTION
Fixes #1273

Can't reopen #1274 for some reason so here it is again, slightly modified. Hides the `--version` and `--log-flush-frequency` global flags that get added when importing the kubectl cmd package.

Signed-off-by: Kimmo Lehto <klehto@mirantis.com>
