### PR TITLE
inttest: Verify that we actually use kine when we should

### DIFF
--- a/inttest/kine/kine_test.go
+++ b/inttest/kine/kine_test.go
@@ -55,6 +55,14 @@ func (s *KineSuite) TestK0sGetsUp() {
 
 	s.T().Log("waiting to see CNI pods ready")
 	s.NoError(common.WaitForKubeRouterReady(kc), "CNI did not start")
+
+	s.T().Log("verify that we actually use kine")
+	ssh, err := s.SSH(s.ControllerNode(0))
+	s.NoError(err)
+	defer ssh.Disconnect()
+
+	_, err = ssh.ExecWithOutput("test -e /var/lib/k0s/bin/kine && ps xa | grep kine")
+	s.NoError(err)
 }
 
 func TestKineSuite(t *testing.T) {

--- a/inttest/singlenode/singlenode_test.go
+++ b/inttest/singlenode/singlenode_test.go
@@ -50,6 +50,15 @@ func (s *SingleNodeSuite) TestK0sGetsUp() {
 
 	s.T().Log("waiting to see CNI pods ready")
 	s.NoError(common.WaitForKubeRouterReady(kc), "CNI did not start")
+
+	s.T().Log("verify that we use kine as default storage")
+	ssh, err := s.SSH(s.ControllerNode(0))
+	s.NoError(err)
+	defer ssh.Disconnect()
+
+	_, err = ssh.ExecWithOutput("test -e /var/lib/k0s/bin/kine && ps xa | grep kine")
+	s.NoError(err)
+
 }
 
 func TestSingleNodeSuite(t *testing.T) {


### PR DESCRIPTION
check that kine is extracted and actually runs when it is expected.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>
