### PR TITLE
Fix storage for --single regression

### DIFF
--- a/cmd/airgap/listimages_test.go
+++ b/cmd/airgap/listimages_test.go
@@ -39,7 +39,7 @@ spec:
       image: custom.io/coredns/coredns
       version: 1.0.0
 `
-	cfg, err := v1beta1.ConfigFromString(yamlData, "")
+	cfg, err := v1beta1.ConfigFromString(yamlData)
 	s.NoError(err)
 	a := cfg.Spec.Images
 

--- a/cmd/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeconfig/kubeconfig_test.go
@@ -151,7 +151,7 @@ yJm2KSue0toWmkBFK8WMTjAvmAw3Z/qUhJRKoqCu3k6Mf8DNl6t+Uw==
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	s.NoError(err)
 	s.Equal("https://10.0.0.86:6443", config.Host)
-	_, err = v1beta1.ConfigFromString(yamlData, "")
+	_, err = v1beta1.ConfigFromString(yamlData)
 	s.NoError(err)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -195,7 +195,7 @@ $ k0s completion fish > ~/.config/fish/completions/k0s.fish
 }
 
 func (c *cliOpts) buildConfig() error {
-	conf, _ := yaml.Marshal(v1beta1.DefaultClusterConfig(config.DataDir))
+	conf, _ := yaml.Marshal(v1beta1.DefaultClusterConfig())
 	fmt.Print(string(conf))
 	return nil
 }

--- a/hack/validate-images/main.go
+++ b/hack/validate-images/main.go
@@ -34,7 +34,7 @@ func main() {
 	if len(architectures) < 1 {
 		panic("No architectures given")
 	}
-	cfg := v1beta1.DefaultClusterConfig("")
+	cfg := v1beta1.DefaultClusterConfig()
 	uris := airgap.GetImageURIs(cfg.Spec.Images)
 	if err := validateImages(uris, architectures); err != nil {
 		os.Exit(1)

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types_test.go
@@ -23,19 +23,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var dataDir string
-
 func TestClusterDefaults(t *testing.T) {
-	c, err := ConfigFromString("apiVersion: k0s.k0sproject.io/v1beta1", dataDir)
+	c, err := ConfigFromString("apiVersion: k0s.k0sproject.io/v1beta1")
 	assert.NoError(t, err)
-	assert.Equal(t, DefaultStorageSpec(dataDir), c.Spec.Storage)
+	assert.Equal(t, DefaultStorageSpec(), c.Spec.Storage)
 }
 
 func TestUnknownFieldValidation(t *testing.T) {
 	_, err := ConfigFromString(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
-unknown: 1`, dataDir)
+unknown: 1`)
 
 	assert.Error(t, err)
 }
@@ -48,7 +46,7 @@ metadata:
   name: foobar
 `
 
-	c, err := ConfigFromString(yamlData, dataDir)
+	c, err := ConfigFromString(yamlData)
 	assert.NoError(t, err)
 	assert.Equal(t, "etcd", c.Spec.Storage.Type)
 	addr, err := iface.FirstPublicAddress()
@@ -67,7 +65,7 @@ spec:
     type: etcd
 `
 
-	c, err := ConfigFromString(yamlData, dataDir)
+	c, err := ConfigFromString(yamlData)
 	assert.NoError(t, err)
 	assert.Equal(t, "etcd", c.Spec.Storage.Type)
 	addr, err := iface.FirstPublicAddress()
@@ -88,7 +86,7 @@ spec:
     type: etcd
 `
 
-	c, err := ConfigFromString(yamlData, dataDir)
+	c, err := ConfigFromString(yamlData)
 	assert.NoError(t, err)
 	errors := c.Validate()
 	assert.Equal(t, 0, len(errors))
@@ -107,7 +105,7 @@ spec:
     type: etcd
 `
 
-	c, err := ConfigFromString(yamlData, dataDir)
+	c, err := ConfigFromString(yamlData)
 	assert.NoError(t, err)
 	errors := c.Validate()
 	assert.Equal(t, 0, len(errors))
@@ -126,7 +124,7 @@ spec:
     type: etcd
 `
 
-	c, err := ConfigFromString(yamlData, dataDir)
+	c, err := ConfigFromString(yamlData)
 	assert.NoError(t, err)
 	errors := c.Validate()
 	assert.Equal(t, 1, len(errors))
@@ -145,7 +143,7 @@ spec:
     address: 1.2.3.4
 `
 
-	c, err := ConfigFromString(yamlData, dataDir)
+	c, err := ConfigFromString(yamlData)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://foo.bar.com:6443", c.Spec.API.APIAddressURL())
 	assert.Equal(t, "https://foo.bar.com:9443", c.Spec.API.K0sControlPlaneAPIAddress())
@@ -162,7 +160,7 @@ spec:
     address: 1.2.3.4
 `
 
-	c, err := ConfigFromString(yamlData, dataDir)
+	c, err := ConfigFromString(yamlData)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://1.2.3.4:6443", c.Spec.API.APIAddressURL())
 	assert.Equal(t, "https://1.2.3.4:9443", c.Spec.API.K0sControlPlaneAPIAddress())
@@ -191,7 +189,7 @@ spec:
         anonymous:
           enabled: false
 `
-	c, err := ConfigFromString(yamlData, dataDir)
+	c, err := ConfigFromString(yamlData)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(c.Spec.WorkerProfiles))
 	assert.Equal(t, "profile_XXX", c.Spec.WorkerProfiles[0].Name)
@@ -211,7 +209,7 @@ spec:
 }
 
 func TestStripDefaults(t *testing.T) {
-	defaultConfig := DefaultClusterConfig("")
+	defaultConfig := DefaultClusterConfig()
 	stripped := defaultConfig.StripDefaults()
 	a := assert.New(t)
 	a.Nil(stripped.Spec.API)

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/images_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/images_test.go
@@ -34,7 +34,7 @@ func getConfigYAML(t *testing.T, c *ClusterConfig) []byte {
 func TestImagesRepoOverrideInConfiguration(t *testing.T) {
 	t.Run("if_has_repository_not_empty_add_prefix_to_all_images", func(t *testing.T) {
 		t.Run("default_config", func(t *testing.T) {
-			cfg := DefaultClusterConfig(dataDir)
+			cfg := DefaultClusterConfig()
 			cfg.Spec.Images.Repository = "my.repo"
 			var testingConfig *ClusterConfig
 			require.NoError(t, yaml.Unmarshal(getConfigYAML(t, cfg), &testingConfig))
@@ -52,7 +52,7 @@ func TestImagesRepoOverrideInConfiguration(t *testing.T) {
 			require.Equal(t, fmt.Sprintf("my.repo/k0sproject/cni-node:%s", constant.KubeRouterCNIInstallerImageVersion), testingConfig.Spec.Images.KubeRouter.CNIInstaller.URI())
 		})
 		t.Run("config_with_custom_images", func(t *testing.T) {
-			cfg := DefaultClusterConfig(dataDir)
+			cfg := DefaultClusterConfig()
 			cfg.Spec.Images.Konnectivity.Image = "my-custom-image"
 			cfg.Spec.Images.Repository = "my.repo"
 			var testingConfig *ClusterConfig

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/network_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/network_test.go
@@ -102,7 +102,7 @@ spec:
     calico:
 `
 
-	c, err := ConfigFromString(yamlData, dataDir)
+	c, err := ConfigFromString(yamlData)
 	s.NoError(err)
 	n := c.Spec.Network
 
@@ -125,7 +125,7 @@ spec:
     kuberouter:
 `
 
-	c, err := ConfigFromString(yamlData, dataDir)
+	c, err := ConfigFromString(yamlData)
 	s.NoError(err)
 	n := c.Spec.Network
 
@@ -148,7 +148,7 @@ metadata:
 spec:
 `
 
-	c, err := ConfigFromString(yamlData, dataDir)
+	c, err := ConfigFromString(yamlData)
 	s.NoError(err)
 	p := c.Spec.Network.KubeProxy
 
@@ -168,7 +168,7 @@ spec:
       disabled: true
 `
 
-	c, err := ConfigFromString(yamlData, dataDir)
+	c, err := ConfigFromString(yamlData)
 	s.NoError(err)
 	p := c.Spec.Network.KubeProxy
 

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/storage.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/storage.go
@@ -49,14 +49,7 @@ type KineConfig struct {
 }
 
 // DefaultStorageSpec creates StorageSpec with sane defaults
-func DefaultStorageSpec(dataDir string) *StorageSpec {
-	k0sVars := constant.GetConfig(dataDir)
-	if k0sVars.DefaultStorageType == KineStorageType {
-		return &StorageSpec{
-			Type: KineStorageType,
-			Kine: DefaultKineConfig(dataDir),
-		}
-	}
+func DefaultStorageSpec() *StorageSpec {
 	return &StorageSpec{
 		Type: EtcdStorageType,
 		Etcd: DefaultEtcdConfig(),

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/storage_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/storage_test.go
@@ -18,7 +18,6 @@ package v1beta1
 import (
 	"testing"
 
-	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -91,7 +90,7 @@ spec:
   storage:
     type: kine
 `
-	c, err := ConfigFromString(yaml, constant.DataDirDefault)
+	c, err := ConfigFromString(yaml)
 	assert.NoError(t, err)
 	assert.Equal(t, "kine", c.Spec.Storage.Type)
 	assert.NotNil(t, c.Spec.Storage.Kine)

--- a/pkg/backup/manager.go
+++ b/pkg/backup/manager.go
@@ -151,7 +151,7 @@ func (bm Manager) getConfigForRestore(k0sVars constant.CfgVars) (*v1beta1.Cluste
 	configFromBackup := path.Join(bm.tmpDir, "k0s.yaml")
 	_, err := os.Stat(configFromBackup)
 	if os.IsNotExist(err) {
-		return v1beta1.DefaultClusterConfig(bm.dataDir), nil
+		return v1beta1.DefaultClusterConfig(), nil
 	}
 	logrus.Infof("Using k0s.yaml from: %s", configFromBackup)
 

--- a/pkg/component/controller/calico_test.go
+++ b/pkg/component/controller/calico_test.go
@@ -19,7 +19,7 @@ func (i inMemorySaver) Save(dst string, content []byte) error {
 }
 
 func TestCalicoManifests(t *testing.T) {
-	clusterConfig := v1beta1.DefaultClusterConfig(dataDir)
+	clusterConfig := v1beta1.DefaultClusterConfig()
 	clusterConfig.Spec.Network.Calico = v1beta1.DefaultCalico()
 	clusterConfig.Spec.Network.Provider = "calico"
 	clusterConfig.Spec.Network.KubeRouter = nil

--- a/pkg/component/controller/kuberouter_test.go
+++ b/pkg/component/controller/kuberouter_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestKubeRouterConfig(t *testing.T) {
-	cfg := v1beta1.DefaultClusterConfig(dataDir)
+	cfg := v1beta1.DefaultClusterConfig()
 	cfg.Spec.Network.Calico = nil
 	cfg.Spec.Network.Provider = "kuberouter"
 	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
@@ -54,7 +54,7 @@ func TestKubeRouterConfig(t *testing.T) {
 }
 
 func TestKubeRouterDefaultManifests(t *testing.T) {
-	cfg := v1beta1.DefaultClusterConfig(dataDir)
+	cfg := v1beta1.DefaultClusterConfig()
 	cfg.Spec.Network.Calico = nil
 	cfg.Spec.Network.Provider = "kuberouter"
 	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()

--- a/pkg/component/controller/metricserver_test.go
+++ b/pkg/component/controller/metricserver_test.go
@@ -12,7 +12,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var cfg = v1beta1.DefaultClusterConfig("")
+var cfg = v1beta1.DefaultClusterConfig()
 
 func TestGetConfigWithZeroNodes(t *testing.T) {
 	fakeFactory := testutil.NewFakeClientFactory()


### PR DESCRIPTION
Kine should be used as default storage with --single option specified.
commit 22ffa9fb80c7 (ClusterConfig CRD: remove k0Vars in favor of
DataDir var) introduced a regression that caused etcd be used by default
with --single.

Fix this and refactor so that DefaultClusterConfig takes an
optional/variadic clusterConfig. This way we don't always need to
specify which default cluster spec is to be used. Then we set the kine
storage in `ValidateYaml` depending on the DefaultStorageType in
K0sVars. `ValidateYaml` needs data dir from k0s vars so it makes sense
to do this from here.

Fixes https://github.com/k0sproject/k0s/issues/1360

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

