### PR TITLE
Added checking for a leftover socket from the previous runs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -165,6 +165,7 @@ jobs:
           - check-configchange
           - check-upgrade
           - check-psp
+          - check-statussocket
           # skipped, originally titled "Smoke-test for network":
           # - check-etcd
 

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -22,5 +22,6 @@ smoketests := \
 	check-configchange \
 	check-upgrade \
 	check-psp \
-	check-defaultstorage
+	check-defaultstorage \
+	check-statussocket
 

--- a/inttest/statussocket/statussocket_test.go
+++ b/inttest/statussocket/statussocket_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2021 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package statussocket
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/k0sproject/k0s/inttest/common"
+)
+
+type StatusSocketSuite struct {
+	common.FootlooseSuite
+}
+
+func (s *StatusSocketSuite) TestK0sGetsUp() {
+	s.MakeDir(s.ControllerNode(0), "/run/k0s")
+	s.PutFile(s.ControllerNode(0), "/run/k0s/status.sock", "")
+	s.NoError(s.InitController(0, "--single"))
+
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	s.NoError(err)
+
+	err = s.WaitForNodeReady(s.ControllerNode(0), kc)
+	s.NoError(err)
+}
+
+func TestStatusSocketSuite(t *testing.T) {
+	s := StatusSocketSuite{
+		common.FootlooseSuite{
+			ControllerCount: 1,
+		},
+	}
+	suite.Run(t, &s)
+}

--- a/pkg/component/status/status.go
+++ b/pkg/component/status/status.go
@@ -3,12 +3,10 @@ package status
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/pkg/install"
@@ -40,11 +38,7 @@ func (s *Status) Init() error {
 		return fmt.Errorf("failed to create %s: %w", s.Socket, err)
 	}
 
-	err = checkLeftoverSocket(s.Socket)
-	if err != nil {
-		return fmt.Errorf("socket error: %w", err)
-	}
-
+	removeLeftovers(s.Socket)
 	s.listener, err = net.Listen("unix", s.Socket)
 	if err != nil {
 		s.L.Errorf("failed to create listener %s", err)
@@ -55,19 +49,12 @@ func (s *Status) Init() error {
 	return nil
 }
 
-// checkLeftoverSocket checks if there is a leftover socket from the previous runs. This usually happens on crash or SIGKILL
-func checkLeftoverSocket(socket string) error {
+// removeLeftovers tries to remove leftover sockets that nothing is listening on
+func removeLeftovers(socket string) {
 	_, err := net.Dial("unix", socket)
 	if err != nil {
-		// Socket file doesn't exist or exists but nobody is listening
-		if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "connection refused") {
-			os.Remove(socket)
-			return nil
-		}
-
-		return err
+		_ = os.Remove(socket)
 	}
-	return errors.New("socket is busy")
 }
 
 // Run runs the component


### PR DESCRIPTION
**Issue**
When k0s crashes or gets SIGKILL, the status server socket is not unlinked. This can cause troubles on the next runs.
```
Dec 16 12:31:13 ip-172-31-28-129 k0s[4636]: Error: listen unix /run/k0s/status.sock: bind: address already in use
Dec 16 12:31:13 ip-172-31-28-129 k0s[4636]: 2021/12/16 12:31:13 listen unix /run/k0s/status.sock: bind: address already in use
Dec 16 12:31:13 ip-172-31-28-129 systemd[1]: k0scontroller.service: Main process exited, code=exited, status=1/FAILURE
Dec 16 12:31:13 ip-172-31-28-129 systemd[1]: k0scontroller.service: Failed with result 'exit-code'.
Dec 16 12:33:13 ip-172-31-28-129 systemd[1]: k0scontroller.service: Scheduled restart job, restart counter is at 4.
Dec 16 12:33:13 ip-172-31-28-129 systemd[1]: Stopped k0s - Zero Friction Kubernetes.
```

**What this PR Includes**
In the change, we check if there is a leftover socket and if something is listening on this socket. If not, we remove socket file.