### PR TITLE
cli-runtime resource builder is used to get resouces in stack applier

### DIFF
--- a/internal/testutil/kube_client.go
+++ b/internal/testutil/kube_client.go
@@ -12,6 +12,7 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 	kubetesting "k8s.io/client-go/testing"
 
 	cfgClient "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/clientset/typed/k0s.k0sproject.io/v1beta1"
@@ -61,4 +62,8 @@ func (f FakeClientFactory) GetDiscoveryClient() (discovery.CachedDiscoveryInterf
 
 func (f FakeClientFactory) GetConfigClient() (cfgClient.ClusterConfigInterface, error) {
 	return nil, fmt.Errorf("NOT IMPLEMENTED")
+}
+
+func (f FakeClientFactory) GetRESTConfig() *rest.Config {
+	return &rest.Config{}
 }

--- a/pkg/applier/applier_test.go
+++ b/pkg/applier/applier_test.go
@@ -41,28 +41,29 @@ metadata:
   name:  kube-system
 `
 	template := `
-kind: ConfigMap
 apiVersion: v1
-metadata:
-  name: applier-test
-  namespace: kube-system
-  labels:
-    component: applier
-data:
-  foo: bar
-`
-	template2 := `
-kind: Pod
-apiVersion: v1
-metadata:
-  name: applier-test
-  namespace: kube-system
-  labels:
-    component: applier
-spec:
-  containers:
-    - name: nginx
-      image: nginx:1.15
+kind: List
+items:
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: applier-test
+      namespace: kube-system
+      labels:
+        component: applier
+    data:
+      foo: bar
+  - kind: Pod
+    apiVersion: v1
+    metadata:
+      name: applier-test
+      namespace: kube-system
+      labels:
+        component: applier
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.15
 `
 
 	templateDeployment := `
@@ -91,8 +92,7 @@ spec:
           - containerPort: 80
 `
 	assert.NoError(t, os.WriteFile(fmt.Sprintf("%s/test-ns.yaml", dir), []byte(templateNS), 0400))
-	assert.NoError(t, os.WriteFile(fmt.Sprintf("%s/test.yaml", dir), []byte(template), 0400))
-	assert.NoError(t, os.WriteFile(fmt.Sprintf("%s/test-pod.yaml", dir), []byte(template2), 0400))
+	assert.NoError(t, os.WriteFile(fmt.Sprintf("%s/test-list.yaml", dir), []byte(template), 0400))
 	assert.NoError(t, os.WriteFile(fmt.Sprintf("%s/test-deploy.yaml", dir), []byte(templateDeployment), 0400))
 
 	fakes := kubeutil.NewFakeClientFactory()

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -36,6 +36,7 @@ type ClientFactoryInterface interface {
 	GetDynamicClient() (dynamic.Interface, error)
 	GetDiscoveryClient() (discovery.CachedDiscoveryInterface, error)
 	GetConfigClient() (cfgClient.ClusterConfigInterface, error)
+	GetRESTConfig() *rest.Config
 }
 
 // NewAdminClientFactory creates a new factory that loads the admin kubeconfig based client
@@ -166,6 +167,10 @@ func (c *ClientFactory) GetConfigClient() (cfgClient.ClusterConfigInterface, err
 	}
 	c.configClient = configClient.ClusterConfigs(constant.ClusterConfigNamespace)
 	return c.configClient, nil
+}
+
+func (c *ClientFactory) GetRESTConfig() *rest.Config {
+	return c.restConfig
 }
 
 // NewClient creates new k8s client based of the given kubeconfig


### PR DESCRIPTION
Signed-off-by: Alexey Makhov <amakhov@mirantis.com>

**Issue**
Fixes #1211

**What this PR Includes**
We don't support `Kind: List` because of our custom resource parser implementation. 
The PR switches it to `resource.Builder` which is used by `kubectl apply`
https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/apply/apply.go#L386-L395