### PR TITLE
Silence not yet readyz errors in inttest

### DIFF
--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -734,7 +734,6 @@ func (s *FootlooseSuite) WaitForKubeAPI(node string, k0sKubeconfigArgs ...string
 		defer cancel()
 		res := kc.RESTClient().Get().RequestURI("/readyz").Do(ctx)
 		if res.Error() != nil {
-			s.T().Logf("readyz error: %v", res.Error())
 			return false, nil
 		}
 		var statusCode int


### PR DESCRIPTION
Don't log errors that only indicate that API is not yet ready. This
makes the inttest a bit less noisy.

This partially reverts commit 9dcfe37de0b6 (inttest: log errors when
waiting for kube api).

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

