### PR TITLE
Remove -dirty from kubernetes build

### DIFF
--- a/embedded-bins/kubernetes/Dockerfile
+++ b/embedded-bins/kubernetes/Dockerfile
@@ -15,8 +15,7 @@ RUN apk add build-base git go-bindata linux-headers rsync grep coreutils bash
 RUN mkdir -p $GOPATH/src/github.com/kubernetes/kubernetes
 RUN git clone -b v$VERSION --depth=1 https://github.com/kubernetes/kubernetes.git $GOPATH/src/github.com/kubernetes/kubernetes
 WORKDIR /go/src/github.com/kubernetes/kubernetes
-RUN cp /tmp/armv7.patch .
-RUN git apply armv7.patch
+RUN GIT_COMMITTER_EMAIL="foo@example.com" git am /tmp/armv7.patch
 RUN go version
 RUN \
 	# Ensure that all of the binaries are built with CGO \

--- a/embedded-bins/kubernetes/armv7.patch
+++ b/embedded-bins/kubernetes/armv7.patch
@@ -1,3 +1,11 @@
+From b97871c4935d8baef0f4a7feb28c70bf22383268 Mon Sep 17 00:00:00 2001
+From: haoyun <yun.hao@daocloud.io>
+Date: Mon, 13 Dec 2021 14:27:21 +0800
+Subject: [PATCH] fix: atomic operations on 32-byte device
+
+Signed-off-by: haoyun <yun.hao@daocloud.io>
+---
+
 diff --git a/vendor/github.com/google/cadvisor/manager/container.go b/vendor/github.com/google/cadvisor/manager/container.go
 index db2e2b11..71684fe0 100644
 --- a/vendor/github.com/google/cadvisor/manager/container.go


### PR DESCRIPTION
Use git am with original author and a bogus committer email so the
kubernetes build does not get a -dirty suffix in the version string.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

