### PR TITLE
Specify exact go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ ifeq ($(go_clientgen),)
 go_clientgen := cd hack/ci-deps && go install k8s.io/code-generator/cmd/client-gen@v0.22.2 && cd ../.. && test -x "${GOPATH}/bin/client-gen"
 endif
 
-GOLANG_IMAGE = golang:1.17-alpine
+GOLANG_IMAGE = golang:$(go_version)-alpine
 GO ?= GOCACHE=/gocache/build GOMODCACHE=/gocache/mod docker run --rm \
 	-v "$(CURDIR)":/go/src/github.com/k0sproject/k0s \
 	-v k0sbuild.gocache:/gocache \
@@ -80,7 +80,9 @@ build: k0s
 endif
 
 .k0sbuild.docker-image.k0s: build/Dockerfile
-	docker build --rm -t k0sbuild.docker-image.k0s -f build/Dockerfile .
+	docker build --rm \
+		--build-arg BUILDIMAGE=golang:$(go_version)-alpine \
+		-t k0sbuild.docker-image.k0s -f build/Dockerfile .
 	touch $@
 
 .k0sbuild.docker-vol.gocache:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,5 @@
-FROM golang:1.17-alpine
+ARG BUILDIMAGE=golang:1.17-alpine
+
+FROM $BUILDIMAGE
 RUN apk add --no-cache gcc musl-dev binutils-gold
 

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,7 @@
+go_version = 1.17.5
+
 runc_version = 1.0.3
-runc_buildimage = golang:1.17-alpine
+runc_buildimage = golang:$(go_version)-alpine
 runc_build_go_tags = "seccomp"
 #runc_build_go_cgo_enabled =
 #runc_build_go_flags =
@@ -7,7 +9,7 @@ runc_build_go_tags = "seccomp"
 runc_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
 containerd_version = 1.5.8
-containerd_buildimage = golang:1.17-alpine
+containerd_buildimage = golang:$(go_version)-alpine
 containerd_build_go_tags = "apparmor,selinux"
 containerd_build_shim_go_cgo_enabled = 0
 #containerd_build_go_cgo_enabled =
@@ -16,7 +18,7 @@ containerd_build_shim_go_cgo_enabled = 0
 containerd_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
 kubernetes_version = 1.23.1
-kubernetes_buildimage = golang:1.17-alpine
+kubernetes_buildimage = golang:$(go_version)-alpine
 kubernetes_build_go_tags = "providerless"
 #kubernetes_build_go_cgo_enabled =
 kubernetes_build_go_flags = "-v"
@@ -24,7 +26,7 @@ kubernetes_build_go_flags = "-v"
 kubernetes_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
 kine_version = 0.8.1
-kine_buildimage = golang:1.17-alpine
+kine_buildimage = golang:$(go_version)-alpine
 #kine_build_go_tags =
 #kine_build_go_cgo_enabled =
 #kine_build_go_flags =
@@ -32,7 +34,7 @@ kine_build_go_ldflags = "-w -s"
 kine_build_go_ldflags_extra = "-extldflags=-static"
 
 etcd_version = 3.5.1
-etcd_buildimage = golang:1.17-alpine
+etcd_buildimage = golang:$(go_version)-alpine
 #etcd_build_go_tags =
 etcd_build_go_cgo_enabled = 0
 #etcd_build_go_flags =
@@ -40,7 +42,7 @@ etcd_build_go_ldflags = "-w -s"
 #etcd_build_go_ldflags_extra =
 
 konnectivity_version = 0.0.25
-konnectivity_buildimage = golang:1.17-alpine
+konnectivity_buildimage = golang:$(go_version)-alpine
 #konnectivity_build_go_tags =
 konnectivity_build_go_cgo_enabled = 0
 konnectivity_build_go_flags = "-a"


### PR DESCRIPTION
Ensure that we don't use an old and vulnerable cached go version.

This also makes it easier to know exactly what go version was used for
each build.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

