### PR TITLE
estesp/manifest-tool updated to fix concurrent map read/write

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/docker/libnetwork v0.8.0-dev.2.0.20201031180254-535ef365dc1d
-	github.com/estesp/manifest-tool/v2 v2.0.0-beta.1
+	github.com/estesp/manifest-tool/v2 v2.0.0-rc.1.0.20211221025119-6df3173d8aae
 	github.com/evanphx/json-patch v4.12.0+incompatible
 	github.com/garyburd/redigo v1.6.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5
@@ -25,7 +25,7 @@ require (
 	github.com/kardianos/service v1.2.1-0.20210728001519-a323c3813bc7
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/opencontainers/image-spec v1.0.1
+	github.com/opencontainers/image-spec v1.0.2
 	github.com/opencontainers/selinux v1.8.4 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/rqlite/rqlite v0.0.0-20210528155034-8dc8788f37db

--- a/go.sum
+++ b/go.sum
@@ -251,7 +251,6 @@ github.com/containerd/containerd v1.5.0-rc.0/go.mod h1:V/IXoMqNGgBlabz3tHD2TWDoT
 github.com/containerd/containerd v1.5.1/go.mod h1:0DOxVqwDy2iZvrZp2JUx/E+hS0UNTVn7dJnIOwtYR4g=
 github.com/containerd/containerd v1.5.2/go.mod h1:0DOxVqwDy2iZvrZp2JUx/E+hS0UNTVn7dJnIOwtYR4g=
 github.com/containerd/containerd v1.5.4/go.mod h1:sx18RgvW6ABJ4iYUw7Q5x7bgFOAB9B6G7+yO0XBc4zw=
-github.com/containerd/containerd v1.5.5/go.mod h1:oSTh0QpT1w6jYcGmbiSbxv9OSQYaa88mPyWIuU79zyo=
 github.com/containerd/containerd v1.5.8 h1:NmkCC1/QxyZFBny8JogwLpOy2f+VEbO/f6bV2Mqtwuw=
 github.com/containerd/containerd v1.5.8/go.mod h1:YdFSv5bTFLpG2HIYmfqDpSYYTDX+mc5qtSuYx1YUb/s=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc h1:TP+534wVlf61smEIq1nwLLAjQVEK2EADoW3CX9AuT+8=
@@ -397,8 +396,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/estesp/manifest-tool/v2 v2.0.0-beta.1 h1:pYzVoEdNNmdouxkkBP2xBmNRfgfW1oKEsNLg7HawIF4=
-github.com/estesp/manifest-tool/v2 v2.0.0-beta.1/go.mod h1:7OBy0Eb+JVqm8Tw6SjhIP7Nfbk113uU/49/WJYmispw=
+github.com/estesp/manifest-tool/v2 v2.0.0-rc.1.0.20211221025119-6df3173d8aae h1:cF9LRHtYHp8LlS6hpOzhPfmNiTzRfVCMGV8IL/d1CaM=
+github.com/estesp/manifest-tool/v2 v2.0.0-rc.1.0.20211221025119-6df3173d8aae/go.mod h1:NsngPHBV2N96DHMMlni+aYgPveKXf7upUa6E3oXzfaQ=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -889,14 +888,14 @@ github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQ
 github.com/opencontainers/go-digest v1.0.0-rc1.0.20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
+github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc93/go.mod h1:3NOsor4w32B2tC0Zbl8Knk4Wg84SM2ImC1fxBuqJ/H0=
-github.com/opencontainers/runc v1.0.1/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
 github.com/opencontainers/runc v1.0.2 h1:opHZMaswlyxz1OuGpBE53Dwe4/xF7EZTY0A2L/FpCOg=
 github.com/opencontainers/runc v1.0.2/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=


### PR DESCRIPTION
Signed-off-by: Alexey Makhov <amakhov@mirantis.com>

**Issue**
Fixes fatal error on our CI [builds](https://github.com/k0sproject/k0s/runs/4563786117?check_suite_focus=true).
```
fatal error: concurrent map read and map write
2021-12-17T18:15:42.8029105Z 
2021-12-17T18:15:42.8029940Z goroutine 566 [running]:
2021-12-17T18:15:42.8031106Z runtime.throw({0xad8696, 0xbbc210})
2021-12-17T18:15:42.8032688Z 	/opt/hostedtoolcache/go/1.17.5/x64/src/runtime/panic.go:1198 +0x71 fp=0xc000cf7990 sp=0xc000cf7960 pc=0x435d91
2021-12-17T18:15:42.8034224Z runtime.mapaccess1_faststr(0x3, 0xc0004f3680, {0xc000cba230, 0x47})
2021-12-17T18:15:42.8036332Z 	/opt/hostedtoolcache/go/1.17.5/x64/src/runtime/map_faststr.go:21 +0x3a5 fp=0xc000cf79f8 sp=0xc000cf7990 pc=0x413f65
2021-12-17T18:15:42.8038956Z github.com/estesp/manifest-tool/v2/pkg/store.(*MemoryStore).Info(0x50, {0x1048d60, 0xc0004f3680}, {0xc000cba230, 0xc000b51c80})
2021-12-17T18:15:42.8041216Z 	/home/runner/go/pkg/mod/github.com/estesp/manifest-tool/v2@v2.0.0-beta.1/pkg/store/store.go:92 +0x90 fp=0xc000cf7a78 sp=0xc000cf79f8 pc=0x92f750
2021-12-17T18:15:42.8043194Z github.com/containerd/containerd/remotes/docker.AppendDistributionSourceLabel.func1({0xba8bf8, 0xc000d14780}, {{0xc000cb4180, 0x34}, {0xc000cba230, 0x47}, 0x20e, {0x0, 0x0, 0x0}, ...})
…
```

**What this PR Includes**
[The fix](https://github.com/estesp/manifest-tool/pull/137) was merged to the library. The PR updates the library version. 