### PR TITLE
stop polluting logs with noderole pseudo errors

### DIFF
--- a/pkg/component/controller/noderole.go
+++ b/pkg/component/controller/noderole.go
@@ -100,10 +100,13 @@ func (n *NodeRole) ensureNodeLabel(ctx context.Context, client kubernetes.Interf
 		}
 	}
 
-	_, err := n.addNodeLabel(ctx, client, node.Name, labelToAdd, "true")
-	if err != nil {
-		return fmt.Errorf("failed to set label '%s' to node %s: %w", labelToAdd, node.Name, err)
+	if labelToAdd != "" {
+		_, err := n.addNodeLabel(ctx, client, node.Name, labelToAdd, "true")
+		if err != nil {
+			return fmt.Errorf("failed to set label '%s' to node %s: %w", labelToAdd, node.Name, err)
+		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Alexey Makhov <amakhov@mirantis.com>

There are a lot of errors in logs 
```
time="2021-12-22 14:46:47" level=error msg="failed to set label '' to node worker1: Node \"worker1\" is invalid: [metadata.labels: Invalid value: \"\": name part must be non-empty, metadata.labels: Invalid value: \"\": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')]" component=noderole
```

We don't use node role labels for workers, so no need to try setting it at all