### PR TITLE
Split command line example and output in docs

### DIFF
--- a/docs/contributors/github_workflow.md
+++ b/docs/contributors/github_workflow.md
@@ -10,7 +10,7 @@ This guide assumes you have already cloned the upstream repo to your system via 
 ## Adding the Forked Remote
 
 ```shell
-export GITHUB_USER={ your github's username }
+export GITHUB_USER={ your github username }
 ```
 
 ```shell
@@ -27,7 +27,10 @@ git push --set-upstream $GITHUB_USER main
 Your remotes should look something like this:
 
 ```shell
-$ git remote -v
+git remote -v
+```
+
+```shell
 origin  https://github.com/k0sproject/k0s (fetch)
 origin  no_push (push)
 my_fork git@github.com:{ github_username }/k0s.git (fetch)
@@ -45,8 +48,11 @@ git checkout -b my_feature_branch
 Rebase your branch:
 
 ```shell
-$ git fetch origin
-$ git rebase origin/main
+git fetch origin && \
+  git rebase origin/main
+```
+
+```shell
 Current branch my_feature_branch is up to date.
 ```
 

--- a/docs/examples/ansible-playbook.md
+++ b/docs/examples/ansible-playbook.md
@@ -34,7 +34,10 @@ You will require the following tools to install k0s on local virtual machines:
     This creates 7 virtual machines:
 
     ```shell
-    $ ./tools/multipass_create_instances.sh 7
+    ./tools/multipass_create_instances.sh 7
+    ```
+
+    ```shell
     Create cloud-init to import ssh key...
     [1/7] Creating instance k0s-1 with multipass...
     Launched: k0s-1
@@ -81,7 +84,10 @@ You will require the following tools to install k0s on local virtual machines:
     3. Fill in `inventory/multipass/inventory.yml`. This can be done by direct entry using the metadata provided by `multipass list,`, or you can use the following Python script `multipass_generate_inventory.py`:
 
         ```shell
-        $ ./tools/multipass_generate_inventory.py
+        ./tools/multipass_generate_inventory.py
+        ```
+
+        ```shell
         Designate first three instances as control plane
         Created Ansible Inventory at: /Users/dev/k0s-ansible/tools/inventory.yml
         $ cp tools/inventory.yml inventory/multipass/inventory.yml
@@ -130,7 +136,10 @@ You will require the following tools to install k0s on local virtual machines:
     Run the following command to test the connection to your hosts:
 
     ```shell
-    $ ansible -i inventory/multipass/inventory.yml -m ping
+    ansible -i inventory/multipass/inventory.yml -m ping
+    ```
+
+    ```shell
     k0s-4 | SUCCESS => {
         "ansible_facts": {
             "discovered_interpreter_python": "/usr/bin/python3"
@@ -148,7 +157,10 @@ You will require the following tools to install k0s on local virtual machines:
     Applying the playbook, k0s download and be set up on all nodes, tokens will be exchanged, and a kubeconfig will be dumped to your local deployment environment.
 
     ```shell
-    $ ansible-playbook site.yml -i inventory/multipass/inventory.yml
+    ansible-playbook site.yml -i inventory/multipass/inventory.yml
+    ```
+
+    ```shell
     TASK [k0s/initial_controller : print kubeconfig command] *******************************************************
     Tuesday 22 December 2020  17:43:20 +0100 (0:00:00.257)       0:00:41.287 ******
     ok: [k0s-1] => {
@@ -193,8 +205,11 @@ You will require the following tools to install k0s on local virtual machines:
 A kubeconfig was copied to your local machine while the playbook was running which you can use to gain access to your new Kubernetes cluster:
 
 ```shell
-$ export KUBECONFIG=/Users/dev/k0s-ansible/inventory/multipass/artifacts/k0s-kubeconfig.yml
-$ kubectl cluster-info
+export KUBECONFIG=/Users/dev/k0s-ansible/inventory/multipass/artifacts/k0s-kubeconfig.yml
+kubectl cluster-info
+```
+
+```shell
 Kubernetes control plane is running at https://192.168.64.32:6443
 CoreDNS is running at https://192.168.64.32:6443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
 Metrics-server is running at https://192.168.64.32:6443/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
@@ -210,7 +225,10 @@ k0s-7   NotReady   <none>   21s   v1.20.1-k0s1   192.168.64.61   <none>        U
 **Note**: The first three control plane nodes will not display, as the control plane is fully isolated. To check on the distributed etcd cluster, you can use ssh to securely log a controller node, or you can run the following ad-hoc command:
 
 ```shell
-$ ansible k0s-1 -a "k0s etcd member-list -c /etc/k0s/k0s.yaml" -i inventory/multipass/inventory.yml | tail -1 | jq
+ansible k0s-1 -a "k0s etcd member-list -c /etc/k0s/k0s.yaml" -i inventory/multipass/inventory.yml | tail -1 | jq
+```
+
+```json
 {
   "level": "info",
   "members": {
@@ -226,13 +244,26 @@ $ ansible k0s-1 -a "k0s etcd member-list -c /etc/k0s/k0s.yaml" -i inventory/mult
 Once all worker nodes are at `Ready` state you can use the cluster. You can test the cluster state by creating a simple nginx deployment.
 
 ```shell
-$ kubectl create deployment nginx --image=gcr.io/google-containers/nginx --replicas=5
+kubectl create deployment nginx --image=gcr.io/google-containers/nginx --replicas=5
+```
+
+```shell
 deployment.apps/nginx created
+```
 
-$ kubectl expose deployment nginx --target-port=80 --port=8100
+```shell
+kubectl expose deployment nginx --target-port=80 --port=8100
+```
+
+```shell
 service/nginx exposed
+```
 
-$ kubectl run hello-k0s --image=quay.io/prometheus/busybox --rm -it --restart=Never --command -- wget -qO- nginx:8100
+```shell
+kubectl run hello-k0s --image=quay.io/prometheus/busybox --rm -it --restart=Never --command -- wget -qO- nginx:8100
+```
+
+```shell
 <!DOCTYPE html>
 <html>
 <head>

--- a/docs/examples/rook-ceph.md
+++ b/docs/examples/rook-ceph.md
@@ -94,7 +94,10 @@ Deploy AWS EBS volumes, one for each worker node. You can manually create three 
 After you have attached the EBS volumes to the worker nodes, log in to one of the workers and check the available block devices:
 
 ```shell
-$ lsblk -f
+lsblk -f
+```
+
+```shell
 NAME        FSTYPE   LABEL           UUID                                 FSAVAIL FSUSE% MOUNTPOINT
 loop0       squashfs                                                            0   100% /snap/amazon-ssm-agent/3552
 loop1       squashfs                                                            0   100% /snap/core18/1997
@@ -178,8 +181,10 @@ kubectl apply -f cluster.yaml
 It takes some minutes to prepare the volumes and create the cluster. Once this is completed you should see the following output:
 
 ```shell
-$ kubectl get pods -n rook-ceph
+kubectl get pods -n rook-ceph
+```
 
+```shell
 NAME                                                         READY   STATUS      RESTARTS   AGE
 csi-cephfsplugin-nhxc8                                       3/3     Running     0          2m48s
 csi-cephfsplugin-provisioner-db45f85f5-ldhjp                 6/6     Running     0          2m48s
@@ -248,8 +253,10 @@ kubectl get pvc
 When the PVC gets the requested volume reserved (bound), it should look like this:
 
 ```shell
-$ kubectl get pvc
+kubectl get pvc
+```
 
+```shell
 NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
 mongo-pvc   Bound    pvc-08337736-65dd-49d2-938c-8197a8871739   2Gi        RWO            rook-ceph-block   6s
 ```
@@ -298,11 +305,16 @@ kubectl apply -f mongo.yaml
 Open the MongoDB shell using the mongo pod:
 
 ```shell
-$ kubectl get pods
+kubectl get pods
+```
+
+```shell
 NAME                    READY   STATUS    RESTARTS   AGE
 mongo-b87cbd5cc-4wx8t   1/1     Running   0          76s
+```
 
-$ kubectl exec -it mongo-b87cbd5cc-4wx8t -- mongo
+```shell
+kubectl exec -it mongo-b87cbd5cc-4wx8t -- mongo
 ```
 
 Create a DB and insert some data:

--- a/docs/examples/traefik-ingress.md
+++ b/docs/examples/traefik-ingress.md
@@ -78,7 +78,10 @@ service/traefik-1607085579   LoadBalancer   10.105.119.102   192.168.0.5      80
 Receiving a 404 response here is normal, as you've not configured any Ingress resources to respond yet:
 
 ```shell
-$ curl http://192.168.0.5
+curl http://192.168.0.5
+```
+
+```shell
 404 page not found
 ```
 
@@ -107,7 +110,7 @@ With an available and addressable load balancer present on your cluster, now you
 2. Deploy the resource:
 
     ```shell
-    root@k0s-host ➜ kubectl apply -f traefik-dashboard.yaml
+    kubectl apply -f traefik-dashboard.yaml
     ```
 
     *Output*:
@@ -173,7 +176,7 @@ With an available and addressable load balancer present on your cluster, now you
 4. Apply the manifests:
 
     ```shell
-    root@k0s-host ➜ kubectl apply -f whoami.yaml
+    kubectl apply -f whoami.yaml
     ```
 
     *Output*:

--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -63,7 +63,9 @@ listen stats
 
 The last block "listen stats" is optional, but can be helpful. It enables HAProxy statistics with a separate dashboard to monitor for example the health of each backend server. You can access it using a web browser:
 
-```http://<ip-addr>:9000```
+```txt
+http://<ip-addr>:9000
+```
 
 Restart HAProxy to apply the configuration changes.
 

--- a/docs/k0s-multi-node.md
+++ b/docs/k0s-multi-node.md
@@ -122,7 +122,10 @@ k0s start
 To get general information about your k0s instance's status:
 
 ```shell
-$ sudo k0s status
+ sudo k0s status
+```
+
+```shell
 Version: v1.23.1+k0s.0
 Process ID: 2769
 Parent Process ID: 1
@@ -136,7 +139,10 @@ Service file: /etc/systemd/system/k0scontroller.service
 Use the Kubernetes 'kubectl' command-line tool that comes with k0s binary to deploy your application or check your node status:
 
 ```shell
-$ sudo k0s kubectl get nodes
+sudo k0s kubectl get nodes
+```
+
+```shell
 NAME   STATUS   ROLES    AGE    VERSION
 k0s    Ready    <none>   4m6s   v1.23.1-k0s1
 ```

--- a/docs/manifests.md
+++ b/docs/manifests.md
@@ -53,7 +53,10 @@ spec:
 New pods will appear soon thereafter.
 
 ```shell
-$ sudo k0s kubectl get pods --namespace nginx
+sudo k0s kubectl get pods --namespace nginx
+```
+
+```shell
 NAME                                READY   STATUS    RESTARTS   AGE
 nginx-deployment-66b6c48dd5-8zq7d   1/1     Running   0          10m
 nginx-deployment-66b6c48dd5-br4jv   1/1     Running   0          10m

--- a/docs/raspberry-pi4.md
+++ b/docs/raspberry-pi4.md
@@ -116,8 +116,11 @@ curl -sSLf https://get.k0s.sh | sudo sh
 At this point you can run `k0s`:
 
 ```shell
-$ k0s version
-v0.9.1
+k0s version
+```
+
+```shell
+v1.22.1+k0s.0
 ```
 
 ### Deploy Kubernetes
@@ -194,7 +197,10 @@ kubectl create clusterrolebinding k0s-admin-binding --clusterrole=admin --user=k
 You can now access and use the cluster:
 
 ```shell
-$ kubectl get nodes,deployments,pods -A
+kubectl get nodes,deployments,pods -A
+```
+
+```shell
 NAME         STATUS   ROLES    AGE     VERSION
 node/k8s-4   Ready    <none>   5m9s    v1.20.1-k0s1
 node/k8s-5   Ready    <none>   5m      v1.20.1-k0s1

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -28,7 +28,10 @@ kube-system   metrics-server-7d4bcb75dd-pqkrs            1/1     Running   0    
 When you check the logs, it'll show something like this:
 
 ```shell
-$ kubectl -n kube-system logs coredns-5c98d7d4d8-tfs4q
+kubectl -n kube-system logs coredns-5c98d7d4d8-tfs4q
+```
+
+```shell
 plugin/loop: Loop (127.0.0.1:55953 -> :1053) detected for zone ".", see https://coredns.io/plugins/loop#troubleshooting. Query: "HINFO 4547991504243258144.3688648895315093531."
 ```
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -58,7 +58,10 @@ spec:
 If you do not specify a version, k0sctl checks online for the latest version and defaults to it.
 
 ```shell
-$ k0sctl apply
+k0sctl apply
+```
+
+```shell
 ...
 ...
 INFO[0001] ==> Running phase: Upgrade controllers

--- a/docs/worker-node-config.md
+++ b/docs/worker-node-config.md
@@ -9,7 +9,10 @@ The `k0s worker` command accepts the `--labels` flag, with which you can make th
 For example, running the worker with `k0s worker --token-file k0s.token --labels="k0sproject.io/foo=bar,k0sproject.io/other=xyz"` results in:
 
 ```shell
-$ kubectl get node --show-labels
+kubectl get node --show-labels
+```
+
+```shell
 NAME      STATUS     ROLES    AGE   VERSION        LABELS
 worker0   NotReady   <none>   10s   v1.20.2-k0s1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,k0sproject.io/foo=bar,k0sproject.io/other=xyz,kubernetes.io/arch=amd64,kubernetes.io/hostname=worker0,kubernetes.io/os=linux
 ```
@@ -17,7 +20,10 @@ worker0   NotReady   <none>   10s   v1.20.2-k0s1   beta.kubernetes.io/arch=amd64
 Controller worker nodes are assigned `node.k0sproject.io/role=control-plane` and `node-role.kubernetes.io/control-plane=true` labels:
 
 ```shell
-$ kubectl get node --show-labels
+kubectl get node --show-labels
+```
+
+```shell
 NAME          STATUS     ROLES           AGE   VERSION        LABELS
 controller0   NotReady   control-plane   10s   v1.20.2-k0s1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/hostname=worker0,kubernetes.io/os=linux,node.k0sproject.io/role=control-plane,node-role.kubernetes.io/control-plane=true
 ```
@@ -31,7 +37,10 @@ The `k0s worker` command accepts the `--taints` flag, with which you can make th
 **Note:** Controller nodes running with `--enable-worker` are assigned `node-role.kubernetes.io/master:NoExecute` taint automatically.
 
 ```shell
-$ kubectl get nodes -o custom-columns=NAME:.metadata.name,TAINTS:.spec.taints
+kubectl get nodes -o custom-columns=NAME:.metadata.name,TAINTS:.spec.taints
+```
+
+```shell
 NAME          TAINTS
 controller0   [map[effect:NoSchedule key:node-role.kubernetes.io/master]]
 worker0       <none>


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Closes #1291 (abandoned)
Fixes #1290 

Several occcurences of combined command example + output I found via grep split into two codeblocks to make single-click copy work nice.
