### PR TITLE
Use github-actions user for marking issues stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,8 +9,8 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          repo-token: ${{ secrets.GH_TOKEN }}
           stale-issue-message: 'The issue is marked as stale since no activity has been recorded in 30 days'
           stale-pr-message: 'The PR is marked as stale since no activity has been recorded in 30 days'
           days-before-stale: 30
           close-pr-label: "stale"
+


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Fixes #1387 

The [default](https://github.com/actions/stale#repo-token) should be `github.token` which I believe is the `github-actions` user.
