### PR TITLE
add calico images to the airgap bundle for armv7 architecture

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -80,7 +80,7 @@ jobs:
         run: make check-unit
       
       - name: Validate OCI images manifests
-        run: go run hack/validate-images/main.go -architectures amd64,arm64
+        run: go run hack/validate-images/main.go -architectures amd64,arm64,arm
       
       - name: Cache compiled binary for further testing
         uses: actions/cache@v2

--- a/hack/validate-images/main.go
+++ b/hack/validate-images/main.go
@@ -28,7 +28,7 @@ func check(e error) {
 func main() {
 	var architectures []string
 	var architecturesString string
-	flag.StringVar(&architecturesString, "architectures", "amd64,arm64", "which architectures to search for")
+	flag.StringVar(&architecturesString, "architectures", "amd64,arm64,arm", "which architectures to search for")
 	flag.Parse()
 	architectures = strings.Split(architecturesString, ",")
 	if len(architectures) < 1 {

--- a/pkg/airgap/images.go
+++ b/pkg/airgap/images.go
@@ -1,8 +1,6 @@
 package airgap
 
 import (
-	"runtime"
-
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
 )
@@ -23,12 +21,9 @@ func GetImageURIs(spec *v1beta1.ClusterImages) []string {
 		spec.KubeRouter.CNI.URI(),
 		spec.KubeRouter.CNIInstaller.URI(),
 	}
-	// Calico images do not currently support armv7, thus we need to exclude them from the list if we're running this on arm
-	if runtime.GOARCH != "arm" {
-		images = append(images,
-			spec.Calico.CNI.URI(),
-			spec.Calico.KubeControllers.URI(),
-			spec.Calico.Node.URI())
-	}
+	images = append(images,
+		spec.Calico.CNI.URI(),
+		spec.Calico.KubeControllers.URI(),
+		spec.Calico.Node.URI())
 	return images
 }


### PR DESCRIPTION
- add calico images to the airgap bundle (we used to have it disabled for armv7 architecture)
- modify list of target architectures to check in the validate-images CI step

Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>

