### PR TITLE
Update metrics-server image

### DIFF
--- a/pkg/component/controller/metricserver.go
+++ b/pkg/component/controller/metricserver.go
@@ -169,7 +169,7 @@ spec:
       containers:
       - args:
         - --cert-dir=/tmp
-        - --secure-port=443
+        - --secure-port=10250
         - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
@@ -184,7 +184,7 @@ spec:
           periodSeconds: 10
         name: metrics-server
         ports:
-        - containerPort: 443
+        - containerPort: 10250
           name: https
           protocol: TCP
         readinessProbe:

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -78,7 +78,7 @@ const (
 	KonnectivityImage                  = "quay.io/k0sproject/apiserver-network-proxy-agent"
 	KonnectivityImageVersion           = "0.0.27-k0s1"
 	MetricsImage                       = "k8s.gcr.io/metrics-server/metrics-server"
-	MetricsImageVersion                = "v0.5.0"
+	MetricsImageVersion                = "v0.5.2"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"
 	KubeProxyImageVersion              = "v1.23.1"
 	CoreDNSImage                       = "k8s.gcr.io/coredns/coredns"


### PR DESCRIPTION
Updates image version for the metrics-server
Changes default ports because  new version doesn't use cap_net_bind_service

Closes issue #1396 

Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>
