### PR TITLE
Fix manual docs update workflow dispatch

### DIFF
--- a/.github/workflows/publish-docs-manual.yml
+++ b/.github/workflows/publish-docs-manual.yml
@@ -1,11 +1,10 @@
-name: Publish docs via GitHub Pages
+name: Manually publish docs via GitHub Pages
 on:
-  push:
-    branches:
-      - main
-  release:
-    types:
-      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g."v1.22.4+k0s.0")'
+        required: true
 
 env:
   GO_VERSION: ^1.17
@@ -29,10 +28,16 @@ jobs:
           pip install git+https://${{ secrets.GH_TOKEN }}@github.com/lensapp/mkdocs-material-insiders.git
           pip install mike
 
-      - name: Checkout k0s release
+      - name: Checkout k0s ${{ github.event.inputs.version }}
         uses: actions/checkout@v2
         with:
+          ref: '${{ github.event.inputs.version }}'
           fetch-depth: 0
+
+      - name: Check out files from main to ${{ github.event.inputs.version }}
+        run: |
+          git checkout main docs/Makefile
+          git checkout main mkdocs.yml
 
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v2
@@ -61,19 +66,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: mike deploy main
-        if: contains(github.ref, 'refs/heads/main')
+      - name: mike deploy ${{ github.event.inputs.version }}
         run: |
-          mike deploy --push main
-
-      - name: Get the release version
-        if: contains(github.ref, 'refs/tags/v') && !github.event.release.prerelease # (don't generate for pre-releases)
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
-      - name: mike deploy new release
-        if: contains(github.ref, 'refs/tags/v') && !github.event.release.prerelease # (don't generate for pre-releases)
-        run: |
-          mike deploy --push --update-aliases ${{ steps.get_version.outputs.VERSION }} latest
-          mike set-default --push ${{ steps.get_version.outputs.VERSION }}
-
+          mike deploy --push --force ${{ github.event.inputs.version }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -31,24 +31,38 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install mkdocs
-          pip install mkdocs-exclude
           pip install git+https://${{ secrets.GH_TOKEN }}@github.com/lensapp/mkdocs-material-insiders.git
           pip install mike
 
       - name: Checkout k0s release
         uses: actions/checkout@v2
-        if: "!github.event.workflow_dispatch"
+        if: github.event_name != "workflow_dispatch"
         with:
           fetch-depth: 0
 
-      - name: Checkout k0s main
+      - name: Checkout k0s ${{ github.event.inputs.version }}
         uses: actions/checkout@v2
-        if: github.event.workflow_dispatch
+        if: github.event_name == "workflow_dispatch"
         with:
           ref: '${{ github.event.inputs.version }}'
           fetch-depth: 0
 
-      - name: Set up Go
+      - name: Checkout k0s main into subdirectory
+        uses: actions/checkout@v2
+        if: github.event_name == "workflow_dispatch"
+        with:
+          ref: main
+          path: git.main
+          fetch-depth: 0
+
+      - name: Copy files from main to ${{ github.event.inputs.version }}
+        if: github.event_name == "workflow_dispatch"
+        run: |
+          cp -p main/docs/Makefile docs/Makefile
+          cp -p main/mkdocs.yml mkdocs.yml
+          rm -rf main
+
+      - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -63,7 +77,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Generate docs
-        run: make docs EMBEDDED_BINS_BUILDMODE=none
+        run: make -C docs
 
       - name: git config
         run: |
@@ -76,22 +90,22 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: mike deploy main
-        if: "!github.event.workflow_dispatch && contains(github.ref, 'refs/heads/main')"
+        if: contains(github.ref, 'refs/heads/main')
         run: |
           mike deploy --push main
 
       - name: Get the release version
-        if: "!github.event.workflow_dispatch && contains(github.ref, 'refs/tags/v') && !github.event.release.prerelease" # (don't generate for pre-releases)
+        if: github.event_name != "workflow_dispatch" && contains(github.ref, 'refs/tags/v') && !github.event.release.prerelease # (don't generate for pre-releases)
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
       - name: mike deploy new release
-        if: "!github.event.workflow_dispatch && contains(github.ref, 'refs/tags/v') && !github.event.release.prerelease" # (don't generate for pre-releases)
+        if: github.event_name != "workflow_dispatch" && contains(github.ref, 'refs/tags/v') && !github.event.release.prerelease # (don't generate for pre-releases)
         run: |
           mike deploy --push --update-aliases ${{ steps.get_version.outputs.VERSION }} latest
           mike set-default --push ${{ steps.get_version.outputs.VERSION }}
 
       - name: mike deploy ${{ github.event.inputs.version }}
-        if: github.event.workflow_dispatch
+        if: github.event_name == "workflow_dispatch"
         run: |
           mike deploy --push --force ${{ github.event.inputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -207,25 +207,6 @@ image-bundle/image.list: k0s
 image-bundle/bundle.tar: image-bundle/image.list
 	$(MAKE) -C image-bundle bundle.tar
 
-ifeq ($(OS),Windows_NT)
-detected_OS := windows
-else
-detected_OS := $(shell uname | tr [:upper:] [:lower:])
-endif
-
-ifeq ($(detected_OS),darwin)
-sedopt := -i "" -e
-else
-sedopt := -i -e
-endif
-
-docs/cli: static/gen_manifests.go pkg/assets/zz_generated_offsets_$(detected_OS).go $(shell find ./cmd/ -type f) mkdocs.yml
-	rm -rf docs/cli
-	mkdir -p docs/cli
-	go run main.go docs markdown
-	rm docs/cli/k0s_kubectl_*
-	sed $(sedopt) '/\[k0s kubectl /d' docs/cli/k0s_kubectl.md
-	ln -s k0s.md docs/cli/README.md
-
-docs: docs/cli
-	mkdocs build --strict
+.PHONY: docs
+docs:
+	$(MAKE) -C docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,38 @@
+mkdocs := $(shell which mkdocs)
+ifeq ($(mkdocs),)
+@echo "mkdocs required, use pip install mkdocs"
+endif
+
+ifeq ($(OS),Windows_NT)
+detected_OS := windows
+else
+detected_OS := $(shell uname | tr [:upper:] [:lower:])
+endif
+
+ifeq ($(detected_OS),darwin)
+sedopt := -i "" -e
+else
+sedopt := -i -e
+endif
+
+# mkdocs.yml refuses to live in the docs-directory, this is why "cd .." is needed
+# gives: "Error: The 'docs_dir' should not be the parent directory of the config file."
+# even if docs_dir is "."
+docs: cli
+	cd .. && mkdocs build --strict
+
+.PHONY: cli
+cli:
+	rm -rf cli
+	mkdir cli
+	$(MAKE) -C .. static/gen_manifests.go EMBEDDED_BINS_BUILDMODE=none
+	$(MAKE) -C .. generate-bindata TARGET_OS=$(detected_OS)
+	cd .. && go run main.go docs markdown
+	rm cli/k0s_kubectl_*
+	sed $(sedopt) '/\[k0s kubectl /d' cli/k0s_kubectl.md
+	ln -s k0s.md cli/README.md
+
+.PHONY: clean
+clean:
+	rm -rf cli
+	rm -rf ../site


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Attempts to fix the manual dispatch of docs workflow introduced in #1395 

Moves the doc-generation into `docs/Makefile` so it can be easily included when backporting typofixes for example.

