### PR TITLE
Update copyright boilerplate year and add CI check

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -46,13 +46,10 @@ jobs:
         env:
           EMBEDDED_BINS_BUILDMODE: none
 
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42
           skip-pkg-cache: true
           only-new-issues: true
           skip-build-cache: true
-          config: .golangci.yml
           args: --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,11 @@
 # options for analysis running
 run:
-
   timeout: 8m
 
   skip-dirs-use-default: false
   skip-dirs:
     - pkg/helm
   tests: false
-
-
   modules-download-mode: readonly
   allow-parallel-runners: true
 
@@ -16,6 +13,7 @@ linters:
   enable:
     - revive
     - gofmt
+    - goheader
 
 linters-settings:
   gofmt:
@@ -23,3 +21,5 @@ linters-settings:
     simplify: false
   golint:
     min-confidence: 0
+  goheader:
+    template-path: hack/client-gen/boilerplate.go.txt

--- a/hack/client-gen/boilerplate.go.txt
+++ b/hack/client-gen/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Updates the copyright year in `hack/client-gen/boilerplate.go.txt` and adds a linter check to see that the copyright header exists in all go files.

According to internet wisdom, it's not necessary to regex-replace copyright headerrs in every file, but only update it in files that are changed during that year.
