### PR TITLE
Support for user lookup via NSS

### DIFF
--- a/internal/pkg/users/users_test.go
+++ b/internal/pkg/users/users_test.go
@@ -1,0 +1,21 @@
+package users
+
+import (
+	"testing"
+)
+
+func TestGetUID(t *testing.T) {
+	uid, err := GetUID("root")
+	if err != nil {
+		t.Errorf("failed to find uid for root: %v", err)
+	}
+	if uid != 0 {
+		t.Errorf("root uid is not 0. It is %d", uid)
+	}
+
+	uid, err = GetUID("some-non-existing-user")
+	if err == nil {
+		t.Errorf("unexpedly got uid for some-non-existing-user: %d", uid)
+	}
+
+}


### PR DESCRIPTION
Add support to lookup users via NSS by calling external command  `id`.

Fixes #1402