### PR TITLE
fix "default-config" deprecated message.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -137,7 +137,7 @@ func newDocsCmd() *cobra.Command {
 func newDefaultConfigCmd() *cobra.Command {
 	cmd := cfg.NewCreateCmd()
 	cmd.Hidden = true
-	cmd.Deprecated = "use 'k0s config generate' instead"
+	cmd.Deprecated = "use 'k0s config create' instead"
 	cmd.Use = "default-config"
 	return cmd
 }


### PR DESCRIPTION
`k0s default-config` says `Command "default-config" is deprecated, use 'k0s config generate' instead`, but `k0s config generate` is invalid subcommand. k0s config **create** is correct.