### PR TITLE
Add links and example of commit message in contributor guide

### DIFF
--- a/docs/contributors/github_workflow.md
+++ b/docs/contributors/github_workflow.md
@@ -66,7 +66,44 @@ Commit and sign your changes:
 git commit --signoff
 ```
 
-The commit message should have a short title as first line, an empty line and then a longer description that explains why the change was made, unless it is obvious.
+The commit message should have a [short](https://cbea.ms/git-commit/#limit-50), [capitalized](https://cbea.ms/git-commit/#capitalize) title [without trailing period](https://cbea.ms/git-commit/#end) as first line. After the title
+a [blank line](https://cbea.ms/git-commit/#separate) and then a longer description that [explains why](https://cbea.ms/git-commit/#why-not-how) the change was made, unless it is obvious.
+
+Use [imperative mood](https://cbea.ms/git-commit/#imperative) in the commit message.
+
+For example:
+
+```text
+Summarize changes in around 50 characters or less
+
+More detailed explanatory text, if necessary. Wrap it to about 72
+characters or so. In some contexts, the first line is treated as the
+subject of the commit and the rest of the text as the body. The
+blank line separating the summary from the body is critical (unless
+you omit the body entirely); various tools like `log`, `shortlog`
+and `rebase` can get confused if you run the two together.
+
+Explain the problem that this commit is solving. Focus on why you
+are making this change as opposed to how (the code explains that).
+Are there side effects or other unintuitive consequences of this
+change? Here's the place to explain them.
+
+Further paragraphs come after blank lines.
+
+ - Bullet points are okay, too
+
+ - Typically a hyphen or asterisk is used for the bullet, preceded
+   by a single space, with blank lines in between.
+
+If you use an issue tracker, put references to them at the bottom,
+like this:
+
+Fixes: https://github.com/k0sproject/k0s/issues/373
+See also: #456, #789
+
+Signed-off-by: Name Lastname <user@example.com>
+
+```
 
 You can go back and edit/build/test some more, then `commit --amend` in a few cycles.
 


### PR DESCRIPTION
Try make it easier for contributors to write good commit messages by
adding references and an example.

Fixes: https://github.com/k0sproject/k0s/issues/373
