### PR TITLE
use dest host strategy for konnectivity in the tunneled mode

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -42,7 +42,7 @@ etcd_build_go_ldflags = "-w -s"
 #etcd_build_go_ldflags_extra =
 
 konnectivity_buildimage = golang:$(go_version)-alpine
-konnectivity_version = 0.0.27-k0s1
+konnectivity_version = 0.0.27-k0s2
 #konnectivity_build_go_tags =
 konnectivity_build_go_cgo_enabled = 0
 konnectivity_build_go_flags = "-a"

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -131,7 +131,7 @@ func (k *Konnectivity) defaultArgs() stringmap.StringMap {
 		"--v":                       k.LogLevel,
 		"--enable-profiling":        "false",
 		"--server-id":               serverID,
-		"--proxy-strategies":        "destHost",
+		"--proxy-strategies":        "destHost,default",
 	}
 }
 

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -131,6 +131,7 @@ func (k *Konnectivity) defaultArgs() stringmap.StringMap {
 		"--v":                       k.LogLevel,
 		"--enable-profiling":        "false",
 		"--server-id":               serverID,
+		"--proxy-strategies":        "destHost",
 	}
 }
 
@@ -354,8 +355,10 @@ spec:
                   # this is the IP address of the master machine.
                   "--proxy-server-host={{ .APIAddress }}",
                   "--proxy-server-port={{ .AgentPort }}",
-                  "--service-account-token-path=/var/run/secrets/tokens/konnectivity-agent-token"
-                  {{ if .TunneledNetworkingMode }},
+                  "--service-account-token-path=/var/run/secrets/tokens/konnectivity-agent-token",
+                  "--agent-identifiers=host=$(NODE_IP)",
+                  "--agent-id=$(NODE_IP)",
+                  {{ if .TunneledNetworkingMode }}
                   # agent need to listen on the node ip to be on pair with the tunneled network reconciler
                   "--bind-address=$(NODE_IP)",
                   "--apiserver-port-mapping=6443:localhost:{{.KASPort}}"

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -76,7 +76,7 @@ const (
 	DefaultPSP = "00-k0s-privileged"
 	// Image Constants
 	KonnectivityImage                  = "quay.io/k0sproject/apiserver-network-proxy-agent"
-	KonnectivityImageVersion           = "0.0.27-k0s1"
+	KonnectivityImageVersion           = "0.0.27-k0s2"
 	MetricsImage                       = "k8s.gcr.io/metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.5.2"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"


### PR DESCRIPTION
use dest host strategy for konnectivity in the tunneled mode to avoid breaking connectivity in the network set up when workers don't have crossconnectivity

Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>

