### PR TITLE
Bump go to 1.17.6

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,4 +1,4 @@
-go_version = 1.17.5
+go_version = 1.17.6
 
 runc_version = 1.0.3
 runc_buildimage = golang:$(go_version)-alpine


### PR DESCRIPTION
Ref: https://github.com/golang/go/issues?q=milestone%3AGo1.17.6+label%3ACherryPickApproved

Signed-off-by: Natanael Copa <ncopa@mirantis.com>
