### PR TITLE
Use path "-" in backup and restore to write to stdout or read from stdin

### DIFF
--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -55,7 +55,7 @@ func NewBackupCmd() *cobra.Command {
 		},
 		PreRunE: preRunValidateConfig,
 	}
-	cmd.Flags().StringVar(&savePath, "save-path", "", "destination directory path for backup assets")
+	cmd.Flags().StringVar(&savePath, "save-path", "", "destination directory path for backup assets, use '-' for stdout")
 	cmd.SilenceUsage = true
 	cmd.Flags().AddFlagSet(config.FileInputFlag())
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
@@ -67,7 +67,7 @@ func (c *CmdOpts) backup() error {
 		logrus.Fatal("this command must be run as root!")
 	}
 
-	if !dir.IsDirectory(savePath) {
+	if savePath != "-" && !dir.IsDirectory(savePath) {
 		return fmt.Errorf("the save-path directory (%v) does not exist", savePath)
 	}
 

--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -43,7 +43,7 @@ var restoredConfigPath string
 func NewRestoreCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "restore filename",
-		Short: "restore k0s state from given backup archive. Must be run as root (or with sudo)",
+		Short: "restore k0s state from given backup archive. Use '-' as filename to read from stdin. Must be run as root (or with sudo)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := CmdOpts(config.GetCmdOpts())
 			if len(args) != 1 {
@@ -71,7 +71,7 @@ func (c *CmdOpts) restore(path string) error {
 		logrus.Fatal("k0s seems to be running! k0s must be down during the restore operation.")
 	}
 
-	if !file.Exists(path) {
+	if path != "-" && !file.Exists(path) {
 		return fmt.Errorf("given file %s does not exist", path)
 	}
 
@@ -107,6 +107,9 @@ func preRunValidateConfig(_ *cobra.Command, _ []string) error {
 // the default location for the restore operation is the currently running cwd
 // this can be override, by using the --config-out flag
 func defaultConfigFileOutputPath(archivePath string) string {
+	if archivePath == "-" {
+		return "-"
+	}
 	f := filepath.Base(archivePath)
 	nameWithoutExt := strings.Split(f, ".")[0]
 	fName := strings.TrimPrefix(nameWithoutExt, "k0s_backup_")

--- a/internal/pkg/archive/archive.go
+++ b/internal/pkg/archive/archive.go
@@ -36,13 +36,7 @@ func sanitizeExtractPath(dstDir string, filePath string) (string, error) {
 }
 
 // Extract the given tar.gz archive to given dst path
-func Extract(path, dst string) error {
-	input, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer input.Close()
-
+func Extract(input io.Reader, dst string) error {
 	gzr, err := gzip.NewReader(input)
 	if err != nil {
 		return err

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -57,6 +57,9 @@ check-configchange: TIMEOUT=8m
 # Node role check runs several cases
 check-noderole: TIMEOUT=6m
 
+# Backup check runs two scenarios
+check-backup: TIMEOUT=6m
+
 .PHONY: $(smoketests)
 include Makefile.variables
 

--- a/pkg/backup/config.go
+++ b/pkg/backup/config.go
@@ -5,6 +5,7 @@ package backup
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path"
 
@@ -50,6 +51,15 @@ func (c configurationStep) Restore(restoreFrom, restoreTo string) error {
 	}
 	logrus.Infof("Previously used k0s.yaml saved under the data directory `%s`", restoreTo)
 
+	if c.restoredConfigPath == "-" {
+		f, err := os.Open(objectPathInArchive)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = io.Copy(f, os.Stdout)
+		return err
+	}
 	logrus.Infof("restoring from `%s` to `%s`", objectPathInArchive, c.restoredConfigPath)
 	return file.Copy(objectPathInArchive, c.restoredConfigPath)
 }


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Fixes #1410 

* `k0s backup --save-path -` will output the archive to stdout
* `k0s restore -` will read the archive from stdin

You can use these to get encrypted backups via something like:

```shell
k0s backup --save-path - | gpg -c > backup.tar.gz.gpg
```

```shell
gpg -d backup.tar.gz.gpg | k0s restore -
```

Or remote backups via something like:

```shell
ssh host.example.com k0s backup --save-path - > backup.tar.gz
```

```shell
ssh host.example.com k0s restore - < backup.tar.gz
```

Note that the unencrypted backups will still briefly exist on the controller filesystem while the archive is being built.
