### PR TITLE
Fix lint on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ k0s.exe k0s: $(GO_SRCS)
 
 
 .PHONY: lint
-lint: pkg/assets/zz_generated_offsets_$(TARGET_OS).go
+lint: pkg/assets/zz_generated_offsets_$(shell go env GOOS).go
 	$(golint) run --verbose ./...
 
 .PHONY: $(smoketests)


### PR DESCRIPTION
Make sure that zz_generated_offsets_darwin.go is generated when running
lint on macos.

