### PR TITLE
Test that kubeconfig returns externalAddress

### DIFF
--- a/inttest/customports/customports_test.go
+++ b/inttest/customports/customports_test.go
@@ -138,13 +138,13 @@ func (ds *Suite) TestControllerJoinsWithCustomPort() {
 	ds.Require().NoError(common.WaitForPodLogs(kc, "kube-system"))
 
 	// https://github.com/k0sproject/k0s/issues/1202
-	ds.T().Log("test that kubeconfig includes externalAddress")
-	ssh, err := ds.SSH(ds.ControllerNode(0))
-	ds.Require().NoError(err)
-	defer ssh.Disconnect()
+	ds.T().Run("kubeconfigIncludesExternalAddress", func(t *testing.T) {
+		ssh, err := ds.SSH(ds.ControllerNode(0))
+		ds.Require().NoError(err)
+		defer ssh.Disconnect()
 
-	out, err := ssh.ExecWithOutput("k0s kubeconfig create user | awk '$1 == \"server:\" {print $2}'")
-	ds.Require().NoError(err)
-	ds.Require().Equal(fmt.Sprintf("https://%s:%d", ipAddress, kubeAPIPort), out)
-
+		out, err := ssh.ExecWithOutput("k0s kubeconfig create user | awk '$1 == \"server:\" {print $2}'")
+		ds.Require().NoError(err)
+		ds.Require().Equal(fmt.Sprintf("https://%s:%d", ipAddress, kubeAPIPort), out)
+	})
 }


### PR DESCRIPTION
Add a test to verify that the server address is set to externalAddress
when it is set, and that the custom ports are included in the
kubeconfig.

This is a test for issue https://github.com/k0sproject/k0s/issues/1202

Signed-off-by: Natanael Copa <ncopa@mirantis.com>
