### PR TITLE
Remove kube-proxy mode check for dual stack

### DIFF
--- a/pkg/apis/k0s.k0sproject.io/v1beta1/network.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/network.go
@@ -81,9 +81,6 @@ func (n *Network) Validate() []error {
 		if err != nil {
 			errors = append(errors, fmt.Errorf("invalid service IPv6 CIDR %s", n.DualStack.IPv6ServiceCIDR))
 		}
-		if !n.KubeProxy.Disabled && n.KubeProxy.Mode != ModeIPVS {
-			errors = append(errors, fmt.Errorf("dual-stack requires kube-proxy in ipvs mode"))
-		}
 	}
 	errors = append(errors, n.KubeProxy.Validate()...)
 	return errors

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/network_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/network_test.go
@@ -253,22 +253,6 @@ func (s *NetworkSuite) TestValidation() {
 		s.Contains(errors[0].Error(), "unsupported mode")
 	})
 
-	s.T().Run("invalid_proxy_mode_for_dualstack", func(t *testing.T) {
-		n := DefaultNetwork()
-		n.Calico = DefaultCalico()
-		n.Calico.Mode = "bird"
-		n.DualStack = DefaultDualStack()
-		n.DualStack.Enabled = true
-		n.KubeProxy.Mode = "iptables"
-		n.DualStack.IPv6PodCIDR = "fd00::/108"
-		n.DualStack.IPv6ServiceCIDR = "fd01::/108"
-
-		errors := n.Validate()
-		s.NotNil(errors)
-		s.Len(errors, 1)
-		s.Contains(errors[0].Error(), "dual-stack requires kube-proxy in ipvs mode")
-	})
-
 	s.T().Run("valid_proxy_disabled_for_dualstack", func(t *testing.T) {
 		n := DefaultNetwork()
 		n.Calico = DefaultCalico()


### PR DESCRIPTION
Nowadays, neither Calico doc (https://projectcalico.docs.tigera.io/networking/ipv6) nor Kubernetes doc (https://kubernetes.io/docs/concepts/services-networking/dual-stack/) requires kube-proxy mode to be `ipvs` for running dual stack.

I also tested `v1.23.1+k0s.0` using `iptables` kube-proxy mode, the dual stack works well.

This simple PR drops the  kube-proxy mode check for dual stack.

(No need to update the documentation, since the documentation does not mention kube-proxy mode for dual stack)

Signed-off-by: Xinfeng Liu <Xinfeng.Liu@gmail.com>

