### PR TITLE
Add an example of encrypting backups to docs/backup.md

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -35,6 +35,8 @@ The command provides backup archive using following naming convention: `k0s_back
 
 Because of the DateTime usage, it is guaranteed that none of the previously created archives would be overwritten.
 
+To output the backup archive to stdout, use `-` as the save path.
+
 ### Restore (local)
 
 To restore cluster state from the archive use the following command on the controller node:
@@ -53,6 +55,68 @@ E.g. steps for N nodes cluster would be:
 - Restore backup on fresh machine
 - Run controller there
 - Join N-1 new machines to the cluster the same way as for the first setup.
+
+To read the backup archive from stdin, use `-` as the file path.
+
+### Encrypting backups (local)
+
+By using `-` as the save or restore path, it is possible to pipe the backup archive through an encryption utility such as [GnuPG](https://gnupg.org/) or [OpenSSL](https://www.openssl.org/).
+
+Note that unencrypted data will still briefly exist as temporary files on the local file system during the backup archvive generation.
+
+#### Encrypting backups using GnuPG
+
+Follow the instructions for your operating system to install the `gpg` command if it is not already installed.
+
+This tutorial only covers the bare minimum for example purposes. For secure key management practices and advanced usage refer to the GnuPG user manual.
+
+To generate a new key-pair, use:
+
+```shell
+gpg --gen-key
+```
+
+The key will be stored in your key ring.
+
+```shell
+gpg --list-keys
+```
+
+This will output a list of keys:
+
+```shell
+/home/user/.gnupg/pubring.gpg
+------------------------------
+pub   4096R/BD33228F 2022-01-13
+uid                  Example User <user@example.com>
+sub   4096R/2F78C251 2022-01-13
+```
+
+To export the private key for decrypting the backup on another host, note the key ID ("BD33228F" in this example) in the list and use:
+
+```shell
+gpg --export-secret-keys --armor BD33228F > k0s.key
+```
+
+To create an encrypted k0s backup:
+
+```shell
+k0s backup --save-path - | gpg --encrypt --recipient user@example.com > backup.tar.gz.gpg
+```
+
+#### Restoring encrypted backups using GnuPG
+
+You must have the private key in your gpg keychain. To import the key that was exported in the previous example, use:
+
+```shell
+gpg --import k0s.key
+```
+
+To restore the encrypted backup, use:
+
+```shell
+gpg --decrypt backup.tar.gz.gpg | k0s restore -
+```
 
 ## Backup/restore a k0s cluster using k0sctl
 


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Adds a simple example of how to encrypt backups by piping them through gpg.
