### PR TITLE
Building multiarch k0s image on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,7 @@
 *
 !docker-entrypoint.sh
 !k0s
+!k0s-arm
+!k0s-arm64
+!k0s-amd64
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       tag_name: ${{ steps.branch_name.outputs.TAG_NAME }}
+      image_tag: ${{ steps.image_tag.outputs.IMAGE_TAGS }}
     steps:
       # Ugly hack to get the tag name
       # github.ref gives the full reference like refs.tags.v0.0.1-beta1
@@ -33,7 +34,13 @@ jobs:
           release_name: ${{ github.ref }}
           draft: true # So we can manually edit before publishing
           prerelease: ${{ contains(github.ref, '-') }} # v0.1.2-beta1, 1.2.3-rc1
-
+      - name: Prepare image tags
+        id: image_tag
+        # Basically just replace the '+' with '-' as '+' is not allowed in tags
+        run: |
+          TAGS=${{ steps.branch_name.outputs.TAG_NAME }}
+          TAGS=${TAGS//+/-}
+          echo ::set-output name=IMAGE_TAGS::${TAGS}
   x64:
     needs: release
     runs-on: [self-hosted,linux,x64]
@@ -99,43 +106,6 @@ jobs:
           asset_name: k0s-airgap-bundle-${{ needs.release.outputs.tag_name }}-amd64
           asset_content_type: application/octet-stream
 
-      - name: Prepare tags
-        id: prep
-        # Basically just replace the '+' with '-' as '+' is not allowed in tags
-        run: |
-          TAGS=${{ needs.release.outputs.tag_name }}
-          TAGS=${TAGS//+/-}
-          echo ::set-output name=tags::${TAGS}
-
-      - name: Build image and push to GitHub image registry
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: k0sproject/k0s/k0s
-          tags: ${{ steps.prep.outputs.tags }}
-
-      - name: Build image and push to Docker hub
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          registry: docker.io
-          repository: k0sproject/k0s
-          tags: ${{ steps.prep.outputs.tags }}
-
-      # Need to remove this from maintenance branches
-      # Done as separate step for better control when we push latest
-      - name: Build image and push to Docker hub
-        if: "!contains(github.ref, '-')"
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          registry: docker.io
-          repository: k0sproject/k0s
-          tags: latest
 
   windows:
     needs: release
@@ -223,6 +193,12 @@ jobs:
           asset_name: k0s-${{ needs.release.outputs.tag_name }}-arm64
           asset_content_type: application/octet-stream
 
+      - name: Upload Artifact for use in other Jobs
+        uses: actions/upload-artifact@v2
+        with:
+          name: k0s-arm64
+          path: ./k0s
+
       - name: Upload Release Assets - Bundle
         id: upload-release-asset-images
         uses: actions/upload-release-asset@v1
@@ -279,6 +255,12 @@ jobs:
           asset_name: k0s-${{ needs.release.outputs.tag_name }}-arm
           asset_content_type: application/octet-stream
 
+      - name: Upload Artifact for use in other Jobs
+        uses: actions/upload-artifact@v2
+        with:
+          name: k0s-arm
+          path: ./k0s
+
       - name: Upload Release Assets - Bundle
         id: upload-release-asset-images
         uses: actions/upload-release-asset@v1
@@ -289,6 +271,54 @@ jobs:
           asset_path: ./image-bundle/bundle.tar
           asset_name: k0s-airgap-bundle-${{ needs.release.outputs.tag_name }}-arm
           asset_content_type: application/octet-stream
+
+
+  build-image:
+    needs:
+      - release
+      - x64
+      - arm64
+      - armv7
+    runs-on: [self-hosted,linux,x64]
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Fetch k0s amd64
+        uses: actions/download-artifact@v2
+        with:
+          name: k0s-amd64
+      - name: Fetch k0s arm64
+        uses: actions/download-artifact@v2
+        with:
+          name: k0s-arm64
+      - name: Fetch k0s arm
+        uses: actions/download-artifact@v2
+        with:
+          name: k0s-arm
+
+      - name: Build image and push to Docker Hub and GitHub image registry
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: |
+            ghcr.io/k0sproject/k0s:${{ needs.release.outputs.image_tag }}
+            docker.io/k0sproject/k0s:${{ needs.release.outputs.image_tag }}
+          push: true
+
 
   conformance-test:
     needs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
-FROM alpine:3.13
+ARG ARCH
+FROM ${ARCH}alpine:3.15
+ARG TARGETARCH
 
-RUN apk add --no-cache bash coreutils findutils iptables curl tini
+RUN apk add --no-cache bash coreutils findutils curl tini
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.20.1/bin/linux/amd64/kubectl \
-       && chmod +x ./kubectl \
-       && mv ./kubectl /usr/local/bin/kubectl
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
 ADD docker-entrypoint.sh /entrypoint.sh
-ADD ./k0s /usr/local/bin/k0s 
+ADD ./k0s-${TARGETARCH} /usr/local/bin/k0s
 
 ENTRYPOINT ["/sbin/tini", "--", "/bin/sh", "/entrypoint.sh" ]
 


### PR DESCRIPTION
Signed-off-by: makhov <amakhov@mirantis.com>

Currently, we are building only amd64 docker images: https://hub.docker.com/r/k0sproject/k0s/tags
<img width="764" alt="Screenshot 2022-01-14 at 14 33 00" src="https://user-images.githubusercontent.com/557879/149516105-450469af-14a5-4071-a052-525439647ceb.png">

With this change, we will build a multiarch image with armv7/arm64 support:

<img width="730" alt="Screenshot 2022-01-14 at 14 33 57" src="https://user-images.githubusercontent.com/557879/149516204-415f3668-5e87-45b6-a374-b3c155b95793.png">

