### PR TITLE
Add arguments from upstream kubectl; add e2e tests for common cases

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -151,8 +151,6 @@ jobs:
           - check-dualstack
           - check-externaletcd
           - check-hacontrolplane
-          # exists in inttest/Makefile.variables but there's no matching suite:
-          #- check-install
           - check-kine
           - check-metrics
           - check-multicontroller
@@ -169,8 +167,7 @@ jobs:
           - check-statussocket
           - check-tunneledkas
           - check-workerrestart
-          # skipped, originally titled "Smoke-test for network":
-          # - check-etcd
+          - check-kubectl
 
     steps:
       - name: Get PR Reference and Set Cache Name

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/component-base/logs"
 	kubectl "k8s.io/kubectl/pkg/cmd"
 
 	"github.com/k0sproject/k0s/pkg/config"
@@ -128,6 +129,6 @@ func NewK0sKubectlCmd() *cobra.Command {
 
 		originalRun(cmd, args)
 	}
-
+	logs.AddFlags(cmd.PersistentFlags())
 	return cmd
 }

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -26,4 +26,5 @@ smoketests := \
 	check-statussocket \
 	check-tunneledkas \
 	check-upgrade \
-	check-workerrestart
+	check-workerrestart	\
+	check-kubectl

--- a/inttest/kubectl/kubectl_test.go
+++ b/inttest/kubectl/kubectl_test.go
@@ -1,0 +1,130 @@
+package kubectl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/stretchr/testify/suite"
+)
+
+type KubectlSuite struct {
+	common.FootlooseSuite
+}
+
+const pluginContent = `#!/bin/bash
+
+echo "foo-plugin"
+`
+
+func (s *KubectlSuite) TestEmbeddedKubectl() {
+	s.Require().NoError(s.InitController(0, "--enable-k0s-cloud-provider", "--k0s-cloud-provider-update-frequency=5s"))
+	s.PutFile(s.ControllerNode(0), "/bin/kubectl-foo", pluginContent)
+
+	ssh, err := s.SSH(s.ControllerNode(0))
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	_, err = ssh.ExecWithOutput("chmod +x /bin/kubectl-foo")
+	s.Require().NoError(err)
+	_, err = ssh.ExecWithOutput("ln -s /usr/bin/k0s /usr/bin/kubectl")
+	s.Require().NoError(err)
+
+	s.T().Log("Check that different ways to call kubectl subcommand work")
+
+	tests := []struct {
+		Name    string
+		Command string
+		Check   func(output string, err error)
+	}{
+		{
+			Name:    "full subcommand name",
+			Command: "k0s kubectl version",
+			Check: func(output string, e error) {
+				s.Require().NoError(e)
+				s.Require().True(strings.HasPrefix(output, "Client Version: version.Info"))
+			},
+		},
+		{
+			Name:    "short subcommand name",
+			Command: "k0s kc version",
+			Check: func(output string, e error) {
+				s.Require().NoError(e)
+				s.Require().True(strings.HasPrefix(output, "Client Version: version.Info"))
+			},
+		},
+		{
+			Name:    "full command arguments",
+			Command: "k0s kubectl version -v 8",
+			Check: func(output string, e error) {
+				s.Require().NoError(e)
+				// Check for debug log messages
+				s.Require().True(strings.Contains(output, "round_trippers.go"))
+			},
+		},
+		{
+			Name:    "short command arguments",
+			Command: "k0s kc version -v 8",
+			Check: func(output string, e error) {
+				s.Require().NoError(e)
+				// Check for debug log messages
+				s.Require().True(strings.Contains(output, "round_trippers.go"))
+			},
+		},
+		{
+			Name:    "full command plugin loader",
+			Command: "k0s kubectl foo",
+			Check: func(output string, e error) {
+				s.Require().NoError(e)
+				s.Require().Equal(output, "foo-plugin")
+			},
+		},
+		{
+			Name:    "short command plugin loader",
+			Command: "k0s kc foo",
+			Check: func(output string, e error) {
+				s.Require().NoError(e)
+				s.Require().Equal(output, "foo-plugin")
+			},
+		},
+
+		{
+			Name:    "symlink command",
+			Command: "kubectl version",
+			Check: func(output string, e error) {
+				s.Require().NoError(e)
+				s.Require().True(strings.HasPrefix(output, "Client Version: version.Info"))
+			},
+		},
+		{
+			Name:    "symlink arguments",
+			Command: "kubectl version -v 8",
+			Check: func(output string, e error) {
+				s.Require().NoError(e)
+				// Check for debug log messages
+				s.Require().True(strings.Contains(output, "round_trippers.go"))
+			},
+		},
+		{
+			Name:    "symlink plugin loader",
+			Command: "k0s kubectl foo",
+			Check: func(output string, e error) {
+				s.Require().NoError(e)
+				s.Require().Equal(output, "foo-plugin")
+			},
+		},
+	}
+	for _, test := range tests {
+		s.T().Logf("Trying %s with command `%s`", test.Name, test.Command)
+		output, err := ssh.ExecWithOutput(test.Command)
+		test.Check(output, err)
+	}
+}
+
+func TestKubectlCommand(t *testing.T) {
+	suite.Run(t, &KubectlSuite{
+		common.FootlooseSuite{
+			ControllerCount: 1,
+		},
+	})
+}

--- a/inttest/kubectl/kubectl_test.go
+++ b/inttest/kubectl/kubectl_test.go
@@ -18,7 +18,7 @@ echo "foo-plugin"
 `
 
 func (s *KubectlSuite) TestEmbeddedKubectl() {
-	s.Require().NoError(s.InitController(0, "--enable-k0s-cloud-provider", "--k0s-cloud-provider-update-frequency=5s"))
+	s.Require().NoError(s.InitController(0))
 	s.PutFile(s.ControllerNode(0), "/bin/kubectl-foo", pluginContent)
 
 	ssh, err := s.SSH(s.ControllerNode(0))


### PR DESCRIPTION
Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>
Addressed #1405 

Ports e2e tests from #1408 but uses more simpler approach which doesn't fails on arm.

The approach used in #1408 is broken on arm due to different logic for argument handling: attaching KubectlCmd to the RootCmd overrides some arguments (but only on arm). 