### PR TITLE
Instead of compiling binary use latest release for the manual publish workflow

### DIFF
--- a/.github/workflows/publish-docs-manual.yml
+++ b/.github/workflows/publish-docs-manual.yml
@@ -47,20 +47,6 @@ jobs:
           cp -p main/mkdocs.yml mkdocs.yml
           rm -rf main
 
-      - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GO_VERSION }}
-        id: go
-
-      - uses: actions/cache@v2
-        name: Go modules cache
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Generate docs
         run: make -C docs
 

--- a/.github/workflows/publish-docs-manual.yml
+++ b/.github/workflows/publish-docs-manual.yml
@@ -10,7 +10,8 @@ env:
   GO_VERSION: ^1.17
   NODE_VERSION: 12.x
   PYTHON_VERSION: 3.x
-
+  TARGET_VERSION: ${{ github.event.inputs.version }}
+  
 jobs:
   build:
     name: Deploy docs

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -15,6 +15,8 @@ RUN \
   apk add --no-cache \
     git \
     git-fast-import \
+    curl \
+    jq \
   && apk add --no-cache --virtual .build gcc musl-dev \
   && python -m pip install --upgrade pip \
   && pip install -r requirements.txt \

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,13 +21,19 @@ endif
 docs: cli
 	cd .. && mkdocs build --strict
 
+LATEST_RELEASE_META_URL=https://api.github.com/repos/k0sproject/k0s/releases/latest
+JQ_COMMAND=jq -r '.assets[]|select(.browser_download_url|contains("amd64"))|select(.browser_download_url|contains(".exe")|not)|select(.browser_download_url|contains("bundle")|not).browser_download_url'
+
+.PHONY: k0s_release_binary
+k0s_release_binary:
+	curl -L -o ./k0s `curl $(LATEST_RELEASE_META_URL) | $(JQ_COMMAND)`
+	chmod +x ./k0s
+
 .PHONY: cli
-cli:
+cli: k0s_release_binary
 	rm -rf cli
 	mkdir cli
-	$(MAKE) -C .. static/gen_manifests.go EMBEDDED_BINS_BUILDMODE=none
-	$(MAKE) -C .. generate-bindata TARGET_OS=$(detected_OS)
-	cd .. && go run main.go docs markdown
+	cd .. && ./k0s docs markdown
 	rm cli/k0s_kubectl_*
 	sed $(sedopt) '/\[k0s kubectl /d' cli/k0s_kubectl.md
 	ln -s k0s.md cli/README.md

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,13 +15,14 @@ else
 sedopt := -i -e
 endif
 
+TARGET_VERSION ?= latest
 # mkdocs.yml refuses to live in the docs-directory, this is why "cd .." is needed
 # gives: "Error: The 'docs_dir' should not be the parent directory of the config file."
 # even if docs_dir is "."
 docs: cli
 	cd .. && mkdocs build --strict
 
-LATEST_RELEASE_META_URL=https://api.github.com/repos/k0sproject/k0s/releases/latest
+LATEST_RELEASE_META_URL=https://api.github.com/repos/k0sproject/k0s/releases/$(TARGET_VERSION)
 JQ_COMMAND=jq -r '.assets[]|select(.browser_download_url|contains("amd64"))|select(.browser_download_url|contains(".exe")|not)|select(.browser_download_url|contains("bundle")|not).browser_download_url'
 
 .PHONY: k0s_release_binary
@@ -33,7 +34,7 @@ k0s_release_binary:
 cli: k0s_release_binary
 	rm -rf cli
 	mkdir cli
-	cd .. && ./k0s docs markdown
+	cd .. && ./docs/k0s docs markdown
 	rm cli/k0s_kubectl_*
 	sed $(sedopt) '/\[k0s kubectl /d' cli/k0s_kubectl.md
 	ln -s k0s.md cli/README.md


### PR DESCRIPTION
Use latest public release for publishing docs, instead of compiling by `go run main.go`

Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>

