### PR TITLE
Using extension name as a helm release name

### DIFF
--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -138,7 +138,7 @@ func (as *AddonsSuite) waitForPrometheusServerEnvs(releaseName string) error {
 	}
 
 	return wait.PollImmediate(time.Second, 2*time.Minute, func() (done bool, err error) {
-		serverDeployment := fmt.Sprintf("%s-server", releaseName)
+		serverDeployment := fmt.Sprintf("%s-prometheus-server", releaseName)
 		d, err := kc.AppsV1().Deployments("default").Get(context.TODO(), serverDeployment, v1.GetOptions{})
 		if err != nil {
 			return false, nil
@@ -226,6 +226,7 @@ metadata:
     - helm.k0sproject.io/uninstall-helm-release 
 spec:
   chartName: {{ .ChartName }}
+  releaseName: {{ .Name }}
   values: |
 {{ .Values | nindent 4 }}
   version: {{ .Version }}

--- a/pkg/apis/helm.k0sproject.io/v1beta1/chart_types.go
+++ b/pkg/apis/helm.k0sproject.io/v1beta1/chart_types.go
@@ -23,10 +23,11 @@ import (
 
 // ChartSpec defines the desired state of Chart
 type ChartSpec struct {
-	ChartName string `json:"chartName,omitempty"`
-	Values    string `json:"values,omitempty"`
-	Version   string `json:"version,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
+	ChartName   string `json:"chartName,omitempty"`
+	ReleaseName string `json:"releaseName,omitempty"`
+	Values      string `json:"values,omitempty"`
+	Version     string `json:"version,omitempty"`
+	Namespace   string `json:"namespace,omitempty"`
 }
 
 // YamlValues returns values as map

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/extensions.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/extensions.go
@@ -15,7 +15,11 @@ limitations under the License.
 */
 package v1beta1
 
-import "errors"
+import (
+	"errors"
+
+	"helm.sh/helm/v3/pkg/chartutil"
+)
 
 var _ Validateable = (*ClusterExtensions)(nil)
 
@@ -93,6 +97,9 @@ type Chart struct {
 func (c Chart) Validate() error {
 	if c.Name == "" {
 		return errors.New("chart must have Name field not empty")
+	}
+	if err := chartutil.ValidateReleaseName(c.Name); err != nil {
+		return err
 	}
 	if c.ChartName == "" {
 		return errors.New("chart must have ChartName field not empty")

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -207,6 +207,7 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart v1bet
 		// new chartRelease
 		chartRelease, err = cr.helm.InstallChart(chart.Spec.ChartName,
 			chart.Spec.Version,
+			chart.Spec.ReleaseName,
 			chart.Spec.Namespace,
 			chart.Spec.YamlValues())
 		if err != nil {
@@ -253,6 +254,7 @@ metadata:
     - {{ .Finalizer }}
 spec:
   chartName: {{ .ChartName }}
+  releaseName: {{ .Name }}
   values: |
 {{ .Values | nindent 4 }}
   version: {{ .Version }}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -208,7 +208,7 @@ func (hc *Commands) isInstallable(chart *chart.Chart) bool {
 	return true
 }
 
-func (hc *Commands) InstallChart(chartName string, version string, namespace string, values map[string]interface{}) (*release.Release, error) {
+func (hc *Commands) InstallChart(chartName string, version string, releaseName string, namespace string, values map[string]interface{}) (*release.Release, error) {
 	cfg, err := hc.getActionCfg(namespace)
 	if err != nil {
 		return nil, fmt.Errorf("can't create action configuration: %v", err)
@@ -220,7 +220,7 @@ func (hc *Commands) InstallChart(chartName string, version string, namespace str
 		return nil, err
 	}
 	install.Namespace = namespace
-	install.GenerateName = true
+	install.ReleaseName = releaseName
 	name, _, err := install.NameAndChart([]string{chartName})
 	install.ReleaseName = name
 

--- a/static/manifests/helm/CustomResourceDefinition/helm.k0sproject.io_charts.yaml
+++ b/static/manifests/helm/CustomResourceDefinition/helm.k0sproject.io_charts.yaml
@@ -38,6 +38,8 @@ spec:
             properties:
               chartName:
                 type: string
+              releaseName:
+                type: string
               namespace:
                 type: string
               values:


### PR DESCRIPTION
Addresses https://github.com/k0sproject/k0s/issues/1456#issuecomment-1018656788

Currently, the helm release name is generated by Helm itself which is not very useful. With the change, k0s passes  `extensions.helm.charts[].name` as a release name.