### PR TITLE
Bump kubernetes to 1.22.6 and konnectivity to 0.0.27-k0s2

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,7 +79,7 @@ spec:
       version: v0.5.0
     kubeproxy:
       image: k8s.gcr.io/kube-proxy
-      version: v1.22.5
+      version: v1.22.6
     coredns:
       image: k8s.gcr.io/coredns/coredns
       version: v1.7.0

--- a/docs/install.md
+++ b/docs/install.md
@@ -48,7 +48,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
 
     ```shell
     $ sudo k0s status
-    Version: v1.22.5+k0s.1
+    Version: v1.22.6+k0s.1
     Process ID: 436
     Role: controller
     Workloads: true
@@ -64,7 +64,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
     ```shell
     $ sudo k0s kubectl get nodes
     NAME   STATUS   ROLES    AGE    VERSION
-    k0s    Ready    <none>   4m6s   v1.22.5-k0s1
+    k0s    Ready    <none>   4m6s   v1.22.6-k0s1
     ```
 
 ## Uninstall k0s

--- a/docs/k0s-multi-node.md
+++ b/docs/k0s-multi-node.md
@@ -24,13 +24,13 @@ The download script accepts the following environment variables:
 
 | Variable                   | Purpose                                           |
 |:---------------------------|:--------------------------------------------------|
-| `K0S_VERSION=v1.22.5+k0s.0 | Select the version of k0s to be installed         |
+| `K0S_VERSION=v1.22.6+k0s.0 | Select the version of k0s to be installed         |
 | `DEBUG=true`               | Output commands and their arguments at execution. |
 
 **Note**: If you require environment variables and use sudo, you can do:
 
 ```shell
-curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.22.5+k0s.0 sh
+curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.22.6+k0s.0 sh
 ```
 
 ### 2. Bootstrap a controller node
@@ -123,7 +123,7 @@ To get general information about your k0s instance's status:
 
 ```shell
 $ sudo k0s status
-Version: v1.22.5+k0s.0
+Version: v1.22.6+k0s.0
 Process ID: 2769
 Parent Process ID: 1
 Role: controller
@@ -138,7 +138,7 @@ Use the Kubernetes 'kubectl' command-line tool that comes with k0s binary to dep
 ```shell
 $ sudo k0s kubectl get nodes
 NAME   STATUS   ROLES    AGE    VERSION
-k0s    Ready    <none>   4m6s   v1.22.5-k0s1
+k0s    Ready    <none>   4m6s   v1.22.6-k0s1
 ```
 
 You can also access your cluster easily with [Lens](https://k8slens.dev/), simply by copying the kubeconfig and pasting it to Lens:

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -12,6 +12,6 @@ The biggest new k0s features will typically only be delivered on top of the late
 
 The k0s version string consists of the Kubernetes version and the k0s version. For example:
 
-- v1.22.5+k0s.0
+- v1.22.6+k0s.0
 
-The Kubernetes version (1.22.5) is the first part, and the last part (k0s.0) reflects the k0s version, which is built on top of the certain Kubernetes version.
+The Kubernetes version (1.22.6) is the first part, and the last part (k0s.0) reflects the k0s version, which is built on top of the certain Kubernetes version.

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -17,7 +17,7 @@ containerd_build_shim_go_cgo_enabled = 0
 #containerd_build_go_ldflags =
 containerd_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
-kubernetes_version = 1.22.5
+kubernetes_version = 1.22.6
 kubernetes_buildimage = golang:$(go_version)-alpine
 kubernetes_build_go_tags = "providerless"
 #kubernetes_build_go_cgo_enabled =

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -41,7 +41,7 @@ etcd_build_go_cgo_enabled = 0
 etcd_build_go_ldflags = "-w -s"
 #etcd_build_go_ldflags_extra =
 
-konnectivity_version = 0.0.25
+konnectivity_version = 0.0.27-k0s2
 konnectivity_buildimage = golang:$(go_version)-alpine
 #konnectivity_build_go_tags =
 konnectivity_build_go_cgo_enabled = 0

--- a/embedded-bins/konnectivity/Dockerfile
+++ b/embedded-bins/konnectivity/Dockerfile
@@ -10,7 +10,7 @@ ARG BUILD_GO_LDFLAGS_EXTRA
 
 RUN apk add build-base git make
 
-RUN git clone -b v$VERSION --depth=1 https://github.com/kubernetes-sigs/apiserver-network-proxy.git /apiserver-network-proxy
+RUN git clone -b v$VERSION --depth=1 https://github.com/k0sproject/apiserver-network-proxy.git /apiserver-network-proxy
 WORKDIR /apiserver-network-proxy
 RUN go version
 RUN GO111MODULE=on go get github.com/golang/mock/mockgen@v1.4.4 && \

--- a/examples/footloose-ha-controllers/Dockerfile
+++ b/examples/footloose-ha-controllers/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/footloose/ubuntu18.04
 
 ADD k0s.service /etc/systemd/system/k0s.service
 
-RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.5/bin/linux/amd64/kubectl && \
+RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.6/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf

--- a/inttest/conformance/README.md
+++ b/inttest/conformance/README.md
@@ -35,15 +35,15 @@ In order to run the conformance test, you will need to set the tested k0s versio
 In the same directory as your `main.tf` file, create an additional file `terraform.tfvars` with the following input:
 
 ```terraform
-k0s_version=v1.22.5+k0s.0
-k8s_version=v1.22.5
+k0s_version=v1.22.6+k0s.0
+k8s_version=v1.22.6
 sonobuoy_version=0.53.2
 ```
 
 ### 2. Environment variables
 
 ```shell
-TF_VAR_k0s_version=v1.22.5+k0s.0 TF_VAR_sonobuoy_version=0.20.0 TF_VAR_k8s_version=v1.22.5 terraform apply
+TF_VAR_k0s_version=v1.22.6+k0s.0 TF_VAR_sonobuoy_version=0.20.0 TF_VAR_k8s_version=v1.22.6 terraform apply
 ```
 
 **NOTE:** By default, terraform will fetch sonobuoy version **0.53.2**. If you want to use a different version you can override this with one of the above methods.

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/images_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/images_test.go
@@ -38,7 +38,7 @@ func TestImagesRepoOverrideInConfiguration(t *testing.T) {
 			cfg.Spec.Images.Repository = "my.repo"
 			var testingConfig *ClusterConfig
 			require.NoError(t, yaml.Unmarshal(getConfigYAML(t, cfg), &testingConfig))
-			require.Equal(t, fmt.Sprintf("my.repo/kas-network-proxy/proxy-agent:%s", constant.KonnectivityImageVersion), testingConfig.Spec.Images.Konnectivity.URI())
+			require.Equal(t, fmt.Sprintf("my.repo/k0sproject/apiserver-network-proxy-agent:%s", constant.KonnectivityImageVersion), testingConfig.Spec.Images.Konnectivity.URI())
 			require.Equal(t, fmt.Sprintf("my.repo/metrics-server/metrics-server:%s", constant.MetricsImageVersion), testingConfig.Spec.Images.MetricsServer.URI())
 			require.Equal(t, fmt.Sprintf("my.repo/kube-proxy:%s", constant.KubeProxyImageVersion), testingConfig.Spec.Images.KubeProxy.URI())
 			require.Equal(t, fmt.Sprintf("my.repo/coredns/coredns:%s", constant.CoreDNSImageVersion), testingConfig.Spec.Images.CoreDNS.URI())

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -75,8 +75,8 @@ const (
 	// DefaultPSP defines the system level default PSP to apply
 	DefaultPSP = "00-k0s-privileged"
 	// Image Constants
-	KonnectivityImage                  = "k8s.gcr.io/kas-network-proxy/proxy-agent"
-	KonnectivityImageVersion           = "v0.0.25"
+	KonnectivityImage                  = "quay.io/k0sproject/apiserver-network-proxy-agent"
+	KonnectivityImageVersion           = "0.0.27-k0s2"
 	MetricsImage                       = "k8s.gcr.io/metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.5.0"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -80,7 +80,7 @@ const (
 	MetricsImage                       = "k8s.gcr.io/metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.5.0"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"
-	KubeProxyImageVersion              = "v1.22.5"
+	KubeProxyImageVersion              = "v1.22.6"
 	CoreDNSImage                       = "k8s.gcr.io/coredns/coredns"
 	CoreDNSImageVersion                = "v1.7.0"
 	CalicoImage                        = "docker.io/calico/cni"


### PR DESCRIPTION
Use the k0sproject fork of konnectivity so we get the armv7 image.

Ref: https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/309

Bump kubernetes to 1.22.6.