### PR TITLE
Fix k0s kubeconfig create usage hint

### DIFF
--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -59,16 +59,16 @@ users:
 
 func kubeconfigCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create [username]",
+		Use:   "create username",
 		Short: "Create a kubeconfig for a user",
 		Long: `Create a kubeconfig with a signed certificate and public key for a given user (and optionally user groups)
 Note: A certificate once signed cannot be revoked for a particular user`,
 		Example: `	Command to create a kubeconfig for a user:
 	CLI argument:
-	$ k0s kubeconfig create [username]
+	$ k0s kubeconfig create username
 
 	optionally add groups:
-	$ k0s kubeconfig create [username] --groups [groups]`,
+	$ k0s kubeconfig create username --groups [groups]`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// disable cfssl log
 			log.Level = log.LevelFatal


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Before:

```
$ ./k0s kubeconfig create --help
Usage:
  create [username] [flags]
```

After:

```
$ ./k0s kubeconfig create --help
Usage:
  create username [flags]
```

The usage hint implies that username is optional.

Also noticed something odd:

```
$ ./k0s kubeconfig
Usage:
  create [username] [flags]
$ ./k0s kubeconfig --help
Create a kubeconfig file for a specified user

Usage:
  k0s kubeconfig [command] [flags]
  k0s kubeconfig [command]

Available Commands:
  admin       Display Admin's Kubeconfig file
  create      Create a kubeconfig for a user
```

For some reason `k0s kubeconfig` without arguments outputs the `k0s kubeconfig create` help text.

Also not sure why it is necessary to have separate `k0s kubeconfig create` and `k0s kubeconfig admin` sub-commands.

