### PR TITLE
Prepare for release 1.21.9

### DIFF
--- a/docs/airgap-install.md
+++ b/docs/airgap-install.md
@@ -84,7 +84,7 @@ spec:
         dstDir: /var/lib/k0s/images/
         perm: 0755
   k0s:
-    version: 1.21.8+k0s.0
+    version: 1.21.9+k0s.0
 ```
 
 ## 3. Ensure pull policy in the k0s.yaml (optional)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,7 +78,7 @@ spec:
       version: v0.3.7
     kubeproxy:
       image: k8s.gcr.io/kube-proxy
-      version: v1.21.8
+      version: v1.21.9
     coredns:
       image: docker.io/coredns/coredns
       version: 1.7.0

--- a/docs/install.md
+++ b/docs/install.md
@@ -64,7 +64,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
     ```shell
     $ sudo k0s kubectl get nodes
     NAME   STATUS   ROLES    AGE    VERSION
-    k0s    Ready    <none>   4m6s   v1.21.8-k0s1
+    k0s    Ready    <none>   4m6s   v1.21.9-k0s1
     ```
 
 ## Uninstall k0s

--- a/docs/k0s-multi-node.md
+++ b/docs/k0s-multi-node.md
@@ -24,13 +24,13 @@ The download script accepts the following environment variables:
 
 | Variable                   | Purpose                                           |
 |:---------------------------|:--------------------------------------------------|
-| `K0S_VERSION=v1.21.8+k0s.0 | Select the version of k0s to be installed         |
+| `K0S_VERSION=v1.21.9+k0s.0 | Select the version of k0s to be installed         |
 | `DEBUG=true`               | Output commands and their arguments at execution. |
 
 **Note**: If you require environment variables and use sudo, you can do:
 
 ```shell
-curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.21.8+k0s.0 sh
+curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.21.9+k0s.0 sh
 ```
 
 ### 2. Bootstrap a controller node
@@ -119,7 +119,7 @@ To get general information about your k0s instance's status:
 
 ```shell
 $ sudo k0s status
-Version: v1.21.8+k0s.0
+Version: v1.21.9+k0s.0
 Process ID: 2769
 Parent Process ID: 1
 Role: controller
@@ -134,7 +134,7 @@ Use the Kubernetes 'kubectl' command-line tool that comes with k0s binary to dep
 ```shell
 $ sudo k0s kubectl get nodes
 NAME   STATUS   ROLES    AGE    VERSION
-k0s    Ready    <none>   4m6s   v1.21.8-k0s1
+k0s    Ready    <none>   4m6s   v1.21.9-k0s1
 ```
 
 You can also access your cluster easily with [Lens](https://k8slens.dev/), simply by copying the kubeconfig and pasting it to Lens:

--- a/docs/reset.md
+++ b/docs/reset.md
@@ -50,8 +50,8 @@ k0sctl can be used to connect each node and remove all k0s-related files and pro
     INFO ==> Running phase: Prepare hosts    
     INFO ==> Running phase: Gather k0s facts 
     INFO [ssh] 13.53.43.63:22: found existing configuration 
-    INFO [ssh] 13.53.43.63:22: is running k0s controller version 1.21.8+k0s.0
-    INFO [ssh] 13.53.218.149:22: is running k0s worker version 1.21.8+k0s.0
+    INFO [ssh] 13.53.43.63:22: is running k0s controller version 1.21.9+k0s.0
+    INFO [ssh] 13.53.218.149:22: is running k0s worker version 1.21.9+k0s.0
     INFO [ssh] 13.53.43.63:22: checking if worker  has joined 
     INFO ==> Running phase: Reset hosts      
     INFO [ssh] 13.53.43.63:22: stopping k0s           

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -52,7 +52,7 @@ You can configure the desired cluster version in the k0sctl configuration by set
 ```yaml
 spec:
   k0s:
-    version: 1.21.8+k0s.0
+    version: 1.21.9+k0s.0
 ```
 
 If you do not specify a version, k0sctl checks online for the latest version and defaults to it.
@@ -72,7 +72,7 @@ INFO[0027] [ssh] 10.0.0.17:22: waiting for node to become ready again
 INFO[0027] [ssh] 10.0.0.17:22: upgrade successful
 INFO[0027] ==> Running phase: Disconnect from hosts
 INFO[0027] ==> Finished in 27s
-INFO[0027] k0s cluster version 1.21.8+k0s.0 is now installed
+INFO[0027] k0s cluster version 1.21.9+k0s.0 is now installed
 INFO[0027] Tip: To access the cluster you can now fetch the admin kubeconfig using:
 INFO[0027]      k0sctl kubeconfig
 ```

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -39,7 +39,7 @@ etcd_build_go_cgo_enabled = 0
 etcd_build_go_ldflags = "-w -s"
 #etcd_build_go_ldflags_extra =
 
-konnectivity_version = 0.0.25
+konnectivity_version = 0.0.27-k0s2
 konnectivity_buildimage = golang:1.16-alpine
 #konnectivity_build_go_tags =
 konnectivity_build_go_cgo_enabled = 0

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -15,7 +15,7 @@ containerd_build_shim_go_cgo_enabled = 0
 #containerd_build_go_ldflags =
 containerd_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
-kubernetes_version = 1.21.8
+kubernetes_version = 1.21.9
 kubernetes_buildimage = golang:1.16-alpine
 kubernetes_build_go_tags = "providerless"
 #kubernetes_build_go_cgo_enabled =

--- a/embedded-bins/konnectivity/Dockerfile
+++ b/embedded-bins/konnectivity/Dockerfile
@@ -10,7 +10,7 @@ ARG BUILD_GO_LDFLAGS_EXTRA
 
 RUN apk add build-base git make
 
-RUN git clone -b v$VERSION --depth=1 https://github.com/kubernetes-sigs/apiserver-network-proxy.git /apiserver-network-proxy
+RUN git clone -b v$VERSION --depth=1 https://github.com/k0sproject/apiserver-network-proxy.git /apiserver-network-proxy
 WORKDIR /apiserver-network-proxy
 RUN go version
 RUN GO111MODULE=on go get github.com/golang/mock/mockgen@v1.4.4 && \

--- a/examples/footloose-ha-controllers/Dockerfile
+++ b/examples/footloose-ha-controllers/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/footloose/ubuntu18.04
 
 ADD k0s.service /etc/systemd/system/k0s.service
 
-RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.21.8/bin/linux/amd64/kubectl && \
+RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.21.9/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf

--- a/inttest/conformance/README.md
+++ b/inttest/conformance/README.md
@@ -36,14 +36,14 @@ In the same directory as your `main.tf` file, create an additional file `terrafo
 
 ```terraform
 k0s_version=v0.9.0
-k8s_version=v1.21.8
+k8s_version=v1.21.9
 onobuoy_version=0.20.0
 ```
 
 ### 2. Environment variables
 
 ```shell
-TF_VAR_k0s_version=v0.7.0-beta1 TF_VAR_sonobuoy_version=0.18.0 TF_VAR_k8s_version=v1.21.8 terraform apply
+TF_VAR_k0s_version=v0.7.0-beta1 TF_VAR_sonobuoy_version=0.18.0 TF_VAR_k8s_version=v1.21.9 terraform apply
 ```
 
 **NOTE:** By default, terraform will fetch sonobuoy version **0.20.0**. If you want to use a different version you can override this with one of the above methods.

--- a/inttest/conformance/terraform/main.tf
+++ b/inttest/conformance/terraform/main.tf
@@ -13,7 +13,7 @@ variable "sonobuoy_version" {
 }
 
 variable "k8s_version" {
-  // format: v1.21.8
+  // format: v1.21.9
   type = string
 }
 

--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13
 
-ENV KUBE_VERSION=1.21.8
+ENV KUBE_VERSION=1.21.9
 
 RUN apk add openrc openssh-server bash busybox-initscripts coreutils findutils iptables curl haproxy
 # enable syslog and sshd

--- a/inttest/sonobuoy/signetwork_test.go
+++ b/inttest/sonobuoy/signetwork_test.go
@@ -69,7 +69,7 @@ func (s *NetworkSuite) TestSigNetwork() {
 		`--e2e-focus=\[sig-network\].*\[Conformance\]`,
 		`--e2e-skip=\[Serial\]`,
 		"--e2e-parallel=y",
-		"--kube-conformance-image-version=v1.21.8",
+		"--kube-conformance-image-version=v1.21.9",
 	}
 	s.T().Log("running sonobuoy, this may take a while")
 	sonoFinished := make(chan bool)

--- a/pkg/apis/v1beta1/images_test.go
+++ b/pkg/apis/v1beta1/images_test.go
@@ -39,7 +39,7 @@ func TestImagesRepoOverrideInConfiguration(t *testing.T) {
 			cfg.Spec.Images.Repository = "my.repo"
 			var testingConfig *ClusterConfig
 			require.NoError(t, yaml.Unmarshal(getConfigYAML(t, cfg), &testingConfig))
-			require.Equal(t, fmt.Sprintf("my.repo/k8s-artifacts-prod/kas-network-proxy/proxy-agent:%s", constant.KonnectivityImageVersion), testingConfig.Spec.Images.Konnectivity.URI())
+			require.Equal(t, fmt.Sprintf("my.repo/k0sproject/apiserver-network-proxy-agent:%s", constant.KonnectivityImageVersion), testingConfig.Spec.Images.Konnectivity.URI())
 			require.Equal(t, fmt.Sprintf("my.repo/k8s-staging-metrics-server/metrics-server:%s", constant.MetricsImageVersion), testingConfig.Spec.Images.MetricsServer.URI())
 			require.Equal(t, fmt.Sprintf("my.repo/kube-proxy:%s", constant.KubeProxyImageVersion), testingConfig.Spec.Images.KubeProxy.URI())
 			require.Equal(t, fmt.Sprintf("my.repo/coredns/coredns:%s", constant.CoreDNSImageVersion), testingConfig.Spec.Images.CoreDNS.URI())

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -54,8 +54,8 @@ const (
 	// DefaultPSP defines the system level default PSP to apply
 	DefaultPSP = "00-k0s-privileged"
 	// Image Constants
-	KonnectivityImage                  = "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent"
-	KonnectivityImageVersion           = "v0.0.25"
+	KonnectivityImage                  = "quay.io/k0sproject/apiserver-network-proxy-agent"
+	KonnectivityImageVersion           = "0.0.27-k0s2"
 	MetricsImage                       = "gcr.io/k8s-staging-metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.3.7"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -59,7 +59,7 @@ const (
 	MetricsImage                       = "gcr.io/k8s-staging-metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.3.7"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"
-	KubeProxyImageVersion              = "v1.21.8"
+	KubeProxyImageVersion              = "v1.21.9"
 	CoreDNSImage                       = "docker.io/coredns/coredns"
 	CoreDNSImageVersion                = "1.7.0"
 	CalicoImage                        = "docker.io/calico/cni"


### PR DESCRIPTION
- bump konnectivity to 0.0.27 (k0sproject fork)
- bump kubernetes to 1.21.9