### PR TITLE
Fix k0s kubectl config flag

### DIFF
--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -26,7 +26,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/component-base/logs"
 	kubectl "k8s.io/kubectl/pkg/cmd"
 
 	"github.com/k0sproject/k0s/pkg/config"
@@ -129,6 +128,6 @@ func NewK0sKubectlCmd() *cobra.Command {
 
 		originalRun(cmd, args)
 	}
-	logs.AddFlags(cmd.PersistentFlags())
+	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	return cmd
 }


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

There was a strange `logs.AddFlags` call in `cmd/kubectl/kubectl.go`. Likely caused by some editor auto-importing magic.

Not entirely sure how it affected functionality.
