### PR TITLE
Config edit and status subcommands

### DIFF
--- a/cmd/config/edit.go
+++ b/cmd/config/edit.go
@@ -16,21 +16,22 @@ limitations under the License.
 package config
 
 import (
+	"os"
+
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/spf13/cobra"
 )
 
-type CmdOpts config.CLIOptions
-
-func NewConfigCmd() *cobra.Command {
+func NewEditCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "config",
-		Short: "Configuration related sub-commands",
+		Use:   "edit",
+		Short: "Launch the editor configured in your shell to edit k0s configuration",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			c := CmdOpts(config.GetCmdOpts())
+			os.Args = []string{os.Args[0], "kubectl", "--data-dir", c.K0sVars.DataDir, "-n", "kube-system", "edit", "clusterconfig", "k0s"}
+			return cmd.Execute()
+		},
 	}
-	cmd.AddCommand(NewCreateCmd())
-	cmd.AddCommand(NewEditCmd())
-	cmd.AddCommand(NewStatusCmd())
-	cmd.AddCommand(NewValidateCmd())
-	cmd.SilenceUsage = true
+	cmd.PersistentFlags().AddFlagSet(config.GetKubeCtlFlagSet())
 	return cmd
 }

--- a/docs/dynamic-configuration.md
+++ b/docs/dynamic-configuration.md
@@ -24,7 +24,7 @@ In case of HA control plane, all the controllers will need this part of the conf
 The cluster wide configuration is stored in the Kubernetes API as a custom resource called `clusterconfig`. There's currently only one instance named `k0s`. You can edit the configuration with what ever means possible, for example with:
 
 ```shell
-kubectl -n kube-system edit clusterconfig k0s
+k0s config edit
 ```
 
 This will open the configuration object for editing in your system's default editor.
@@ -53,10 +53,13 @@ As with any Kubernetes cluster there are certain things that just cannot be chan
 
 ## Configuration status
 
-The dynamic configuration reconciler operator will write status events for all the changes it detects. To see all related events you can query the events where the source object is this k0s config object:
+The dynamic configuration reconciler operator will write status events for all the changes it detects. To see all dynamic config related events, use:
 
 ```shell
-bash-5.1# k0s kc -n kube-system get event --field-selector involvedObject.name=k0s
+k0s config status
+```
+
+```shell
 LAST SEEN   TYPE      REASON                OBJECT              MESSAGE
 64s         Warning   FailedReconciling     clusterconfig/k0s   failed to validate config: [invalid pod CIDR invalid ip address]
 59s         Normal    SuccessfulReconcile   clusterconfig/k0s   Succesfully reconciler cluster config


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Fixes #1453 

Adds `k0s config edit` which is a shortcut to `k0s kubectl -n kube-system edit clusterconfig k0s`.
and `k0s config status` which is a shortcut to `k0s kubectl -n kube-system get event --field-selector involvedObject.name=k0s`
