### PR TITLE
release-1.23: Bump kubernetes to 1.23.3

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,7 +79,7 @@ spec:
       version: v0.5.0
     kubeproxy:
       image: k8s.gcr.io/kube-proxy
-      version: v1.23.2
+      version: v1.23.3
     coredns:
       image: k8s.gcr.io/coredns/coredns
       version: v1.7.0

--- a/docs/install.md
+++ b/docs/install.md
@@ -48,7 +48,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
 
     ```shell
     $ sudo k0s status
-    Version: v1.23.2+k0s.1
+    Version: v1.23.3+k0s.1
     Process ID: 436
     Role: controller
     Workloads: true
@@ -64,7 +64,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
     ```shell
     $ sudo k0s kubectl get nodes
     NAME   STATUS   ROLES    AGE    VERSION
-    k0s    Ready    <none>   4m6s   v1.23.2-k0s1
+    k0s    Ready    <none>   4m6s   v1.23.3-k0s1
     ```
 
 ## Uninstall k0s

--- a/docs/k0s-multi-node.md
+++ b/docs/k0s-multi-node.md
@@ -24,13 +24,13 @@ The download script accepts the following environment variables:
 
 | Variable                   | Purpose                                           |
 |:---------------------------|:--------------------------------------------------|
-| `K0S_VERSION=v1.23.2+k0s.0 | Select the version of k0s to be installed         |
+| `K0S_VERSION=v1.23.3+k0s.0 | Select the version of k0s to be installed         |
 | `DEBUG=true`               | Output commands and their arguments at execution. |
 
 **Note**: If you require environment variables and use sudo, you can do:
 
 ```shell
-curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.23.2+k0s.0 sh
+curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.23.3+k0s.0 sh
 ```
 
 ### 2. Bootstrap a controller node
@@ -126,7 +126,7 @@ To get general information about your k0s instance's status:
 ```
 
 ```shell
-Version: v1.23.2+k0s.0
+Version: v1.23.3+k0s.0
 Process ID: 2769
 Parent Process ID: 1
 Role: controller
@@ -144,7 +144,7 @@ sudo k0s kubectl get nodes
 
 ```shell
 NAME   STATUS   ROLES    AGE    VERSION
-k0s    Ready    <none>   4m6s   v1.23.2-k0s1
+k0s    Ready    <none>   4m6s   v1.23.3-k0s1
 ```
 
 You can also access your cluster easily with [Lens](https://k8slens.dev/), simply by copying the kubeconfig and pasting it to Lens:

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -12,6 +12,6 @@ The biggest new k0s features will typically only be delivered on top of the late
 
 The k0s version string consists of the Kubernetes version and the k0s version. For example:
 
-- v1.23.2+k0s.0
+- v1.23.3+k0s.0
 
-The Kubernetes version (1.23.2) is the first part, and the last part (k0s.0) reflects the k0s version, which is built on top of the certain Kubernetes version.
+The Kubernetes version (1.23.3) is the first part, and the last part (k0s.0) reflects the k0s version, which is built on top of the certain Kubernetes version.

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -17,7 +17,7 @@ containerd_build_shim_go_cgo_enabled = 0
 #containerd_build_go_ldflags =
 containerd_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
-kubernetes_version = 1.23.2
+kubernetes_version = 1.23.3
 kubernetes_buildimage = golang:$(go_version)-alpine
 kubernetes_build_go_tags = "providerless"
 #kubernetes_build_go_cgo_enabled =

--- a/examples/footloose-ha-controllers/Dockerfile
+++ b/examples/footloose-ha-controllers/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/footloose/ubuntu18.04
 
 ADD k0s.service /etc/systemd/system/k0s.service
 
-RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.23.2/bin/linux/amd64/kubectl && \
+RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.23.3/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf

--- a/inttest/conformance/README.md
+++ b/inttest/conformance/README.md
@@ -35,15 +35,15 @@ In order to run the conformance test, you will need to set the tested k0s versio
 In the same directory as your `main.tf` file, create an additional file `terraform.tfvars` with the following input:
 
 ```terraform
-k0s_version=v1.23.2+k0s.0
-k8s_version=v1.23.2
+k0s_version=v1.23.3+k0s.0
+k8s_version=v1.23.3
 sonobuoy_version=0.53.2
 ```
 
 ### 2. Environment variables
 
 ```shell
-TF_VAR_k0s_version=v1.23.2+k0s.0 TF_VAR_sonobuoy_version=0.20.0 TF_VAR_k8s_version=v1.23.2 terraform apply
+TF_VAR_k0s_version=v1.23.3+k0s.0 TF_VAR_sonobuoy_version=0.20.0 TF_VAR_k8s_version=v1.23.3 terraform apply
 ```
 
 **NOTE:** By default, terraform will fetch sonobuoy version **0.53.2**. If you want to use a different version you can override this with one of the above methods.

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -80,7 +80,7 @@ const (
 	MetricsImage                       = "k8s.gcr.io/metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.5.2"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"
-	KubeProxyImageVersion              = "v1.23.2"
+	KubeProxyImageVersion              = "v1.23.3"
 	CoreDNSImage                       = "k8s.gcr.io/coredns/coredns"
 	CoreDNSImageVersion                = "v1.7.0"
 	CalicoImage                        = "docker.io/calico/cni"


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#changelog-since-v1232

Signed-off-by: Natanael Copa <ncopa@mirantis.com>
(cherry picked from commit ea296420f2206c8cd481727e50eb136cefcb4d78)

