### PR TITLE
Finetune the embedded local storage docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ k0s is distributed as a single binary with zero host OS dependencies besides the
 - Scalable from a single node to large, [high-available](high-availability.md) clusters
 - Supports custom [Container Network Interface (CNI)](networking.md) plugins (Kube-Router is the default, Calico is offered as a preconfigured alternative)
 - Supports custom [Container Runtime Interface (CRI)](runtime.md) plugins (containerd is the default)
-- Supports all Kubernetes storage options with [Container Storage Interface (CSI)](storage.md)
+- Supports all Kubernetes storage options with [Container Storage Interface (CSI)](storage.md), includes [OpenEBS host-local storage provider](storage.md#bundled-openebs-storage)
 - Supports a variety of [datastore backends](configuration.md#specstorage): etcd (default for multi-node clusters), SQLite (default for single node clusters), MySQL, and PostgreSQL
 - Supports x86-64, ARM64 and ARMv7
 - Includes [Konnectivity service](networking.md#controller-worker-communication), CoreDNS and Metrics Server

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,9 +279,17 @@ In the runtime the image names are calculated as `my.own.repo/calico/kube-contro
 
 ### `spec.extensions.storage`
 
-`spec.extensions.storage` controls bundled storage.
+`spec.extensions.storage` controls bundled storage provider.
 The default value `external` makes no storage deployed.
-Value `openebs_local_storage` deploys OpenEBS with the local path set up.
+
+To enable [embedded host-local storage provider](storage.md#bundled-openebs-storage) use the following configuration:
+
+```yaml
+spec:
+  extensions:
+    storage:
+      type: openebs_local_storage
+```
 
 ### `spec.konnectivity`
 
@@ -298,8 +306,8 @@ The telemetry interval is ten minutes.
 
 ```yaml
 spec:
-    telemetry:
-      enabled: true
+  telemetry:
+    enabled: true
 ```
 
 ## Disabling controller components


### PR DESCRIPTION
Small finetunings on embedded storage provider docs. 

Basically just adds "cross reference" between the CSI page and bit deeper config options documentation.

Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

