### PR TITLE
Helm addons deletion fixed

### DIFF
--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -65,11 +65,15 @@ func (as *AddonsSuite) TestHelmBasedAddons() {
 
 func (as *AddonsSuite) doPrometheusDelete(chart *v1beta1.Chart) {
 	as.T().Logf("Deleting chart %s/%s", chart.Namespace, chart.Name)
+	ssh, err := as.SSH(as.ControllerNode(0))
+	as.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	_, err = ssh.ExecWithOutput("rm /var/lib/k0s/manifests/helm/addon_crd_manifest_test-addon.yaml")
+	as.Require().NoError(err)
+
 	cfg, err := as.GetKubeConfig(as.ControllerNode(0))
 	as.Require().NoError(err)
-	client, err := client.New(cfg, client.Options{})
-	as.Require().NoError(err)
-	as.Require().NoError(client.Delete(context.Background(), chart))
 	k8sclient, err := k8s.NewForConfig(cfg)
 	as.Require().NoError(err)
 	as.Require().NoError(wait.PollImmediate(time.Second, 5*time.Minute, func() (done bool, err error) {

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -17,7 +17,9 @@ package applier
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -163,7 +165,11 @@ func (a *Applier) parseFiles(files []string) ([]*unstructured.Unstructured, erro
 
 	objects, err := r.Infos()
 	if err != nil {
-		return nil, fmt.Errorf("enable to get object infos: %w", err)
+		// don't return an error on file removal
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("enable to get object infos: %w", err)
+		}
+
 	}
 	for _, o := range objects {
 		item := o.Object.(*unstructured.Unstructured)


### PR DESCRIPTION
Signed-off-by: makhov <amakhov@mirantis.com>

Helm addons deletion was broken with the latest stack applier changes. 
Test updated to delete the manifest file rather than directly Chart CRD to verify that the whole process works.