### PR TITLE
Add configuration ability to collect  Calico PrometheusMetrics

### DIFF
--- a/pkg/apis/k0s.k0sproject.io/v1beta1/calico.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/calico.go
@@ -48,6 +48,9 @@ type Calico struct {
 
 	// Windows Nodes (default: false)
 	WithWindowsNodes bool `json:"withWindowsNodes"`
+
+	// PrometheusMetricsEnabled enables the Prometheus metrics server in Felix if set to true
+	PrometheusMetricsEnabled bool `json:"prometheusMetricsEnabled"`
 }
 
 // DefaultCalico returns sane defaults for calico

--- a/pkg/component/controller/calico.go
+++ b/pkg/component/controller/calico.go
@@ -55,16 +55,17 @@ type manifestsSaver interface {
 }
 
 type calicoConfig struct {
-	MTU                  int
-	Mode                 string
-	VxlanPort            int
-	VxlanVNI             int
-	ClusterCIDRIPv4      string
-	ClusterCIDRIPv6      string
-	EnableWireguard      bool
-	WithWindowsNodes     bool
-	FlexVolumeDriverPath string
-	DualStack            bool
+	MTU                      int
+	Mode                     string
+	VxlanPort                int
+	VxlanVNI                 int
+	ClusterCIDRIPv4          string
+	ClusterCIDRIPv6          string
+	EnableWireguard          bool
+	WithWindowsNodes         bool
+	FlexVolumeDriverPath     string
+	DualStack                bool
+	PrometheusMetricsEnabled bool
 
 	CalicoCNIImage             string
 	CalicoNodeImage            string
@@ -199,6 +200,7 @@ func (c *Calico) getConfig(clusterConfig *v1beta1.ClusterConfig) (calicoConfig, 
 		IPAutodetectionMethod:      clusterConfig.Spec.Network.Calico.IPAutodetectionMethod,
 		IPV6AutodetectionMethod:    ipv6AutoDetectionMethod,
 		PullPolicy:                 clusterConfig.Spec.Images.DefaultPullPolicy,
+		PrometheusMetricsEnabled:   clusterConfig.Spec.Network.Calico.PrometheusMetricsEnabled,
 	}
 
 	return config, nil

--- a/static/manifests/calico/DaemonSet/calico-node.yaml
+++ b/static/manifests/calico/DaemonSet/calico-node.yaml
@@ -171,6 +171,11 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: veth_mtu
+            # Enable the Prometheus metrics server in Felix
+            {{- if .PrometheusMetricsEnabled }}
+            - name: FELIX_PROMETHEUSMETRICSENABLED
+              value: "true"
+            {{- end }}
             # The default IPv4 pool to create on startup if none exists. Pod IPs will be
             # chosen from this range. Changing this value after installation will have
             # no effect. This should fall within `--cluster-cidr`.


### PR DESCRIPTION
This PR includes the changes that add ability to manage Calico Prometheus Metrics collection that by default is switched off