### PR TITLE
adds documentation for use on ZFS systems

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,27 +54,33 @@ As Etcd is not fully supported on ARM architecture it also means that k0s contro
 On ZFS-based systems k0s will fail to start because containerd runs by default in overlayfs mode to manage image layers. This is not compatible with ZFS and requires a custom config of containerd. The following steps should get k0s working on ZFS-based systems:
 
 - check with `$ ctr -a /run/k0s/containerd.sock plugins ls` that the containerd ZFS snapshotter plugin is in `ok` state (should be the case if ZFS kernel modules and ZFS userspace utils are correctly configured):
-```
+
+```console
 TYPE                            ID                       PLATFORMS      STATUS    
 ...
 io.containerd.snapshotter.v1    zfs                      linux/amd64    ok
 ...
 ```
+
 - create a containerd config according to the [documentation](/runtime): `$ containerd config default > /etc/k0s/containerd.toml`
 - modify the line in `/etc/k0s/containerd.toml`:
-```
+
+```toml
 ...
     [plugins."io.containerd.grpc.v1.cri".containerd]
       snapshotter = "overlayfs"
 ...
 ```
+
 to
-```
+
+```toml
 ...
     [plugins."io.containerd.grpc.v1.cri".containerd]
       snapshotter = "zfs"
 ...
 ```
+
 - create a ZFS dataset to be used as snapshot storage at your desired location, e.g. `$ zfs create -o mountpoint=/var/lib/k0s/containerd/io.containerd.snapshotter.v1.zfs rpool/containerd`
 - install k0s as usual, e.g `$ k0s install controller --single -c /etc/k0s/k0s.yaml`
 - containerd should be launched with ZFS support and k0s should initialize the cluster correctly

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,6 +49,36 @@ Etcd is [not fully supported](https://github.com/etcd-io/etcd/blob/master/Docume
 
 As Etcd is not fully supported on ARM architecture it also means that k0s controlplane with etcd itself is not fully supported on ARM either.
 
+## `k0s` will not start on ZFS-based systems
+
+On ZFS-based systems k0s will fail to start because containerd runs by default in overlayfs mode to manage image layers. This is not compatible with ZFS and requires a custom config of containerd. The following steps should get k0s working on ZFS-based systems:
+
+- check with `$ ctr -a /run/k0s/containerd.sock plugins ls` that the containerd ZFS snapshotter plugin is in `ok` state (should be the case if ZFS kernel modules and ZFS userspace utils are correctly configured):
+```
+TYPE                            ID                       PLATFORMS      STATUS    
+...
+io.containerd.snapshotter.v1    zfs                      linux/amd64    ok
+...
+```
+- create a containerd config according to the [documentation](/runtime): `$ containerd config default > /etc/k0s/containerd.toml`
+- modify the line in `/etc/k0s/containerd.toml`:
+```
+...
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      snapshotter = "overlayfs"
+...
+```
+to
+```
+...
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      snapshotter = "zfs"
+...
+```
+- create a ZFS dataset to be used as snapshot storage at your desired location, e.g. `$ zfs create -o mountpoint=/var/lib/k0s/containerd/io.containerd.snapshotter.v1.zfs rpool/containerd`
+- install k0s as usual, e.g `$ k0s install controller --single -c /etc/k0s/k0s.yaml`
+- containerd should be launched with ZFS support and k0s should initialize the cluster correctly
+
 ## Pods pending when using cloud providers
 
 Once we enable [cloud provider support](cloud-providers.md) on kubelet on worker nodes, kubelet will automatically add a taint `node.cloudprovider.kubernetes.io/uninitialized` for the node. This tain will prevent normal workloads to be scheduled on the node until the cloud provider controller actually runs second initialization on the node and removes the taint. This means that these nodes are not available for scheduling until the cloud provider controller is actually successfully running on the cluster.


### PR DESCRIPTION
k0s fails to start on ZFS-based systems.

**Issue**
Fixes #1490 

**What this PR Includes**
Adds a section for setup of k0s on ZFS-based systems to troubleshooting guide of the documentation.