### PR TITLE
Refuse to create join tokens when joining is impossible

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -609,7 +609,7 @@ func (c *CmdOpts) startControllerWorker(ctx context.Context, profile string) err
 			// we use retry.Do with 10 attempts, back-off delay and delay duration 500 ms which gives us
 			// 225 seconds here
 			tokenAge := time.Second * 225
-			cfg, err := token.CreateKubeletBootstrapConfig(ctx, c.NodeConfig, c.K0sVars, "worker", tokenAge)
+			cfg, err := token.CreateKubeletBootstrapConfig(ctx, c.NodeConfig.Spec.API, c.K0sVars, token.RoleWorker, tokenAge)
 			if err != nil {
 				return err
 			}

--- a/cmd/token/list.go
+++ b/cmd/token/list.go
@@ -79,9 +79,9 @@ func tokenListCmd() *cobra.Command {
 }
 
 func checkListTokenRole(cmd *cobra.Command, args []string) error {
-	if listTokenRole != "" && (listTokenRole != controllerRole && listTokenRole != workerRole) {
+	err := checkTokenRole(listTokenRole)
+	if err != nil {
 		cmd.SilenceUsage = true
-		return fmt.Errorf("unsupported role %q, supported roles are %q and %q", listTokenRole, controllerRole, workerRole)
 	}
-	return nil
+	return err
 }

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -16,9 +16,12 @@ limitations under the License.
 package token
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/k0sproject/k0s/pkg/config"
+	"github.com/k0sproject/k0s/pkg/token"
 )
 
 type CmdOpts config.CLIOptions
@@ -26,11 +29,6 @@ type CmdOpts config.CLIOptions
 var (
 	tokenExpiry string
 	waitCreate  bool
-)
-
-const (
-	controllerRole = "controller"
-	workerRole     = "worker"
 )
 
 func NewTokenCmd() *cobra.Command {
@@ -44,4 +42,11 @@ func NewTokenCmd() *cobra.Command {
 	cmd.AddCommand(tokenListCmd())
 	cmd.AddCommand(tokenInvalidateCmd())
 	return cmd
+}
+
+func checkTokenRole(tokenRole string) error {
+	if tokenRole != token.RoleController && tokenRole != token.RoleWorker {
+		return fmt.Errorf("unsupported role %q; supported roles are %q and %q", tokenRole, token.RoleController, token.RoleWorker)
+	}
+	return nil
 }

--- a/inttest/singlenode/singlenode_test.go
+++ b/inttest/singlenode/singlenode_test.go
@@ -16,9 +16,11 @@ limitations under the License.
 package singlenode
 
 import (
-	"context"
+	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/k0sproject/k0s/inttest/common"
@@ -33,12 +35,12 @@ func (s *SingleNodeSuite) TestK0sGetsUp() {
 	s.NoError(s.InitController(0, "--single"))
 
 	kc, err := s.KubeClient(s.ControllerNode(0))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = s.WaitForNodeReady(s.ControllerNode(0), kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
+	pods, err := kc.CoreV1().Pods("kube-system").List(s.Context(), v1.ListOptions{
 		Limit: 100,
 	})
 	s.NoError(err)
@@ -49,16 +51,30 @@ func (s *SingleNodeSuite) TestK0sGetsUp() {
 	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 	s.T().Log("waiting to see CNI pods ready")
-	s.NoError(common.WaitForKubeRouterReady(kc), "CNI did not start")
+	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "CNI did not start")
 
-	s.T().Log("verify that we use kine as default storage")
-	ssh, err := s.SSH(s.ControllerNode(0))
-	s.NoError(err)
-	defer ssh.Disconnect()
+	s.T().Run("verify", func(t *testing.T) {
+		ssh, err := s.SSH(s.ControllerNode(0))
+		require.NoError(t, err, "failed to SSH into controller")
+		defer ssh.Disconnect()
 
-	_, err = ssh.ExecWithOutput("test -e /var/lib/k0s/bin/kine && ps xa | grep kine")
-	s.NoError(err)
+		t.Run(("kineIsDefaultStorage"), func(t *testing.T) {
+			_, err = ssh.ExecWithOutput("test -e /var/lib/k0s/bin/kine && ps xa | grep kine")
+			assert.NoError(t, err)
+		})
 
+		t.Run(("noControllerJoinTokens"), func(t *testing.T) {
+			noToken, err := ssh.ExecWithOutput(fmt.Sprintf("'%s' token create --role=controller", s.K0sFullPath))
+			assert.Error(t, err)
+			assert.Equal(t, "Error: refusing to create token: cannot join into a single node cluster", noToken)
+		})
+
+		t.Run(("noWorkerJoinTokens"), func(t *testing.T) {
+			noToken, err := ssh.ExecWithOutput(fmt.Sprintf("'%s' token create --role=worker", s.K0sFullPath))
+			assert.Error(t, err)
+			assert.Equal(t, "Error: refusing to create token: cannot join into a single node cluster", noToken)
+		})
+	})
 }
 
 func TestSingleNodeSuite(t *testing.T) {


### PR DESCRIPTION
## Description

The `token create` command will error out in situations where joining a node is known not to work. This is currently the case for two scenarios:

* k0s is running as a single node cluster
* attempting to join new controllers into clusters whose storage isn't joinable (applies to kine+sqlite for now)

Fixes #1284.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings