### PR TITLE
Fix download of go binary for armv7 workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -331,13 +331,13 @@ jobs:
       #   with:
       #     go-version: ${{ env.GO_VERSION }}
       #   id: go
-      - name: Install GoLang for ARMHF
-        run: "echo $HOME/.local/go/bin >> $GITHUB_PATH; rm -rf $HOME/.local/go && mkdir -p $HOME/.local/go && curl --silent -L https://golang.org/dl/$(curl --silent -L 'https://golang.org/VERSION?m=text').linux-armv6l.tar.gz | tar -C $HOME/.local -xz"
-      - name: Go Version
-        run: go version
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+
+      - name: Install GoLang for ARMHF
+        run: "echo $HOME/.local/go/bin >> $GITHUB_PATH; rm -rf $HOME/.local/go && mkdir -p $HOME/.local/go && curl --silent -L https://golang.org/dl/go$(make -s -f go_version.mk).linux-armv6l.tar.gz | tar -C $HOME/.local -xz"
+      - name: Go Version
+        run: go version
 
       - name: Bindata cache
         uses: actions/cache@v2

--- a/go_version.mk
+++ b/go_version.mk
@@ -1,0 +1,6 @@
+include embedded-bins/Makefile.variables
+
+.PHONY: go_version
+go_version:
+	@echo $(go_version)
+


### PR DESCRIPTION
Trying to fetch latest go version from upstream does not always work.
Get the go version from embedded-bins/Makefile.variables so we use same
go version that we use for the k0s build.

Ref: https://github.com/k0sproject/k0s/pull/1503#issuecomment-1035153709

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings