### PR TITLE
[release-1.22] Fix download of go binary for armv7 workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -327,13 +327,13 @@ jobs:
       #   with:
       #     go-version: ${{ env.GO_VERSION }}
       #   id: go
-      - name: Install GoLang for ARMHF
-        run: "echo $HOME/.local/go/bin >> $GITHUB_PATH; rm -rf $HOME/.local/go && mkdir -p $HOME/.local/go && curl --silent -L https://golang.org/dl/$(curl --silent -L 'https://golang.org/VERSION?m=text').linux-armv6l.tar.gz | tar -C $HOME/.local -xz"
-      - name: Go Version
-        run: go version
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+
+      - name: Install GoLang for ARMHF
+        run: "echo $HOME/.local/go/bin >> $GITHUB_PATH; rm -rf $HOME/.local/go && mkdir -p $HOME/.local/go && curl --silent -L https://golang.org/dl/go$(make -s -f go_version.mk).linux-armv6l.tar.gz | tar -C $HOME/.local -xz"
+      - name: Go Version
+        run: go version
 
       - name: Bindata cache
         uses: actions/cache@v2

--- a/go_version.mk
+++ b/go_version.mk
@@ -1,0 +1,6 @@
+include embedded-bins/Makefile.variables
+
+.PHONY: go_version
+go_version:
+	@echo $(go_version)
+


### PR DESCRIPTION
Trying to fetch latest go version from upstream does not always work.
Get the go version from embedded-bins/Makefile.variables so we use same
go version that we use for the k0s build.

Ref: https://github.com/k0sproject/k0s/pull/1503#issuecomment-1035153709

Signed-off-by: Natanael Copa <ncopa@mirantis.com>
(cherry picked from commit 96b13497d8d0de3a2d90a610e73b2d26d358082c)
