### PR TITLE
[release-1.21] Fixes to support the proper Go version in armv7 smoke tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -319,13 +319,13 @@ jobs:
       #   with:
       #     go-version: ${{ env.GO_VERSION }}
       #   id: go
-      - name: Install GoLang for ARMHF
-        run: "echo $HOME/.local/go/bin >> $GITHUB_PATH; rm -rf $HOME/.local/go && mkdir -p $HOME/.local/go && curl --silent -L https://golang.org/dl/$(curl --silent -L 'https://golang.org/VERSION?m=text').linux-armv6l.tar.gz | tar -C $HOME/.local -xz"
-      - name: Go Version
-        run: go version
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+
+      - name: Install GoLang for ARMHF
+        run: "echo $HOME/.local/go/bin >> $GITHUB_PATH; rm -rf $HOME/.local/go && mkdir -p $HOME/.local/go && curl --silent -L https://golang.org/dl/go$(make -s -f go_version.mk).linux-armv6l.tar.gz | tar -C $HOME/.local -xz"
+      - name: Go Version
+        run: go version
 
       - name: Bindata cache
         uses: actions/cache@v2

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ifeq ($(go_bindata),)
 go_bindata := cd hack/ci-deps && go install github.com/kevinburke/go-bindata/... && cd ../.. && "${GOPATH}/bin/go-bindata"
 endif
 
-GOLANG_IMAGE = golang:1.16-alpine
+GOLANG_IMAGE = golang:$(go_version)-alpine
 GO ?= GOCACHE=/gocache/build GOMODCACHE=/gocache/mod docker run --rm \
 	-v "$(CURDIR)":/go/src/github.com/k0sproject/k0s \
 	-v k0sbuild.gocache:/gocache \
@@ -76,7 +76,9 @@ build: k0s
 endif
 
 .k0sbuild.docker-image.k0s: build/Dockerfile
-	docker build --rm -t k0sbuild.docker-image.k0s -f build/Dockerfile .
+	docker build --rm \
+		--build-arg BUILDIMAGE=golang:$(go_version)-alpine \
+		-t k0sbuild.docker-image.k0s -f build/Dockerfile .
 	touch $@
 
 .k0sbuild.docker-vol.gocache:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,5 @@
-FROM golang:1.16-alpine
+ARG BUILDIMAGE=golang:1.16-alpine
+
+FROM $BUILDIMAGE
 RUN apk add --no-cache gcc musl-dev binutils-gold
 

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,8 @@
+go_version = 1.16.12
+go_version15 = 1.15.15
+
 runc_version = 1.0.2
-runc_buildimage = golang:1.16-alpine
+runc_buildimage = golang:$(go_version)-alpine
 runc_build_go_tags = "seccomp"
 #runc_build_go_cgo_enabled =
 #runc_build_go_flags =
@@ -7,7 +10,7 @@ runc_build_go_tags = "seccomp"
 runc_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
 containerd_version = 1.4.12
-containerd_buildimage = golang:1.15-alpine
+containerd_buildimage = golang:$(go_version15)-alpine
 containerd_build_go_tags = "apparmor,selinux"
 containerd_build_shim_go_cgo_enabled = 0
 #containerd_build_go_cgo_enabled =
@@ -16,7 +19,7 @@ containerd_build_shim_go_cgo_enabled = 0
 containerd_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
 kubernetes_version = 1.21.9
-kubernetes_buildimage = golang:1.16-alpine
+kubernetes_buildimage = golang:$(go_version)-alpine
 kubernetes_build_go_tags = "providerless"
 #kubernetes_build_go_cgo_enabled =
 kubernetes_build_go_flags = "-v"
@@ -24,7 +27,7 @@ kubernetes_build_go_flags = "-v"
 kubernetes_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
 kine_version = 0.6.4
-kine_buildimage = golang:1.16-alpine
+kine_buildimage = golang:$(go_version)-alpine
 #kine_build_go_tags =
 #kine_build_go_cgo_enabled =
 #kine_build_go_flags =
@@ -32,7 +35,7 @@ kine_build_go_ldflags = "-w -s"
 kine_build_go_ldflags_extra = "-extldflags=-static"
 
 etcd_version = 3.4.18
-etcd_buildimage = golang:1.16-alpine
+etcd_buildimage = golang:$(go_version)-alpine
 #etcd_build_go_tags =
 etcd_build_go_cgo_enabled = 0
 #etcd_build_go_flags =
@@ -40,7 +43,7 @@ etcd_build_go_ldflags = "-w -s"
 #etcd_build_go_ldflags_extra =
 
 konnectivity_version = 0.0.27-k0s2
-konnectivity_buildimage = golang:1.16-alpine
+konnectivity_buildimage = golang:$(go_version)-alpine
 #konnectivity_build_go_tags =
 konnectivity_build_go_cgo_enabled = 0
 konnectivity_build_go_flags = "-a"

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,4 +1,4 @@
-go_version = 1.16.12
+go_version = 1.16.13
 go_version15 = 1.15.15
 
 runc_version = 1.0.2

--- a/go_version.mk
+++ b/go_version.mk
@@ -1,0 +1,6 @@
+include embedded-bins/Makefile.variables
+
+.PHONY: go_version
+go_version:
+	@echo $(go_version)
+


### PR DESCRIPTION
## Description
This backports a number of commits to support the recent changes in `main` to fix the Go version being used on armv7 smoketests.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings