### PR TITLE
Controller components metrics scraper

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -169,6 +169,7 @@ jobs:
           - check-workerrestart
           - check-kubectl
           - check-k0sctl
+          - check-metricscraper
 
     steps:
       - name: Get PR Reference and Set Cache Name

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -511,6 +511,20 @@ func (c *CmdOpts) createClusterReconcilers(ctx context.Context, cf kubernetes.Cl
 		reconcilers["metricServer"] = metricServer
 	}
 
+	if c.EnableMetricsScraper {
+		metricsSaver, err := controller.NewManifestsSaver("metrics", c.K0sVars.DataDir)
+		if err != nil {
+			logrus.Warnf("failed to initialize metrics manifests saver: %s", err.Error())
+			return err
+		}
+		metricServer, err := controller.NewMetrics(c.K0sVars, metricsSaver, cf)
+		if err != nil {
+			logrus.Warnf("failed to initialize metrics reconciler: %s", err.Error())
+			return err
+		}
+		reconcilers["metrics"] = metricServer
+	}
+
 	if !stringslice.Contains(c.DisableComponents, constant.KubeletConfigComponentName) {
 
 		kubeletConfig, err := controller.NewKubeletConfig(c.K0sVars, cf)

--- a/internal/testutil/kube_client.go
+++ b/internal/testutil/kube_client.go
@@ -17,6 +17,7 @@ package testutil
 
 import (
 	"fmt"
+	"k8s.io/client-go/rest"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -27,7 +28,7 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/rest"
+	restfake "k8s.io/client-go/rest/fake"
 	kubetesting "k8s.io/client-go/testing"
 
 	cfgClient "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/clientset/typed/k0s.k0sproject.io/v1beta1"
@@ -53,6 +54,7 @@ func NewFakeClientFactory(objects ...runtime.Object) FakeClientFactory {
 		DynamicClient:   dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvkLists),
 		DiscoveryClient: memory.NewMemCacheClient(rawDiscovery),
 		RawDiscovery:    rawDiscovery,
+		RESTClient:      &restfake.RESTClient{},
 	}
 }
 
@@ -61,6 +63,7 @@ type FakeClientFactory struct {
 	DynamicClient   dynamic.Interface
 	DiscoveryClient discovery.CachedDiscoveryInterface
 	RawDiscovery    *discoveryfake.FakeDiscovery
+	RESTClient      rest.Interface
 }
 
 func (f FakeClientFactory) GetClient() (kubernetes.Interface, error) {
@@ -79,6 +82,9 @@ func (f FakeClientFactory) GetConfigClient() (cfgClient.ClusterConfigInterface, 
 	return nil, fmt.Errorf("NOT IMPLEMENTED")
 }
 
+func (f FakeClientFactory) GetRESTClient() (rest.Interface, error) {
+	return f.RESTClient, nil
+}
 func (f FakeClientFactory) GetRESTConfig() *rest.Config {
 	return &rest.Config{}
 }

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -46,6 +46,8 @@ check-ctr: TIMEOUT=10m
 check-byocri: TIMEOUT=5m
 # readiness check for metric tests takes between around 5 and 6 minutes.
 check-metrics: TIMEOUT=6m
+check-metricscraper: TIMEOUT=6m
+
 check-calico: TIMEOUT=6m
 
 # Establishing konnectivity tunnels with the LB in place takes a while, thus a bit longer timeout for the smoke

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -28,4 +28,5 @@ smoketests := \
 	check-upgrade \
 	check-workerrestart \
 	check-kubectl \
-	check-k0sctl
+	check-k0sctl \
+	check-metricscraper

--- a/inttest/metricscraper/metricscraper_test.go
+++ b/inttest/metricscraper/metricscraper_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package metricscraper
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type MetricScraperSuite struct {
+	common.FootlooseSuite
+}
+
+func (s *MetricScraperSuite) TestK0sGetsUp() {
+	s.NoError(s.InitController(0, "--single", "--enable-metrics-scraper"))
+
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+
+	err = s.WaitForNodeReady(s.ControllerNode(0), kc)
+	s.NoError(err)
+
+	s.NoError(s.waitForPushgateway())
+
+	s.NoError(s.waitForMetrics())
+}
+
+func (s *MetricScraperSuite) waitForPushgateway() error {
+	s.T().Logf("waiting to see pushgateway is ready")
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	if err != nil {
+		return err
+	}
+
+	return wait.PollImmediate(time.Second, 2*time.Minute, func() (done bool, err error) {
+		pods, err := kc.CoreV1().Pods("k0s-system").List(context.TODO(), v1.ListOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		for _, pod := range pods.Items {
+			if strings.HasPrefix(pod.Name, "k0s-pushgateway") {
+				return pods.Items[0].Status.Phase == corev1.PodRunning, nil
+			}
+		}
+
+		return false, nil
+	})
+}
+
+func (s *MetricScraperSuite) waitForMetrics() error {
+	s.T().Logf("waiting to see metrics")
+
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	if err != nil {
+		return err
+	}
+
+	return wait.PollImmediate(time.Second*5, 2*time.Minute, func() (done bool, err error) {
+
+		b, err := kc.RESTClient().Get().AbsPath("/api/v1/namespaces/k0s-system/services/http:k0s-pushgateway:http/proxy/metrics").DoRaw(context.Background())
+		if err != nil {
+			return false, nil
+		}
+
+		// wait for kube-scheduler and kube-controller-manager metrics
+		return strings.Contains(string(b), `job="kube-scheduler"`) && strings.Contains(string(b), `job="kube-controller-manager"`), nil
+	})
+}
+
+func TestMetricScraperSuite(t *testing.T) {
+	s := MetricScraperSuite{
+		common.FootlooseSuite{
+			ControllerCount: 1,
+			ControllerUmask: 027,
+		},
+	}
+	suite.Run(t, &s)
+}

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/images.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/images.go
@@ -37,6 +37,7 @@ func (is ImageSpec) URI() string {
 // ClusterImages sets docker images for addon components
 type ClusterImages struct {
 	Konnectivity  ImageSpec `json:"konnectivity"`
+	PushGateway   ImageSpec `json:"pushgateway"`
 	MetricsServer ImageSpec `json:"metricsserver"`
 	KubeProxy     ImageSpec `json:"kubeproxy"`
 	CoreDNS       ImageSpec `json:"coredns"`
@@ -97,6 +98,10 @@ func DefaultClusterImages() *ClusterImages {
 		Konnectivity: ImageSpec{
 			Image:   constant.KonnectivityImage,
 			Version: constant.KonnectivityImageVersion,
+		},
+		PushGateway: ImageSpec{
+			Image:   constant.PushGatewayImage,
+			Version: constant.PushGatewayImageVersion,
 		},
 		MetricsServer: ImageSpec{
 			Image:   constant.MetricsImage,

--- a/pkg/component/controller/metrics.go
+++ b/pkg/component/controller/metrics.go
@@ -1,0 +1,359 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controller
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"k8s.io/client-go/rest"
+	"net/http"
+	"os"
+	"path"
+	"time"
+
+	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
+	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component"
+	"github.com/k0sproject/k0s/pkg/constant"
+	"github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	namespace       = "k0s-system"
+	pushGatewayName = "k0s-pushgateway"
+)
+
+// Metrics is the reconciler implementation for metrics server
+type Metrics struct {
+	hostname      string
+	log           *logrus.Entry
+	clusterConfig *v1beta1.ClusterConfig
+	tickerDone    context.CancelFunc
+	K0sVars       constant.CfgVars
+	jobs          []*job
+	saver         manifestsSaver
+	restClient    rest.Interface
+}
+
+var _ component.Component = &Metrics{}
+var _ component.ReconcilerComponent = &Metrics{}
+
+// NewMetrics creates new Metrics reconciler
+func NewMetrics(k0sVars constant.CfgVars, saver manifestsSaver, clientCF kubernetes.ClientFactoryInterface) (*Metrics, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+	log := logrus.WithFields(logrus.Fields{"component": "Metrics"})
+
+	restClient, err := clientCF.GetRESTClient()
+	if err != nil {
+		return nil, fmt.Errorf("error getting REST client for metrics: %w", err)
+	}
+
+	return &Metrics{
+		hostname:   hostname,
+		log:        log,
+		K0sVars:    k0sVars,
+		saver:      saver,
+		restClient: restClient,
+	}, nil
+}
+
+// Init does nothing
+func (m *Metrics) Init(_ context.Context) error {
+	tw := templatewriter.TemplateWriter{
+		Name:     "pushgateway-with-ttl",
+		Template: pushGatewayTemplate,
+		Data: map[string]string{
+			"Namespace": namespace,
+			"Name":      pushGatewayName,
+		},
+	}
+	output := bytes.NewBuffer([]byte{})
+	err := tw.WriteToBuffer(output)
+	if err != nil {
+		return err
+	}
+	err = m.saver.Save("pushgateway.yaml", output.Bytes())
+	if err != nil {
+		return err
+	}
+
+	var j *job
+	j, err = m.newJob("kube-scheduler", "https://localhost:10259/metrics")
+	if err != nil {
+		return err
+	}
+	m.jobs = append(m.jobs, j)
+
+	j, err = m.newJob("kube-controller-manager", "https://localhost:10257/metrics")
+	if err != nil {
+		return err
+	}
+	m.jobs = append(m.jobs, j)
+
+	return nil
+}
+
+// Run runs the metric server reconciler
+func (m *Metrics) Run(ctx context.Context) error {
+	ctx, m.tickerDone = context.WithCancel(ctx)
+
+	for _, j := range m.jobs {
+		go j.Run(ctx)
+	}
+
+	return nil
+}
+
+// Stop stops the reconciler
+func (m *Metrics) Stop() error {
+	if m.tickerDone != nil {
+		m.tickerDone()
+	}
+	return nil
+}
+
+// Reconcile detects changes in configuration and applies them to the component
+func (m *Metrics) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterConfig) error {
+	m.log.Debug("reconcile method called for: Metrics")
+
+	// We just store the last known config
+	for _, j := range m.jobs {
+		j.clusterConfig = clusterConfig
+	}
+	m.clusterConfig = clusterConfig
+	return nil
+}
+
+// Healthy is the health-check interface
+func (m *Metrics) Healthy() error { return nil }
+
+type job struct {
+	scrapeURL     string
+	name          string
+	hostname      string
+	clusterConfig *v1beta1.ClusterConfig
+	log           *logrus.Entry
+	scrapeClient  *http.Client
+	restClient    rest.Interface
+}
+
+func (m *Metrics) newJob(name, scrapeURL string) (*job, error) {
+	certFile := path.Join(m.K0sVars.CertRootDir, "admin.crt")
+	keyFile := path.Join(m.K0sVars.CertRootDir, "admin.key")
+
+	httpClient, err := getClient(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return &job{
+		scrapeURL:    scrapeURL,
+		name:         name,
+		hostname:     m.hostname,
+		log:          m.log,
+		scrapeClient: httpClient,
+		restClient:   m.restClient,
+	}, nil
+}
+
+func (j *job) Run(ctx context.Context) {
+	j.log.Debugf("Running %s job", j.name)
+
+	t := time.NewTicker(time.Second * 30)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if j.clusterConfig == nil {
+				continue
+			}
+
+			err := j.collectAndPush(ctx)
+			if err != nil {
+				j.log.Error(err)
+			}
+		}
+	}
+}
+func (j *job) pushURL() string {
+	pushAddress := fmt.Sprintf("/api/v1/namespaces/%s/services/http:%s:http/proxy", namespace, pushGatewayName)
+	return fmt.Sprintf("%s/metrics/job/%s/instance/%s", pushAddress, j.name, j.hostname)
+}
+
+func (j *job) collectAndPush(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, j.scrapeURL, nil)
+	if err != nil {
+		return fmt.Errorf("error creating GET request for %s: %w", j.scrapeURL, err)
+	}
+
+	resp, err := j.scrapeClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error collecting metrics from %s: %w", j.scrapeURL, err)
+	}
+	defer resp.Body.Close()
+
+	res := j.restClient.Post().AbsPath(j.pushURL()).Body(resp.Body).Do(ctx)
+	if res.Error() != nil {
+		return fmt.Errorf("error sending POST request for job %s: %w", j.name, res.Error())
+	}
+	return nil
+}
+
+func getClient(certFile, keyFile string) (*http.Client, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = time.Minute
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	transport.TLSClientConfig = tlsConfig
+
+	if certFile != "" && keyFile != "" {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+	return &http.Client{
+		Transport: transport,
+		Timeout:   time.Minute,
+	}, nil
+}
+
+const pushGatewayTemplate = `
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: "pushgateway"
+    app: k0s-observability
+  name: k0s-pushgateway
+  namespace: {{ .Namespace }}
+  annotations:
+    {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: "pushgateway"
+    app: k0s-observability
+  name: {{ .Name }}
+rules:
+  []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: "pushgateway"
+    app: k0s-observability
+  name: {{ .Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Name }}
+    namespace: {{ .Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Name }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/probe: pushgateway
+  labels:
+    component: "pushgateway"
+    app: k0s-observability
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+spec:
+  ports:
+    - name: http
+      port: 9091
+      protocol: TCP
+      targetPort: 9091
+  selector:
+    component: "pushgateway"
+    app: k0s-observability
+  type: "ClusterIP"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: "pushgateway"
+    app: k0s-observability
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+spec:
+  selector:
+    matchLabels:
+      component: "pushgateway"
+      app: k0s-observability
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: "pushgateway"
+        app: k0s-observability
+    spec:
+      serviceAccountName: {{ .Name }}
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+      containers:
+        - name: prometheus-pushgateway
+          image: "dmathai/prom-pushgateway-ttl:1.4.0-ttl"
+          imagePullPolicy: "IfNotPresent"
+          args: 
+          - --metric.timetolive=120s
+          ports:
+            - containerPort: 9091
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9091
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9091
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+          resources:
+            {}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+`

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -74,6 +74,7 @@ type ControllerOptions struct {
 	K0sCloudProviderUpdateFrequency time.Duration
 	NodeComponents                  *component.Manager
 	EnableDynamicConfig             bool
+	EnableMetricsScraper            bool
 }
 
 // Shared worker cli flags
@@ -181,6 +182,7 @@ func GetControllerFlags() *pflag.FlagSet {
 	flagset.IntVar(&controllerOpts.K0sCloudProviderPort, "k0s-cloud-provider-port", cloudprovider.CloudControllerManagerPort, "the port that k0s-cloud-provider binds on")
 	flagset.AddFlagSet(GetCriSocketFlag())
 	flagset.BoolVar(&controllerOpts.EnableDynamicConfig, "enable-dynamic-config", false, "enable cluster-wide dynamic config based on custom resource")
+	flagset.BoolVar(&controllerOpts.EnableMetricsScraper, "enable-metrics-scraper", false, "enable scraping metrics from the controller components (kube-scheduler, kube-controller-manager)")
 	flagset.AddFlagSet(FileInputFlag())
 	return flagset
 }

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -77,6 +77,8 @@ const (
 	// Image Constants
 	KonnectivityImage                  = "quay.io/k0sproject/apiserver-network-proxy-agent"
 	KonnectivityImageVersion           = "0.0.27-k0s2"
+	PushGatewayImage                   = "quay.io/k0sproject/pushgateway-ttl"
+	PushGatewayImageVersion            = "edge@sha256:7031f6bf6c957e2fdb496161fe3bea0a5bde3de800deeba7b2155187196ecbd9"
 	MetricsImage                       = "k8s.gcr.io/metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.5.2"
 	KubeProxyImage                     = "k8s.gcr.io/kube-proxy"

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -36,6 +36,7 @@ type ClientFactoryInterface interface {
 	GetDynamicClient() (dynamic.Interface, error)
 	GetDiscoveryClient() (discovery.CachedDiscoveryInterface, error)
 	GetConfigClient() (cfgClient.ClusterConfigInterface, error)
+	GetRESTClient() (rest.Interface, error)
 	GetRESTConfig() *rest.Config
 }
 
@@ -167,6 +168,14 @@ func (c *ClientFactory) GetConfigClient() (cfgClient.ClusterConfigInterface, err
 	}
 	c.configClient = configClient.ClusterConfigs(constant.ClusterConfigNamespace)
 	return c.configClient, nil
+}
+
+func (c *ClientFactory) GetRESTClient() (rest.Interface, error) {
+	cs, ok := c.client.(*kubernetes.Clientset)
+	if !ok {
+		return nil, fmt.Errorf("error converting interface")
+	}
+	return cs.RESTClient(), nil
 }
 
 func (c *ClientFactory) GetRESTConfig() *rest.Config {


### PR DESCRIPTION
Signed-off-by: makhov <amakhov@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Added a component for scraping metrics from controller components (kube-scheduler, kube-controller-manager) that are not accessible from the cluster. The new component deploys a dedicated [pushgateway with TTL](https://github.com/Eidison186/prometheus-pushgateway-with-ttl), scrapes metrics from the system components and pushes them to the gateway. TTL is used to make it possible to detect outages (missing Prometheus jobs).

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings