### PR TITLE
[release-1.21] Go version enforcements for GHA semver + lint job

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -9,7 +9,7 @@ on:
     - cron: "0 23 * * *"
 
 env:
-  GO_VERSION: ^1.16
+  GO_VERSION: ~1.16
   GO_VERSION_WIN: ^1.13
 
 jobs:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ on:
       - '.github/workflows/mkdocs-set-default-version.yml'
       - 'mkdocs.yml'
 env:
-  GO_VERSION: ^1.16
+  GO_VERSION: ~1.16
   GO_VERSION_WIN: ^1.13
 
 jobs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,7 +30,7 @@ on:
       - '*.md'
 
 env:
-  GO_VERSION: ^1.16
+  GO_VERSION: ~1.16
   GO_VERSION_WIN: ^1.13
 
 jobs:
@@ -46,6 +46,11 @@ jobs:
         env:
           EMBEDDED_BINS_BUILDMODE: none
 
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+        id: go
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
   #pull_request:
 env:
-  GO_VERSION: ^1.16
+  GO_VERSION: ~1.16
   GO_VERSION_WIN: ^1.13
 
 jobs:


### PR DESCRIPTION
## Description
This is a backport of 2 changes which enforce the use of Go patch-release versioning in GHA, and adding explicit Go versioning in the lint GHA job. 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings