### PR TITLE
[release-1.21] Don't let `golangci-lint-action` install its own version of Go.

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -59,5 +59,6 @@ jobs:
           skip-pkg-cache: true
           only-new-issues: true
           skip-build-cache: true
+          skip-go-installation: true
           config: .golangci.yml
           args: --verbose


### PR DESCRIPTION
## Description
Previously, `golangci-lint-action` was installing its own version of Go (currently go1.17.6), which obviously conflicts with the versioning that we're trying to enforce with `setup-go`

Signed-off-by: Shane Jarych <sjarych@mirantis.com>
(cherry picked from commit b53e149e86a1e87beb052253cf24cb75079f24e1)
(cherry picked from commit 77c4363a1e04ccd9b2acb466bb76ab6fb332a251)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings