### PR TITLE
Set Windows Go version to 1.17 in CI

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   GO_VERSION: ~1.17
-  GO_VERSION_WIN: ^1.13
+  GO_VERSION_WIN: ~1.17
 
 jobs:
   terraform:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ on:
       - 'mkdocs.yml'
 env:
   GO_VERSION: ~1.17
-  GO_VERSION_WIN: ^1.13
+  GO_VERSION_WIN: ~1.17
 
 jobs:
   build:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,7 +31,7 @@ on:
 
 env:
   GO_VERSION: ~1.17
-  GO_VERSION_WIN: ^1.13
+  GO_VERSION_WIN: ~1.17
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   #pull_request:
 env:
   GO_VERSION: ~1.17
-  GO_VERSION_WIN: ^1.13
+  GO_VERSION_WIN: ~1.17
 
 jobs:
   release:


### PR DESCRIPTION
## Description

The Windows build is using the same version as the Linux build, so also use 1.17 there. Use a tilde instead of a caret, so that the minor version is pinned.

See #1516.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings