### PR TITLE
Use common dependency versions in footloose container

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -26,7 +26,11 @@ bin/sonobuoy: | bin
 	$(curl) $(sonobuoy_url) | tar -C bin/ -zxv $(notdir $@)
 
 .footloose-alpine.stamp: footloose-alpine/Dockerfile
-	docker build --build-arg ETCD_ARCH=$(etcd_arch) -t footloose-alpine -f $< $(dir $<)
+	docker build \
+	  --build-arg ETCD_ARCH=$(etcd_arch) \
+	  --build-arg ETCD_VERSION=$(etcd_version) \
+	  --build-arg KUBE_VERSION=$(kubernetes_version) \
+	  -t footloose-alpine - <'$<'
 	touch $@
 
 check-network: bin/sonobuoy .footloose-alpine.stamp

--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -1,9 +1,10 @@
 FROM alpine:3.13
 
 ARG ETCD_ARCH
-ENV KUBE_VERSION=1.21.3
+ARG ETCD_VERSION
+ARG KUBE_VERSION
 
-RUN apk add openrc openssh-server bash busybox-initscripts coreutils findutils curl haproxy
+RUN apk add openrc openssh-server bash busybox-initscripts coreutils curl haproxy
 # enable syslog and sshd
 RUN rc-update add cgroups boot
 RUN rc-update add syslog boot
@@ -18,14 +19,13 @@ RUN sed -i -e 's/^\(tty[0-9]\)/# \1/' /etc/inittab
 RUN sed -i -e 's/^root:!:/root::/' /etc/shadow
 
 # Put kubectl into place to ease up debugging
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl \
-       && chmod +x ./kubectl \
-       && mv ./kubectl /usr/local/bin/kubectl
+RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl \
+  && chmod +x /usr/local/bin/kubectl
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
 # Install etcd for smoke tests with external etcd
-RUN wget https://github.com/etcd-io/etcd/releases/download/v3.5.1/etcd-v3.5.1-linux-$ETCD_ARCH.tar.gz
-RUN tar -xvf etcd-v3.5.1-linux-$ETCD_ARCH.tar.gz -C /opt --strip-components=1
+RUN curl -L https://github.com/etcd-io/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-$ETCD_ARCH.tar.gz \
+  | tar xz -C /opt --strip-components=1
 
 # This lets etcd start when running on arm in smokes
 ENV ETCD_UNSUPPORTED_ARCH=arm64


### PR DESCRIPTION
## Description

Instead of harcoding dependency versions, inject them as Docker build args taken from the Makefile variables.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings