### PR TITLE
Fix link to external runtime deps docs section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ k0s is distributed as a single binary with zero host OS dependencies besides the
 - Multiple installation methods: [single-node](install.md), [multi-node](k0sctl-install.md), [airgap](airgap-install.md) and [Docker](k0s-in-docker.md)
 - Automatic lifecycle management with k0sctl: [upgrade](upgrade.md), [backup and restore](backup.md)
 - Modest [system requirements](system-requirements.md) (1 vCPU, 1 GB RAM)
-- Available as a single binary with no [external runtime dependencies](external-runtime--deps.md) besides the kernel
+- Available as a single binary with no [external runtime dependencies](external-runtime-deps.md) besides the kernel
 - Flexible deployment options with [control plane isolation](networking.md#controller-worker-communication) as default
 - Scalable from a single node to large, [high-available](high-availability.md) clusters
 - Supports custom [Container Network Interface (CNI)](networking.md) plugins (Kube-Router is the default, Calico is offered as a preconfigured alternative)


### PR DESCRIPTION
## Description

Fix link to external runtime deps docs section. Follow-up to #1561.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings