### PR TITLE
Revise local docs testing setup

### DIFF
--- a/.github/workflows/publish-docs-manual.yml
+++ b/.github/workflows/publish-docs-manual.yml
@@ -7,8 +7,6 @@ on:
         required: true
 
 env:
-  GO_VERSION: ~1.17
-  NODE_VERSION: 12.x
   PYTHON_VERSION: 3.x
   TARGET_VERSION: ${{ github.event.inputs.version }}
   
@@ -50,17 +48,13 @@ jobs:
           rm -rf main
 
       - name: Generate docs
-        run: make -C docs
+        run: make -C docs docs clean-k0s
 
       - name: git config
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
-      - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ env.NODE_VERSION }}
 
       - name: mike deploy ${{ github.event.inputs.version }}
         run: |

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -8,8 +8,6 @@ on:
       - published
 
 env:
-  GO_VERSION: ~1.17
-  NODE_VERSION: 12.x
   PYTHON_VERSION: 3.x
 
 jobs:
@@ -17,6 +15,14 @@ jobs:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
+      - name: checkout k0s release
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Prepare build environment
+        run: .github/workflows/prepare-build-env.sh
+
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:
@@ -26,15 +32,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
-        id: go
-
-      - uses: actions/cache@v2
-        name: Go modules cache
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Install dependencies
         run: |
@@ -45,23 +42,13 @@ jobs:
           pip install mike
           go install github.com/k0sproject/version/cmd/k0s_sort@v0.2.2
 
-      - name: checkout k0s release
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
       - name: Generate docs
-        run: make -C docs
+        run: make -C docs docs clean-k0s
 
       - name: git config
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-
-      - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ env.NODE_VERSION }}
 
       # This deploys the current docs into gh-pages/head on merges to main
       # The old "main" gets deleted if it exists, head is more descriptive

--- a/Makefile
+++ b/Makefile
@@ -193,8 +193,7 @@ clean-docker-image:
 .PHONY: clean
 clean: clean-gocache clean-docker-image
 	-rm -f pkg/assets/zz_generated_offsets_*.go k0s k0s.exe .bins.*stamp bindata* static/gen_manifests.go
-	rm -rf site
-	rm -rf docs/cli
+	-$(MAKE) -C docs clean
 	-$(MAKE) -C embedded-bins clean
 	-$(MAKE) -C image-bundle clean
 	-$(MAKE) -C inttest clean
@@ -231,3 +230,14 @@ image-bundle/bundle.tar: image-bundle/image.list
 .PHONY: docs
 docs:
 	$(MAKE) -C docs
+
+DOCS_DEV_PORT = 8000
+
+.PHONY: docs-serve-dev
+docs-serve-dev:
+	$(MAKE) -C docs .docker-image.serve-dev.stamp
+	docker run --rm \
+	  -v "$(CURDIR):/docs:ro" \
+	  -w /docs \
+	  -p '$(DOCS_DEV_PORT):8000' \
+	  k0sdocs.docker-image.serve-dev

--- a/docs/.dockerignore
+++ b/docs/.dockerignore
@@ -1,0 +1,3 @@
+.*
+*
+!requirements.txt

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+/*.etag
+/.docker-image.*

--- a/docs/Dockerfile.serve-dev
+++ b/docs/Dockerfile.serve-dev
@@ -1,6 +1,6 @@
-ARG PYTHON_VERSION=3.8.1-alpine3.11
+ARG PYTHON_IMAGE_VERSION
 
-FROM python:${PYTHON_VERSION} as builder
+FROM python:${PYTHON_IMAGE_VERSION} as builder
 
 ENV PYTHONUNBUFFERED 1
 
@@ -23,8 +23,6 @@ RUN \
   && apk del .build gcc musl-dev \
   && rm -rf /usr/local/lib/python3.8/site-packages/mkdocs/themes/*/* \
   && rm -rf /tmp/*
-
-
 
 # Set final MkDocs working directory
 WORKDIR /docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,7 +1,4 @@
-mkdocs := $(shell which mkdocs)
-ifeq ($(mkdocs),)
-@echo "mkdocs required, use pip install mkdocs"
-endif
+include Makefile.variables
 
 ifeq ($(OS),Windows_NT)
 detected_OS := windows
@@ -19,28 +16,78 @@ TARGET_VERSION ?= latest
 # mkdocs.yml refuses to live in the docs-directory, this is why "cd .." is needed
 # gives: "Error: The 'docs_dir' should not be the parent directory of the config file."
 # even if docs_dir is "."
-docs: cli
+docs: .require-mkdocs cli
 	cd .. && mkdocs build --strict
 
-LATEST_RELEASE_META_URL=https://api.github.com/repos/k0sproject/k0s/releases/$(TARGET_VERSION)
-JQ_COMMAND=jq -r '.assets[]|select(.browser_download_url|contains("amd64"))|select(.browser_download_url|contains(".exe")|not)|select(.browser_download_url|contains("bundle")|not).browser_download_url'
+.PHONY: .require-mkdocs
+.require-mkdocs:
+	@which mkdocs >/dev/null 2>/dev/null || { \
+	  echo 'mkdocs required, use pip install mkdocs' >&2; \
+	  exit 1; \
+	}
 
-.PHONY: k0s_release_binary
-k0s_release_binary:
-	curl -L -o ./k0s `curl $(LATEST_RELEASE_META_URL) | $(JQ_COMMAND)`
-	chmod +x ./k0s
+.PHONY: .k0s-download-url .k0s.exe-download-url
+ifeq ($(TARGET_VERSION),latest)
+.k0s-download-url .k0s.exe-download-url: release_metadata_url = $(k0s_releases_url)/latest
+else
+.k0s-download-url .k0s.exe-download-url: release_metadata_url = $(k0s_releases_url)/tags/$(TARGET_VERSION)
+endif
+.k0s-download-url .k0s.exe-download-url:
+	$(eval binary_suffix = $(patsubst .k0s%,%,$(@:-download-url=)))
+	curl -sS -- '$(release_metadata_url)' \
+	  | jq -r '. as {name: $$ver, assets: $$a} | $$a[] | select(.name == "k0s-"+$$ver+"-amd64$(binary_suffix)") | .browser_download_url'
+
+.PHONY: k0s k0s.exe
+ifeq ($(TARGET_VERSION),local)
+cli: k0s_binary_path := $(abspath ..)
+else
+cli: k0s_binary_path := $(abspath .)
+k0s k0s.exe::
+	[ ! -f '$@.etag' ] || { if [ ! -f '$@' ] || [ '$@.etag' -ot '$@' ]; then rm -- '$@.etag'; fi }
+	touch -- '$@.etag'
+	@downloadUrl="$$($(MAKE) --no-print-directory -s '.$@-download-url')" \
+	  && echo "Download URL for $@ $(TARGET_VERSION): $$downloadUrl" \
+	  && curl -Lo '$@.tmp' --etag-compare '$@.etag' --etag-save '$@.etag.tmp' -- "$$downloadUrl"
+	if [ -f '$@.tmp' ]; then \
+	  mv -- '$@.tmp' '$@' && touch -r '$@' -- '$@.etag.tmp'; \
+	fi
+	mv -- '$@.etag.tmp' '$@.etag'
+
+k0s::
+	chmod +x -- '$@'
+endif
 
 .PHONY: cli
-cli: k0s_release_binary
+ifeq ($(detected_OS),windows)
+cli: k0s.exe
+cli: k0s_binary = k0s.exe
+else
+cli: k0s
+cli: k0s_binary = k0s
+endif
+cli:
 	rm -rf cli
 	mkdir cli
-	cd .. && ./docs/k0s docs markdown
-	rm ./k0s
+	cd .. && '$(k0s_binary_path)/$(k0s_binary)' docs markdown
 	rm cli/k0s_kubectl_*
 	sed $(sedopt) '/\[k0s kubectl /d' cli/k0s_kubectl.md
 	ln -s k0s.md cli/README.md
 
+.docker-image.serve-dev.stamp: Dockerfile.serve-dev requirements.txt
+	docker build \
+	  --build-arg PYTHON_IMAGE_VERSION=$(python_version)-alpine3.15 \
+	  -t 'k0sdocs$(basename $@)' -f '$<' .
+	touch -- '$@'
+
+clean-k0s:
+	rm -f k0s k0s.exe k0s.etag k0s.exe.etag
+
 .PHONY: clean
-clean:
+clean: clean-k0s
 	rm -rf cli
 	rm -rf ../site
+	for i in .docker-image.*.stamp; do \
+	  if [ -f "$$i" ]; then \
+	    docker rmi -f "k0sdocs$$(basename "$$i" .stamp)" && rm -- "$$i";\
+	  fi; \
+	done

--- a/docs/Makefile.variables
+++ b/docs/Makefile.variables
@@ -1,0 +1,3 @@
+python_version = 3.10.2
+
+k0s_releases_url = https://api.github.com/repos/k0sproject/k0s/releases

--- a/docs/contributors/testing.md
+++ b/docs/contributors/testing.md
@@ -22,7 +22,12 @@ Please run the following style and formatting commands and fix/check-in any chan
     go fmt ./...
     ```
 
-3. Pre-submit Flight Checks
+3. Checking the documentation
+
+   Verify any changes to the documentation by following the instructions
+   [here](../internal/publishing_docs_using_mkdocs.md#testing-docs-locally).
+
+4. Pre-submit Flight Checks
 
     In the repository root directory, make sure that:
 

--- a/docs/docker-compose.yml
+++ b/docs/docker-compose.yml
@@ -1,8 +1,0 @@
-version: "3.9"
-services:
-  k0s-docs:
-    build: .
-    volumes:
-      - ../:/docs
-    ports:
-      - 80:8000

--- a/docs/internal/publishing_docs_using_mkdocs.md
+++ b/docs/internal/publishing_docs_using_mkdocs.md
@@ -41,6 +41,9 @@ nav:
 
 ## Testing docs locally
 
-We've got a dockerized setup for easily testing docs in local environment. Simply run `docker-compose up` in the docs root folder. The docs will be available on `localhost:80`.
+We've got a dockerized setup for easily testing docs locally. Simply run
+`make docs-serve-dev`. The docs will be available on http://localhost:8000.
 
-**Note** If you have something already running locally on port `80` you need to change the mapped port on the `docker-compose.yml` file.
+**Note** If you have something already running locally on port `8000` you can
+choose another port like so: `make docs-serve-dev DOCS_DEV_PORT=9999`. The docs
+will then be available on http://localhost:9999.


### PR DESCRIPTION
## Description

Integrate the dockerized docs testing setup into the main Makefile. Don't require docker-compose to run it and allow an easy override of the local HTTP port.

* Add Makefile.variables to capture the following:
  * Python version
  * k0s releases GitHub API URL
* Make the mkdocs check dependent on the docs goal  
  So that other targets in the Makefile may be used without mkdocs
* Fix the handling of TARGET_VERSION  
  The latest release and specific releases require different URLs.
* Add support to build the docs using the local k0s binary  
  Use TARGET_VERSION=local for this
* Add caching support for downloaded k0s binaries  
  This is done via curl's ETag HTTP header support.
* Remove superfluous Node.js steps from docs actions.
* Add basic support for building docs on Windows

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings