### PR TITLE
Better list rendering in docs

### DIFF
--- a/.github/workflows/mkdocs-set-default-version.yml
+++ b/.github/workflows/mkdocs-set-default-version.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ./mkdocs-material-insiders
+          pip install mdx-truly-sane-lists
           pip install mike
 
       - name: Checkout Release from k0s

--- a/.github/workflows/publish-docs-manual.yml
+++ b/.github/workflows/publish-docs-manual.yml
@@ -27,6 +27,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install mkdocs
           pip install git+https://${{ secrets.GH_TOKEN }}@github.com/lensapp/mkdocs-material-insiders.git
+          pip install mdx-truly-sane-lists
           pip install mike
 
       - name: Checkout k0s ${{ github.event.inputs.version }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,6 +27,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install mkdocs
           pip install git+https://${{ secrets.GH_TOKEN }}@github.com/lensapp/mkdocs-material-insiders.git
+          pip install mdx-truly-sane-lists
           pip install mike
 
       - name: Checkout k0s release

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,3 +6,4 @@ pymdown-extensions>=7.0
 mkdocs-material-extensions>=1.0
 mkdocs-git-revision-date-localized-plugin>=0.7.3
 mkdocs-material>=6.1.0
+mdx-truly-sane-lists>=1.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,9 @@ markdown_extensions:
   - pymdownx.highlight: {}
   - pymdownx.superfences: {}
   - pymdownx.inlinehilite: {}
+  - mdx_truly_sane_lists: # https://github.com/mkdocs/mkdocs/issues/545#issuecomment-522196661
+      nested_indent: 2
+      truly_sane: true
   - toc:
         permalink: "#"
         toc_depth: 3


### PR DESCRIPTION
## Description

The docs use a two spaces indentation for lists, which is not properly picked up by mkdocs by default. Add the mdx-truly-sane-lists extension to fix this.

Before:
![before](https://user-images.githubusercontent.com/1215104/156165522-bf0dc77b-4936-4744-a84f-4ec471e08318.png)

After:
![after](https://user-images.githubusercontent.com/1215104/156165525-2149ef79-eaef-4487-acdf-a45c174f6171.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings