### PR TITLE
Add clusterDomain configuration option

### DIFF
--- a/cmd/controller/certificates.go
+++ b/cmd/controller/certificates.go
@@ -188,7 +188,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 		"kubernetes.default",
 		"kubernetes.default.svc",
 		"kubernetes.default.svc.cluster",
-		"kubernetes.svc.cluster.local",
+		fmt.Sprintf("kubernetes.svc.%s", c.ClusterSpec.Network.ClusterDomain),
 		"127.0.0.1",
 		"localhost",
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,7 @@ spec:
     serviceCIDR: 10.96.0.0/12
     provider: kuberouter
     calico: null
+    clusterDomain: cluster.local
     dualStack: {}
     kuberouter:
       mtu: 0
@@ -147,6 +148,7 @@ spec:
 | `provider`    | Network provider (valid values: `calico`, `kuberouter`, or `custom`). For `custom`, you can push any network provider (default: `kuberouter`). Be aware that it is your responsibility to configure all of the CNI-related setups, including the CNI provider itself and all necessary host levels setups (for example, CNI binaries). **Note:** Once you initialize the cluster with a network provider the only way to change providers is through a full cluster redeployment. |
 | `podCIDR`     | Pod network CIDR to use in the cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `serviceCIDR` | Network CIDR to use for cluster VIP services.                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `clusterDomain` | Cluster Domain to be passed to the [kubelet](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration) and the coredns configuration.                                                                                                                                                                                                                                                                        |
 
 #### `spec.network.calico`
 

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/network.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/network.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/asaskevich/govalidator"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -38,17 +39,20 @@ type Network struct {
 	Provider string `json:"provider"`
 	// Network CIDR to use for cluster VIP services
 	ServiceCIDR string `json:"serviceCIDR,omitempty"`
+	// Cluster Domain
+	ClusterDomain string `json:"clusterDomain,omitempty"`
 }
 
 // DefaultNetwork creates the Network config struct with sane default values
 func DefaultNetwork() *Network {
 	return &Network{
-		PodCIDR:     "10.244.0.0/16",
-		ServiceCIDR: "10.96.0.0/12",
-		Provider:    "kuberouter",
-		KubeRouter:  DefaultKubeRouter(),
-		DualStack:   DefaultDualStack(),
-		KubeProxy:   DefaultKubeProxy(),
+		PodCIDR:       "10.244.0.0/16",
+		ServiceCIDR:   "10.96.0.0/12",
+		Provider:      "kuberouter",
+		KubeRouter:    DefaultKubeRouter(),
+		DualStack:     DefaultDualStack(),
+		KubeProxy:     DefaultKubeProxy(),
+		ClusterDomain: "cluster.local",
 	}
 }
 
@@ -67,6 +71,10 @@ func (n *Network) Validate() []error {
 	_, _, err = net.ParseCIDR(n.ServiceCIDR)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("invalid service CIDR %s", n.ServiceCIDR))
+	}
+
+	if !govalidator.IsDNSName(n.ClusterDomain) {
+		errors = append(errors, fmt.Errorf("invalid clusterDomain %s", n.ClusterDomain))
 	}
 
 	if n.DualStack.Enabled {

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/network_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/network_test.go
@@ -211,6 +211,16 @@ func (s *NetworkSuite) TestValidation() {
 		s.Contains(errors[0].Error(), "invalid service CIDR")
 	})
 
+	s.T().Run("invalid_cluster_domain", func(t *testing.T) {
+		n := DefaultNetwork()
+		n.ClusterDomain = ".invalid-cluster-domain"
+
+		errors := n.Validate()
+		s.NotNil(errors)
+		s.Len(errors, 1)
+		s.Contains(errors[0].Error(), "invalid clusterDomain .invalid-cluster-domain")
+	})
+
 	s.T().Run("invalid_ipv6_service_cidr", func(t *testing.T) {
 		n := DefaultNetwork()
 		n.Calico = DefaultCalico()

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -334,7 +334,7 @@ func (c *CoreDNS) getConfig(ctx context.Context, clusterConfig *v1beta1.ClusterC
 
 	config := coreDNSConfig{
 		Replicas:      replicas,
-		ClusterDomain: "cluster.local",
+		ClusterDomain: clusterConfig.Spec.Network.ClusterDomain,
 		ClusterDNSIP:  dns,
 		Image:         clusterConfig.Spec.Images.CoreDNS.URI(),
 		PullPolicy:    clusterConfig.Spec.Images.DefaultPullPolicy,

--- a/pkg/component/controller/kubeletconfig_test.go
+++ b/pkg/component/controller/kubeletconfig_test.go
@@ -56,10 +56,16 @@ func Test_KubeletConfig(t *testing.T) {
 		})
 	})
 	t.Run("default_profile_must_have_feature_gates_if_dualstack_setup", func(t *testing.T) {
-		profile := getDefaultProfile(dnsAddr, true)
+		profile := getDefaultProfile(dnsAddr, true, "cluster.local")
 		require.Equal(t, map[string]bool{
 			"IPv6DualStack": true,
 		}, profile["featureGates"])
+	})
+	t.Run("default_profile_must_pass_down_cluster_domain", func(t *testing.T) {
+		profile := getDefaultProfile(dnsAddr, true, "cluster.local.custom")
+		require.Equal(t, string(
+			"cluster.local.custom",
+		), profile["clusterDomain"])
 	})
 	t.Run("with_user_provided_profiles", func(t *testing.T) {
 		k := defaultConfigWithUserProvidedProfiles(t)
@@ -92,12 +98,12 @@ func Test_KubeletConfig(t *testing.T) {
 			require.NoError(t, yaml.Unmarshal([]byte(manifestYamls[3]), &profileYYY))
 
 			// manually apple the same changes to default config and check that there is no diff
-			defaultProfileKubeletConfig := getDefaultProfile(dnsAddr, false)
+			defaultProfileKubeletConfig := getDefaultProfile(dnsAddr, false, "cluster.local")
 			defaultProfileKubeletConfig["authentication"].(map[string]interface{})["anonymous"].(map[string]interface{})["enabled"] = false
 			defaultWithChangesXXX, err := yaml.Marshal(defaultProfileKubeletConfig)
 			require.NoError(t, err)
 
-			defaultProfileKubeletConfig = getDefaultProfile(dnsAddr, false)
+			defaultProfileKubeletConfig = getDefaultProfile(dnsAddr, false, "cluster.local")
 			defaultProfileKubeletConfig["authentication"].(map[string]interface{})["webhook"].(map[string]interface{})["cacheTTL"] = "15s"
 			defaultWithChangesYYY, err := yaml.Marshal(defaultProfileKubeletConfig)
 

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -154,7 +154,6 @@ func (k *Kubelet) Run(ctx context.Context) error {
 		args["--cni-bin-dir"] = "C:\\k\\cni"
 		args["--cni-conf-dir"] = "C:\\k\\cni\\config"
 		args["--hostname-override"] = node
-		args["--cluster-domain"] = "cluster.local"
 		args["--hairpin-mode"] = "promiscuous-bridge"
 		args["--cert-dir"] = "C:\\var\\lib\\k0s\\kubelet_certs"
 	} else {

--- a/pkg/constant/constant_windows.go
+++ b/pkg/constant/constant_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*


### PR DESCRIPTION
## Description
Allows the user to override the default clusterDomain (cluster.local) by setting it in:
 - coredns config
 - kubelet config
 - hostnames of certificates

This is my first experience with go but I tried my best ;)

`make lint` failed with `go/pkg/mod/github.com/yeya24/promlinter@v0.1.0/promlinter.go:11:2: missing go.sum entry for module providing package github.com/prometheus/client_golang/prometheus (imported by github.com/yeya24/promlinter); to add:` and 

`make check-unit` with 
```
time="2022-03-04T16:33:37+01:00" level=warning msg="Failed to start: fork/exec /tmp: permission denied" component=supervisor-test-non-executable
time="2022-03-04T16:33:37+01:00" level=warning msg="failed to initialize dir: mkdir /bin/sh: not a directory" component=supervisor-test-rundir-fail
time="2022-03-04T16:33:37+01:00" level=info msg="Starting to supervise" component=supervisor-test-respawn
time="2022-03-04T16:33:37+01:00" level=warning msg="Failed to start: fork/exec /bin/true: no such file or directory" component=supervisor-test-respawn
```

This doesn't seem related. I'm on a mac, might that be the issue?

`make check-basic` and `make check-hacontrolplane` passed.

Fixes: https://github.com/k0sproject/k0s/issues/1501

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

I've deployed a cluster with a custom clusterDomain setting and tested minio-operator (kubelet configuration) relying on this custom domain as well as telepresence (coredns)

## Checklist:

- [x] My code follows the style [guidelines](X) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
