### PR TITLE
Replace hard /bin/true and /bin/false paths in tests with exec.LookPath

### DIFF
--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -18,6 +18,7 @@ package supervisor
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"sort"
 	"strings"
 	"syscall"
@@ -123,14 +124,19 @@ func TestGetEnv(t *testing.T) {
 }
 
 func TestRespawn(t *testing.T) {
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Errorf("could not find a path for 'true' executable: %s", err)
+	}
+
 	s := Supervisor{
 		Name:           "supervisor-test-respawn",
-		BinPath:        "/bin/true",
+		BinPath:        truePath,
 		RunDir:         ".",
 		Args:           []string{},
 		TimeoutRespawn: 10 * time.Millisecond,
 	}
-	err := s.Supervise()
+	err = s.Supervise()
 	if err != nil {
 		t.Errorf("Failed to start %s: %v", s.Name, err)
 	}
@@ -156,14 +162,19 @@ func TestRespawn(t *testing.T) {
 }
 
 func TestStopWhileRespawn(t *testing.T) {
+	falsePath, err := exec.LookPath("false")
+	if err != nil {
+		t.Errorf("could not find a path for 'false' executable: %s", err)
+	}
+
 	s := Supervisor{
 		Name:           "supervisor-test-stop-while-respawn",
-		BinPath:        "/bin/false",
+		BinPath:        falsePath,
 		RunDir:         ".",
 		Args:           []string{},
 		TimeoutRespawn: 1 * time.Second,
 	}
-	err := s.Supervise()
+	err = s.Supervise()
 	if err != nil {
 		t.Errorf("Failed to start %s: %v", s.Name, err)
 	}


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>


## Description

Replaces the hardcoded /bin/true and /bin/false paths with `exec.LookPath("true")` and `"false"` in supervisor unit tests.

Fixes #1572

## Type of change

<!-- check the related options -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [X] Manual test
- [ ] Auto test added

## Checklist:

- [X] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [X] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
