### PR TITLE
Add pre-flight checks and probes module

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -186,11 +186,13 @@ jobs:
         with:
           name: k0s
 
-      - name: Run inttest
+      - name: k0s sysinfo
         run: |
           chmod +x k0s
           ./k0s sysinfo
-          make -C inttest ${{ matrix.smoke-suite }}
+
+      - name: Run inttest
+        run: make -C inttest ${{ matrix.smoke-suite }}
 
       - name: Collect test logs
         if: failure()
@@ -330,6 +332,9 @@ jobs:
 
       - name: Build
         run: make build
+
+      - name: k0s sysinfo
+        run: ./k0s sysinfo
 
       - name: Run smoketest
         run: make -C inttest check-basic

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -187,7 +187,10 @@ jobs:
           name: k0s
 
       - name: Run inttest
-        run: chmod +x k0s && make -C inttest ${{ matrix.smoke-suite }}
+        run: |
+          chmod +x k0s
+          ./k0s sysinfo
+          make -C inttest ${{ matrix.smoke-suite }}
 
       - name: Collect test logs
         if: failure()

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -101,7 +101,7 @@ func NewControllerCmd() *cobra.Command {
 				ControllerRoleEnabled: true,
 				WorkerRoleEnabled:     c.SingleNode || c.EnableWorker,
 				DataDir:               c.K0sVars.DataDir,
-			}).RunPreFlightChecks(ignorePreFlightChecks); err != nil {
+			}).RunPreFlightChecks(ignorePreFlightChecks); !ignorePreFlightChecks && err != nil {
 				return err
 			}
 

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/internal/pkg/stringmap"
 	"github.com/k0sproject/k0s/internal/pkg/stringslice"
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/applier"
 	"github.com/k0sproject/k0s/pkg/build"
@@ -53,6 +54,8 @@ import (
 )
 
 type CmdOpts config.CLIOptions
+
+var ignorePreFlightChecks bool
 
 func NewControllerCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -94,6 +97,14 @@ func NewControllerCmd() *cobra.Command {
 			c.Logging = stringmap.Merge(c.CmdLogLevels, c.DefaultLogLevels)
 			cmd.SilenceUsage = true
 
+			if err := (&sysinfo.K0sSysinfoSpec{
+				ControllerRoleEnabled: true,
+				WorkerRoleEnabled:     c.SingleNode || c.EnableWorker,
+				DataDir:               c.K0sVars.DataDir,
+			}).RunPreFlightChecks(ignorePreFlightChecks); err != nil {
+				return err
+			}
+
 			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 			defer cancel()
 			return c.startController(ctx)
@@ -101,6 +112,7 @@ func NewControllerCmd() *cobra.Command {
 	}
 
 	// append flags
+	cmd.Flags().BoolVar(&ignorePreFlightChecks, "ignore-pre-flight-checks", false, "continue even if pre-flight checks fail")
 	cmd.Flags().AddFlagSet(config.GetPersistentFlagSet())
 	cmd.PersistentFlags().AddFlagSet(config.GetControllerFlags())
 	cmd.PersistentFlags().AddFlagSet(config.GetWorkerFlags())

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -79,7 +79,7 @@ func NewWorkerCmd() *cobra.Command {
 				ControllerRoleEnabled: false,
 				WorkerRoleEnabled:     true,
 				DataDir:               c.K0sVars.DataDir,
-			}).RunPreFlightChecks(ignorePreFlightChecks); err != nil {
+			}).RunPreFlightChecks(ignorePreFlightChecks); !ignorePreFlightChecks && err != nil {
 				return err
 			}
 

--- a/docs/external-runtime-deps.md
+++ b/docs/external-runtime-deps.md
@@ -35,7 +35,7 @@ have been created from the same image.
 ## Linux specific
 <!--
 This piece of documentation is best-effort and considered to be augmented and
-extended in the future. The kernel and cgroups requirements are basically taken
+extended in the future. The kernel and cgroup requirements are basically taken
 from kubernetes/system-validators. Often there's no real hint as to why they are
 required (although most requirements seem pretty obvious). Also need to check
 for requirements of kube-router and calico.
@@ -49,37 +49,87 @@ system. This basically stems from the need to run both containers and also be
 able to set up networking for the containers.
 
 The needed kernel configuration items are listed below. All of them are
-available in Kernel versions 4.3 and above. The list covers ONLY the
-k0s/kubernetes components’ needs on worker nodes. Your own workloads may require
-more.
+available in Kernel versions 4.3 and above. If running on older kernels, check
+if the distro in use has backported some features; nevertheless, it might meet
+the requirements. k0s will check the Linux kernel release as part of its
+pre-flight checks and issue a warning if it's below 3.10.
 
-- [CONFIG_INET](https://github.com/torvalds/linux/blob/v4.3/net/Kconfig#L5)
-  - [CONFIG_NETFILTER_XT_TARGET_REDIRECT](https://github.com/torvalds/linux/blob/v4.3/net/netfilter/Kconfig#L853)
-  - [CONFIG_NETFILTER_XT_MATCH_COMMENT](https://github.com/torvalds/linux/blob/v4.3/net/netfilter/Kconfig#L1002)
-    (this used to be IP_NF_TARGET_REDIRECT before kernel version 3.7)
+The list covers ONLY the k0s/kubernetes components’ needs on worker nodes. Your
+own workloads may require more.
 
-- [CONFIG_NAMESPACES](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1168)
-  - [CONFIG_UTS_NS](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1180)
-  - [CONFIG_IPC_NS](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1187)
-  - [CONFIG_PID_NS](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1210)
-  - [CONFIG_NET_NS](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1218)
+<!-- Kernel config nesting is taken from the v4.3 kernel's menuconfig structure. -->
 
-- [CONFIG_CGROUPS](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L927)
-  - [CONFIG_CGROUP_FREEZER](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L953)
-  - [CONFIG_CGROUP_PIDS](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L959)
-  - [CONFIG_CGROUP_DEVICE](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L975)
-  - [CONFIG_CPUSETS](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L981)
-  - [CONFIG_CGROUP_CPUACCT](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L996)
-  - [CONFIG_MEMCG](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1005)
-  - [CONFIG_CGROUP_SCHED](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1081)
-    - [CONFIG_FAIR_GROUP_SCHED](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1090)
+- [`CONFIG_CGROUPS`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L927):
+  Control Group support
+  - [`CONFIG_CGROUP_FREEZER`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L953):
+    Freezer cgroup subsystem
+  - [`CONFIG_CGROUP_PIDS`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L959):
+    PIDs cgroup subsystem  
+    [kubernetes/kubeadm#2335 (comment)](https://github.com/kubernetes/kubeadm/issues/2335#issuecomment-722405527)
+  - [`CONFIG_CGROUP_DEVICE`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L975):
+    Device controller for cgroups
+  - [`CONFIG_CPUSETS`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L981):
+    Cpuset support
+  - [`CONFIG_CGROUP_CPUACCT`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L996):
+    Simple CPU accounting cgroup subsystem
+  - [`CONFIG_MEMCG`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1005):
+    Memory Resource Controller for Control Groups
+  - _(optional)_ [`CONFIG_CGROUP_HUGETLB`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1055):
+    HugeTLB Resource Controller for Control Groups  
+    [kubernetes/kubeadm#2335 (comment)](https://github.com/kubernetes/kubeadm/issues/2335#issuecomment-722405527)
+  - [`CONFIG_CGROUP_SCHED`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1081):
+    Group CPU scheduler
+    - [`CONFIG_FAIR_GROUP_SCHED`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1090):
+      Group scheduling for SCHED_OTHER  
+      [kubernetes/kubeadm#2335 (comment)](https://github.com/kubernetes/kubeadm/issues/2335#issuecomment-717996215)
+      - _(optional)_ [`CONFIG_CFS_BANDWIDTH`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1095):
+        CPU bandwidth provisioning for FAIR_GROUP_SCHED  
+        Required if CPU CFS quota enforcement is enabled for containers that
+        specify CPU limits (`--cpu-cfs-quota`).
+  - _(optional)_ [`CONFIG_BLK_CGROUP`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1119):
+    Block IO controller  
+    [kubernetes/kubernetes#92287 (comment)](https://github.com/kubernetes/kubernetes/issues/92287#issuecomment-1010723587)
+- [`CONFIG_NAMESPACES`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1168):
+  Namespaces support
+  - [`CONFIG_UTS_NS`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1180):
+    UTS namespace
+  - [`CONFIG_IPC_NS`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1187):
+    IPC namespace
+  - [`CONFIG_PID_NS`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1210):
+    PID namespace
+  - [`CONFIG_NET_NS`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L1218):
+    Network namespace
+- [`CONFIG_NET`](https://github.com/torvalds/linux/blob/v4.3/net/Kconfig#L5):
+  Networking support
+  - [`CONFIG_INET`](https://github.com/torvalds/linux/blob/v4.3/net/Kconfig#L58):
+    TCP/IP networking
+  - [`CONFIG_NETFILTER`](https://github.com/torvalds/linux/blob/v4.3/net/Kconfig#L109):
+    Network packet filtering framework (Netfilter)
+    - _(optional)_ [`CONFIG_NETFILTER_ADVANCED`](https://github.com/torvalds/linux/blob/v4.3/net/Kconfig#L171):
+      Advanced netfilter configuration
+    - [`CONFIG_NETFILTER_XTABLES`](https://github.com/torvalds/linux/blob/v4.3/net/netfilter/Kconfig#L567):
+      Netfilter Xtables support
+      - [`CONFIG_NETFILTER_XT_TARGET_REDIRECT`](https://github.com/torvalds/linux/blob/v4.3/net/netfilter/Kconfig#L853):
+        REDIRECT target support
+      - [`CONFIG_NETFILTER_XT_MATCH_COMMENT`](https://github.com/torvalds/linux/blob/v4.3/net/netfilter/Kconfig#L1002):
+        "comment" match support
+- [`CONFIG_EXT4_FS`](https://github.com/torvalds/linux/blob/v4.3/fs/ext4/Kconfig#L33):
+  The Extended 4 (ext4) filesystem
+- [`CONFIG_PROC_FS`](https://github.com/torvalds/linux/blob/v4.3/fs/proc/Kconfig#L1):
+  /proc file system support
 
-- [CONFIG_EXT4_FS](https://github.com/torvalds/linux/blob/v4.3/fs/ext4/Kconfig#L33)
-- [CONFIG_PROC_FS](https://github.com/torvalds/linux/blob/v4.3/fs/proc/Kconfig#L1)
+**Note:** As part of its pre-flight checks, k0s will try to inspect and validate
+the kernel configuration. In order for that to succeed, the configuration needs
+to be accessible at runtime. There are some typical places that k0s will check.
+A bullet-proof way to ensure the accessibility is to enable
+[`CONFIG_IKCONFIG_PROC`](https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L807),
+and, if enabled as a module, to load the `configs` module: `modprobe configs`.
 
-### cgroups
+### Control Groups (cgroups)
 
-Required [cgroups] controllers:
+Both [cgroup v1] and [cgroup v2] are supported.
+
+Required [cgroup] controllers:
 
 - cpu
 - cpuacct
@@ -89,7 +139,16 @@ Required [cgroups] controllers:
 - freezer
 - pids
 
-[cgroups]: https://man7.org/linux/man-pages/man7/cgroups.7.html
+Optional cgroup controllers:
+
+- hugetlb ([kubernetes/kubeadm#2335 (comment)](https://github.com/kubernetes/kubeadm/issues/2335#issuecomment-722405527))
+- blkio ([kubernetes/kubernetes#92287 (comment)](https://github.com/kubernetes/kubernetes/issues/92287#issuecomment-1010723587))  
+   containerd and cri-o will use blkio to track disk I/O and throttling in both
+   cgroup v1 and v2.
+
+[cgroup]: https://man7.org/linux/man-pages/man7/cgroups.7.html
+[cgroup v1]: https://www.kernel.org/doc/html/v5.16/admin-guide/cgroup-v1/
+[cgroup v2]: https://www.kernel.org/doc/html/v5.16/admin-guide/cgroup-v2.html
 
 ### containerd needs `apparmor_parser`
 

--- a/docs/raspberry-pi4.md
+++ b/docs/raspberry-pi4.md
@@ -44,7 +44,7 @@ Where `${HOST}` is any node and the login can succeed with no further prompts.
 
 Every node (whether control plane or not) requires additional configuration in preparation for k0s deployment.
 
-#### CGroup Configuration
+#### cgroup Configuration
 
 1. Ensure that the following packages are installed on each node:
 

--- a/docs/system-requirements.md
+++ b/docs/system-requirements.md
@@ -43,8 +43,10 @@ The specific storage consumption for k0s is as follows:
 
 ## Host operating system
 
-- Linux (kernel v4.3 or later)
+- Linux (see [Linux specific requirements] for details)
 - Windows Server 2019
+
+[Linux specific requirements]: external-runtime-deps.md#linux-specific
 
 ## Architecture
 
@@ -60,6 +62,9 @@ For information on the required ports and protocols, refer to [networking](netwo
 
 k0s strives to be as independent from the OS as possible. The current and past
 external runtime dependencies are documented [here](external-runtime-deps.md).
+
+To run some automated compatiblility checks on your system, use
+[`k0s sysinfo`](cli/k0s_sysinfo.md).
 
 ## Controller node measured memory consumption
 

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/k0sproject/dig v0.2.0
 	github.com/k0sproject/k0sctl v0.12.3
 	github.com/kardianos/service v1.2.1-0.20210728001519-a323c3813bc7
+	github.com/logrusorgru/aurora/v3 v3.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/image-spec v1.0.2
@@ -63,7 +64,6 @@ require (
 	k8s.io/kube-aggregator v0.23.0
 	k8s.io/kubectl v0.23.0
 	k8s.io/mount-utils v0.23.0
-	k8s.io/system-validators v1.4.0
 	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
 	sigs.k8s.io/controller-runtime v0.11.0
 	sigs.k8s.io/yaml v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -154,7 +154,6 @@ github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edY
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
@@ -743,7 +742,10 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
+github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
 github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
+github.com/logrusorgru/aurora/v3 v3.0.0 h1:R6zcoZZbvVcGMvDCKo45A9U/lzYyzl5NfYIvznmDfE4=
+github.com/logrusorgru/aurora/v3 v3.0.0/go.mod h1:vsR12bk5grlLvLXAYrBsb5Oc/N+LxAlxggSjiwMnCUc=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
@@ -1778,8 +1780,6 @@ k8s.io/metrics v0.23.0 h1:hJH0UMmgmOZHuVuOjbxE/b3710DbwpmWLT6qh33RiJY=
 k8s.io/metrics v0.23.0/go.mod h1:NDiZTwppEtAuKJ1Rxt3S4dhyRzdp6yUcJf0vo023dPo=
 k8s.io/mount-utils v0.23.0 h1:8sGMlbbQOA268SidZVoL7wOgEcbByoa6+bvFZCywhbg=
 k8s.io/mount-utils v0.23.0/go.mod h1:9pFhzVjxle1osJUo++9MFDat9HPkQUOoHCn+eExZ3Ew=
-k8s.io/system-validators v1.4.0 h1:8ruXIHkuTAGfv9rHJproNWFW8oLASThFkCOxeHPYkNU=
-k8s.io/system-validators v1.4.0/go.mod h1:bPldcLgkIUK22ALflnsXk8pvkTEndYdNuaHH6gRrl0Q=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210707171843-4b05e18ac7d9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=

--- a/internal/pkg/sysinfo/host_linux.go
+++ b/internal/pkg/sysinfo/host_linux.go
@@ -172,7 +172,7 @@ func (s *K0sSysinfoSpec) addKernelConfigs(linux *linux.LinuxProbes) {
 	ip6NFIPTables.AssertKernelConfig("IP6_NF_NAT", "ip6tables NAT support")
 	netfilter.AssertKernelConfig("NF_DEFRAG_IPV6", "")
 
-	bridge := linux.AssertKernelConfig("BRIDGE", "802.1d Ethernet Bridging")
+	bridge := net.AssertKernelConfig("BRIDGE", "802.1d Ethernet Bridging")
 	bridge.AssertKernelConfig("LLC", "")
 	bridge.AssertKernelConfig("STP", "")
 }

--- a/internal/pkg/sysinfo/host_linux.go
+++ b/internal/pkg/sysinfo/host_linux.go
@@ -1,0 +1,178 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysinfo
+
+import (
+	"regexp"
+
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes/linux"
+)
+
+func (s *K0sSysinfoSpec) addHostSpecificProbes(p probes.Probes) {
+
+	linux := linux.RequireLinux(p)
+
+	linux.AssertKernelRelease(func(release string) string {
+		re := regexp.MustCompile(`^3\.1[0-9]|[4-9]|[1-9][0-9]`)
+		if !re.MatchString(release) {
+			return "expected 3.10 and above"
+		}
+		return ""
+	})
+
+	s.addKernelConfigs(linux)
+
+	cgroups := linux.RequireCgroups()
+	cgroups.RequireControllers(
+		"cpu",
+		"cpuacct",
+		"cpuset",
+		"memory",
+		"devices",
+		"freezer",
+		"pids",
+	)
+	cgroups.AssertControllers(
+		"hugetlb",
+		"blkio",
+	)
+}
+
+func (s *K0sSysinfoSpec) addKernelConfigs(linux *linux.LinuxProbes) {
+	// Most of the probes were added in k/k#32427 (k8s 1.5) without much
+	// explanation. The probes here are documented as good as possible in
+	// docs/external-runtime-deps.md (except for "debug" probes).
+
+	//  Kernel config nesting is taken from the v4.3 kernel's menuconfig
+	//  structure. If not stated otherwise, all comments are based on Linux 4.3,
+	//  which is the first kernel release that supports all of those configs.
+
+	if s.WorkerRoleEnabled {
+		cgroups := linux.RequireKernelConfig("CGROUPS", "Control Group support")
+		cgroups.RequireKernelConfig("CGROUP_FREEZER", "Freezer cgroup subsystem")
+		cgroups.RequireKernelConfig("CGROUP_PIDS", "PIDs cgroup subsystem")
+		cgroups.RequireKernelConfig("CGROUP_DEVICE", "Device controller for cgroups")
+		cgroups.RequireKernelConfig("CPUSETS", "Cpuset support")
+		cgroups.RequireKernelConfig("CGROUP_CPUACCT", "Simple CPU accounting cgroup subsystem")
+		cgroups.RequireKernelConfig("MEMCG", "Memory Resource Controller for Control Groups")
+		cgroups.AssertKernelConfig("CGROUP_HUGETLB", "HugeTLB Resource Controller for Control Groups")
+		cgSched := cgroups.RequireKernelConfig("CGROUP_SCHED", "Group CPU scheduler")
+		// https://github.com/kubernetes/kubeadm/issues/2335#issuecomment-717996215
+		// > For reference https://github.com/torvalds/linux/blob/v4.3/kernel/sched/core.c#L8511-L8533
+		// >
+		// > - CONFIG_FAIR_GROUP_SCHED should be set as required, since there is
+		// >   currently no way to disable using it in Kubernetes
+		// > - CONFIG_CFS_BANDWIDTH should be set as optional, as long as
+		// >   --cpu-cfs-quota=false actually works when CONFIG_CFS_BANDWIDTH=n
+		fairGroupSched := cgSched.RequireKernelConfig("FAIR_GROUP_SCHED", "Group scheduling for SCHED_OTHER")
+		fairGroupSched.AssertKernelConfig("CFS_BANDWIDTH", "CPU bandwidth provisioning for FAIR_GROUP_SCHED")
+		cgroups.AssertKernelConfig("BLK_CGROUP", "Block IO controller")
+
+		ns := linux.RequireKernelConfig("NAMESPACES", "Namespaces support")
+		ns.RequireKernelConfig("UTS_NS", "UTS namespace")
+		ns.RequireKernelConfig("IPC_NS", "IPC namespace")
+		ns.RequireKernelConfig("PID_NS", "PID namespace")
+		ns.RequireKernelConfig("NET_NS", "Network namespace")
+	}
+
+	net := linux.RequireKernelConfig("NET", "Networking support")
+	inet := net.RequireKernelConfig("INET", "TCP/IP networking")
+
+	if !s.WorkerRoleEnabled {
+		return
+	}
+
+	netfilter := net.RequireKernelConfig("NETFILTER", "Network packet filtering framework (Netfilter)")
+
+	// Prerequisite for required config NETFILTER_XT_MATCH_COMMENT
+	netfilter.AssertKernelConfig("NETFILTER_ADVANCED", "Advanced netfilter configuration")
+
+	// Core Netfilter Configuration
+	xtables := netfilter.RequireKernelConfig("NETFILTER_XTABLES", "Netfilter Xtables support")
+	//  *** Xtables targets ***
+	xtables.RequireKernelConfig("NETFILTER_XT_TARGET_REDIRECT", "REDIRECT target support", "IP_NF_TARGET_REDIRECT") // depends on NF_NAT
+	//  *** Xtables matches ***
+	xtables.RequireKernelConfig("NETFILTER_XT_MATCH_COMMENT", `"comment" match support`)
+
+	// File systems
+	linux.RequireKernelConfig("EXT4_FS", "The Extended 4 (ext4) filesystem")
+	// Pseudo filesystems
+	linux.RequireKernelConfig("PROC_FS", "/proc file system support")
+
+	if !s.AddDebugProbes {
+		return
+	}
+
+	inet.AssertKernelConfig("IPV6", "The IPv6 protocol")
+
+	// It was found that the following modules were loaded automatically by
+	// comparing the output of `lsmod` before and after running k0s.
+
+	// Core Netfilter Configuration
+	netfilter.AssertKernelConfig("NETFILTER_NETLINK", "")
+	netfilter.AssertKernelConfig("NF_CONNTRACK", "Netfilter connection tracking support")
+	netfilter.AssertKernelConfig("NF_NAT", "") // prerequisite for some required configs
+	//  *** Xtables combined modules ***
+	xtables.AssertKernelConfig("NETFILTER_XT_MARK", "nfmark target and match support")
+	xtables.AssertKernelConfig("NETFILTER_XT_SET", `set target and match support`)
+	//  *** Xtables targets ***
+	xtables.AssertKernelConfig("NETFILTER_XT_TARGET_MASQUERADE", "MASQUERADE target support",
+		// This has been added in Linux 5.2 (adf82accc5f5), in v4.3 it was two modules:
+		"IP_NF_TARGET_MASQUERADE", "IP6_NF_TARGET_MASQUERADE")
+	xtables.AssertKernelConfig("NETFILTER_XT_NAT", `"SNAT and DNAT" targets support`)
+	//  *** Xtables matches ***
+	xtables.AssertKernelConfig("NETFILTER_XT_MATCH_ADDRTYPE", `"addrtype" address type match support`)
+	xtables.AssertKernelConfig("NETFILTER_XT_MATCH_CONNTRACK", `"conntrack" connection tracking match support`)
+	xtables.AssertKernelConfig("NETFILTER_XT_MATCH_MULTIPORT", `"multiport" Multiple port match support`)
+	xtables.AssertKernelConfig("NETFILTER_XT_MATCH_RECENT", `"recent" match support`)
+	xtables.AssertKernelConfig("NETFILTER_XT_MATCH_STATISTIC", `"statistic" match support`)
+
+	ipSet := netfilter.AssertKernelConfig("IP_SET", "IP set support")
+	ipSet.AssertKernelConfig("IP_SET_HASH_IP", "hash:ip set support")
+	ipSet.AssertKernelConfig("IP_SET_HASH_NET", "hash:net set support")
+
+	ipvs := netfilter.AssertKernelConfig("IP_VS", "IP virtual server support")
+	ipvs.AssertKernelConfig("IP_VS_NFCT", "Netfilter connection tracking")
+
+	// IP: Netfilter Configuration
+	netfilter.AssertKernelConfig("NF_CONNTRACK_IPV4", "IPv4 connetion tracking support (required for NAT)") // enables NF_NAT_IPV4, merged into NF_CONNTRACK in Linux 4.19 (a0ae2562c6c4)
+	netfilter.AssertKernelConfig("NF_REJECT_IPV4", "IPv4 packet rejection")
+	netfilter.AssertKernelConfig("NF_NAT_IPV4", "IPv4 NAT") // depends on NF_CONNTRACK_IPV4, selects NF_NAT, merged into NF_NAT in Linux 5.1 (3bf195ae6037)
+	ipNFIPTables := netfilter.AssertKernelConfig("IP_NF_IPTABLES", "IP tables support")
+	ipNFFilter := ipNFIPTables.AssertKernelConfig("IP_NF_FILTER", "Packet filtering")
+	ipNFFilter.AssertKernelConfig("IP_NF_TARGET_REJECT", "REJECT target support")
+	ipNFIPTables.AssertKernelConfig("IP_NF_NAT", "iptables NAT support") // selects NF_NAT
+	ipNFIPTables.AssertKernelConfig("IP_NF_MANGLE", "Packet mangling")
+	netfilter.AssertKernelConfig("NF_DEFRAG_IPV4", "")
+
+	// IPv6: Netfilter Configuration
+	netfilter.AssertKernelConfig("NF_CONNTRACK_IPV6", "IPv6 connetion tracking support (required for NAT)") // enables NF_NAT_IPV6, merged into NF_CONNTRACK in Linux 4.19 (a0ae2562c6c4)
+	netfilter.AssertKernelConfig("NF_NAT_IPV6", "IPv6 NAT")                                                 // depends on NF_CONNTRACK_IPV6, selects NF_NAT, merged into NF_NAT in Linux 5.1 (3bf195ae6037)
+	ip6NFIPTables := netfilter.AssertKernelConfig("IP6_NF_IPTABLES", "IP6 tables support")
+	ip6NFIPTables.AssertKernelConfig("IP6_NF_FILTER", "Packet filtering")
+	ip6NFIPTables.AssertKernelConfig("IP6_NF_MANGLE", "Packet mangling")
+	ip6NFIPTables.AssertKernelConfig("IP6_NF_NAT", "ip6tables NAT support")
+	netfilter.AssertKernelConfig("NF_DEFRAG_IPV6", "")
+
+	bridge := linux.AssertKernelConfig("BRIDGE", "802.1d Ethernet Bridging")
+	bridge.AssertKernelConfig("LLC", "")
+	bridge.AssertKernelConfig("STP", "")
+}

--- a/internal/pkg/sysinfo/host_other.go
+++ b/internal/pkg/sysinfo/host_other.go
@@ -1,0 +1,28 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysinfo
+
+import (
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+)
+
+func (s *K0sSysinfoSpec) addHostSpecificProbes(p probes.Probes) {
+	// no-op
+}

--- a/internal/pkg/sysinfo/machineid/machineid.go
+++ b/internal/pkg/sysinfo/machineid/machineid.go
@@ -18,26 +18,51 @@ package machineid
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"fmt"
 	"os"
 
 	"github.com/denisbrodbeck/machineid"
 )
 
+type MachineID struct {
+	id, source string
+}
+
+func (id *MachineID) ID() string {
+	if id == nil {
+		return ""
+	}
+
+	return id.id
+}
+
+func (id *MachineID) Source() string {
+	if id == nil {
+		return ""
+	}
+
+	return id.source
+}
+
+func (id *MachineID) String() string {
+	return fmt.Sprintf("%q (from %s)", id.id, id.source)
+}
+
 // Generate returns protected id for the current machine
-func Generate() (string, error) {
+func Generate() (*MachineID, error) {
 	id, err := machineid.ProtectedID("k0sproject-k0s")
 	if err != nil {
 		return fromHostname()
 	}
-	return id, err
+	return &MachineID{id, "machine"}, err
 }
 
 // fromHostname generates a machine id hash from hostname
-func fromHostname() (string, error) {
+func fromHostname() (*MachineID, error) {
 	name, err := os.Hostname()
 	if err != nil {
-		return "", err
+		return nil, fmt.Errorf("failed to get hostname: %w", err)
 	}
 	sum := md5.Sum([]byte(name))
-	return hex.EncodeToString(sum[:]), nil
+	return &MachineID{hex.EncodeToString(sum[:]), "hostname"}, nil
 }

--- a/internal/pkg/sysinfo/machineid/machineid_test.go
+++ b/internal/pkg/sysinfo/machineid/machineid_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package machineid
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMachineIDFromHostname(t *testing.T) {
+	id, err := fromHostname()
+	require.NoError(t, err, "fromHostname() failed")
+	assert.Len(t, id.ID(), 32)
+
+	// test that id does not change
+	id2, err := fromHostname()
+	require.NoError(t, err, "fromHostname() is flaky")
+	assert.Equal(t, id, id2, "fromHostname() is not deterministic")
+}

--- a/internal/pkg/sysinfo/probes/disk.go
+++ b/internal/pkg/sysinfo/probes/disk.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probes
+
+import (
+	"fmt"
+)
+
+// AssertDiskSpace asserts a minimum amount of free disk space.
+func AssertFreeDiskSpace(parent ParentProbe, fsPath string, minFree uint64) {
+	parent.Set("disk:"+fsPath, func(path ProbePath, current Probe) Probe {
+		return &assertDiskSpace{path, fsPath, minFree}
+	})
+}
+
+type assertDiskSpace struct {
+	path    ProbePath
+	fsPath  string
+	minFree uint64
+}
+
+func (a *assertDiskSpace) Path() ProbePath {
+	return a.path
+}
+
+func (a *assertDiskSpace) DisplayName() string {
+	return fmt.Sprintf("Disk space available for %s", a.fsPath)
+}

--- a/internal/pkg/sysinfo/probes/disk_linux.go
+++ b/internal/pkg/sysinfo/probes/disk_linux.go
@@ -1,0 +1,54 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probes
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"golang.org/x/sys/unix"
+)
+
+func (a *assertDiskSpace) Probe(reporter Reporter) error {
+	var stat unix.Statfs_t
+	for p := a.fsPath; ; {
+		if err := unix.Statfs(p, &stat); err != nil {
+			if os.IsNotExist(err) {
+				if parent := path.Dir(p); parent != p {
+					p = parent
+					continue
+				}
+			}
+			return reporter.Error(a, err)
+		}
+
+		break
+	}
+
+	// https://stackoverflow.com/a/20110856
+	// Available blocks * size per block = available space in bytes
+	free := stat.Bavail * uint64(stat.Bsize)
+	if free >= a.minFree {
+		return reporter.Pass(a, iecBytes(free))
+	}
+
+	return reporter.Warn(a, iecBytes(free), fmt.Sprintf("%s recommended", iecBytes(a.minFree)))
+}

--- a/internal/pkg/sysinfo/probes/disk_other.go
+++ b/internal/pkg/sysinfo/probes/disk_other.go
@@ -1,0 +1,24 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probes
+
+func (a *assertDiskSpace) Probe(reporter Reporter) error {
+	return reporter.Warn(a, probeUnsupported("Disk space detection unsupported on this platform"), "")
+}

--- a/internal/pkg/sysinfo/probes/linux/cgroup_controllers.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroup_controllers.go
@@ -1,0 +1,112 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linux
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+)
+
+func (c *CgroupsProbes) RequireControllers(controllerNames ...string) {
+	c.probeControllers(true, controllerNames...)
+}
+
+func (c *CgroupsProbes) AssertControllers(controllerNames ...string) {
+	c.probeControllers(false, controllerNames...)
+}
+
+func (c *CgroupsProbes) probeControllers(require bool, controllerNames ...string) {
+	for _, controllerName := range controllerNames {
+		c.probes.Set(controllerName, func(path probes.ProbePath, _ probes.Probe) probes.Probe {
+			return &cgroupControllerProbe{
+				append(c.path, path...),
+				c.probeCgroupSystem,
+				controllerName,
+				require,
+			}
+		})
+	}
+}
+
+type cgroupControllerProbe struct {
+	path        probes.ProbePath
+	probeSystem cgroupSystemProber
+	name        string
+	require     bool
+}
+
+func (c *cgroupControllerProbe) Path() probes.ProbePath {
+	return c.path
+}
+
+func (c *cgroupControllerProbe) DisplayName() string {
+	return fmt.Sprintf("cgroup controller %q", c.name)
+}
+
+func (c *cgroupControllerProbe) Probe(reporter probes.Reporter) error {
+	if sys, err := c.probeSystem(); err != nil {
+		return reportCgroupSystemErr(reporter, c, err)
+	} else if available, err := sys.probeController(c.name); err != nil {
+		return reporter.Error(c, err)
+	} else if available.available {
+		return reporter.Pass(c, available)
+	} else if c.require {
+		return reporter.Reject(c, available, "")
+	} else {
+		return reporter.Warn(c, available, "")
+	}
+}
+
+type cgroupControllerAvailable struct {
+	available bool
+	msg       string
+}
+
+func (a cgroupControllerAvailable) String() (msg string) {
+	if a.available {
+		msg = "available"
+	} else {
+		msg = "unavailable"
+	}
+
+	if a.msg != "" {
+		msg = fmt.Sprintf("%s (%s)", msg, a.msg)
+	}
+
+	return
+}
+
+type cgroupControllerProber struct {
+	once        sync.Once
+	controllers map[string]cgroupControllerAvailable
+	err         error
+}
+
+func (p *cgroupControllerProber) probeContoller(s cgroupSystem, controllerName string) (cgroupControllerAvailable, error) {
+	p.once.Do(func() {
+		p.controllers = make(map[string]cgroupControllerAvailable)
+		p.err = s.loadControllers(func(name, msg string) {
+			p.controllers[name] = cgroupControllerAvailable{true, msg}
+		})
+	})
+	return p.controllers[controllerName], p.err
+}

--- a/internal/pkg/sysinfo/probes/linux/cgroup_v1.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroup_v1.go
@@ -1,0 +1,68 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linux
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type cgroupV1 struct {
+	controllers cgroupControllerProber
+}
+
+func (*cgroupV1) String() string {
+	return "version 1"
+}
+
+func (s *cgroupV1) probeController(controllerName string) (cgroupControllerAvailable, error) {
+	return s.controllers.probeContoller(s, controllerName)
+}
+
+func (s *cgroupV1) loadControllers(seen func(name, msg string)) error {
+	// Get the available controllers from /proc/cgroups.
+	// See https://www.man7.org/linux/man-pages/man7/cgroups.7.html#NOTES
+
+	f, err := os.Open("/proc/cgroups")
+	if err != nil {
+		return fmt.Errorf("failed to open /proc/cgroups: %w", err)
+	}
+	defer f.Close()
+
+	var lineNo uint
+	lines := bufio.NewScanner(f)
+	for lines.Scan() {
+		lineNo = lineNo + 1
+		if err := lines.Err(); err != nil {
+			return fmt.Errorf("failed to parse /proc/cgroups at line %d: %w ", lineNo, err)
+		}
+		text := lines.Text()
+		if text[0] != '#' {
+			parts := strings.Fields(text)
+			if len(parts) >= 4 && parts[3] != "0" {
+				seen(parts[0], "")
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/pkg/sysinfo/probes/linux/cgroup_v2.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroup_v2.go
@@ -1,0 +1,96 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linux
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type cgroupV2 struct {
+	mountPoint  string
+	controllers cgroupControllerProber
+	probeUname  unameProber
+}
+
+func (*cgroupV2) String() string {
+	return "version 2"
+}
+
+func (s *cgroupV2) probeController(controllerName string) (cgroupControllerAvailable, error) {
+	return s.controllers.probeContoller(s, controllerName)
+}
+
+func (s *cgroupV2) loadControllers(seen func(string, string)) error {
+	// Some controllers are implicitly enabled by the kernel. Those controllers
+	// do not appear in /sys/fs/cgroup/cgroup.controllers. Their availability is
+	// assumed based on the kernel version, as it is hard to detect them
+	// directly.
+	// https://github.com/torvalds/linux/blob/v5.3/kernel/cgroup/cgroup.c#L433-L434
+	if major, minor, err := parseKernelRelease(s.probeUname); err == nil {
+		/* devices: since 4.15 */ if major > 4 || (major == 4 && minor >= 15) {
+			seen("devices", "assumed")
+		}
+		/* freezer: since 5.2 */ if major > 5 || (major == 5 && minor >= 2) {
+			seen("freezer", "assumed")
+		}
+	} else {
+		return err
+	}
+
+	controllerData, err := ioutil.ReadFile(filepath.Join(s.mountPoint, "cgroup.controllers"))
+	if err != nil {
+		return err
+	}
+
+	for _, controllerName := range strings.Fields(string(controllerData)) {
+		seen(controllerName, "")
+	}
+
+	return nil
+}
+
+func parseKernelRelease(probeUname unameProber) (int64, int64, error) {
+	uname, err := probeUname()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	var major, minor int64
+	r := regexp.MustCompile(`^(\d+)\.(\d)(\.|$)`)
+	if matches := r.FindStringSubmatch(uname.osRelease.value); matches == nil {
+		err = errors.New("unsupported format")
+	} else {
+		if major, err = strconv.ParseInt(matches[1], 10, 16); err == nil {
+			minor, err = strconv.ParseInt(matches[2], 10, 16)
+		}
+	}
+
+	if err != nil {
+		err = fmt.Errorf("failed to parse kernel release %q: %w", uname.osRelease, err)
+	}
+
+	return major, minor, err
+}

--- a/internal/pkg/sysinfo/probes/linux/cgroups.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroups.go
@@ -1,0 +1,153 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linux
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+)
+
+type CgroupsProbes struct {
+	path              probes.ProbePath
+	probeUname        unameProber
+	probeCgroupSystem cgroupSystemProber
+	probes            probes.Probes
+}
+
+func (p *LinuxProbes) RequireCgroups() *CgroupsProbes {
+	var c *CgroupsProbes
+	p.probes.Set("cgroups", func(path probes.ProbePath, current probes.Probe) probes.Probe {
+		if probe, ok := current.(*CgroupsProbes); ok {
+			c = probe
+			return c
+		}
+
+		c = newCgroupsProbes(append(p.path, path...), p.probeUname, "/sys/fs/cgroup")
+		return c
+	})
+
+	return c
+}
+
+func newCgroupsProbes(path probes.ProbePath, unameProber unameProber, mountPoint string) *CgroupsProbes {
+	return &CgroupsProbes{
+		path,
+		unameProber,
+		newCgroupSystemProber(unameProber, mountPoint),
+		probes.NewProbes(),
+	}
+}
+
+func (c *CgroupsProbes) Path() probes.ProbePath {
+	return c.path
+}
+
+func (c *CgroupsProbes) DisplayName() string {
+	return "Control Groups"
+}
+
+func (c *CgroupsProbes) Probe(reporter probes.Reporter) error {
+	if err := c.probeSystem(reporter); err != nil {
+		return err
+	}
+
+	return c.probes.Probe(reporter)
+}
+
+func (c *CgroupsProbes) probeSystem(reporter probes.Reporter) error {
+	sys, err := c.probeCgroupSystem()
+	if err != nil {
+		return reportCgroupSystemErr(reporter, c, err)
+	}
+	return reporter.Pass(c, sys)
+}
+
+func reportCgroupSystemErr(reporter probes.Reporter, d probes.ProbeDesc, err error) error {
+	if detectionFailed, ok := err.(cgroupFsDetectionFailed); ok {
+		return reporter.Reject(d, detectionFailed, "")
+	}
+
+	return reporter.Error(d, err)
+}
+
+type cgroupSystem interface {
+	probes.ProbedProp
+	probeController(string) (cgroupControllerAvailable, error)
+	loadControllers(func(name, msg string)) error
+}
+
+type cgroupSystemProber func() (cgroupSystem, error)
+
+func loadCgroupSystem(probeUname unameProber, mountPoint string) (cgroupSystem, error) {
+	// https://man7.org/linux/man-pages/man7/cgroups.7.html
+
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(mountPoint, &st); err != nil {
+		if os.IsNotExist(err) {
+			msg := fmt.Sprintf("no file system mounted at %q", mountPoint)
+			return nil, cgroupFsDetectionFailed(msg)
+		}
+
+		return nil, fmt.Errorf("failed to stat %q: %w", mountPoint, err)
+	}
+
+	switch st.Type {
+	case unix.CGROUP2_SUPER_MAGIC:
+		// https://www.kernel.org/doc/html/v5.16/admin-guide/cgroup-v2.html#mounting
+		return &cgroupV2{probeUname: probeUname}, nil
+	case unix.CGROUP_SUPER_MAGIC, unix.TMPFS_MAGIC:
+		// https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man7/cgroups.7?h=man-pages-5.13#n159
+		// https://www.kernel.org/doc/html/v5.16/admin-guide/cgroup-v1/cgroups.html#how-do-i-use-cgroups
+		return &cgroupV1{}, nil
+	default:
+		msg := fmt.Sprintf("unexpected file system type of %q: 0x%x", mountPoint, st.Type)
+		return nil, cgroupFsDetectionFailed(msg)
+	}
+}
+
+type cgroupFsDetectionFailed string
+
+func (c cgroupFsDetectionFailed) Error() string {
+	return string(c)
+}
+
+func (c cgroupFsDetectionFailed) String() string {
+	return string(c)
+}
+
+func newCgroupSystemProber(probeUname unameProber, mountPoint string) cgroupSystemProber {
+	var once sync.Once
+	var sys cgroupSystem
+	var err error
+
+	return func() (cgroupSystem, error) {
+		once.Do(func() {
+			sys, err = loadCgroupSystem(probeUname, mountPoint)
+		})
+
+		return sys, err
+	}
+}

--- a/internal/pkg/sysinfo/probes/linux/cgroups_test.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroups_test.go
@@ -1,0 +1,117 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linux
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"testing"
+
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+	test_sysinfo "github.com/k0sproject/k0s/internal/testutil/sysinfo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestRequireCgroups(t *testing.T) {
+	path := probes.ProbePath{t.Name()}
+	linux := newLinuxProbes(path)
+
+	cgroupsA := linux.RequireCgroups()
+	cgroupsB := linux.RequireCgroups()
+
+	assert.Same(t, cgroupsA, cgroupsB)
+}
+
+func TestCgroupsProbes_Probe(t *testing.T) {
+	path := probes.ProbePath{t.Name()}
+	var mockSys *mockCgroupSystem
+	var mockSysErr error
+
+	reporter := new(test_sysinfo.MockReporter)
+
+	init := func() {
+		reporter.Mock = mock.Mock{}
+		mockSys, mockSysErr = new(mockCgroupSystem), nil
+	}
+
+	underTest := newCgroupsProbes(path, nil, "")
+	underTest.probeCgroupSystem = func() (cgroupSystem, error) { return mockSys, mockSysErr }
+	underTest.AssertControllers("foo")
+
+	t.Run("Pass", func(t *testing.T) {
+		init()
+
+		available := cgroupControllerAvailable{true, ""}
+
+		reporter.On("Pass", mock.Anything, mockSys).Return(nil)
+		mockSys.On("probeController", "foo").Return(available, nil)
+		reporter.On("Pass", mock.Anything, available).Return(nil)
+
+		err := underTest.Probe(reporter)
+
+		reporter.AssertExpectations(t)
+		mockSys.AssertExpectations(t)
+		assert.NoError(t, err)
+		assert.Equal(t, path, reporter.Calls[0].Arguments[0].(probes.ProbeDesc).Path())
+		assert.Equal(t, append(path, "foo"), reporter.Calls[1].Arguments[0].(probes.ProbeDesc).Path())
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		init()
+
+		mockSys, mockSysErr = nil, errors.New(t.Name())
+
+		reporter.On("Error", mock.Anything, mockSysErr).Return(mockSysErr)
+
+		err := underTest.Probe(reporter)
+
+		reporter.AssertExpectations(t)
+		assert.Same(t, mockSysErr, err)
+		assert.Len(t, reporter.Calls, 1)
+	})
+
+}
+
+func TestCgroupsProbes_Probe_NonExistent(t *testing.T) {
+	nonExistent := path.Join(t.TempDir(), "non-existent")
+	path := probes.ProbePath{t.Name()}
+	reporter := new(test_sysinfo.MockReporter)
+	reporter.On("Reject", mock.Anything, mock.Anything, "").Return(nil)
+
+	underTest := newCgroupsProbes(path, nil, nonExistent)
+	underTest.Probe(reporter)
+
+	reporter.AssertExpectations(t)
+	args := reporter.Calls[0].Arguments
+	assert.Equal(t, path, args[0].(probes.ProbeDesc).Path())
+	assert.Equal(t, fmt.Sprintf("no file system mounted at %q", nonExistent), args[1].(error).Error())
+}
+
+type mockCgroupSystem struct {
+	mock.Mock
+	cgroupSystem
+}
+
+func (m *mockCgroupSystem) probeController(name string) (cgroupControllerAvailable, error) {
+	args := m.Called(name)
+	return args.Get(0).(cgroupControllerAvailable), args.Error(1)
+}

--- a/internal/pkg/sysinfo/probes/linux/kernel.go
+++ b/internal/pkg/sysinfo/probes/linux/kernel.go
@@ -1,0 +1,353 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linux
+
+import (
+	"bufio"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+)
+
+func (l *LinuxProbes) AssertKernelRelease(assert func(string) string) {
+	l.probes.Set("kernelRelease", func(path probes.ProbePath, current probes.Probe) probes.Probe {
+		return &assertKRelease{append(l.path, path...), l.probeUname, assert}
+	})
+}
+
+func (l *LinuxProbes) RequireKernelConfig(config, desc string, alternativeConfigs ...string) *KernelConfigProbes {
+	return l.newKProbes().RequireKernelConfig(config, desc, alternativeConfigs...)
+}
+
+func (l *LinuxProbes) AssertKernelConfig(config, desc string, alternativeConfigs ...string) *KernelConfigProbes {
+	return l.newKProbes().AssertKernelConfig(config, desc, alternativeConfigs...)
+}
+
+func (l *LinuxProbes) newKProbes() (k *KernelConfigProbes) {
+	l.probes.Set("kernelConfig", func(path probes.ProbePath, current probes.Probe) probes.Probe {
+		var ok bool
+		if k, ok = current.(*KernelConfigProbes); !ok {
+			k = &KernelConfigProbes{path, l.probeKConfig, probes.NewProbes()}
+		}
+
+		return k
+	})
+
+	return
+}
+
+func (k *KernelConfigProbes) Probe(reporter probes.Reporter) error {
+	return k.probes.Probe(reporter)
+}
+
+type KernelConfigProbes struct {
+	path        probes.ProbePath
+	probeConfig kConfigProber
+	probes      probes.Probes
+}
+
+func (k *KernelConfigProbes) RequireKernelConfig(config, desc string, alternativeConfigs ...string) *KernelConfigProbes {
+	return k.probeKConfig(true, config, desc, alternativeConfigs...)
+}
+
+func (k *KernelConfigProbes) AssertKernelConfig(config, desc string, alternativeConfigs ...string) *KernelConfigProbes {
+	return k.probeKConfig(false, config, desc, alternativeConfigs...)
+}
+
+//revive:disable:var-naming
+
+type kConfigSpec struct {
+	kConfig
+	desc                string
+	alternativeKConfigs []kConfig
+	require             bool
+}
+
+func (k *KernelConfigProbes) probeKConfig(require bool, config, desc string, alternativeConfigs ...string) *KernelConfigProbes {
+	spec := &kConfigSpec{ensureKConfig(config), desc, nil, require}
+	for _, alternativeConfig := range alternativeConfigs {
+		spec.alternativeKConfigs = append(spec.alternativeKConfigs, ensureKConfig(alternativeConfig))
+	}
+
+	var kp *kConfigProbe
+	k.probes.Set(config, func(path probes.ProbePath, current probes.Probe) probes.Probe {
+		path = append(k.path, path...)
+		if probe, ok := current.(*kConfigProbe); ok {
+			kp = probe
+			kp.kConfigSpec = spec
+		} else {
+			kp = &kConfigProbe{&KernelConfigProbes{path, k.probeConfig, probes.NewProbes()}, spec}
+		}
+		return kp
+	})
+
+	return kp.KernelConfigProbes
+}
+
+type assertKRelease struct {
+	path       probes.ProbePath
+	probeUname unameProber
+	assert     func(string) string
+}
+
+func (a *assertKRelease) Path() probes.ProbePath {
+	return a.path
+}
+
+func (*assertKRelease) DisplayName() string {
+	return "Linux kernel release"
+}
+
+func (a *assertKRelease) Probe(reporter probes.Reporter) error {
+	if uname, err := a.probeUname(); err != nil {
+		return reporter.Error(a, err)
+	} else if uname.osRelease.truncated {
+		return reporter.Error(a, errors.New(uname.osRelease.String()))
+	} else if msg := a.assert(uname.osRelease.value); msg != "" {
+		return reporter.Warn(a, uname.osRelease, msg)
+	} else {
+		return reporter.Pass(a, uname.osRelease)
+	}
+}
+
+// https://github.com/torvalds/linux/blob/v4.3/Documentation/kbuild/kconfig-language.txt
+
+type kConfigOption string
+
+const (
+	kConfigUnknown  kConfigOption = ""
+	kConfigBuiltIn  kConfigOption = "y"
+	kConfigAsModule kConfigOption = "m"
+	kConfigLeftOut  kConfigOption = "n"
+)
+
+func (v kConfigOption) String() string {
+	switch v {
+	case kConfigBuiltIn:
+		return "built-in"
+	case kConfigAsModule:
+		return "module"
+	case kConfigLeftOut:
+		return "left out"
+	case kConfigUnknown:
+		return "unknown"
+	}
+
+	return fmt.Sprintf("??? %q", string(v))
+}
+
+type kConfigProber func(config kConfig) (kConfigOption, error)
+
+type KernelChecks struct {
+	probeUname   unameProber
+	probeKConfig kConfigProber
+}
+
+func NewKernelChecks() *KernelChecks {
+	probeUname := newUnameProber()
+	probeConfig := newKConfigProber(probeUname)
+	return &KernelChecks{probeUname, probeConfig}
+}
+
+type kConfigs map[kConfig]kConfigOption
+
+func newKConfigProber(probeUname unameProber) kConfigProber {
+	var once sync.Once
+	var kConfigs kConfigs
+	var kConfigsErr error
+
+	return func(config kConfig) (kConfigOption, error) {
+		once.Do(func() {
+			var u *uname
+			u, kConfigsErr = probeUname()
+			if kConfigsErr == nil {
+				kConfigs, kConfigsErr = loadKConfigs(u.osRelease.value)
+			}
+		})
+
+		return kConfigs[config], kConfigsErr
+	}
+}
+
+const validKConfig = "[A-Z0-9_]+"
+
+var validKConfigRegex = regexp.MustCompile("^" + validKConfig + "$")
+
+type kConfig string
+
+func ensureKConfig(config string) kConfig {
+	if !validKConfigRegex.MatchString(config) {
+		panic(fmt.Sprintf("invalid kernel config: %q", config))
+	}
+
+	return kConfig(config)
+}
+
+func (c kConfig) String() string {
+	return fmt.Sprintf("CONFIG_%s", string(c))
+}
+
+type kConfigProbe struct {
+	*KernelConfigProbes
+	*kConfigSpec
+}
+
+func (k *kConfigProbe) Path() probes.ProbePath {
+	return k.path
+}
+
+func (k *kConfigProbe) DisplayName() string {
+	var buf strings.Builder
+	buf.WriteString(k.kConfig.String())
+	if k.desc != "" {
+		buf.WriteString(": ")
+		buf.WriteString(k.desc)
+	}
+
+	return buf.String()
+}
+
+func (k *kConfigProbe) Probe(reporter probes.Reporter) error {
+	if err := k.probe(reporter); err != nil {
+		return err
+	}
+
+	return k.probes.Probe(reporter)
+}
+
+func (k *kConfigProbe) probe(reporter probes.Reporter) error {
+	option, err := k.probeConfig(k.kConfig)
+	if err != nil {
+		return reporter.Error(k, err)
+	}
+
+	switch option {
+	case kConfigBuiltIn, kConfigAsModule:
+		return reporter.Pass(k, option)
+	}
+
+	var alsoTried []string
+	for _, kConfig := range k.alternativeKConfigs {
+		alsoTried = append(alsoTried, kConfig.String())
+		altOption, err := k.probeConfig(k.kConfig)
+		if err != nil {
+			return reporter.Error(k, err)
+		}
+
+		switch altOption {
+		case kConfigBuiltIn, kConfigAsModule:
+			return reporter.Pass(k, &altKConfigOption{altOption, kConfig})
+		}
+	}
+
+	msg := ""
+	if len(k.alternativeKConfigs) > 0 {
+		msg = fmt.Sprintf("also tried %s", strings.Join(alsoTried, ", "))
+	}
+
+	if k.require {
+		return reporter.Reject(k, &option, msg)
+	}
+
+	return reporter.Warn(k, &option, msg)
+}
+
+type altKConfigOption struct {
+	kConfigOption
+	kConfig
+}
+
+func (a *altKConfigOption) String() string {
+	return fmt.Sprintf("%s (via %s)", a.kConfigOption, &a.kConfig)
+}
+
+// loadKConfigs checks a list of well-known file system paths for kernel
+// configuration files and tries to parse them.
+func loadKConfigs(kernelRelease string) (kConfigs, error) {
+	// At least some references to those paths may be fond here:
+	// https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L794
+	// https://github.com/torvalds/linux/blob/v4.3/init/Kconfig#L9
+	possiblePaths := []string{
+		"/proc/config.gz",
+		"/boot/config-" + kernelRelease,
+		"/usr/src/linux-" + kernelRelease + "/.config",
+		"/usr/src/linux/.config",
+		"/usr/lib/modules/" + kernelRelease + "/config",
+		"/usr/lib/ostree-boot/config-" + kernelRelease,
+		"/usr/lib/kernel/config-" + kernelRelease,
+		"/usr/src/linux-headers-" + kernelRelease + "/.config",
+		"/lib/modules/" + kernelRelease + "/build/.config",
+	}
+
+	for _, path := range possiblePaths {
+		// open file for reading
+		f, err := os.Open(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		defer f.Close()
+
+		r := io.Reader(bufio.NewReader(f))
+
+		// This is a gzip file (config.gz), unzip it.
+		if filepath.Ext(path) == ".gz" {
+			gr, err := gzip.NewReader(r)
+			if err != nil {
+				return nil, err
+			}
+			defer gr.Close()
+			r = gr
+		}
+
+		return parseKConfigs(r)
+	}
+	return nil, fmt.Errorf("no kernel config found in %v", strings.Join(possiblePaths, ", "))
+}
+
+// parseKConfigs parses `r` line by line, extracting all kernel config options.
+func parseKConfigs(r io.Reader) (kConfigs, error) {
+	configs := kConfigs{}
+	kConfigLineRegex := regexp.MustCompile(fmt.Sprintf(
+		"^[\\s\\p{Zs}]*CONFIG_(%s)=([%s%s%s])",
+		validKConfig, string(kConfigBuiltIn), string(kConfigLeftOut), string(kConfigAsModule),
+	))
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		if err := s.Err(); err != nil {
+			return nil, err
+		}
+
+		if matches := kConfigLineRegex.FindStringSubmatch(s.Text()); matches != nil {
+			configs[ensureKConfig(matches[1])] = kConfigOption(matches[2])
+		}
+	}
+	return configs, nil
+}

--- a/internal/pkg/sysinfo/probes/linux/kernel_test.go
+++ b/internal/pkg/sysinfo/probes/linux/kernel_test.go
@@ -1,0 +1,153 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linux
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+
+	test_sysinfo "github.com/k0sproject/k0s/internal/testutil/sysinfo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestRequireKernelConfig(t *testing.T) {
+
+	linux := newLinuxProbes(probes.ProbePath{})
+
+	type configResult struct {
+		o kConfigOption
+		e error
+	}
+
+	var c map[string]configResult
+	linux.probeKConfig = func(config kConfig) (kConfigOption, error) {
+		r := c[string(config)]
+		return r.o, r.e
+	}
+
+	t.Run("invalidKConfigPanics", func(t *testing.T) {
+		assert.PanicsWithValue(t, `invalid kernel config: "foo"`, func() {
+			linux.RequireKernelConfig("foo", "")
+		})
+	})
+
+	t.Run("nestedConfigs", func(t *testing.T) {
+		linux.RequireKernelConfig("IKCONFIG", "ikconfig").RequireKernelConfig("IKCONFIG_PROC", "ikconfig_proc")
+
+		c = map[string]configResult{
+			"IKCONFIG":      {kConfigBuiltIn, nil},
+			"IKCONFIG_PROC": {kConfigAsModule, nil},
+		}
+
+		t.Run("calledWhenNoError", func(t *testing.T) {
+			reporter := new(test_sysinfo.MockReporter)
+			reporter.On("Pass", mock.MatchedBy(func(desc probes.ProbeDesc) bool {
+				if (probes.ProbePath{"kernelConfig", "IKCONFIG"}).Equal(desc.Path()) {
+					assert.Equal(t, "CONFIG_IKCONFIG: ikconfig", desc.DisplayName())
+					return true
+				}
+				return false
+			}), kConfigBuiltIn).Return(nil)
+			reporter.On("Pass", mock.MatchedBy(func(desc probes.ProbeDesc) bool {
+				if (probes.ProbePath{"kernelConfig", "IKCONFIG", "IKCONFIG_PROC"}).Equal(desc.Path()) {
+					assert.Equal(t, "CONFIG_IKCONFIG_PROC: ikconfig_proc", desc.DisplayName())
+					return true
+				}
+				return false
+			}), kConfigAsModule).Return(nil)
+
+			err := linux.probes.Probe(reporter)
+
+			reporter.AssertExpectations(t)
+			assert.NoError(t, err)
+		})
+
+		t.Run("notCalledOnError", func(t *testing.T) {
+			expectedErr := errors.New("dummy")
+			reporter := new(test_sysinfo.MockReporter)
+			reporter.On("Pass", mock.MatchedBy(func(desc probes.ProbeDesc) bool {
+				return probes.ProbePath{"kernelConfig", "IKCONFIG"}.Equal(desc.Path())
+			}), kConfigBuiltIn).Return(expectedErr)
+
+			err := linux.probes.Probe(reporter)
+
+			reporter.AssertExpectations(t)
+			assert.Same(t, expectedErr, err)
+
+		})
+	})
+}
+
+func TestKConfigProber(t *testing.T) {
+
+	// This may fail on systems that don't expose their kernel config at runtime.
+	t.Run("smokeTest", func(t *testing.T) {
+		probeKConfig := newKConfigProber(newUnameProber())
+
+		option, err := probeKConfig(ensureKConfig("I_CERTAINLY_DONT_EXIST"))
+		assert.Equal(t, option, kConfigUnknown)
+		assert.NoError(t, err)
+	})
+
+	t.Run("propagatesUnameErr", func(t *testing.T) {
+		unameErr := errors.New("what uname?")
+		probeKConfig := newKConfigProber(func() (*uname, error) {
+			return nil, unameErr
+		})
+
+		option, err := probeKConfig(ensureKConfig("FOO"))
+		assert.Equal(t, kConfigUnknown, option)
+		assert.Same(t, unameErr, err)
+	})
+}
+
+func TestKernelConfigParser(t *testing.T) {
+	kConfigData := `#
+# Automatically generated file; DO NOT EDIT.
+# Linux/x86_64 5.16.8 Kernel Configuration
+#
+CONFIG_CC_VERSION_TEXT="gcc (GCC) 10.3.0"
+CONFIG_CC_IS_GCC=y
+CONFIG_GCC_VERSION=100300
+CONFIG_CLANG_VERSION=0
+CONFIG_AS_IS_GNU=y
+CONFIG_AS_VERSION=23502
+
+CONFIG_IKCONFIG=y
+CONFIG_IKCONFIG_PROC=m
+CONFIG_IKHEADERS=n
+`
+
+	r := strings.NewReader(kConfigData)
+	assert := assert.New(t)
+	x, err := parseKConfigs(r)
+	assert.NoError(err)
+	assert.Equal(kConfigs{
+		ensureKConfig("CC_IS_GCC"):     kConfigBuiltIn,
+		ensureKConfig("AS_IS_GNU"):     kConfigBuiltIn,
+		ensureKConfig("IKCONFIG"):      kConfigBuiltIn,
+		ensureKConfig("IKCONFIG_PROC"): kConfigAsModule,
+		ensureKConfig("IKHEADERS"):     kConfigLeftOut,
+	}, x)
+}

--- a/internal/pkg/sysinfo/probes/linux/kernel_test.go
+++ b/internal/pkg/sysinfo/probes/linux/kernel_test.go
@@ -94,7 +94,18 @@ func TestRequireKernelConfig(t *testing.T) {
 
 			reporter.AssertExpectations(t)
 			assert.Same(t, expectedErr, err)
+		})
 
+		t.Run("warnsIfNotFound", func(t *testing.T) {
+			var expectedErr noKConfigsFound
+			c["IKCONFIG"] = configResult{kConfigUnknown, &expectedErr}
+			reporter := new(test_sysinfo.MockReporter)
+			reporter.On("Warn", mock.Anything, &expectedErr, "").Return(nil)
+
+			err := linux.probes.Probe(reporter)
+
+			reporter.AssertExpectations(t)
+			assert.NoError(t, err)
 		})
 	})
 }

--- a/internal/pkg/sysinfo/probes/linux/linux.go
+++ b/internal/pkg/sysinfo/probes/linux/linux.go
@@ -1,0 +1,171 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linux
+
+import (
+	"fmt"
+	"sync"
+	"syscall"
+
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+)
+
+//revive:disable-next-line:exported
+type LinuxProbes struct {
+	path         probes.ProbePath
+	probeUname   unameProber
+	probeKConfig kConfigProber
+	probes       probes.Probes
+}
+
+func RequireLinux(parent probes.ParentProbe) (l *LinuxProbes) {
+	parent.Set("os", func(path probes.ProbePath, current probes.Probe) probes.Probe {
+		if r, ok := current.(*requireLinuxProbe); ok {
+			l = &r.LinuxProbes
+			return r
+		}
+
+		r := &requireLinuxProbe{newLinuxProbes(path)}
+		l = &r.LinuxProbes
+		return r
+	})
+
+	return
+}
+
+func newLinuxProbes(path probes.ProbePath) LinuxProbes {
+	unameProber := newUnameProber()
+	return LinuxProbes{
+		path,
+		unameProber,
+		newKConfigProber(unameProber),
+		probes.NewProbes(),
+	}
+}
+
+type requireLinuxDesc struct {
+	probes.ProbePath
+}
+
+func (r requireLinuxDesc) Path() probes.ProbePath {
+	return r.ProbePath
+}
+
+func (r requireLinuxDesc) DisplayName() string {
+	return "Operating system"
+}
+
+type requireLinuxProbe struct {
+	LinuxProbes
+}
+
+func (r *requireLinuxProbe) Probe(reporter probes.Reporter) error {
+	if err := r.probe(reporter); err != nil {
+		return err
+	}
+
+	return r.probes.Probe(reporter)
+}
+
+func (r *requireLinuxProbe) probe(reporter probes.Reporter) error {
+	desc := requireLinuxDesc{r.path}
+	if uname, err := r.probeUname(); err != nil {
+		return reporter.Error(desc, err)
+	} else if uname.osName.value == "Linux" {
+		return reporter.Pass(desc, uname.osName)
+	} else {
+		return reporter.Reject(desc, uname.osName, "Linux required")
+	}
+}
+
+// unameField represents a field as returned from the uname syscall.
+type unameField struct {
+	// value is the value returned, converted to a string
+	value string
+	// truncated indicates if the value is potentially truncated, i.e. the
+	// buffer for the return value was full.
+	truncated bool
+}
+
+func (f unameField) String() string {
+	if f.truncated {
+		return fmt.Sprintf("%q (truncated)", f.value)
+	}
+	return f.value
+
+}
+
+// uname represents data as returned by the uname syscall.
+type uname struct {
+	// osName represents the operating system name (e.g., "Linux")
+	osName unameField
+	// nodeName represents a name within "some implementation-defined network"
+	nodeName unameField
+	// osRelease represents the operating system release (e.g., "2.6.28")
+	osRelease unameField
+	// osVersion represents the operating system version
+	osVersion unameField
+	// arch represents some hardware identifier (e.g., "x86_64")
+	arch unameField
+}
+
+type unameProber func() (*uname, error)
+
+func newUnameProber() unameProber {
+	var once sync.Once
+	var loaded *uname
+	var err error
+
+	return func() (*uname, error) {
+		once.Do(func() {
+			var utsname syscall.Utsname
+			if err = syscall.Uname(&utsname); err != nil {
+				err = fmt.Errorf("uname syscall failed: %w", err)
+			} else {
+				loaded = parseUname(&utsname)
+			}
+		})
+
+		return loaded, err
+	}
+}
+
+func parseUname(utsname *syscall.Utsname) *uname {
+	convert := func(chars utsFieldType) unameField {
+		var buf [65]byte
+		var i int
+		for pos, ch := range *chars {
+			i = pos
+			buf[i] = uint8(ch)
+			if ch == 0 {
+				break
+			}
+		}
+		return unameField{string(buf[:i]), i >= 64}
+	}
+
+	return &uname{
+		osName:    convert(&utsname.Sysname),
+		nodeName:  convert(&utsname.Nodename),
+		osRelease: convert(&utsname.Release),
+		osVersion: convert(&utsname.Version),
+		arch:      convert(&utsname.Machine),
+	}
+}

--- a/internal/pkg/sysinfo/probes/linux/linux_test.go
+++ b/internal/pkg/sysinfo/probes/linux/linux_test.go
@@ -1,0 +1,173 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linux
+
+import (
+	"errors"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+
+	test_sysinfo "github.com/k0sproject/k0s/internal/testutil/sysinfo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestRequireLinux(t *testing.T) {
+
+	p := probes.NewProbes()
+	linuxProbes := RequireLinux(p)
+
+	t.Run("reusesPreviousProbe", func(t *testing.T) {
+		assert.Same(t, linuxProbes, RequireLinux(p))
+	})
+
+	linux := unameField{"Linux", false}
+	minix := unameField{"Minix", false}
+
+	expectedErr := errors.New("dummy")
+	expectedPath := func(t *testing.T) interface{} {
+		return mock.MatchedBy(func(d probes.ProbeDesc) bool {
+			assert.Equal(t, probes.ProbePath{"os"}, d.Path())
+			assert.Equal(t, "Operating system", d.DisplayName())
+			return true
+		})
+	}
+
+	var unameResult *uname
+	var unameErr error
+	linuxProbes.probeUname = func() (*uname, error) { return unameResult, unameErr }
+
+	t.Run("probePasses", func(t *testing.T) {
+		unameResult = &uname{osName: linux}
+		unameErr = nil
+		reporter := new(test_sysinfo.MockReporter)
+		reporter.On("Pass", expectedPath(t), linux).Return(expectedErr)
+
+		err := p.Probe(reporter)
+
+		reporter.AssertExpectations(t)
+		assert.Same(t, expectedErr, err)
+	})
+
+	t.Run("probeRejectsNonLinux", func(t *testing.T) {
+		unameResult = &uname{osName: minix}
+		unameErr = nil
+
+		reporter := new(test_sysinfo.MockReporter)
+		reporter.On("Reject", expectedPath(t), minix, "Linux required").Return(expectedErr)
+
+		err := p.Probe(reporter)
+
+		reporter.AssertExpectations(t)
+		assert.Same(t, expectedErr, err)
+	})
+
+	t.Run("probeErrorsOutIfUnameFails", func(t *testing.T) {
+		unameResult = nil
+		unameErr = expectedErr
+		reporter := new(test_sysinfo.MockReporter)
+		reporter.On("Error", expectedPath(t), expectedErr).Return(expectedErr)
+
+		err := p.Probe(reporter)
+
+		reporter.AssertExpectations(t)
+		assert.Same(t, expectedErr, err)
+	})
+
+	t.Run("nestedProbes", func(t *testing.T) {
+		linuxProbes.AssertKernelRelease(func(s string) string { return "" })
+
+		t.Run("calledWhenNoError", func(t *testing.T) {
+			kernelRelease := unameField{"release", false}
+			unameResult = &uname{osName: linux, osRelease: kernelRelease}
+			unameErr = nil
+
+			reporter := new(test_sysinfo.MockReporter)
+			reporter.On("Pass", mock.Anything, mock.Anything).Return(nil).Twice()
+
+			err := p.Probe(reporter)
+
+			reporter.AssertExpectations(t)
+			assert.NoError(t, err)
+		})
+
+		t.Run("notCalledOnError", func(t *testing.T) {
+			unameResult = nil
+			unameErr = expectedErr
+
+			reporter := new(test_sysinfo.MockReporter)
+			reporter.On("Error", expectedPath(t), expectedErr).Return(expectedErr)
+
+			err := p.Probe(reporter)
+
+			reporter.AssertExpectations(t)
+			assert.Same(t, expectedErr, err)
+		})
+	})
+}
+
+func TestUname(t *testing.T) {
+	t.Run("smokeTest", func(t *testing.T) {
+		probeUname := newUnameProber()
+		uname, err := probeUname()
+		if err != nil {
+			t.Error(err)
+		}
+
+		t.Logf("uname: %#v", uname)
+	})
+
+	t.Run("parsesFields", func(t *testing.T) {
+		var utsname syscall.Utsname
+		utsname.Sysname[0] = int8('S')
+		utsname.Nodename[0] = int8('N')
+		utsname.Release[0] = int8('R')
+		utsname.Version[0] = int8('V')
+		utsname.Machine[0] = int8('M')
+
+		parsed := parseUname(&utsname)
+		assert.Equal(t, &uname{
+			osName:    unameField{"S", false},
+			nodeName:  unameField{"N", false},
+			osRelease: unameField{"R", false},
+			osVersion: unameField{"V", false},
+			arch:      unameField{"M", false},
+		}, parsed)
+	})
+
+	t.Run("parseDetectsTruncation", func(t *testing.T) {
+		var utsname syscall.Utsname
+		for i := range utsname.Sysname {
+			utsname.Sysname[i] = int8('x')
+		}
+
+		parsed := parseUname(&utsname).osName
+		assert.Equal(t, strings.Repeat("x", 64), parsed.value)
+		assert.True(t, parsed.truncated)
+
+		utsname.Sysname[64] = 0
+		parsed = parseUname(&utsname).osName
+		assert.Equal(t, strings.Repeat("x", 64), parsed.value)
+		assert.True(t, parsed.truncated)
+	})
+}

--- a/internal/pkg/sysinfo/probes/linux/types.go
+++ b/internal/pkg/sysinfo/probes/linux/types.go
@@ -1,3 +1,6 @@
+//go:build linux && !arm
+// +build linux,!arm
+
 /*
 Copyright 2022 k0s authors
 
@@ -13,23 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package machineid
 
-import "testing"
+package linux
 
-func TestMachineIDFromHostname(t *testing.T) {
-	id, err := fromHostname()
-	if err != nil {
-		t.Errorf("fromHostname() unexpctedly returned error")
-	} else if len(id) != 32 {
-		t.Errorf("len(fromHostname()) = %d, want %d", len(id), 32)
-	}
-
-	// test that id does not change
-	id2, err := fromHostname()
-	if err != nil {
-		t.Errorf("fromHostname() unexpectedly returned error")
-	} else if id != id2 {
-		t.Errorf("fromHostname() = %s, want %s", id2, id)
-	}
-}
+type utsFieldType *[65]int8

--- a/internal/pkg/sysinfo/probes/linux/types_arm.go
+++ b/internal/pkg/sysinfo/probes/linux/types_arm.go
@@ -1,0 +1,22 @@
+//go:build linux && arm
+// +build linux,arm
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linux
+
+type utsFieldType *[65]uint8

--- a/internal/pkg/sysinfo/probes/machineid.go
+++ b/internal/pkg/sysinfo/probes/machineid.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probes
+
+import "github.com/k0sproject/k0s/internal/pkg/sysinfo/machineid"
+
+// RequireMachineID requires a Machine ID
+func RequireMachineID(parent ParentProbe) {
+	parent.Set("machine-id", func(path ProbePath, _ Probe) Probe {
+		return &requireMachineID{path}
+	})
+}
+
+type requireMachineID struct {
+	path ProbePath
+}
+
+func (r *requireMachineID) Path() ProbePath {
+	return r.path
+}
+
+func (*requireMachineID) DisplayName() string {
+	return "Machine ID"
+}
+
+func (r *requireMachineID) Probe(reporter Reporter) error {
+	machineID, err := machineid.Generate()
+	if err != nil {
+		return reporter.Error(r, err)
+	}
+	return reporter.Pass(r, machineID)
+}

--- a/internal/pkg/sysinfo/probes/memory.go
+++ b/internal/pkg/sysinfo/probes/memory.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probes
+
+import "fmt"
+
+// AssertTotalMemory asserts a minimum amount of system RAM.
+func AssertTotalMemory(parent ParentProbe, min uint64) {
+	parent.Set("memory", func(path ProbePath, current Probe) Probe {
+		if p, ok := current.(*assertTotalMem); ok {
+			p.minFree = min
+			return p
+		}
+
+		return &assertTotalMem{path, newTotalMemoryProber(), min}
+	})
+}
+
+type assertTotalMem struct {
+	path             ProbePath
+	probeTotalMemory totalMemoryProber
+	minFree          uint64
+}
+
+func (a *assertTotalMem) Path() ProbePath {
+	return a.path
+}
+
+func (*assertTotalMem) DisplayName() string {
+	return "Total memory"
+}
+
+func (a *assertTotalMem) Probe(reporter Reporter) error {
+	if totalMemory, err := a.probeTotalMemory(); err != nil {
+		if unsupportedErr, unsupported := err.(probeUnsupported); unsupported {
+			return reporter.Warn(a, unsupportedErr, "")
+		}
+		return reporter.Error(a, err)
+	} else if totalMemory >= a.minFree {
+		return reporter.Pass(a, iecBytes(totalMemory))
+	} else {
+		return reporter.Warn(a, iecBytes(totalMemory), fmt.Sprintf("%s recommended", iecBytes(a.minFree)))
+	}
+}
+
+type totalMemoryProber func() (uint64, error)

--- a/internal/pkg/sysinfo/probes/memory_linux.go
+++ b/internal/pkg/sysinfo/probes/memory_linux.go
@@ -1,0 +1,45 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probes
+
+import (
+	"fmt"
+	"sync"
+	"syscall"
+)
+
+func newTotalMemoryProber() totalMemoryProber {
+	var once sync.Once
+	var totalMemory uint64
+	var err error
+
+	return func() (uint64, error) {
+		once.Do(func() {
+			var info syscall.Sysinfo_t
+			if err = syscall.Sysinfo(&info); err != nil {
+				err = fmt.Errorf("sysinfo syscall failed: %w", err)
+			} else {
+				totalMemory = uint64(info.Totalram) // explicit cast to support 32-bit systems
+			}
+		})
+
+		return totalMemory, err
+	}
+}

--- a/internal/pkg/sysinfo/probes/memory_other.go
+++ b/internal/pkg/sysinfo/probes/memory_other.go
@@ -1,0 +1,26 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probes
+
+func newTotalMemoryProber() totalMemoryProber {
+	return func() (uint64, error) {
+		return 0, probeUnsupported("Total memory detection unsupported on this platform")
+	}
+}

--- a/internal/pkg/sysinfo/probes/probes.go
+++ b/internal/pkg/sysinfo/probes/probes.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package probes provides a framework for implementing and executing "probes".
+// A probe represents some check of a certain property, that may simply pass,
+// warn about that property, or reject it.
+//
+// The design of the probes package is inspired by the way Go tests are written.
+// Probes are run via their Probe method that receives a Reporter (think
+// *testing.T) as argument. Probes may or may not contain nested probes. They
+// form a hierarchy. Probes are typically added to a Probes object by functions
+// that either start with "Require", in which they reject properties that don't
+// pass, or with "Assert", in which they just warn about them.
+package probes
+
+import "reflect"
+
+// Probe represents some check that yields its outcome to a Reporter.
+type Probe interface {
+	// Probe executes this probe, reporting its outcome to the given Reporter.
+	// The returned error is typically forwarded from the invocation of a
+	// Reporter method.
+	Probe(Reporter) error
+}
+
+type ProbeFn func(Reporter) error
+
+func (fn ProbeFn) Probe(r Reporter) error {
+	return fn(r)
+}
+
+// ProbePath identifies a probe in its hierarchy.
+type ProbePath []string
+
+func (p ProbePath) Equal(other ProbePath) bool {
+	return reflect.DeepEqual(p, other)
+}
+
+// ProbeDesc describes a probe.
+type ProbeDesc interface {
+	// Path of a probe, which identifies it in a machine readable way.
+	Path() ProbePath
+
+	// DisplayName returns a human readable name for a probe.
+	DisplayName() string
+}
+
+type ParentProbe interface {
+	Get(id string) Probe
+	Set(id string, setter func(path ProbePath, current Probe) Probe)
+}
+
+// ProbedProp represents the property that has been inspected by a probe.
+type ProbedProp interface {
+	// Name returns the string representation of this property.
+	String() string
+}
+
+// Reporter receives the outcome of probes.
+type Reporter interface {
+	// Pass informs about a probe that passed.
+	Pass(ProbeDesc, ProbedProp) error
+
+	// Warn informs about a probe that passed, but produced some sort of
+	// warning.
+	Warn(d ProbeDesc, prop ProbedProp, msg string) error
+
+	// Reject informs about a probe that rejected its value.
+	Reject(d ProbeDesc, prop ProbedProp, msg string) error
+
+	// Error informs about some error that prevented the probe from producing a
+	// meaningful result.
+	Error(ProbeDesc, error) error
+}
+
+// Probes represents a "composite" Probe.
+type Probes interface {
+	ParentProbe
+	Probe
+}
+
+// NewProbes returns a new, empty composite probe.
+func NewProbes() Probes {
+	return &probes{}
+}
+
+type probes struct {
+	path   ProbePath
+	probes []*containedProbe
+}
+
+type containedProbe struct {
+	id    string
+	probe Probe
+}
+
+func (p *probes) Get(id string) Probe {
+	for _, probe := range p.probes {
+		if probe.id == id {
+			return probe.probe
+		}
+	}
+
+	return nil
+}
+
+func (p *probes) Set(id string, setter func(ProbePath, Probe) Probe) {
+	path := append(p.path, id)
+	for _, probe := range p.probes {
+		if probe.id == id {
+			probe.probe = ensureSet(setter(path, probe.probe))
+			return
+		}
+	}
+
+	p.probes = append(p.probes, &containedProbe{id, ensureSet(setter(path, nil))})
+}
+
+func ensureSet(probe Probe) Probe {
+	if probe == nil {
+		panic("probe not set")
+	}
+
+	return probe
+}
+
+// Probe executes all contained probes, short-circuiting as soon as the first
+// one reports an error.
+func (p *probes) Probe(reporter Reporter) error {
+	for _, probe := range p.probes {
+		if err := probe.probe.Probe(reporter); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/pkg/sysinfo/probes/util.go
+++ b/internal/pkg/sysinfo/probes/util.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probes
+
+import (
+	"fmt"
+)
+
+type probeUnsupported string
+
+func (p probeUnsupported) Error() string {
+	return string(p)
+}
+
+func (p probeUnsupported) String() string {
+	return string(p)
+}
+
+const (
+	_ = 1 << (10 * iota)
+	Ki
+	Mi
+	Gi
+	Ti
+)
+
+type iecBytes uint64
+
+func (b iecBytes) String() string {
+	const prefixes = "KMGTPE"
+	const unit = 1 << 10
+
+	for i := 0; ; i = i + 1 {
+		x := float32(b) / float32((uint64(1) << (i * 10)))
+		if x < unit {
+			if i == 0 {
+				return fmt.Sprintf("%d B", b)
+			}
+
+			return fmt.Sprintf("%.1f %ciB", x, prefixes[i-1])
+		}
+	}
+}

--- a/internal/pkg/sysinfo/probes/util_test.go
+++ b/internal/pkg/sysinfo/probes/util_test.go
@@ -1,0 +1,28 @@
+package probes
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIECBytes_String(t *testing.T) {
+
+	for _, data := range []struct {
+		v   uint64
+		str string
+	}{
+		{0, "0 B"},
+		{1*Ki - 1, "1023 B"},
+		{1 * Ki, "1.0 KiB"},
+		{1*Mi - 1, "1024.0 KiB"},
+		{1 * Mi, "1.0 MiB"},
+		{math.MaxUint64, "16.0 EiB"},
+	} {
+		t.Run(strconv.FormatUint(data.v, 10), func(t *testing.T) {
+			assert.Equal(t, data.str, iecBytes(data.v).String())
+		})
+	}
+}

--- a/internal/pkg/sysinfo/sysinfo.go
+++ b/internal/pkg/sysinfo/sysinfo.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysinfo
+
+import (
+	"errors"
+
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+
+	"github.com/sirupsen/logrus"
+)
+
+type K0sSysinfoSpec struct {
+	ControllerRoleEnabled bool
+	WorkerRoleEnabled     bool
+	DataDir               string
+
+	// This is mainly for the sysinfo CLI subcommand.
+	AddDebugProbes bool
+
+	// May be extended with more flags in the future, e.g. for
+	// kube-router, calico, konnectivity, ...
+}
+
+func (s *K0sSysinfoSpec) RunPreFlightChecks(lenient bool) error {
+	reporter := &preFlightReporter{lenient: lenient}
+	if err := s.NewSysinfoProbes().Probe(reporter); err != nil {
+		return err
+	}
+
+	if reporter.failed {
+		return errors.New("pre-flight checks failed")
+	}
+
+	return nil
+}
+
+func (s *K0sSysinfoSpec) NewSysinfoProbes() probes.Probes {
+	p := probes.NewProbes()
+
+	// https://docs.k0sproject.io/main/external-runtime-deps/#a-unique-machine-id-for-multi-node-setups
+	probes.RequireMachineID(p)
+
+	// https://docs.k0sproject.io/main/system-requirements/#minimum-memory-and-cpu-requirements
+	if s.ControllerRoleEnabled {
+		probes.AssertTotalMemory(p, 1*probes.Gi)
+	} else if s.WorkerRoleEnabled {
+		probes.AssertTotalMemory(p, 500*probes.Mi)
+	}
+
+	// https://docs.k0sproject.io/main/system-requirements/#storage
+	var minFreeDiskSpace uint64
+	if s.ControllerRoleEnabled {
+		minFreeDiskSpace = minFreeDiskSpace + 500*probes.Mi
+	}
+	if s.WorkerRoleEnabled {
+		minFreeDiskSpace = minFreeDiskSpace + 1300*probes.Mi
+	}
+	probes.AssertFreeDiskSpace(p, s.DataDir, minFreeDiskSpace)
+
+	s.addHostSpecificProbes(p)
+
+	return p
+}
+
+type preFlightReporter struct {
+	lenient, failed bool
+}
+
+func (*preFlightReporter) Pass(d probes.ProbeDesc, prop probes.ProbedProp) error {
+	logrus.Debug(d.DisplayName(), prop)
+	return nil
+}
+
+func (*preFlightReporter) Warn(d probes.ProbeDesc, prop probes.ProbedProp, msg string) error {
+	logrus.Warn(d.DisplayName(), prop, msg)
+	return nil
+}
+
+func (p *preFlightReporter) Reject(d probes.ProbeDesc, prop probes.ProbedProp, msg string) error {
+	if p.lenient {
+		logrus.Warn(d.DisplayName(), prop, msg)
+	} else {
+		p.failed = true
+		logrus.Error(d.DisplayName(), prop, msg)
+	}
+
+	return nil
+}
+
+func (p *preFlightReporter) Error(d probes.ProbeDesc, err error) error {
+	p.failed = true
+	return err
+}

--- a/internal/testutil/sysinfo/reporter.go
+++ b/internal/testutil/sysinfo/reporter.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysinfo
+
+import (
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockReporter struct {
+	mock.Mock
+}
+
+func (m *MockReporter) Pass(d probes.ProbeDesc, prop probes.ProbedProp) error {
+	args := m.Called(d, prop)
+	return args.Error(0)
+}
+
+func (m *MockReporter) Warn(d probes.ProbeDesc, prop probes.ProbedProp, msg string) error {
+	args := m.Called(d, prop, msg)
+	return args.Error(0)
+}
+
+func (m *MockReporter) Reject(d probes.ProbeDesc, prop probes.ProbedProp, msg string) error {
+	args := m.Called(d, prop, msg)
+	return args.Error(0)
+}
+
+func (m *MockReporter) Error(d probes.ProbeDesc, err error) error {
+	args := m.Called(d, err)
+	return args.Error(0)
+}

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path"
 	"runtime"
@@ -839,13 +840,9 @@ func (s *FootlooseSuite) initializeFootlooseClusterInDir(dir string) error {
 	volumes := []config.Volume{
 		{
 			Type:        "bind",
-			Source:      "/lib/modules",
-			Destination: "/lib/modules",
-		},
-		{
-			Type:        "bind",
 			Source:      binPath,
 			Destination: s.K0sFullPath,
+			ReadOnly:    true,
 		},
 		{
 			Type:        "volume",
@@ -853,7 +850,43 @@ func (s *FootlooseSuite) initializeFootlooseClusterInDir(dir string) error {
 		},
 	}
 
+	// Ensure that kernel config is available in the footloose boxes.
+	// See https://github.com/kubernetes/system-validators/blob/v1.6.0/validators/kernel_validator.go#L180-L190
+
+	bindPaths := []string{
+		"/usr/src/linux/.config",
+		"/usr/lib/modules",
+		"/lib/modules",
+	}
+
+	if kernelVersion, err := exec.Command("uname", "-r").Output(); err == nil {
+		kernelVersion := strings.TrimSpace(string(kernelVersion))
+		bindPaths = append(bindPaths, []string{
+			"/boot/config-" + kernelVersion,
+			"/usr/src/linux-" + kernelVersion,
+			"/usr/lib/ostree-boot/config-" + kernelVersion,
+			"/usr/lib/kernel/config-" + kernelVersion,
+			"/usr/src/linux-headers-" + kernelVersion,
+		}...)
+	} else {
+		s.T().Logf("not mounting any kernel-specific paths: %v", err)
+	}
+
+	for _, path := range bindPaths {
+		if _, err := os.Stat(path); err != nil {
+			continue
+		}
+		volumes = append(volumes, config.Volume{
+			Type:        "bind",
+			Source:      path,
+			Destination: path,
+			ReadOnly:    true,
+		})
+	}
+
 	volumes = append(volumes, s.ExtraVolumes...)
+
+	s.T().Logf("mounting volumes: %v", volumes)
 
 	portMaps := []config.PortMapping{
 		{

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -27,8 +27,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
-	"github.com/k0sproject/k0s/internal/pkg/machineid"
 	"github.com/k0sproject/k0s/internal/pkg/stringmap"
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/machineid"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/internal/pkg/users"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
@@ -110,9 +110,9 @@ func (k *Konnectivity) Reconcile(ctx context.Context, clusterCfg *v1beta1.Cluste
 }
 
 func (k *Konnectivity) defaultArgs() stringmap.StringMap {
-	serverID, err := machineid.Generate()
+	machineID, err := machineid.Generate()
 	if err != nil {
-		logrus.Errorf("failed to fetch server ID for konnectivity-server")
+		logrus.Errorf("failed to fetch machine ID for konnectivity-server")
 	}
 	return stringmap.StringMap{
 		"--uds-name":                filepath.Join(k.K0sVars.KonnectivitySocketDir, "konnectivity-server.sock"),
@@ -130,7 +130,7 @@ func (k *Konnectivity) defaultArgs() stringmap.StringMap {
 		"--stderrthreshold":         "1",
 		"--v":                       k.LogLevel,
 		"--enable-profiling":        "false",
-		"--server-id":               serverID,
+		"--server-id":               machineID.ID(),
 		"--proxy-strategies":        "destHost,default",
 	}
 }

--- a/pkg/leaderelection/lease_pool.go
+++ b/pkg/leaderelection/lease_pool.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/cloudflare/cfssl/log"
-	"github.com/k0sproject/k0s/internal/pkg/machineid"
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/machineid"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -133,7 +133,7 @@ func NewLeasePool(client kubernetes.Interface, name string, opts ...LeaseOpt) (*
 			return nil, err
 		}
 
-		leaseConfig.identity = machineID
+		leaseConfig.identity = machineID.ID()
 	}
 
 	for _, opt := range opts {

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/k0sproject/k0s/internal/pkg/machineid"
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/machineid"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 )
@@ -160,5 +160,5 @@ func (c Component) sendTelemetry(ctx context.Context) {
 
 func machineID() string {
 	id, _ := machineid.Generate()
-	return id
+	return id.ID()
 }


### PR DESCRIPTION
## Description

Users can choose to ignore the results of the pre-flight checks by adding the `--ignore-pre-flight-checks` command line argument.

Re-implement the sysinfo subcommand without the system-validators library. Some reasons as to why this makes sense:

* The system-validators library has some weird error reporting, where callers cannot easily distinguish between validation failures and hard errors.
* The lib wasn't easily extensible with k0s-specific checks.
* It still relies on external binaries (uname) (although this is certainly fixable upstream).

Add a new internal package sysinfo/probes whose design loosely borrows from Go's testing framework and Testify's assert/require nomenclature. Those probes are being used to implement a "K0sSysSpec", which is the foundation for both the sysinfo subcommand and the pre-flight checks.

Supersedes #1526.
Fixes #1289.

The output of `k0s sysinfo` looks like this on my box now:

```text
Machine ID: "d02e3609003cf4b2d96bf16e7f1729c02fa3be9f8e0eab85d9ec38b0aa11528f" (from machine) (pass)
Total memory: 14.9 GiB (pass)
Disk space available for /var/lib/k0s: 279.7 GiB (pass)
Operating system: Linux (pass)
  Linux kernel release: 5.16.8 (pass)
  CONFIG_CGROUPS: Control Group support: built-in (pass)
    CONFIG_CGROUP_FREEZER: Freezer cgroup subsystem: built-in (pass)
    CONFIG_CGROUP_PIDS: PIDs cgroup subsystem: built-in (pass)
    CONFIG_CGROUP_DEVICE: Device controller for cgroups: built-in (pass)
    CONFIG_CPUSETS: Cpuset support: built-in (pass)
    CONFIG_CGROUP_CPUACCT: Simple CPU accounting cgroup subsystem: built-in (pass)
    CONFIG_MEMCG: Memory Resource Controller for Control Groups: built-in (pass)
    CONFIG_CGROUP_HUGETLB: HugeTLB Resource Controller for Control Groups: built-in (pass)
    CONFIG_CGROUP_SCHED: Group CPU scheduler: built-in (pass)
      CONFIG_FAIR_GROUP_SCHED: Group scheduling for SCHED_OTHER: built-in (pass)
        CONFIG_CFS_BANDWIDTH: CPU bandwidth provisioning for FAIR_GROUP_SCHED: built-in (pass)
    CONFIG_BLK_CGROUP: Block IO controller: built-in (pass)
  CONFIG_NAMESPACES: Namespaces support: built-in (pass)
    CONFIG_UTS_NS: UTS namespace: built-in (pass)
    CONFIG_IPC_NS: IPC namespace: built-in (pass)
    CONFIG_PID_NS: PID namespace: built-in (pass)
    CONFIG_NET_NS: Network namespace: built-in (pass)
  CONFIG_NET: Networking support: built-in (pass)
    CONFIG_INET: TCP/IP networking: built-in (pass)
      CONFIG_IPV6: The IPv6 protocol: built-in (pass)
    CONFIG_NETFILTER: Network packet filtering framework (Netfilter): built-in (pass)
      CONFIG_NETFILTER_ADVANCED: Advanced netfilter configuration: built-in (pass)
      CONFIG_NETFILTER_XTABLES: Netfilter Xtables support: module (pass)
        CONFIG_NETFILTER_XT_TARGET_REDIRECT: REDIRECT target support: module (pass)
        CONFIG_NETFILTER_XT_MATCH_COMMENT: "comment" match support: module (pass)
        CONFIG_NETFILTER_XT_MARK: nfmark target and match support: module (pass)
        CONFIG_NETFILTER_XT_SET: set target and match support: module (pass)
        CONFIG_NETFILTER_XT_TARGET_MASQUERADE: MASQUERADE target support: module (pass)
        CONFIG_NETFILTER_XT_NAT: "SNAT and DNAT" targets support: module (pass)
        CONFIG_NETFILTER_XT_MATCH_ADDRTYPE: "addrtype" address type match support: module (pass)
        CONFIG_NETFILTER_XT_MATCH_CONNTRACK: "conntrack" connection tracking match support: module (pass)
        CONFIG_NETFILTER_XT_MATCH_MULTIPORT: "multiport" Multiple port match support: module (pass)
        CONFIG_NETFILTER_XT_MATCH_RECENT: "recent" match support: module (pass)
        CONFIG_NETFILTER_XT_MATCH_STATISTIC: "statistic" match support: module (pass)
      CONFIG_NETFILTER_NETLINK: module (pass)
      CONFIG_NF_CONNTRACK: Netfilter connection tracking support: module (pass)
      CONFIG_NF_NAT: module (pass)
      CONFIG_IP_SET: IP set support: module (pass)
        CONFIG_IP_SET_HASH_IP: hash:ip set support: module (pass)
        CONFIG_IP_SET_HASH_NET: hash:net set support: module (pass)
      CONFIG_IP_VS: IP virtual server support: module (pass)
        CONFIG_IP_VS_NFCT: Netfilter connection tracking: built-in (pass)
      CONFIG_NF_CONNTRACK_IPV4: IPv4 connetion tracking support (required for NAT): unknown (warning)
      CONFIG_NF_REJECT_IPV4: IPv4 packet rejection: module (pass)
      CONFIG_NF_NAT_IPV4: IPv4 NAT: unknown (warning)
      CONFIG_IP_NF_IPTABLES: IP tables support: module (pass)
        CONFIG_IP_NF_FILTER: Packet filtering: module (pass)
          CONFIG_IP_NF_TARGET_REJECT: REJECT target support: module (pass)
        CONFIG_IP_NF_NAT: iptables NAT support: module (pass)
        CONFIG_IP_NF_MANGLE: Packet mangling: module (pass)
      CONFIG_NF_DEFRAG_IPV4: module (pass)
      CONFIG_NF_CONNTRACK_IPV6: IPv6 connetion tracking support (required for NAT): unknown (warning)
      CONFIG_NF_NAT_IPV6: IPv6 NAT: unknown (warning)
      CONFIG_IP6_NF_IPTABLES: IP6 tables support: module (pass)
        CONFIG_IP6_NF_FILTER: Packet filtering: module (pass)
        CONFIG_IP6_NF_MANGLE: Packet mangling: module (pass)
        CONFIG_IP6_NF_NAT: ip6tables NAT support: module (pass)
      CONFIG_NF_DEFRAG_IPV6: module (pass)
  CONFIG_EXT4_FS: The Extended 4 (ext4) filesystem: module (pass)
  CONFIG_PROC_FS: /proc file system support: built-in (pass)
  CONFIG_BRIDGE: 802.1d Ethernet Bridging: module (pass)
    CONFIG_LLC: module (pass)
    CONFIG_STP: module (pass)
  Control Groups: version 1 (pass)
    cgroup controller "cpu": available (pass)
    cgroup controller "cpuacct": available (pass)
    cgroup controller "cpuset": available (pass)
    cgroup controller "memory": available (pass)
    cgroup controller "devices": available (pass)
    cgroup controller "freezer": available (pass)
    cgroup controller "pids": available (pass)
    cgroup controller "hugetlb": available (pass)
    cgroup controller "blkio": available (pass)
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings