### PR TITLE
Bring back docs version selector

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,20 +101,20 @@ markdown_extensions:
         toc_depth: 3
 
 extra:
-    generator: false
-    social:
-      - icon: fontawesome/brands/github
-        link: https://github.com/k0sproject/k0s
-        name: k0s on GitHub
-      - icon: fontawesome/brands/twitter
-        link: https://twitter.com/k0sproject
-        name: k0s on Twitter
-      - icon: fontawesome/brands/slack
-        link: http://k8slens.slack.com/
-        name: k0s on Slack
-      - icon: fontawesome/solid/link
-        link: https://k0sproject.io/
-        name: k0s Website
-    version:
-      method: mike
+  generator: false
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/k0sproject/k0s
+      name: k0s on GitHub
+    - icon: fontawesome/brands/twitter
+      link: https://twitter.com/k0sproject
+      name: k0s on Twitter
+    - icon: fontawesome/brands/slack
+      link: http://k8slens.slack.com/
+      name: k0s on Slack
+    - icon: fontawesome/solid/link
+      link: https://k0sproject.io/
+      name: k0s Website
+  version:
+    provider: mike
 


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

## Description

According to [mkdocs-matrial docs](https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/) the version provider should be set via `extra.version.provider: mike`, k0s had `extra.version.method: mike`. Maybe that is why the selector was lost. We are using a forked theme from lens, not sure if it is even the same theme.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [X] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [X] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

