### PR TITLE
Added cloud-provider enabling instruction for k0sctl

### DIFF
--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -8,6 +8,21 @@ k0s builds Kubernetes components in *providerless* mode, meaning that cloud prov
 
 Even when all components are built with providerless mode, you must be able to enable cloud provider mode for kubelet. To do this, run the workers with `--enable-cloud-provider=true`.
 
+When deploying with [k0sctl](k0sctl-install.md), you can add this into the `installFlags` of worker hosts.
+
+```yaml
+spec:
+  hosts:
+  - ssh:
+      address: 10.0.0.1
+      user: root
+      keyPath: ~/.ssh/id_rsa
+    installFlags:
+      - --enable-cloud-provider
+      - --kubelet-extra-args="--cloud-provider=external"
+    role: worker
+```
+
 ### Deploy the cloud provider
 
 The easiest way to deploy cloud provider controllers is on the k0s cluster.
@@ -18,27 +33,22 @@ Use the built-in [manifest deployer](manifests.md) built into k0s to deploy your
 
 ## k0s Cloud Provider
 
-Alternatively, k0s provides its own lightweight cloud provider that can
-be used to statically assign `ExternalIP` values to worker nodes via
-Kubernetes annotations.  This is beneficial for those who need to expose
-worker nodes externally via static IP assignments.
+Alternatively, k0s provides its own lightweight cloud provider that can be used to statically assign `ExternalIP` values to worker nodes via Kubernetes annotations.  This is beneficial for those who need to expose worker nodes externally via static IP assignments.
 
-To enable this functionality, add the parameter `--enable-k0s-cloud-provider=true`
-to all controllers, and `--enable-cloud-provider=true` to all workers.
+To enable this functionality, add the parameter `--enable-k0s-cloud-provider=true` to all controllers, and `--enable-cloud-provider=true` to all workers.
 
 Adding a static IP address to a node using `kubectl`:
 
-    kubectl annotate \
-        node <node> \
-        k0sproject.io/node-ip-external=<external IP>
+```shell
+kubectl annotate \
+    node <node> \
+    k0sproject.io/node-ip-external=<external IP>
+```
 
 Both IPv4 and IPv6 addresses are supported.
 
 ### Defaults
 
-The default node refresh interval is `2m`, which can be overridden using
-the `--k0s-cloud-provider-update-frequency=<duration>` parameter when launching
-the controller(s).
+The default node refresh interval is `2m`, which can be overridden using the `--k0s-cloud-provider-update-frequency=<duration>` parameter when launching the controller(s).
 
-The default port that the cloud provider binds to can be overridden using the
-`--k0s-cloud-provider-port=<int>` parameter when launching the controller(s).
+The default port that the cloud provider binds to can be overridden using the `--k0s-cloud-provider-port=<int>` parameter when launching the controller(s).


### PR DESCRIPTION
## Description

Added short instruction for how to enable cloud-provider support on hosts spun up via k0sctl. This was missing throughout the documentation.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## How Has This Been Tested?

- [X] Manual test
- [ ] Auto test added

Tested spinning cluster with the documented configuration.

## Checklist:

- [X] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings