### PR TITLE
Make docs "main" an alias of "head"

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -68,7 +68,6 @@ jobs:
       - name: mike deploy head
         if: contains(github.ref, 'refs/heads/main')
         run: |
-          mike delete main || true
           mike deploy --push head
 
       # If this is a tag build, deploy as a new version
@@ -86,6 +85,7 @@ jobs:
           TAGS=$(gh release list -L 1000 -R k0sproject/k0s | grep "+k0s." | grep -v Draft | cut -f 1 | k0s_sort)
           LATEST=$(echo "${TAGS}" | tail -1)
           STABLE=$(echo "${TAGS}" | grep -v -- "-" | tail -1)
+          mike alias -u head main
           mike alias -u "${LATEST}" latest
           mike alias -u "${STABLE}" stable
           mike set-default --push stable


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

## Description

Makes "main" an alias of "head" so both '/main' and '/head' will work.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
