### PR TITLE
Use single node mode flag to decide if we want to run leader-election

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -188,7 +188,7 @@ func (c *CmdOpts) startController(ctx context.Context) error {
 	})
 
 	if c.NodeConfig.Spec.API.ExternalAddress != "" {
-		c.NodeComponents.Add(ctx, &controller.K0sLease{
+		c.NodeComponents.Add(ctx, &controller.K0sControllersLeaseCounter{
 			ClusterConfig:     c.NodeConfig,
 			KubeClientFactory: adminClientFactory,
 		})
@@ -197,7 +197,7 @@ func (c *CmdOpts) startController(ctx context.Context) error {
 	var leaderElector controller.LeaderElector
 
 	// One leader elector per controller
-	if c.NodeConfig.Spec.API.ExternalAddress != "" {
+	if !c.SingleNode {
 		leaderElector = controller.NewLeaderElector(adminClientFactory)
 	} else {
 		leaderElector = &controller.DummyLeaderElector{Leader: true}
@@ -309,14 +309,16 @@ func (c *CmdOpts) startController(ctx context.Context) error {
 	}
 	if !stringslice.Contains(c.DisableComponents, constant.KubeSchedulerComponentName) {
 		c.ClusterComponents.Add(ctx, &controller.Scheduler{
-			LogLevel: c.Logging[constant.KubeSchedulerComponentName],
-			K0sVars:  c.K0sVars,
+			LogLevel:   c.Logging[constant.KubeSchedulerComponentName],
+			K0sVars:    c.K0sVars,
+			SingleNode: c.SingleNode,
 		})
 	}
 	if !stringslice.Contains(c.DisableComponents, constant.KubeControllerManagerComponentName) {
 		c.ClusterComponents.Add(ctx, &controller.Manager{
-			LogLevel: c.Logging[constant.KubeControllerManagerComponentName],
-			K0sVars:  c.K0sVars,
+			LogLevel:   c.Logging[constant.KubeControllerManagerComponentName],
+			K0sVars:    c.K0sVars,
+			SingleNode: c.SingleNode,
 		})
 
 	}

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -187,7 +187,7 @@ func (c *CmdOpts) startController(ctx context.Context) error {
 		EnableKonnectivity: enableKonnectivity,
 	})
 
-	if c.NodeConfig.Spec.API.ExternalAddress != "" {
+	if !c.SingleNode {
 		c.NodeComponents.Add(ctx, &controller.K0sControllersLeaseCounter{
 			ClusterConfig:     c.NodeConfig,
 			KubeClientFactory: adminClientFactory,
@@ -301,6 +301,7 @@ func (c *CmdOpts) startController(ctx context.Context) error {
 
 	if enableKonnectivity {
 		c.ClusterComponents.Add(ctx, &controller.Konnectivity{
+			SingleNode:        c.SingleNode,
 			LogLevel:          c.Logging[constant.KonnectivityServerComponentName],
 			K0sVars:           c.K0sVars,
 			KubeClientFactory: adminClientFactory,

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -74,6 +74,8 @@ func (s *BasicSuite) TestK0sGetsUp() {
 
 	s.Require().NoError(s.verifyKubeletAddressFlag(s.WorkerNode(0)))
 	s.Require().NoError(s.verifyKubeletAddressFlag(s.WorkerNode(1)))
+	s.Require().NoError(common.WaitForLease(s.Context(), kc, "kube-scheduler", "kube-system"))
+	s.Require().NoError(common.WaitForLease(s.Context(), kc, "kube-controller-manager", "kube-system"))
 }
 
 func (s *BasicSuite) checkCertPerms(node string) error {

--- a/inttest/common/util.go
+++ b/inttest/common/util.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -151,5 +152,20 @@ func WaitForPodLogs(kc *kubernetes.Clientset, namespace string) error {
 		}
 
 		return true, nil
+	})
+}
+
+func WaitForLease(ctx context.Context, kc *kubernetes.Clientset, name string, namespace string) error {
+
+	return Poll(ctx, func(ctx context.Context) (done bool, err error) {
+		lease, err := kc.CoordinationV1().Leases(namespace).Get(ctx, name, v1.GetOptions{})
+		if err != nil && apierrors.IsNotFound(err) {
+			return false, nil // Not found, keep polling
+		} else if err != nil {
+			return false, err
+		}
+
+		// Verify that there's a valid holder on the lease
+		return *lease.Spec.HolderIdentity != "", nil
 	})
 }

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -41,6 +41,7 @@ type Manager struct {
 	supervisor     *supervisor.Supervisor
 	uid            int
 	previousConfig stringmap.StringMap
+	SingleNode     bool
 }
 
 var cmDefaultArgs = stringmap.StringMap{
@@ -118,8 +119,7 @@ func (a *Manager) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterCon
 			args[name] = value
 		}
 	}
-
-	if clusterConfig.Spec.API.ExternalAddress == "" {
+	if a.SingleNode {
 		args["leader-elect"] = "false"
 	}
 

--- a/pkg/component/controller/controllersleasecounter.go
+++ b/pkg/component/controller/controllersleasecounter.go
@@ -28,9 +28,9 @@ import (
 	"github.com/k0sproject/k0s/pkg/leaderelection"
 )
 
-// ControllerLease implements a component that manages a lease per controller.
+// K0sControllersLeaseCounter implements a component that manages a lease per controller.
 // The per-controller leases are used to determine the amount of currently running controllers
-type K0sLease struct {
+type K0sControllersLeaseCounter struct {
 	ClusterConfig     *v1beta1.ClusterConfig
 	KubeClientFactory kubeutil.ClientFactoryInterface
 
@@ -39,12 +39,12 @@ type K0sLease struct {
 }
 
 // Init initializes the component needs
-func (l *K0sLease) Init(_ context.Context) error {
+func (l *K0sControllersLeaseCounter) Init(_ context.Context) error {
 	return nil
 }
 
 // Run runs the leader elector to keep the lease object up-to-date.
-func (l *K0sLease) Run(ctx context.Context) error {
+func (l *K0sControllersLeaseCounter) Run(ctx context.Context) error {
 	ctx, l.cancelFunc = context.WithCancel(ctx)
 	log := logrus.WithFields(logrus.Fields{"component": "controllerlease"})
 	client, err := l.KubeClientFactory.GetClient()
@@ -88,7 +88,7 @@ func (l *K0sLease) Run(ctx context.Context) error {
 }
 
 // Stop stops the component
-func (l *K0sLease) Stop() error {
+func (l *K0sControllersLeaseCounter) Stop() error {
 	if l.leaseCancel != nil {
 		l.leaseCancel()
 	}
@@ -100,10 +100,10 @@ func (l *K0sLease) Stop() error {
 }
 
 // Reconcile detects changes in configuration and applies them to the component
-func (l *K0sLease) Reconcile() error {
+func (l *K0sControllersLeaseCounter) Reconcile() error {
 	logrus.Debug("reconcile method called for: K0sLease")
 	return nil
 }
 
 // Healthy is a no-op healchcheck
-func (l *K0sLease) Healthy() error { return nil }
+func (l *K0sControllersLeaseCounter) Healthy() error { return nil }

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -42,8 +42,9 @@ import (
 
 // Konnectivity implements the component interface of konnectivity server
 type Konnectivity struct {
-	K0sVars  constant.CfgVars
-	LogLevel string
+	K0sVars    constant.CfgVars
+	LogLevel   string
+	SingleNode bool
 	// used for lease lock
 	KubeClientFactory k8sutil.ClientFactoryInterface
 	NodeConfig        *v1beta1.ClusterConfig
@@ -100,7 +101,7 @@ func (k *Konnectivity) Run(ctx context.Context) error {
 // Reconcile detects changes in configuration and applies them to the component
 func (k *Konnectivity) Reconcile(ctx context.Context, clusterCfg *v1beta1.ClusterConfig) error {
 	k.clusterConfig = clusterCfg
-	if k.NodeConfig.Spec.API.ExternalAddress != "" {
+	if !k.SingleNode {
 		go k.runLeaseCounter(ctx)
 	} else {
 		// It's a buffered channel so once we start the runServer routine it'll pick this up and just sees it never changing

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -36,6 +36,7 @@ type Scheduler struct {
 	gid            int
 	K0sVars        constant.CfgVars
 	LogLevel       string
+	SingleNode     bool
 	supervisor     *supervisor.Supervisor
 	uid            int
 	previousConfig stringmap.StringMap
@@ -88,8 +89,7 @@ func (a *Scheduler) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterC
 		}
 		args[name] = value
 	}
-
-	if clusterConfig.Spec.API.ExternalAddress == "" {
+	if a.SingleNode {
 		args["leader-elect"] = "false"
 	}
 


### PR DESCRIPTION
Use single node mode flag to decide if we want to run leader-election
Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>

## Description

This PR introduces changes to disable leader-election only if we explicitly run cluster in the single node mode
The previously used behavior used to rely on the config ExternalAddress.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1585

## Type of change

<!-- check the related options -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [X] Manual test
- [X] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings