### PR TITLE
Make kernel config smoketest more lenient

### DIFF
--- a/internal/pkg/sysinfo/probes/linux/kernel_test.go
+++ b/internal/pkg/sysinfo/probes/linux/kernel_test.go
@@ -118,7 +118,11 @@ func TestKConfigProber(t *testing.T) {
 
 		option, err := probeKConfig(ensureKConfig("I_CERTAINLY_DONT_EXIST"))
 		assert.Equal(t, option, kConfigUnknown)
-		assert.NoError(t, err)
+		if _, ok := err.(*noKConfigsFound); ok {
+			t.Log("system doesn't expose its kernel config")
+		} else {
+			assert.NoError(t, err)
+		}
 	})
 
 	t.Run("propagatesUnameErr", func(t *testing.T) {


### PR DESCRIPTION
## Description

It'll fail on systems which don't expose their kernel config at runtime, hence it may produce some unnecessary noise in those cases.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings