### PR TITLE
Add component to provision static pod manifests

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,6 +227,7 @@ Note that there are several fields that cannot be overridden:
 - `clusterDomain`
 - `apiVersion`
 - `kind`
+- `staticPodURL`
 
 #### Examples
 

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/workerprofile.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/workerprofile.go
@@ -49,6 +49,7 @@ var lockedFields = map[string]struct{}{
 	"clusterDomain": {},
 	"apiVersion":    {},
 	"kind":          {},
+	"staticPodURL":  {},
 }
 
 // Validate validates instance

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/workerprofile_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/workerprofile_test.go
@@ -62,6 +62,12 @@ func TestWorkerProfile(t *testing.T) {
 					"kind": "Controller",
 				},
 				valid: false,
+			}, {
+				name: "Locked field staticPodURL",
+				spec: map[string]interface{}{
+					"staticPodURL": "foo",
+				},
+				valid: false,
 			},
 		}
 

--- a/pkg/component/worker/static_pods.go
+++ b/pkg/component/worker/static_pods.go
@@ -1,0 +1,545 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/avast/retry-go"
+	"github.com/gorilla/mux"
+	"github.com/k0sproject/k0s/pkg/component"
+	"github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/yaml"
+)
+
+// StaticPods represents the way how k0s manages node-local static pod manifests
+// exposed to the kubelet.
+type StaticPods interface {
+	// ManifestURL returns the HTTP URL that can be used by the kubelet to
+	// obtain static pod manifests managed by this StaticPods instance.
+	ManifestURL() (string, error)
+
+	// ClaimStaticPod returns a new, empty StaticPod associated with the given
+	// namespace and name. Note that only one StaticPod for a given combination
+	// may be claimed, and needs to be dropped when no longer in use.
+	ClaimStaticPod(namespace, name string) (StaticPod, error)
+}
+
+// StaticPod represents a single, node-local static pod manifest exposed to the
+// kubelet, managed by k0s.
+type StaticPod interface {
+	// SetManifest replaces the manifest for this static pod. The new manifest
+	// has to be a valid pod manifest, and needs to have the same namespace and
+	// name that have been used when claiming this pod.
+	SetManifest(podResource interface{}) error
+
+	// Clear removes this static pod manifest from kubelet, leaving it claimed.
+	// A new manifest can be set via SetManifest.
+	Clear()
+
+	// Drop drops this static pod, removing it from the kubelet and invalidating
+	// this instance. When Drop returns, subsequent calls to SetManifest will
+	// err out and the pod can be reclaimed.
+	Drop()
+}
+
+// staticPodID uniquely identifies static pod manifests managed by staticPods.
+type staticPodID struct {
+	namespace, name string
+}
+
+// staticPod implements the StaticPod interface.
+type staticPod struct {
+	staticPodID // initially set, immutable
+
+	mu           sync.Mutex
+	manifestPtr  atomic.Value // Store only when mu is locked, concurrent Load is okay
+	update, drop func()
+}
+
+// staticPods implements the StaticPods interface, as well as the Component
+// interface, so that it can be hooked in as a k0s component.
+type staticPods struct {
+	log logrus.FieldLogger // initially set, immutable
+
+	mu        sync.Mutex
+	lifecycle staticPodsLifecycle
+
+	contentPtr  atomic.Value // Store only when mu is locked, concurrent Load is okay
+	claimedPods map[staticPodID]*staticPod
+
+	manifestURL string // guaranteed to be initialized when started, immutable afterwards
+	stopSignal  context.CancelFunc
+	stopped     sync.WaitGroup
+}
+
+// NewStaticPods creates a new static_pods component.
+func NewStaticPods() interface {
+	StaticPods
+	component.Component
+} {
+	staticPods := &staticPods{
+		log:         logrus.WithFields(logrus.Fields{"component": "static_pods"}),
+		claimedPods: make(map[staticPodID]*staticPod),
+	}
+	staticPods.contentPtr.Store(generateContent(nil))
+	return staticPods
+}
+
+func (s *staticPods) ManifestURL() (string, error) {
+	if lifecycle := s.peekLifecycle(); lifecycle < staticPodsStarted {
+		return "", staticPodsNotYet(staticPodsStarted)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.manifestURL, nil
+}
+
+func (s *staticPods) ClaimStaticPod(namespace, name string) (StaticPod, error) {
+	staticPod, err := newStaticPod(namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	id := staticPod.staticPodID
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.claimedPods[id]; ok {
+		return nil, fmt.Errorf("%s is already claimed", &id)
+	}
+
+	// hook the static pod into this instance
+	staticPod.drop = func() { s.drop(id) }
+	staticPod.update = s.update
+	s.claimedPods[id] = staticPod
+
+	return staticPod, nil
+}
+
+func newStaticPod(namespace, name string) (*staticPod, error) {
+	if errs := validation.IsDNS1123Label(namespace); errs != nil {
+		return nil, fmt.Errorf("invalid namespace: %q: %s", namespace, strings.Join(errs, ", "))
+	}
+	if errs := validation.IsDNS1123Subdomain(name); errs != nil {
+		return nil, fmt.Errorf("invalid name: %q: %s", name, strings.Join(errs, ", "))
+	}
+
+	staticPod := staticPod{staticPodID: staticPodID{namespace, name}}
+	staticPod.manifestPtr.Store([]byte{})
+
+	return &staticPod, nil
+}
+
+func (p *staticPod) SetManifest(podResource interface{}) error {
+	// convert podResource into JSON
+	var jsonBytes []byte
+	var err error
+	switch data := podResource.(type) {
+	case []byte:
+		jsonBytes, err = yaml.YAMLToJSON(data)
+		if err != nil {
+			return err
+		}
+	case string:
+		jsonBytes, err = yaml.YAMLToJSON([]byte(data))
+		if err != nil {
+			return err
+		}
+	default:
+		jsonBytes, err = json.Marshal(data)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := validatePodResource(&p.staticPodID, jsonBytes); err != nil {
+		return err
+	}
+
+	// Update this pod's content, if not already dropped.
+	p.mu.Lock()
+	update := p.update
+	if update == nil {
+		p.mu.Unlock()
+		return errors.New("already dropped")
+	}
+	p.manifestPtr.Store(jsonBytes)
+	p.mu.Unlock()
+
+	// Update the content of the enclosing staticPods instance, without holding
+	// this pod's lock, so that there's no potential deadlocks. The update
+	// method itself will check if the staticPods instance has been stopped
+	// concurrently, anyways.
+	update()
+	return nil
+}
+
+func validatePodResource(claimedID *staticPodID, json []byte) error {
+	// Validate the manifest to have only fields that are valid for pods.
+	var pod corev1.Pod
+	err := yaml.UnmarshalStrict(json, &pod)
+	if err != nil {
+		return err
+	}
+
+	// Validate that it's actually a pod.
+	if pod.APIVersion != "v1" || pod.Kind != "Pod" {
+		return fmt.Errorf("not a Pod: %s/%s", pod.APIVersion, pod.Kind)
+	}
+
+	// Validate that the pod is matching this claim.
+	if actualID := (staticPodID{pod.Namespace, pod.Name}); actualID != *claimedID {
+		return fmt.Errorf("attempt to set the manifest to %q, whereas %q was claimed", &actualID, claimedID)
+	}
+
+	return nil
+}
+
+func (p *staticPod) Clear() {
+	// Clear this pod's content.
+	p.mu.Lock()
+	update := p.update
+	p.manifestPtr.Store([]byte{})
+	p.mu.Unlock()
+
+	// If this pod hasn't been dropped already, update the content of the
+	// enclosing staticPods instance. Do this without holding this pod's lock,
+	// so that there's no potential deadlocks. The update method itself will
+	// check if the staticPods instance has been stopped concurrently, anyways.
+	if update != nil {
+		update()
+	}
+}
+
+func (p *staticPod) Drop() {
+	// Clear this pod's content, and unhook it from its enclosing staticPods instance.
+	p.mu.Lock()
+	drop := p.drop
+	p.update = nil
+	p.drop = nil
+	p.manifestPtr.Store([]byte{})
+	p.mu.Unlock()
+
+	// If this pod hasn't been dropped already, drop it from the enclosing
+	// staticPods instance. Do this without holding this pod's lock, so that
+	// there's no potential deadlocks. The drop method will check if the
+	// staticPods instance has been stopped concurrently, anyways.
+	if drop != nil {
+		drop()
+	}
+}
+
+// String returns a loggable representation for staticPodIds.
+func (i *staticPodID) String() string {
+	return fmt.Sprintf("%s/%s", i.namespace, i.name)
+}
+
+// update regenerates the content and stores it.
+func (s *staticPods) update() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Don't update anything if this instance has been stopped already.
+	if s.peekLifecycle() >= staticPodsStopped {
+		return
+	}
+
+	s.contentPtr.Store(generateContent(s.claimedPods))
+}
+
+// drop removes the given id, regenerates the content and stores it.
+func (s *staticPods) drop(id staticPodID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// No need to drop anything if this instance has been stopped already.
+	if s.peekLifecycle() >= staticPodsStopped {
+		return
+	}
+
+	delete(s.claimedPods, id)
+	s.contentPtr.Store(generateContent(s.claimedPods))
+}
+
+// generateContent returns a JSON encoded list of pods, to be consumed by the kubelet.
+func generateContent(pods map[staticPodID]*staticPod) []byte {
+	var buf bytes.Buffer
+
+	buf.WriteString(`{"apiVersion":"v1","kind":"PodList","items":[`)
+
+	var needsComma bool
+	for _, pod := range pods {
+		manifest := pod.loadManifest()
+		if len(manifest) > 0 {
+			if needsComma {
+				buf.WriteRune(',')
+			} else {
+				needsComma = true
+			}
+			buf.Write(manifest)
+		}
+	}
+
+	buf.WriteString("]}")
+
+	return buf.Bytes()
+}
+
+func (p *staticPod) loadManifest() []byte {
+	return p.manifestPtr.Load().([]byte)
+}
+
+func (s *staticPods) content() []byte {
+	return s.contentPtr.Load().([]byte)
+}
+
+func (s *staticPods) Init(context.Context) error {
+	// Nothing to initialize, but still check if this component is used correctly.
+	if !s.transition(staticPodsUninitialized, staticPodsInitialized) {
+		return staticPodsAlready(s.peekLifecycle())
+	}
+
+	return nil
+}
+
+func (s *staticPods) Run(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.transition(staticPodsInitialized, staticPodsStarting) {
+		lifecycle := s.peekLifecycle()
+		if lifecycle < staticPodsInitialized {
+			return staticPodsNotYet(staticPodsInitialized)
+		}
+
+		return staticPodsAlready(lifecycle)
+	}
+
+	// Open a TCP port to listen for incoming HTTP requests.
+	listener, err := net.Listen("tcp", "127.0.0.1:") // FIXME: Support IPv6 / dual stack?
+	if err != nil {
+		s.transition(staticPodsStarting, staticPodsInitialized)
+		return err
+	}
+
+	// Initialize a new HTTP server for static pods.
+	addr := listener.Addr().String()
+	log := s.log.WithField("local_addr", addr)
+	srv, cancelFunc := newStaticPodsServer(log, s.content)
+	srv.Addr = addr
+
+	// Fire up the goroutine to accept HTTP connections.
+	notClosed := func(err error) bool { return err != http.ErrServerClosed }
+	s.stopped.Add(1)
+	go func() {
+		defer s.stopped.Done()
+
+		log.Info("Serving HTTP requests")
+		err := srv.Serve(listener)
+
+		// As long as the server isn't closed, try to restart it.
+		for notClosed(err) {
+			err = retry.Do(func() error {
+				log.WithError(err).Error("HTTP server terminated, restarting ...")
+				return srv.ListenAndServe()
+			}, retry.RetryIf(notClosed), retry.Attempts(math.MaxUint))
+		}
+
+		log.Info("HTTP server closed")
+	}()
+
+	// Store the handles.
+	s.manifestURL = fmt.Sprintf("http://%s/manifests", addr)
+	s.stopSignal = cancelFunc
+
+	// This instance started successfully, everything is setup and running.
+	s.transition(staticPodsStarting, staticPodsStarted)
+	return nil
+}
+
+func newStaticPodsServer(log logrus.FieldLogger, contentFn func() []byte) (*http.Server, context.CancelFunc) {
+	router := mux.NewRouter()
+
+	// The main endpoint to be consumed by the kubelet.
+	router.Path("/manifests").Methods("GET").Handler(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			log := log.WithField("remote_addr", r.RemoteAddr)
+			content := contentFn()
+			log.Debugf("Writing content: %s", string(content))
+			if _, err := w.Write(content); err != nil {
+				log.WithError(err).Warn("Failed to write HTTP response")
+			}
+		}),
+	)
+
+	// Internal health check.
+	router.Path("/manifests/_healthz").Methods("GET").Handler(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			log := log.WithField("remote_addr", r.RemoteAddr)
+			log.Debugf("Answering health check")
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	)
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	srv := &http.Server{
+		Handler:      router,
+		WriteTimeout: 15 * time.Second,
+		ReadTimeout:  15 * time.Second,
+		BaseContext:  func(net.Listener) context.Context { return ctx },
+	}
+
+	// Fire up a goroutine that'll close the HTTP server whenever the context is cancelled.
+	go func() {
+		<-ctx.Done()
+		log.Debug("Closing HTTP server")
+		if err := srv.Close(); err != nil {
+			log.WithError(err).Warn("Failed to close HTTP server")
+		} else {
+			log.Debug("HTTP server closed")
+		}
+	}()
+
+	return srv, cancelFunc
+}
+
+func (s *staticPods) Stop() error {
+	s.mu.Lock()
+
+	if !s.transition(staticPodsStarted, staticPodsStopped) {
+		lifecycle := s.peekLifecycle()
+		if lifecycle < staticPodsStarted {
+			s.mu.Unlock()
+			return staticPodsNotYet(staticPodsStarted)
+		}
+	}
+
+	// Signal the HTTP server to stop.
+	s.stopSignal()
+
+	// Swap out all the claimed pods.
+	claimedPods := s.claimedPods
+	s.claimedPods = map[staticPodID]*staticPod{}
+
+	// Fire up a goroutine for every claimed pod that drops
+	// it concurrently, so that there's no deadlocks.
+	for _, claimedPod := range claimedPods {
+		pod := claimedPod
+		s.stopped.Add(1)
+		go func() {
+			defer s.stopped.Done()
+			pod.mu.Lock()
+			defer pod.mu.Unlock()
+			pod.update = nil
+			pod.drop = nil
+			pod.manifestPtr.Store([]byte{})
+		}()
+	}
+
+	s.mu.Unlock()
+
+	s.stopped.Wait()
+	s.contentPtr.Store([]byte{})
+
+	return nil
+}
+
+// Health-check interface
+func (s *staticPods) Healthy() error {
+	url, err := s.ManifestURL()
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/_healthz", url), nil)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
+	defer cancel()
+
+	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("unexpected HTTP response status: %s", resp.Status)
+	}
+	return nil
+}
+
+type staticPodsLifecycle int32
+
+const (
+	staticPodsUninitialized = staticPodsLifecycle(iota)
+	staticPodsInitialized
+	staticPodsStarting
+	staticPodsStarted
+	staticPodsStopped
+)
+
+func (l staticPodsLifecycle) String() string {
+	switch l {
+	case staticPodsUninitialized, staticPodsInitialized, staticPodsStarting:
+		return "initialized"
+	case staticPodsStarted:
+		return "running"
+	case staticPodsStopped:
+		return "stopped"
+	default:
+		return fmt.Sprintf("<unknown (%d)>", l)
+	}
+}
+
+func (s *staticPods) transition(old, new staticPodsLifecycle) bool {
+	return atomic.CompareAndSwapInt32((*int32)(&s.lifecycle), int32(old), int32(new))
+}
+
+func (s *staticPods) peekLifecycle() staticPodsLifecycle {
+	return staticPodsLifecycle(atomic.LoadInt32((*int32)(&s.lifecycle)))
+}
+
+type staticPodsNotYet staticPodsLifecycle
+
+func (l staticPodsNotYet) Error() string {
+	return fmt.Sprintf("static_pods component is not yet %s", staticPodsLifecycle(l))
+}
+
+type staticPodsAlready staticPodsLifecycle
+
+func (l staticPodsAlready) Error() string {
+	return fmt.Sprintf("static_pods component is already %s", staticPodsLifecycle(l))
+}

--- a/pkg/component/worker/static_pods_test.go
+++ b/pkg/component/worker/static_pods_test.go
@@ -1,0 +1,374 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package worker
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+const dummyPod = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy-test
+  namespace: default
+spec:
+  containers:
+  - image: nginx
+    name: web
+    ports:
+    - containerPort: 80
+      name: web
+      protocol: TCP
+`
+
+func TestStaticPods_Provisioning(t *testing.T) {
+
+	underTest := NewStaticPods()
+
+	t.Run("content_is_initlially_empty", func(t *testing.T) {
+		assert.Equal(t, newList(t), getContent(t, underTest))
+	})
+
+	podUnderTest, err := underTest.ClaimStaticPod("default", "dummy-test")
+	require.NoError(t, err)
+
+	t.Run("rejects_claims", func(t *testing.T) {
+		for _, test := range []struct{ test, ns, name, err string }{
+			{
+				"pods_without_a_name",
+				"default", "",
+				`invalid name: "": `,
+			},
+			{
+				"pods_without_a_namespace",
+				"", "dummy-test",
+				`invalid namespace: "": `,
+			},
+		} {
+			t.Run(test.test, func(t *testing.T) {
+				_, err := underTest.ClaimStaticPod(test.ns, test.name)
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), test.err)
+				}
+			})
+		}
+	})
+
+	t.Run("rejects", func(t *testing.T) {
+		_, err = underTest.ClaimStaticPod("default", "dummy-test")
+		if assert.Error(t, err) {
+			assert.Equal(t, "default/dummy-test is already claimed", err.Error())
+		}
+
+		for _, test := range []struct {
+			name string
+			pod  interface{}
+			err  string
+		}{
+			{
+				"non_pods",
+				&corev1.Pod{
+					TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+				},
+				"not a Pod: v1/Secret",
+			},
+			{
+				"pods_not_matching_the_claim",
+				&corev1.Pod{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"},
+				},
+				`attempt to set the manifest to "foo/bar", whereas "default/dummy-test" was claimed`,
+			},
+			{
+				"unknown_fields",
+				`{"apiVersion": "v1", "kind": "Pod", "spec":{"foo": "bar"}}`,
+				`error unmarshaling JSON: while decoding JSON: json: unknown field "foo"`,
+			},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				err := podUnderTest.SetManifest(test.pod)
+				if assert.Error(t, err) {
+					assert.Equal(t, test.err, err.Error())
+				}
+				assert.Equal(t, newList(t), getContent(t, underTest))
+			})
+		}
+	})
+
+	t.Run("accepts", func(t *testing.T) {
+		expected := newList(t, []byte(dummyPod))
+
+		for _, test := range []struct {
+			name string
+			pod  interface{}
+		}{
+			{"bytes", []byte(dummyPod)},
+			{"strings", dummyPod},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				assert.NoError(t, podUnderTest.SetManifest(test.pod))
+				assert.Equal(t, expected, getContent(t, underTest))
+			})
+		}
+	})
+
+	t.Run("sets_pod_manifests", func(t *testing.T) {
+		replaced := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"dummy-test","namespace":"default"}}`
+		expected := newList(t, []byte(replaced))
+
+		assert.NoError(t, podUnderTest.SetManifest(dummyPod))
+		assert.NoError(t, podUnderTest.SetManifest(replaced))
+
+		assert.Equal(t, expected, getContent(t, underTest))
+
+		podUnderTest.Clear()
+
+		assert.Equal(t, newList(t), getContent(t, underTest))
+
+		assert.NoError(t, podUnderTest.SetManifest(replaced))
+
+		assert.Equal(t, expected, getContent(t, underTest))
+	})
+
+	t.Run("drops_pods", func(t *testing.T) {
+		podUnderTest.Drop()
+		assert.Equal(t, newList(t), getContent(t, underTest))
+		err := podUnderTest.SetManifest(dummyPod)
+		if assert.Error(t, err) {
+			assert.Equal(t, "already dropped", err.Error())
+		}
+		assert.Equal(t, newList(t), getContent(t, underTest))
+	})
+}
+
+func TestStaticPods_Lifecycle(t *testing.T) {
+	log, logs := test.NewNullLogger()
+	log.SetLevel(logrus.DebugLevel)
+
+	underTest := NewStaticPods()
+	underTest.(*staticPods).log = log
+	podUnderTest, err := underTest.ClaimStaticPod("default", "dummy-test")
+	require.NoError(t, err)
+	assert.NoError(t, podUnderTest.SetManifest(dummyPod))
+
+	t.Run("url_is_unavailable_before_init", func(t *testing.T) {
+		_, err := underTest.ManifestURL()
+		require.Error(t, err)
+		assert.Equal(t, "static_pods component is not yet running", err.Error())
+	})
+
+	t.Run("fails_to_run_without_init", func(t *testing.T) {
+		err := underTest.Run(context.TODO())
+		require.Error(t, err)
+		require.Equal(t, "static_pods component is not yet initialized", err.Error())
+	})
+
+	t.Run("health_check_fails_without_init", func(t *testing.T) {
+		err := underTest.Healthy()
+		require.Error(t, err)
+		require.Equal(t, "static_pods component is not yet running", err.Error())
+	})
+
+	t.Run("fails_to_stop_without_init", func(t *testing.T) {
+		err := underTest.Stop()
+		require.Error(t, err)
+		require.Equal(t, "static_pods component is not yet running", err.Error())
+	})
+
+	t.Run("init", func(t *testing.T) {
+		require.NoError(t, underTest.Init(context.TODO()))
+	})
+
+	t.Run("another_init_fails", func(t *testing.T) {
+		err := underTest.Init(context.TODO())
+		if assert.Error(t, err) {
+			assert.Equal(t, "static_pods component is already initialized", err.Error())
+		}
+	})
+
+	t.Run("url_is_unavailable_after_init", func(t *testing.T) {
+		_, err := underTest.ManifestURL()
+		require.Error(t, err)
+		assert.Equal(t, "static_pods component is not yet running", err.Error())
+	})
+
+	t.Run("health_check_fails_before_run", func(t *testing.T) {
+		err := underTest.Healthy()
+		require.Error(t, err)
+		require.Equal(t, "static_pods component is not yet running", err.Error())
+	})
+
+	t.Run("stop_before_run_fails", func(t *testing.T) {
+		err := underTest.Stop()
+		require.Error(t, err)
+		assert.Equal(t, "static_pods component is not yet running", err.Error())
+	})
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	t.Cleanup(cancel)
+
+	t.Run("runs", func(runT *testing.T) {
+		if assert.NoError(runT, underTest.Run(ctx)) {
+			t.Cleanup(func() { assert.NoError(t, underTest.Stop()) })
+
+			var lastLog *logrus.Entry
+			require.NoError(t, retry.Do(func() error {
+				lastLog = logs.LastEntry()
+				if lastLog == nil {
+					return errors.New("not yet logged")
+				}
+				return nil
+			}, retry.Attempts(5)))
+
+			assert.Equal(t, "Serving HTTP requests", lastLog.Message)
+			assert.Contains(t, lastLog.Data["local_addr"], "127.0.0.1")
+		}
+	})
+
+	t.Run("another_run_fails", func(t *testing.T) {
+		err := underTest.Run(ctx)
+		require.Error(t, err)
+		assert.Equal(t, "static_pods component is already running", err.Error())
+	})
+
+	t.Run("health_check_works", func(t *testing.T) {
+		err := underTest.Healthy()
+		assert.NoError(t, err)
+		lastLog := logs.LastEntry()
+		require.Equal(t, "Answering health check", lastLog.Message)
+		assert.Contains(t, lastLog.Data["local_addr"], "127.0.0.1")
+		assert.Contains(t, lastLog.Data["remote_addr"], "127.0.0.1")
+	})
+
+	t.Run("serves_content", func(t *testing.T) {
+		dummyPod, err := yaml.YAMLToJSON([]byte(dummyPod))
+		require.NoError(t, err)
+		expectedContent := `{"apiVersion":"v1","kind":"PodList","items":[` + string(dummyPod) + "]}"
+
+		url, err := underTest.ManifestURL()
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		t.Cleanup(cancel)
+
+		req = req.WithContext(ctx)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+		assert.Equal(t, resp.StatusCode, http.StatusOK)
+
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		assert.JSONEq(t, expectedContent, string(body))
+
+		lastLog := logs.LastEntry()
+		require.NotNil(t, lastLog)
+		assert.Contains(t, lastLog.Message, "Writing content: ")
+		assert.Contains(t, lastLog.Data["local_addr"], "127.0.0.1")
+		assert.Contains(t, lastLog.Data["remote_addr"], "127.0.0.1")
+	})
+
+	t.Run("stops", func(t *testing.T) {
+		require.NoError(t, underTest.Stop())
+	})
+
+	t.Run("health_check_fails_after_stopped", func(t *testing.T) {
+		err := underTest.Healthy()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "connection refused")
+	})
+
+	t.Run("does_not_serve_content_anymore", func(t *testing.T) {
+		url, err := underTest.ManifestURL()
+		require.NoError(t, err)
+
+		req, err := http.NewRequest("GET", url, nil)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		t.Cleanup(cancel)
+
+		resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+		if assert.Error(t, err) {
+			assert.Contains(t, err.Error(), "connection refused")
+		} else {
+			assert.NoError(t, resp.Body.Close())
+		}
+	})
+
+	t.Run("stop_may_be_called_again", func(t *testing.T) {
+		require.NoError(t, underTest.Stop())
+	})
+
+	t.Run("claimed_pod_may_be_dropped_after_stop", func(t *testing.T) {
+		podUnderTest.Drop()
+	})
+
+	t.Run("reinit_fails", func(t *testing.T) {
+		err := underTest.Init(context.TODO())
+		require.Error(t, err)
+		assert.Equal(t, "static_pods component is already stopped", err.Error())
+	})
+
+	t.Run("rerun_fails", func(t *testing.T) {
+		err := underTest.Run(context.TODO())
+		require.Error(t, err)
+		assert.Equal(t, "static_pods component is already stopped", err.Error())
+	})
+}
+
+func getContent(t *testing.T, underTest StaticPods) (content map[string]interface{}) {
+	require.NoError(t, yaml.Unmarshal(underTest.(*staticPods).content(), &content))
+	return
+}
+
+func newList(t *testing.T, items ...[]byte) map[string]interface{} {
+	parsedItems := []interface{}{}
+	for _, item := range items {
+		var parsedItem map[string]interface{}
+		require.NoError(t, yaml.Unmarshal(item, &parsedItem))
+		parsedItems = append(parsedItems, parsedItem)
+	}
+
+	return map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "PodList",
+		"items":      parsedItems,
+	}
+}


### PR DESCRIPTION
## Description

The static_pods component starts a local HTTP server to serve static pod manifests. The HTTP endpoint is configured as `staticPodURL` in the Kubelet. This enables k0s to manage node-local pods, without the need of a connection to the API server. Note that this now "claims" the `staticPodURL` Kubelet config for internal use inside k0s.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings