### PR TITLE
Refactor sysinfo probes

### DIFF
--- a/internal/pkg/sysinfo/probes/disk.go
+++ b/internal/pkg/sysinfo/probes/disk.go
@@ -33,10 +33,6 @@ type assertDiskSpace struct {
 	minFree uint64
 }
 
-func (a *assertDiskSpace) Path() ProbePath {
-	return a.path
-}
-
-func (a *assertDiskSpace) DisplayName() string {
-	return fmt.Sprintf("Disk space available for %s", a.fsPath)
+func (a *assertDiskSpace) desc() ProbeDesc {
+	return NewProbeDesc(fmt.Sprintf("Disk space available for %s", a.fsPath), a.path)
 }

--- a/internal/pkg/sysinfo/probes/disk_linux.go
+++ b/internal/pkg/sysinfo/probes/disk_linux.go
@@ -37,7 +37,7 @@ func (a *assertDiskSpace) Probe(reporter Reporter) error {
 					continue
 				}
 			}
-			return reporter.Error(a, err)
+			return reporter.Error(a.desc(), err)
 		}
 
 		break
@@ -47,8 +47,8 @@ func (a *assertDiskSpace) Probe(reporter Reporter) error {
 	// Available blocks * size per block = available space in bytes
 	free := stat.Bavail * uint64(stat.Bsize)
 	if free >= a.minFree {
-		return reporter.Pass(a, iecBytes(free))
+		return reporter.Pass(a.desc(), iecBytes(free))
 	}
 
-	return reporter.Warn(a, iecBytes(free), fmt.Sprintf("%s recommended", iecBytes(a.minFree)))
+	return reporter.Warn(a.desc(), iecBytes(free), fmt.Sprintf("%s recommended", iecBytes(a.minFree)))
 }

--- a/internal/pkg/sysinfo/probes/disk_other.go
+++ b/internal/pkg/sysinfo/probes/disk_other.go
@@ -20,5 +20,5 @@ limitations under the License.
 package probes
 
 func (a *assertDiskSpace) Probe(reporter Reporter) error {
-	return reporter.Warn(a, probeUnsupported("Disk space detection unsupported on this platform"), "")
+	return reporter.Warn(a.desc(), probeUnsupported("Disk space detection unsupported on this platform"), "")
 }

--- a/internal/pkg/sysinfo/probes/linux/cgroup_controllers.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroup_controllers.go
@@ -36,9 +36,9 @@ func (c *CgroupsProbes) AssertControllers(controllerNames ...string) {
 
 func (c *CgroupsProbes) probeControllers(require bool, controllerNames ...string) {
 	for _, controllerName := range controllerNames {
-		c.probes.Set(controllerName, func(path probes.ProbePath, _ probes.Probe) probes.Probe {
+		c.Set(controllerName, func(path probes.ProbePath, _ probes.Probe) probes.Probe {
 			return &cgroupControllerProbe{
-				append(c.path, path...),
+				path,
 				c.probeCgroupSystem,
 				controllerName,
 				require,
@@ -54,25 +54,18 @@ type cgroupControllerProbe struct {
 	require     bool
 }
 
-func (c *cgroupControllerProbe) Path() probes.ProbePath {
-	return c.path
-}
-
-func (c *cgroupControllerProbe) DisplayName() string {
-	return fmt.Sprintf("cgroup controller %q", c.name)
-}
-
 func (c *cgroupControllerProbe) Probe(reporter probes.Reporter) error {
+	desc := probes.NewProbeDesc(fmt.Sprintf("cgroup controller %q", c.name), c.path)
 	if sys, err := c.probeSystem(); err != nil {
-		return reportCgroupSystemErr(reporter, c, err)
+		return reportCgroupSystemErr(reporter, desc, err)
 	} else if available, err := sys.probeController(c.name); err != nil {
-		return reporter.Error(c, err)
+		return reporter.Error(desc, err)
 	} else if available.available {
-		return reporter.Pass(c, available)
+		return reporter.Pass(desc, available)
 	} else if c.require {
-		return reporter.Reject(c, available, "")
+		return reporter.Reject(desc, available, "")
 	} else {
-		return reporter.Warn(c, available, "")
+		return reporter.Warn(desc, available, "")
 	}
 }
 

--- a/internal/pkg/sysinfo/probes/linux/cgroups.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroups.go
@@ -55,7 +55,7 @@ func (p *LinuxProbes) RequireCgroups() *CgroupsProbes {
 
 func newCgroupsProbes(path probes.ProbePath, unameProber unameProber, mountPoint string) *CgroupsProbes {
 	return &CgroupsProbes{
-		probes.NewProbes(path),
+		probes.NewProbesAtPath(path),
 
 		path,
 		unameProber,

--- a/internal/pkg/sysinfo/probes/linux/kernel.go
+++ b/internal/pkg/sysinfo/probes/linux/kernel.go
@@ -35,51 +35,46 @@ import (
 )
 
 func (l *LinuxProbes) AssertKernelRelease(assert func(string) string) {
-	l.probes.Set("kernelRelease", func(path probes.ProbePath, current probes.Probe) probes.Probe {
-		return &assertKRelease{append(l.path, path...), l.probeUname, assert}
+	l.Set("kernelRelease", func(path probes.ProbePath, current probes.Probe) probes.Probe {
+		return probes.ProbeFn(func(r probes.Reporter) error {
+			desc := probes.NewProbeDesc("Linux kernel release", path)
+			if uname, err := l.probeUname(); err != nil {
+				return r.Error(desc, err)
+			} else if uname.osRelease.truncated {
+				return r.Error(desc, errors.New(uname.osRelease.String()))
+			} else if msg := assert(uname.osRelease.value); msg != "" {
+				return r.Warn(desc, uname.osRelease, msg)
+			} else {
+				return r.Pass(desc, uname.osRelease)
+			}
+		})
 	})
 }
 
 func (l *LinuxProbes) RequireKernelConfig(config, desc string, alternativeConfigs ...string) *KernelConfigProbes {
-	return l.newKProbes().RequireKernelConfig(config, desc, alternativeConfigs...)
+	return probeKConfig(l, l.probeKConfig, true, config, desc, alternativeConfigs...)
 }
 
 func (l *LinuxProbes) AssertKernelConfig(config, desc string, alternativeConfigs ...string) *KernelConfigProbes {
-	return l.newKProbes().AssertKernelConfig(config, desc, alternativeConfigs...)
-}
-
-func (l *LinuxProbes) newKProbes() (k *KernelConfigProbes) {
-	l.probes.Set("kernelConfig", func(path probes.ProbePath, current probes.Probe) probes.Probe {
-		var ok bool
-		if k, ok = current.(*KernelConfigProbes); !ok {
-			k = &KernelConfigProbes{path, l.probeKConfig, probes.NewProbes()}
-		}
-
-		return k
-	})
-
-	return
-}
-
-func (k *KernelConfigProbes) Probe(reporter probes.Reporter) error {
-	return k.probes.Probe(reporter)
+	return probeKConfig(l, l.probeKConfig, false, config, desc, alternativeConfigs...)
 }
 
 type KernelConfigProbes struct {
+	probes.Probes
+
 	path        probes.ProbePath
 	probeConfig kConfigProber
-	probes      probes.Probes
 }
 
 func (k *KernelConfigProbes) RequireKernelConfig(config, desc string, alternativeConfigs ...string) *KernelConfigProbes {
-	return k.probeKConfig(true, config, desc, alternativeConfigs...)
+	return probeKConfig(k, k.probeConfig, true, config, desc, alternativeConfigs...)
 }
 
 func (k *KernelConfigProbes) AssertKernelConfig(config, desc string, alternativeConfigs ...string) *KernelConfigProbes {
-	return k.probeKConfig(false, config, desc, alternativeConfigs...)
+	return probeKConfig(k, k.probeConfig, false, config, desc, alternativeConfigs...)
 }
 
-//revive:disable:var-naming
+// revive:disable:var-naming
 
 type kConfigSpec struct {
 	kConfig
@@ -88,51 +83,27 @@ type kConfigSpec struct {
 	require             bool
 }
 
-func (k *KernelConfigProbes) probeKConfig(require bool, config, desc string, alternativeConfigs ...string) *KernelConfigProbes {
+func probeKConfig(
+	parent probes.ParentProbe, probeConfig kConfigProber,
+	require bool, config, desc string, alternativeConfigs ...string,
+) *KernelConfigProbes {
 	spec := &kConfigSpec{ensureKConfig(config), desc, nil, require}
 	for _, alternativeConfig := range alternativeConfigs {
 		spec.alternativeKConfigs = append(spec.alternativeKConfigs, ensureKConfig(alternativeConfig))
 	}
 
 	var kp *kConfigProbe
-	k.probes.Set(config, func(path probes.ProbePath, current probes.Probe) probes.Probe {
-		path = append(k.path, path...)
+	parent.Set(config, func(path probes.ProbePath, current probes.Probe) probes.Probe {
 		if probe, ok := current.(*kConfigProbe); ok {
 			kp = probe
 			kp.kConfigSpec = spec
 		} else {
-			kp = &kConfigProbe{&KernelConfigProbes{path, k.probeConfig, probes.NewProbes()}, spec}
+			kp = &kConfigProbe{&KernelConfigProbes{probes.NewProbes(path), path, probeConfig}, spec}
 		}
 		return kp
 	})
 
 	return kp.KernelConfigProbes
-}
-
-type assertKRelease struct {
-	path       probes.ProbePath
-	probeUname unameProber
-	assert     func(string) string
-}
-
-func (a *assertKRelease) Path() probes.ProbePath {
-	return a.path
-}
-
-func (*assertKRelease) DisplayName() string {
-	return "Linux kernel release"
-}
-
-func (a *assertKRelease) Probe(reporter probes.Reporter) error {
-	if uname, err := a.probeUname(); err != nil {
-		return reporter.Error(a, err)
-	} else if uname.osRelease.truncated {
-		return reporter.Error(a, errors.New(uname.osRelease.String()))
-	} else if msg := a.assert(uname.osRelease.value); msg != "" {
-		return reporter.Warn(a, uname.osRelease, msg)
-	} else {
-		return reporter.Pass(a, uname.osRelease)
-	}
 }
 
 // https://github.com/torvalds/linux/blob/v4.3/Documentation/kbuild/kconfig-language.txt
@@ -245,7 +216,7 @@ func (k *kConfigProbe) Probe(reporter probes.Reporter) error {
 		return err
 	}
 
-	return k.probes.Probe(reporter)
+	return k.Probes.Probe(reporter)
 }
 
 func (k *kConfigProbe) probe(reporter probes.Reporter, option kConfigOption) error {

--- a/internal/pkg/sysinfo/probes/linux/kernel.go
+++ b/internal/pkg/sysinfo/probes/linux/kernel.go
@@ -98,7 +98,7 @@ func probeKConfig(
 			kp = probe
 			kp.kConfigSpec = spec
 		} else {
-			kp = &kConfigProbe{&KernelConfigProbes{probes.NewProbes(path), path, probeConfig}, spec}
+			kp = &kConfigProbe{&KernelConfigProbes{probes.NewProbesAtPath(path), path, probeConfig}, spec}
 		}
 		return kp
 	})

--- a/internal/pkg/sysinfo/probes/linux/kernel_test.go
+++ b/internal/pkg/sysinfo/probes/linux/kernel_test.go
@@ -63,21 +63,21 @@ func TestRequireKernelConfig(t *testing.T) {
 		t.Run("calledWhenNoError", func(t *testing.T) {
 			reporter := new(test_sysinfo.MockReporter)
 			reporter.On("Pass", mock.MatchedBy(func(desc probes.ProbeDesc) bool {
-				if (probes.ProbePath{"kernelConfig", "IKCONFIG"}).Equal(desc.Path()) {
+				if (probes.ProbePath{"IKCONFIG"}).Equal(desc.Path()) {
 					assert.Equal(t, "CONFIG_IKCONFIG: ikconfig", desc.DisplayName())
 					return true
 				}
 				return false
 			}), kConfigBuiltIn).Return(nil)
 			reporter.On("Pass", mock.MatchedBy(func(desc probes.ProbeDesc) bool {
-				if (probes.ProbePath{"kernelConfig", "IKCONFIG", "IKCONFIG_PROC"}).Equal(desc.Path()) {
+				if (probes.ProbePath{"IKCONFIG", "IKCONFIG_PROC"}).Equal(desc.Path()) {
 					assert.Equal(t, "CONFIG_IKCONFIG_PROC: ikconfig_proc", desc.DisplayName())
 					return true
 				}
 				return false
 			}), kConfigAsModule).Return(nil)
 
-			err := linux.probes.Probe(reporter)
+			err := linux.Probes.Probe(reporter)
 
 			reporter.AssertExpectations(t)
 			assert.NoError(t, err)
@@ -87,10 +87,10 @@ func TestRequireKernelConfig(t *testing.T) {
 			expectedErr := errors.New("dummy")
 			reporter := new(test_sysinfo.MockReporter)
 			reporter.On("Pass", mock.MatchedBy(func(desc probes.ProbeDesc) bool {
-				return probes.ProbePath{"kernelConfig", "IKCONFIG"}.Equal(desc.Path())
+				return probes.ProbePath{"IKCONFIG"}.Equal(desc.Path())
 			}), kConfigBuiltIn).Return(expectedErr)
 
-			err := linux.probes.Probe(reporter)
+			err := linux.Probes.Probe(reporter)
 
 			reporter.AssertExpectations(t)
 			assert.Same(t, expectedErr, err)
@@ -102,7 +102,7 @@ func TestRequireKernelConfig(t *testing.T) {
 			reporter := new(test_sysinfo.MockReporter)
 			reporter.On("Warn", mock.Anything, &expectedErr, "").Return(nil)
 
-			err := linux.probes.Probe(reporter)
+			err := linux.Probes.Probe(reporter)
 
 			reporter.AssertExpectations(t)
 			assert.NoError(t, err)

--- a/internal/pkg/sysinfo/probes/linux/linux.go
+++ b/internal/pkg/sysinfo/probes/linux/linux.go
@@ -53,7 +53,7 @@ func RequireLinux(parent probes.ParentProbe) (l *LinuxProbes) {
 func newLinuxProbes(path probes.ProbePath) *LinuxProbes {
 	unameProber := newUnameProber()
 	return &LinuxProbes{
-		probes.NewProbes(path),
+		probes.NewProbesAtPath(path),
 
 		path,
 		unameProber,

--- a/internal/pkg/sysinfo/probes/linux/linux.go
+++ b/internal/pkg/sysinfo/probes/linux/linux.go
@@ -27,66 +27,51 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
 )
 
-//revive:disable-next-line:exported
+// revive:disable-next-line:exported
 type LinuxProbes struct {
+	probes.Probes
+
 	path         probes.ProbePath
 	probeUname   unameProber
 	probeKConfig kConfigProber
-	probes       probes.Probes
 }
 
 func RequireLinux(parent probes.ParentProbe) (l *LinuxProbes) {
 	parent.Set("os", func(path probes.ProbePath, current probes.Probe) probes.Probe {
-		if r, ok := current.(*requireLinuxProbe); ok {
-			l = &r.LinuxProbes
-			return r
+		var ok bool
+		if l, ok = current.(*LinuxProbes); ok {
+			return l
 		}
 
-		r := &requireLinuxProbe{newLinuxProbes(path)}
-		l = &r.LinuxProbes
-		return r
+		l = newLinuxProbes(path)
+		return l
 	})
 
 	return
 }
 
-func newLinuxProbes(path probes.ProbePath) LinuxProbes {
+func newLinuxProbes(path probes.ProbePath) *LinuxProbes {
 	unameProber := newUnameProber()
-	return LinuxProbes{
+	return &LinuxProbes{
+		probes.NewProbes(path),
+
 		path,
 		unameProber,
 		newKConfigProber(unameProber),
-		probes.NewProbes(),
 	}
 }
 
-type requireLinuxDesc struct {
-	probes.ProbePath
-}
-
-func (r requireLinuxDesc) Path() probes.ProbePath {
-	return r.ProbePath
-}
-
-func (r requireLinuxDesc) DisplayName() string {
-	return "Operating system"
-}
-
-type requireLinuxProbe struct {
-	LinuxProbes
-}
-
-func (r *requireLinuxProbe) Probe(reporter probes.Reporter) error {
-	if err := r.probe(reporter); err != nil {
+func (l *LinuxProbes) Probe(reporter probes.Reporter) error {
+	if err := l.probe(reporter); err != nil {
 		return err
 	}
 
-	return r.probes.Probe(reporter)
+	return l.Probes.Probe(reporter)
 }
 
-func (r *requireLinuxProbe) probe(reporter probes.Reporter) error {
-	desc := requireLinuxDesc{r.path}
-	if uname, err := r.probeUname(); err != nil {
+func (l *LinuxProbes) probe(reporter probes.Reporter) error {
+	desc := probes.NewProbeDesc("Operating system", l.path)
+	if uname, err := l.probeUname(); err != nil {
 		return reporter.Error(desc, err)
 	} else if uname.osName.value == "Linux" {
 		return reporter.Pass(desc, uname.osName)

--- a/internal/pkg/sysinfo/probes/linux/linux_test.go
+++ b/internal/pkg/sysinfo/probes/linux/linux_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestRequireLinux(t *testing.T) {
 
-	p := probes.NewProbes(nil)
+	p := probes.NewRootProbes()
 	linuxProbes := RequireLinux(p)
 
 	t.Run("reusesPreviousProbe", func(t *testing.T) {

--- a/internal/pkg/sysinfo/probes/linux/linux_test.go
+++ b/internal/pkg/sysinfo/probes/linux/linux_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestRequireLinux(t *testing.T) {
 
-	p := probes.NewProbes()
+	p := probes.NewProbes(nil)
 	linuxProbes := RequireLinux(p)
 
 	t.Run("reusesPreviousProbe", func(t *testing.T) {

--- a/internal/pkg/sysinfo/probes/machineid.go
+++ b/internal/pkg/sysinfo/probes/machineid.go
@@ -21,26 +21,13 @@ import "github.com/k0sproject/k0s/internal/pkg/sysinfo/machineid"
 // RequireMachineID requires a Machine ID
 func RequireMachineID(parent ParentProbe) {
 	parent.Set("machine-id", func(path ProbePath, _ Probe) Probe {
-		return &requireMachineID{path}
+		return ProbeFn(func(r Reporter) error {
+			desc := NewProbeDesc("Machine ID", path)
+			machineID, err := machineid.Generate()
+			if err != nil {
+				return r.Error(desc, err)
+			}
+			return r.Pass(desc, machineID)
+		})
 	})
-}
-
-type requireMachineID struct {
-	path ProbePath
-}
-
-func (r *requireMachineID) Path() ProbePath {
-	return r.path
-}
-
-func (*requireMachineID) DisplayName() string {
-	return "Machine ID"
-}
-
-func (r *requireMachineID) Probe(reporter Reporter) error {
-	machineID, err := machineid.Generate()
-	if err != nil {
-		return reporter.Error(r, err)
-	}
-	return reporter.Pass(r, machineID)
 }

--- a/internal/pkg/sysinfo/probes/memory.go
+++ b/internal/pkg/sysinfo/probes/memory.go
@@ -36,24 +36,17 @@ type assertTotalMem struct {
 	minFree          uint64
 }
 
-func (a *assertTotalMem) Path() ProbePath {
-	return a.path
-}
-
-func (*assertTotalMem) DisplayName() string {
-	return "Total memory"
-}
-
 func (a *assertTotalMem) Probe(reporter Reporter) error {
+	desc := NewProbeDesc("Total memory", a.path)
 	if totalMemory, err := a.probeTotalMemory(); err != nil {
 		if unsupportedErr, unsupported := err.(probeUnsupported); unsupported {
-			return reporter.Warn(a, unsupportedErr, "")
+			return reporter.Warn(desc, unsupportedErr, "")
 		}
-		return reporter.Error(a, err)
+		return reporter.Error(desc, err)
 	} else if totalMemory >= a.minFree {
-		return reporter.Pass(a, iecBytes(totalMemory))
+		return reporter.Pass(desc, iecBytes(totalMemory))
 	} else {
-		return reporter.Warn(a, iecBytes(totalMemory), fmt.Sprintf("%s recommended", iecBytes(a.minFree)))
+		return reporter.Warn(desc, iecBytes(totalMemory), fmt.Sprintf("%s recommended", iecBytes(a.minFree)))
 	}
 }
 

--- a/internal/pkg/sysinfo/probes/probes.go
+++ b/internal/pkg/sysinfo/probes/probes.go
@@ -97,8 +97,13 @@ type Probes interface {
 	Probe
 }
 
-// NewProbes returns a new, empty composite probe at the given path.
-func NewProbes(path ProbePath) Probes {
+// NewRootProbes returns a new, empty composite probe without a path.
+func NewRootProbes() Probes {
+	return &probes{nil, nil}
+}
+
+// NewProbesAtPath returns a new, empty composite probe at the given path.
+func NewProbesAtPath(path ProbePath) Probes {
 	return &probes{path, nil}
 }
 

--- a/internal/pkg/sysinfo/probes/probes.go
+++ b/internal/pkg/sysinfo/probes/probes.go
@@ -58,6 +58,11 @@ type ProbeDesc interface {
 	DisplayName() string
 }
 
+// NewProbeDesc returns a new ProbeDesc with the given display name and path.
+func NewProbeDesc(name string, path ProbePath) ProbeDesc {
+	return &probeDesc{path, name}
+}
+
 type ParentProbe interface {
 	Get(id string) Probe
 	Set(id string, setter func(path ProbePath, current Probe) Probe)
@@ -92,10 +97,18 @@ type Probes interface {
 	Probe
 }
 
-// NewProbes returns a new, empty composite probe.
-func NewProbes() Probes {
-	return &probes{}
+// NewProbes returns a new, empty composite probe at the given path.
+func NewProbes(path ProbePath) Probes {
+	return &probes{path, nil}
 }
+
+type probeDesc struct {
+	path ProbePath
+	name string
+}
+
+func (d *probeDesc) Path() ProbePath     { return d.path }
+func (d *probeDesc) DisplayName() string { return d.name }
 
 type probes struct {
 	path   ProbePath

--- a/internal/pkg/sysinfo/sysinfo.go
+++ b/internal/pkg/sysinfo/sysinfo.go
@@ -52,7 +52,7 @@ func (s *K0sSysinfoSpec) RunPreFlightChecks(lenient bool) error {
 }
 
 func (s *K0sSysinfoSpec) NewSysinfoProbes() probes.Probes {
-	p := probes.NewProbes()
+	p := probes.NewProbes(nil)
 
 	// https://docs.k0sproject.io/main/external-runtime-deps/#a-unique-machine-id-for-multi-node-setups
 	probes.RequireMachineID(p)

--- a/internal/pkg/sysinfo/sysinfo.go
+++ b/internal/pkg/sysinfo/sysinfo.go
@@ -52,7 +52,7 @@ func (s *K0sSysinfoSpec) RunPreFlightChecks(lenient bool) error {
 }
 
 func (s *K0sSysinfoSpec) NewSysinfoProbes() probes.Probes {
-	p := probes.NewProbes(nil)
+	p := probes.NewRootProbes()
 
 	// https://docs.k0sproject.io/main/external-runtime-deps/#a-unique-machine-id-for-multi-node-setups
 	probes.RequireMachineID(p)


### PR DESCRIPTION
## Description

* Use probes.Probes directly in composite probe types
  So that the manual path prefixing is no longer necessary.
* Provide a simple default implementation for probes.ProbeDesc
  This allows for removing some private structs that were mostly only necessary to implement the probes.ProbeDesc interface.
* Remove the bogus "kernelConfig" intermediary probe layer
  It wasn't really reporting anything, and "just" provided a level of indentation. While this was somehow useful for the CLI output, it was a weird thing to do in the first place.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings