### PR TITLE
Opportunistically modprobe ip_tables

### DIFF
--- a/pkg/component/worker/kernelsetup_linux.go
+++ b/pkg/component/worker/kernelsetup_linux.go
@@ -72,6 +72,10 @@ func KernelSetup() {
 	if !file.Exists("/proc/sys/net/bridge/bridge-nf-call-iptables") {
 		modprobe("br_netfilter")
 	}
+	// https://github.com/kubernetes/kubernetes/issues/108877
+	if !file.Exists("/proc/net/ip_tables_targets") {
+		modprobe("ip_tables")
+	}
 	enableSysCtl("net/ipv4/conf/all/forwarding")
 	enableSysCtl("net/ipv4/conf/default/forwarding")
 	enableSysCtl("net/ipv6/conf/all/forwarding")


### PR DESCRIPTION
## Description

As a workaround for kubernetes/kubernetes#108877, try to load the ip_tables kernel module from within k0s, if it seems unavailable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings