### PR TITLE
Don't log same error twice

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -403,7 +403,7 @@ func (c *CmdOpts) startController(ctx context.Context) error {
 
 		err = c.startControllerWorker(ctx, c.WorkerProfile)
 		if err != nil {
-			errCh <- fmt.Errorf("failed to start worker components: %w", err)
+			errCh <- fmt.Errorf("failed to start controller worker: %w", err)
 		}
 	}
 	perfTimer.Checkpoint("started-worker")
@@ -413,7 +413,7 @@ func (c *CmdOpts) startController(ctx context.Context) error {
 	// Wait for k0s process termination
 	select {
 	case err = <-errCh:
-		logrus.Error(err)
+		logrus.WithError(err).Error("Failed to start controller")
 	case <-ctx.Done():
 		logrus.Debug("Context done in main")
 	}

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -184,8 +184,7 @@ func (c *CmdOpts) StartWorker(ctx context.Context) error {
 	worker.KernelSetup()
 	err = componentManager.Start(ctx)
 	if err != nil {
-		logrus.WithError(err).Error("failed to start some of the worker components")
-		return err
+		return fmt.Errorf("failed to start worker components: %w", err)
 	}
 	// Wait for k0s process termination
 	<-ctx.Done()


### PR DESCRIPTION
## Description

Remove a redundant error log that produced two almost identical log entries. Modify the log strings a bit, to better reflect the place in which they they occur.

Before:

```text
time="2022-04-20 11:12:43" level=error msg="failed to start some of the worker components" error="wrapped_error_message"
time="2022-04-20 11:12:43" level=error msg="failed to start worker components: wrapped_error_message"
```

After:

```text
time="2022-04-20 11:57:54" level=error msg="Failed to start controller" error="failed to start controller worker: failed to start worker components: wrapped_error_message"
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings