### PR TITLE
Remove global data-dir flag

### DIFF
--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -116,7 +116,7 @@ func NewK0sKubectlCmd() *cobra.Command {
 
 		return originalPreRunE(cmd, args)
 	}
-
+	cmd.PersistentFlags().AddFlagSet(config.GetKubeCtlFlagSet())
 	originalRun := cmd.Run
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -107,10 +107,6 @@ func NewRootCmd() *cobra.Command {
 		longDesc = longDesc + "\n" + build.EulaNotice
 	}
 	cmd.Long = longDesc
-
-	// workaround for the data-dir location input for the kubectl command
-	cmd.PersistentFlags().AddFlagSet(config.GetKubeCtlFlagSet())
-
 	return cmd
 }
 

--- a/inttest/byocri/byocri_test.go
+++ b/inttest/byocri/byocri_test.go
@@ -80,7 +80,7 @@ func (s *BYOCRISuite) runDockerWorker() error {
 		return err
 	}
 
-	workerCommand := fmt.Sprintf(`nohup k0s --debug worker --cri-socket remote:unix:///var/run/cri-dockerd.sock "%s" >/tmp/k0s-worker.log 2>&1 &`, token)
+	workerCommand := fmt.Sprintf(`nohup k0s worker --debug --cri-socket remote:unix:///var/run/cri-dockerd.sock "%s" >/tmp/k0s-worker.log 2>&1 &`, token)
 	_, err = sshWorker.ExecWithOutput(workerCommand)
 	if err != nil {
 		return err

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -463,7 +463,7 @@ func (s *FootlooseSuite) RunWorkersWithToken(token string, args ...string) error
 	if token == "" {
 		return fmt.Errorf("got empty token for worker join")
 	}
-	workerCommand := fmt.Sprintf(`nohup %s --debug worker %s "%s" >/tmp/k0s-worker.log 2>&1 &`, s.K0sFullPath, strings.Join(args, " "), token)
+	workerCommand := fmt.Sprintf(`nohup %s worker --debug %s "%s" >/tmp/k0s-worker.log 2>&1 &`, s.K0sFullPath, strings.Join(args, " "), token)
 
 	for i := 0; i < s.WorkerCount; i++ {
 		sshWorker, err := s.SSH(s.WorkerNode(i))


### PR DESCRIPTION
Signed-off-by: Karen Almog <kalmog@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #942

## Type of change

`data-dir` is already used as a local flag under controller & worker options.
This PR removed `data-dir` and `config` as a global flag under the root command (and therefore removing it from other non-related subcommands.

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings