### PR TITLE
Some sysprobe fixes for cgroups

### DIFF
--- a/internal/pkg/sysinfo/host_linux.go
+++ b/internal/pkg/sysinfo/host_linux.go
@@ -40,20 +40,9 @@ func (s *K0sSysinfoSpec) addHostSpecificProbes(p probes.Probes) {
 
 	s.addKernelConfigs(linux)
 
-	cgroups := linux.RequireCgroups()
-	cgroups.RequireControllers(
-		"cpu",
-		"cpuacct",
-		"cpuset",
-		"memory",
-		"devices",
-		"freezer",
-		"pids",
-	)
-	cgroups.AssertControllers(
-		"hugetlb",
-		"blkio",
-	)
+	if s.WorkerRoleEnabled {
+		addCgroups(linux)
+	}
 }
 
 func (s *K0sSysinfoSpec) addKernelConfigs(linux *linux.LinuxProbes) {
@@ -175,4 +164,21 @@ func (s *K0sSysinfoSpec) addKernelConfigs(linux *linux.LinuxProbes) {
 	bridge := net.AssertKernelConfig("BRIDGE", "802.1d Ethernet Bridging")
 	bridge.AssertKernelConfig("LLC", "")
 	bridge.AssertKernelConfig("STP", "")
+}
+
+func addCgroups(linux *linux.LinuxProbes) {
+	cgroups := linux.RequireCgroups()
+	cgroups.RequireControllers(
+		"cpu",
+		"cpuacct",
+		"cpuset",
+		"memory",
+		"devices",
+		"freezer",
+		"pids",
+	)
+	cgroups.AssertControllers(
+		"hugetlb",
+		"blkio",
+	)
 }

--- a/internal/pkg/sysinfo/probes/linux/cgroup_v2.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroup_v2.go
@@ -67,6 +67,12 @@ func (s *cgroupV2) loadControllers(seen func(string, string)) error {
 
 	for _, controllerName := range strings.Fields(string(controllerData)) {
 		seen(controllerName, "")
+		switch controllerName {
+		case "cpu": // This is the successor to the version 1 cpu and cpuacct controllers.
+			seen("cpuacct", "via cpu in "+s.String())
+		case "io": // This is the successor of the version 1 blkio controller.
+			seen("blkio", "via io in "+s.String())
+		}
 	}
 
 	return nil
@@ -79,7 +85,7 @@ func parseKernelRelease(probeUname unameProber) (int64, int64, error) {
 	}
 
 	var major, minor int64
-	r := regexp.MustCompile(`^(\d+)\.(\d)(\.|$)`)
+	r := regexp.MustCompile(`^(\d+)\.(\d+)(\.|$)`)
 	if matches := r.FindStringSubmatch(uname.osRelease.value); matches == nil {
 		err = errors.New("unsupported format")
 	} else {

--- a/internal/pkg/sysinfo/probes/linux/cgroups.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroups.go
@@ -117,11 +117,11 @@ func loadCgroupSystem(probeUname unameProber, mountPoint string) (cgroupSystem, 
 	switch st.Type {
 	case unix.CGROUP2_SUPER_MAGIC:
 		// https://www.kernel.org/doc/html/v5.16/admin-guide/cgroup-v2.html#mounting
-		return &cgroupV2{probeUname: probeUname}, nil
+		return &cgroupV2{mountPoint, cgroupControllerProber{}, probeUname}, nil
 	case unix.CGROUP_SUPER_MAGIC, unix.TMPFS_MAGIC:
 		// https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man7/cgroups.7?h=man-pages-5.13#n159
 		// https://www.kernel.org/doc/html/v5.16/admin-guide/cgroup-v1/cgroups.html#how-do-i-use-cgroups
-		return &cgroupV1{}, nil
+		return &cgroupV1{cgroupControllerProber{}}, nil
 	default:
 		msg := fmt.Sprintf("unexpected file system type of %q: 0x%x", mountPoint, st.Type)
 		return nil, cgroupFsDetectionFailed(msg)


### PR DESCRIPTION
## Description

* Only check for cgroup controllers on workers
* The cgroupV2 struct's mountPoint wasn't initialized
* The Linux kernel regex in the v2 code was missing a plus sign
* The cpuacct and blkio controllers are different on v2

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings