### PR TITLE
Remove quoting when parsing flags for service unit files

### DIFF
--- a/cmd/install/util.go
+++ b/cmd/install/util.go
@@ -32,7 +32,7 @@ func cmdFlagsToArgs(cmd *cobra.Command) []string {
 		val := f.Value.String()
 		switch f.Value.Type() {
 		case "stringSlice", "stringToString":
-			flagsAndVals = append(flagsAndVals, fmt.Sprintf(`--%s="%s"`, f.Name, strings.Trim(val, "[]")))
+			flagsAndVals = append(flagsAndVals, fmt.Sprintf(`--%s=%s`, f.Name, strings.Trim(val, "[]")))
 		default:
 			if f.Name == "env" || f.Name == "force" {
 				return

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -824,6 +824,22 @@ func (s *FootlooseSuite) initializeFootlooseCluster() error {
 	return err
 }
 
+// Verifies that kubelet process has the address flag set
+func (s *FootlooseSuite) GetKubeletCMDLine(node string) (string, error) {
+	ssh, err := s.SSH(node)
+	if err != nil {
+		return "", err
+	}
+	defer ssh.Disconnect()
+
+	output, err := ssh.ExecWithOutput(`cat /proc/$(pidof kubelet)/cmdline`)
+	if err != nil {
+		return "", err
+	}
+
+	return output, nil
+}
+
 func (s *FootlooseSuite) initializeFootlooseClusterInDir(dir string) error {
 	binPath := os.Getenv("K0S_PATH")
 	if binPath == "" {

--- a/pkg/install/linux_openrc.go
+++ b/pkg/install/linux_openrc.go
@@ -23,7 +23,7 @@ name="{{.DisplayName}}"
 description="{{.Description}}"
 command={{.Path|cmdEscape}}
 {{- if .Arguments }}
-command_args="{{range .Arguments}}{{.}} {{end}}"
+command_args="{{range .Arguments}}'{{.}}' {{end}}"
 {{- end }}
 name=$(basename $(readlink -f $command))
 supervise_daemon_args="--stdout /var/log/${name}.log --stderr /var/log/${name}.err"


### PR DESCRIPTION
The way we quoted the flag values broke down in older systemd (219 at least) setups.

Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

## Description

The current way we parse and handle the flags from install --> service unit files adds quotes aounrd the values IF they are string arrays and slices. That effectively results into following execs:

```
ExecStart=/usr/local/bin/k0s controller --config=/etc/k0s/k0s.yaml --disable-components="konnectivity-server,default-psp" --enable-worker=true --no-taints=true
```

Now this quoting breaks older systemd (219 at least):
```
Error: unknown component konnectivity-server,default-psp
```

This works perfectly fine on newer systemd (tested on 237 and 245)

So the fix is to remove quoting and rely on kardianos/service for encoding the possible spaces properly.

One possible caveat is that IF there are any kubelet flags passed via `--kubelet-extra-args` that might need spaces those will get probably broken. But reading through the kubelet flag helps does not imply any of those would have values with spaces in them.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings