### PR TITLE
Remove unused Reconcile() methods from components

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -206,11 +206,14 @@ func (c *CmdOpts) startController(ctx context.Context) error {
 		})
 	}
 
-	var leaderElector controller.LeaderElector
+	var leaderElector interface {
+		controller.LeaderElector
+		component.Component
+	}
 
 	// One leader elector per controller
 	if !c.SingleNode {
-		leaderElector = controller.NewLeaderElector(adminClientFactory)
+		leaderElector = controller.NewLeasePoolLeaderElector(adminClientFactory)
 	} else {
 		leaderElector = &controller.DummyLeaderElector{Leader: true}
 	}

--- a/pkg/applier/manager.go
+++ b/pkg/applier/manager.go
@@ -24,6 +24,7 @@ import (
 	"gopkg.in/fsnotify.v1"
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
+	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/component/controller"
 	"github.com/k0sproject/k0s/pkg/constant"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
@@ -43,6 +44,8 @@ type Manager struct {
 
 	LeaderElector controller.LeaderElector
 }
+
+var _ component.Component = (*Manager)(nil)
 
 // Init initializes the Manager
 func (m *Manager) Init(ctx context.Context) error {
@@ -82,12 +85,6 @@ func (m *Manager) Stop() error {
 	if m.cancelWatcher != nil {
 		m.cancelWatcher()
 	}
-	return nil
-}
-
-// Reconcile reconciles the Manager
-func (m *Manager) Reconcile() error {
-	logrus.Debug("reconcile method called for: Manager")
 	return nil
 }
 

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -50,6 +50,8 @@ type APIServer struct {
 	uid                int
 }
 
+var _ component.Component = (*APIServer)(nil)
+
 var apiDefaultArgs = map[string]string{
 	"allow-privileged":                   "true",
 	"requestheader-extra-headers-prefix": "X-Remote-Extra-",
@@ -192,12 +194,6 @@ func (a *APIServer) writeKonnectivityConfig() error {
 // Stop stops APIServer
 func (a *APIServer) Stop() error {
 	return a.supervisor.Stop()
-}
-
-// Reconcile detects changes in configuration and applies them to the component
-func (a *APIServer) Reconcile() error {
-	logrus.Debug("reconcile method called for: APIServer")
-	return nil
 }
 
 // Health-check interface

--- a/pkg/component/controller/controllersleasecounter.go
+++ b/pkg/component/controller/controllersleasecounter.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component"
 
 	"github.com/sirupsen/logrus"
 
@@ -37,6 +38,8 @@ type K0sControllersLeaseCounter struct {
 	cancelFunc  context.CancelFunc
 	leaseCancel context.CancelFunc
 }
+
+var _ component.Component = (*K0sControllersLeaseCounter)(nil)
 
 // Init initializes the component needs
 func (l *K0sControllersLeaseCounter) Init(_ context.Context) error {
@@ -96,12 +99,6 @@ func (l *K0sControllersLeaseCounter) Stop() error {
 	if l.cancelFunc != nil {
 		l.cancelFunc()
 	}
-	return nil
-}
-
-// Reconcile detects changes in configuration and applies them to the component
-func (l *K0sControllersLeaseCounter) Reconcile() error {
-	logrus.Debug("reconcile method called for: K0sLease")
 	return nil
 }
 

--- a/pkg/component/controller/csrapprover.go
+++ b/pkg/component/controller/csrapprover.go
@@ -33,6 +33,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component"
 	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 )
@@ -59,6 +60,8 @@ type CSRApprover struct {
 	clientset         clientset.Interface
 }
 
+var _ component.Component = (*CSRApprover)(nil)
+
 // NewCSRApprover creates the CSRApprover component
 func NewCSRApprover(c *v1beta1.ClusterConfig, leaderElector LeaderElector, kubeClientFactory k8sutil.ClientFactoryInterface) *CSRApprover {
 	d := atomic.Value{}
@@ -76,12 +79,6 @@ func (a *CSRApprover) Healthy() error { return nil }
 // Stop stops the CSRApprover
 func (a *CSRApprover) Stop() error {
 	a.stop()
-	return nil
-}
-
-// Reconcile detects changes in configuration and applies them to the component
-func (a *CSRApprover) Reconcile() error {
-	logrus.Debug("reconcile method called for: CSRApprover")
 	return nil
 }
 

--- a/pkg/component/controller/dummyleaderelector.go
+++ b/pkg/component/controller/dummyleaderelector.go
@@ -15,17 +15,23 @@ limitations under the License.
 */
 package controller
 
-import "context"
+import (
+	"context"
+
+	"github.com/k0sproject/k0s/pkg/component"
+)
 
 type DummyLeaderElector struct {
 	Leader    bool
 	callbacks []func()
 }
 
+var _ LeaderElector = (*DummyLeaderElector)(nil)
+var _ component.Component = (*DummyLeaderElector)(nil)
+
 func (l *DummyLeaderElector) Init(_ context.Context) error { return nil }
 func (l *DummyLeaderElector) Stop() error                  { return nil }
 func (l *DummyLeaderElector) IsLeader() bool               { return l.Leader }
-func (l *DummyLeaderElector) Reconcile() error             { return nil }
 func (l *DummyLeaderElector) Healthy() error               { return nil }
 
 func (l *DummyLeaderElector) AddAcquiredLeaseCallback(fn func()) {

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -34,6 +34,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/assets"
 	"github.com/k0sproject/k0s/pkg/certificate"
+	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/etcd"
 	"github.com/k0sproject/k0s/pkg/supervisor"
@@ -52,6 +53,8 @@ type Etcd struct {
 	uid        int
 	gid        int
 }
+
+var _ component.Component = (*Etcd)(nil)
 
 // Init extracts the needed binaries
 func (e *Etcd) Init(_ context.Context) error {
@@ -207,12 +210,6 @@ func (e *Etcd) Run(ctx context.Context) error {
 // Stop stops etcd
 func (e *Etcd) Stop() error {
 	return e.supervisor.Stop()
-}
-
-// Reconcile detects changes in configuration and applies them to the component
-func (e *Etcd) Reconcile() error {
-	logrus.Debug("reconcile method called for: Etcd")
-	return nil
 }
 
 func (e *Etcd) setupCerts(ctx context.Context) error {

--- a/pkg/component/controller/k0scloudprovider.go
+++ b/pkg/component/controller/k0scloudprovider.go
@@ -21,16 +21,15 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/k0scloudprovider"
-	"github.com/sirupsen/logrus"
 )
 
-type k0sCloudProvider struct {
+type K0sCloudProvider struct {
 	config         k0scloudprovider.Config
 	stopCh         chan struct{}
 	commandBuilder CommandBuilder
 }
 
-var _ component.Component = (*k0sCloudProvider)(nil)
+var _ component.Component = (*K0sCloudProvider)(nil)
 
 // CommandBuilder allows for defining arbitrary functions that can
 // create `Command` instances.
@@ -38,7 +37,7 @@ type CommandBuilder func() (k0scloudprovider.Command, error)
 
 // NewK0sCloudProvider creates a new k0s cloud-provider using the default
 // address collector and command.
-func NewK0sCloudProvider(kubeConfigPath string, frequency time.Duration, port int) component.Component {
+func NewK0sCloudProvider(kubeConfigPath string, frequency time.Duration, port int) *K0sCloudProvider {
 	config := k0scloudprovider.Config{
 		AddressCollector: k0scloudprovider.DefaultAddressCollector(),
 		KubeConfig:       kubeConfigPath,
@@ -53,8 +52,8 @@ func NewK0sCloudProvider(kubeConfigPath string, frequency time.Duration, port in
 
 // newK0sCloudProvider is a helper for creating specialized k0s-cloud-provider
 // instances that can be used for testing.
-func newK0sCloudProvider(config k0scloudprovider.Config, cb CommandBuilder) component.Component {
-	return &k0sCloudProvider{
+func newK0sCloudProvider(config k0scloudprovider.Config, cb CommandBuilder) *K0sCloudProvider {
+	return &K0sCloudProvider{
 		config:         config,
 		stopCh:         make(chan struct{}),
 		commandBuilder: cb,
@@ -62,13 +61,13 @@ func newK0sCloudProvider(config k0scloudprovider.Config, cb CommandBuilder) comp
 }
 
 // Init in the k0s-cloud-provider intentionally does nothing.
-func (c *k0sCloudProvider) Init(_ context.Context) error {
+func (c *K0sCloudProvider) Init(_ context.Context) error {
 	return nil
 }
 
 // Run will create a k0s-cloud-provider command, and run it on a goroutine.
 // Failures to create this command will be returned as an error.
-func (c *k0sCloudProvider) Run(_ context.Context) error {
+func (c *K0sCloudProvider) Run(_ context.Context) error {
 	command, err := c.commandBuilder()
 	if err != nil {
 		return err
@@ -80,19 +79,13 @@ func (c *k0sCloudProvider) Run(_ context.Context) error {
 }
 
 // Stop will stop the k0s-cloud-provider command goroutine (if running)
-func (c *k0sCloudProvider) Stop() error {
+func (c *K0sCloudProvider) Stop() error {
 	close(c.stopCh)
 
 	return nil
 }
 
-// Reconcile detects changes in configuration and applies them to the component
-func (c *k0sCloudProvider) Reconcile() error {
-	logrus.Debug("reconcile method called for: k0sCloudProvider")
-	return nil
-}
-
 // Healthy in the k0s-cloud-provider intentionally does nothing.
-func (c *k0sCloudProvider) Healthy() error {
+func (c *K0sCloudProvider) Healthy() error {
 	return nil
 }

--- a/pkg/component/controller/k0scontrolapi.go
+++ b/pkg/component/controller/k0scontrolapi.go
@@ -20,8 +20,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sirupsen/logrus"
-
+	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/supervisor"
 )
@@ -32,6 +31,8 @@ type K0SControlAPI struct {
 	K0sVars    constant.CfgVars
 	supervisor supervisor.Supervisor
 }
+
+var _ component.Component = (*K0SControlAPI)(nil)
 
 // Init does currently nothing
 func (m *K0SControlAPI) Init(_ context.Context) error {
@@ -64,12 +65,6 @@ func (m *K0SControlAPI) Run(_ context.Context) error {
 // Stop stops k0s api
 func (m *K0SControlAPI) Stop() error {
 	return m.supervisor.Stop()
-}
-
-// Reconcile detects changes in configuration and applies them to the component
-func (m *K0SControlAPI) Reconcile() error {
-	logrus.Debug("reconcile method called for: K0SControlAPI")
-	return nil
 }
 
 // Healthy for health-check interface

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component"
 
 	"github.com/sirupsen/logrus"
 
@@ -41,6 +42,8 @@ type Kine struct {
 	supervisor supervisor.Supervisor
 	uid        int
 }
+
+var _ component.Component = (*Kine)(nil)
 
 // Init extracts the needed binaries
 func (k *Kine) Init(_ context.Context) error {
@@ -105,12 +108,6 @@ func (k *Kine) Run(_ context.Context) error {
 // Stop stops kine
 func (k *Kine) Stop() error {
 	return k.supervisor.Stop()
-}
-
-// Reconcile detects changes in configuration and applies them to the component
-func (k *Kine) Reconcile() error {
-	logrus.Debug("reconcile method called for: Kine")
-	return nil
 }
 
 // Health-check interface

--- a/pkg/component/controller/systemrbac.go
+++ b/pkg/component/controller/systemrbac.go
@@ -23,14 +23,16 @@ import (
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
+	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
-	"github.com/sirupsen/logrus"
 )
 
 // SystemRBAC implements system RBAC reconciler
 type SystemRBAC struct {
 	manifestDir string
 }
+
+var _ component.Component = (*SystemRBAC)(nil)
 
 // NewSystemRBAC creates new system level RBAC reconciler
 func NewSystemRBAC(manifestDir string) *SystemRBAC {
@@ -64,12 +66,6 @@ func (s *SystemRBAC) Run(_ context.Context) error {
 
 // Stop does currently nothing
 func (s *SystemRBAC) Stop() error {
-	return nil
-}
-
-// Reconcile detects changes in configuration and applies them to the component
-func (s *SystemRBAC) Reconcile() error {
-	logrus.Debug("reconcile method called for: SystemRBAC")
 	return nil
 }
 

--- a/pkg/component/manager_test.go
+++ b/pkg/component/manager_test.go
@@ -50,7 +50,6 @@ func (f *Fake) Stop() error {
 	f.StopCalled = true
 	return f.StopErr
 }
-func (f *Fake) Reconcile() error { return nil }
 func (f *Fake) Healthy() error {
 	f.HealthyCalled = true
 	return f.HealthyErr

--- a/pkg/component/status/status.go
+++ b/pkg/component/status/status.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
+	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/install"
 	"github.com/sirupsen/logrus"
 )
@@ -36,6 +37,8 @@ type Status struct {
 	listener          net.Listener
 	runCtx            context.Context
 }
+
+var _ component.Component = (*Status)(nil)
 
 // Healthy dummy implementation
 func (s *Status) Healthy() error { return nil }
@@ -89,12 +92,6 @@ func (s *Status) Stop() error {
 		return err
 	}
 	return os.Remove(s.Socket)
-}
-
-// Reconcile detects changes in configuration and applies them to the component
-func (s *Status) Reconcile() error {
-	logrus.Debug("reconcile method called for: Status")
-	return nil
 }
 
 type statusHandler struct {

--- a/pkg/component/worker/calico_installer_windows.go
+++ b/pkg/component/worker/calico_installer_windows.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Microsoft/hcsshim"
 	"github.com/avast/retry-go"
+	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/token"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/clientcmd"
@@ -24,6 +25,8 @@ type CalicoInstaller struct {
 	CIDRRange  string
 	ClusterDNS string
 }
+
+var _ component.Component = (*CalicoInstaller)(nil)
 
 func (c CalicoInstaller) Init(_ context.Context) error {
 	path := "C:\\bootstrap.ps1"
@@ -103,11 +106,6 @@ func (c CalicoInstaller) Stop() error {
 }
 
 func (c CalicoInstaller) Healthy() error {
-	return nil
-}
-
-func (c CalicoInstaller) Reconcile() error {
-	logrus.Debug("reconcile method called for: CalicoInstaller")
 	return nil
 }
 

--- a/pkg/component/worker/containerd.go
+++ b/pkg/component/worker/containerd.go
@@ -27,6 +27,7 @@ import (
 	dirutil "github.com/k0sproject/k0s/internal/pkg/dir"
 	fileutil "github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/pkg/assets"
+	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/supervisor"
 )
@@ -47,6 +48,8 @@ type ContainerD struct {
 
 	OCIBundlePath string
 }
+
+var _ component.Component = (*ContainerD)(nil)
 
 // Init extracts the needed binaries
 func (c *ContainerD) Init(ctx context.Context) error {
@@ -101,12 +104,6 @@ func (c *ContainerD) setupConfig() error {
 // Stop stops containerD
 func (c *ContainerD) Stop() error {
 	return c.supervisor.Stop()
-}
-
-// Reconcile detects changes in configuration and applies them to the component
-func (c *ContainerD) Reconcile() error {
-	logrus.Debug("reconcile method called for: ContainerD")
-	return nil
 }
 
 // Health-check interface

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -41,6 +41,7 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/flags"
 	"github.com/k0sproject/k0s/internal/pkg/stringmap"
 	"github.com/k0sproject/k0s/pkg/assets"
+	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/supervisor"
 )
@@ -60,6 +61,8 @@ type Kubelet struct {
 	Taints              []string
 	ExtraArgs           string
 }
+
+var _ component.Component = (*Kubelet)(nil)
 
 type kubeletConfig struct {
 	ClientCAFile       string
@@ -227,12 +230,6 @@ func (k *Kubelet) Run(ctx context.Context) error {
 // Stop stops kubelet
 func (k *Kubelet) Stop() error {
 	return k.supervisor.Stop()
-}
-
-// Reconcile detects changes in configuration and applies them to the component
-func (k *Kubelet) Reconcile() error {
-	logrus.Debug("reconcile method called for: Kubelet")
-	return nil
 }
 
 // Health-check interface

--- a/pkg/component/worker/kubeproxy_windows.go
+++ b/pkg/component/worker/kubeproxy_windows.go
@@ -21,9 +21,9 @@ import (
 	"strings"
 
 	"github.com/k0sproject/k0s/pkg/assets"
+	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/supervisor"
-	"github.com/sirupsen/logrus"
 )
 
 type KubeProxy struct {
@@ -32,6 +32,8 @@ type KubeProxy struct {
 	LogLevel   string
 	supervisor supervisor.Supervisor
 }
+
+var _ component.Component = (*KubeProxy)(nil)
 
 // Init
 func (k KubeProxy) Init(_ context.Context) error {
@@ -73,12 +75,6 @@ func (k KubeProxy) Run(ctx context.Context) error {
 
 func (k KubeProxy) Stop() error {
 	return k.supervisor.Stop()
-}
-
-// Reconcile detects changes in configuration and applies them to the component
-func (k KubeProxy) Reconcile() error {
-	logrus.Debug("reconcile method called for: worker KubeProxy")
-	return nil
 }
 
 func (k KubeProxy) Healthy() error {

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -25,6 +25,7 @@ import (
 	"github.com/avast/retry-go"
 	"github.com/containerd/containerd"
 	"github.com/k0sproject/k0s/internal/pkg/dir"
+	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/sirupsen/logrus"
 )
@@ -34,6 +35,8 @@ type OCIBundleReconciler struct {
 	k0sVars constant.CfgVars
 	log     *logrus.Entry
 }
+
+var _ component.Component = (*OCIBundleReconciler)(nil)
 
 // NewOCIBundleReconciler builds new reconciler
 func NewOCIBundleReconciler(vars constant.CfgVars) *OCIBundleReconciler {
@@ -104,8 +107,4 @@ func (a *OCIBundleReconciler) Stop() error {
 	return nil
 }
 
-func (a *OCIBundleReconciler) Reconcile() error {
-	logrus.Debug("reconcile method called for: OCIBundleReconciler")
-	return nil
-}
 func (a *OCIBundleReconciler) Healthy() error { return nil }

--- a/pkg/component/worker/stubs.go
+++ b/pkg/component/worker/stubs.go
@@ -21,6 +21,7 @@ package worker
 import (
 	"context"
 
+	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 )
 
@@ -30,6 +31,8 @@ type CalicoInstaller struct {
 	CIDRRange  string
 	ClusterDNS string
 }
+
+var _ component.Component = (*CalicoInstaller)(nil)
 
 func (c CalicoInstaller) Init(_ context.Context) error {
 	panic("stub component is used: CalicoInstaller")
@@ -47,15 +50,13 @@ func (c CalicoInstaller) Healthy() error {
 	panic("stub component is used: CalicoInstaller")
 }
 
-func (c CalicoInstaller) Reconcile() error {
-	panic("stub component is used: CalicoInstaller")
-}
-
 type KubeProxy struct {
 	K0sVars   constant.CfgVars
 	CIDRRange string
 	LogLevel  string
 }
+
+var _ component.Component = (*KubeProxy)(nil)
 
 func (k KubeProxy) Init(_ context.Context) error {
 	panic("stub component is used: KubeProxy")
@@ -66,10 +67,6 @@ func (k KubeProxy) Run(_ context.Context) error {
 }
 
 func (k KubeProxy) Stop() error {
-	panic("stub component is used: KubeProxy")
-}
-
-func (k KubeProxy) Reconcile() error {
 	panic("stub component is used: KubeProxy")
 }
 


### PR DESCRIPTION
## Description

This is probably a leftover from a previous refactoring. Those methods are not matching the signatures as required by ReconcilerComponent, and weren't doing anything useful in the first place. Also add a constraint to all the structs to actually adhere to the component interface.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings