### PR TITLE
Fix total memory detection on ARM

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -332,8 +332,15 @@ jobs:
           path: |
             build/cache/go/mod
 
+      - name: Disable race checker
+        if: matrix.arch == 'arm'
+        run: echo GO_TEST_RACE= >>"$GITHUB_ENV"
+
       - name: Build
         run: make build
+
+      - name: Unit tests
+        run: make check-unit
 
       - name: k0s sysinfo
         run: ./k0s sysinfo

--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,9 @@ $(smoketests): k0s
 smoketests:  $(smoketests)
 
 .PHONY: check-unit
+check-unit: GO_TEST_RACE ?= -race
 check-unit: go.sum codegen
-	$(GO) test -race `$(GO) list $(GO_DIRS)`
+	$(GO) test $(GO_TEST_RACE) `$(GO) list $(GO_DIRS)`
 
 .PHONY: check-image-validity
 check-image-validity: go.sum

--- a/internal/pkg/sysinfo/probes/linux/linux.go
+++ b/internal/pkg/sysinfo/probes/linux/linux.go
@@ -148,7 +148,7 @@ func newUnameProber() unameProber {
 }
 
 func parseUname(utsname *syscall.Utsname) *uname {
-	convert := func(chars utsFieldType) unameField {
+	convert := func(chars utsStringPtr) unameField {
 		var buf [65]byte
 		var i int
 		for pos, ch := range *chars {

--- a/internal/pkg/sysinfo/probes/linux/linux_test.go
+++ b/internal/pkg/sysinfo/probes/linux/linux_test.go
@@ -139,11 +139,11 @@ func TestUname(t *testing.T) {
 
 	t.Run("parsesFields", func(t *testing.T) {
 		var utsname syscall.Utsname
-		utsname.Sysname[0] = int8('S')
-		utsname.Nodename[0] = int8('N')
-		utsname.Release[0] = int8('R')
-		utsname.Version[0] = int8('V')
-		utsname.Machine[0] = int8('M')
+		utsname.Sysname[0] = utsChar('S')
+		utsname.Nodename[0] = utsChar('N')
+		utsname.Release[0] = utsChar('R')
+		utsname.Version[0] = utsChar('V')
+		utsname.Machine[0] = utsChar('M')
 
 		parsed := parseUname(&utsname)
 		assert.Equal(t, &uname{
@@ -158,7 +158,7 @@ func TestUname(t *testing.T) {
 	t.Run("parseDetectsTruncation", func(t *testing.T) {
 		var utsname syscall.Utsname
 		for i := range utsname.Sysname {
-			utsname.Sysname[i] = int8('x')
+			utsname.Sysname[i] = utsChar('x')
 		}
 
 		parsed := parseUname(&utsname).osName

--- a/internal/pkg/sysinfo/probes/linux/types.go
+++ b/internal/pkg/sysinfo/probes/linux/types.go
@@ -19,4 +19,6 @@ limitations under the License.
 
 package linux
 
-type utsFieldType *[65]int8
+func utsChar(ch rune) int8 { return int8(ch) } //nolint:deadcode,unused // just for tests 🙄
+
+type utsStringPtr *[65]int8

--- a/internal/pkg/sysinfo/probes/linux/types_arm.go
+++ b/internal/pkg/sysinfo/probes/linux/types_arm.go
@@ -19,4 +19,6 @@ limitations under the License.
 
 package linux
 
-type utsFieldType *[65]uint8
+func utsChar(ch rune) uint8 { return uint8(ch) } //nolint:deadcode,unused // just for tests 🙄
+
+type utsStringPtr *[65]uint8

--- a/internal/pkg/sysinfo/probes/memory_linux.go
+++ b/internal/pkg/sysinfo/probes/memory_linux.go
@@ -36,7 +36,7 @@ func newTotalMemoryProber() totalMemoryProber {
 			if err = syscall.Sysinfo(&info); err != nil {
 				err = fmt.Errorf("sysinfo syscall failed: %w", err)
 			} else {
-				totalMemory = uint64(info.Totalram) // explicit cast to support 32-bit systems
+				totalMemory = uint64(info.Totalram) * uint64(info.Unit) // explicit cast to support 32-bit systems
 			}
 		})
 

--- a/internal/pkg/sysinfo/probes/memory_linux_test.go
+++ b/internal/pkg/sysinfo/probes/memory_linux_test.go
@@ -1,0 +1,64 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probes
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTotalMemoryProber(t *testing.T) {
+	underTest := newTotalMemoryProber()
+
+	ram, err := underTest()
+	require.NoError(t, err)
+
+	procMeminfo, err := os.Open("/proc/meminfo")
+	if os.IsNotExist(err) {
+		t.Logf("Determined total RAM of %d bytes, /proc/meminfo not found, nothing to compare against...", ram)
+		return
+	}
+	require.NoError(t, err)
+	defer procMeminfo.Close()
+
+	// https://github.com/torvalds/linux/blob/v4.9/fs/proc/meminfo.c#L68
+	// https://github.com/torvalds/linux/blob/v2.6.28/fs/proc/meminfo.c#L56
+	// https://github.com/torvalds/linux/blob/1da177e4c3f41524e886b7f1b8a0c1fc7321cac2/fs/proc/proc_misc.c#L149
+	re := regexp.MustCompile(`^\s*MemTotal\s*:\s*(\d+)\s*kB\s*$`)
+
+	lines := bufio.NewScanner(procMeminfo)
+	lines.Split(bufio.ScanLines)
+	for lines.Scan() {
+		line := lines.Text()
+		if matches := re.FindStringSubmatch(line); matches != nil {
+			kibiBytes, err := strconv.ParseUint(matches[1], 10, 64)
+			require.NoError(t, err, "expected an unsigned integer: %s", line)
+			require.Equal(t, kibiBytes*1024, ram, "/proc/meminfo differs: %s", line)
+			return
+		}
+	}
+
+	t.Error("No MemTotal found in /proc/meminfo.")
+}


### PR DESCRIPTION
## Description

The unit seems to be != 1 for architectures < 64 bit.

Add a test case for that, comparing the detected memory size with the one reported via /proc/meminfo. Execute unit tests in CI on ARM as well, so that those tests are actually run on those platforms as well.

This is being printed by `k0s sysinfo` during the ARM smoketest:
> Total memory: 6.8 MiB (warning: 1.0 GiB recommended)

:monocle_face:

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings