### PR TITLE
Remove error return value when releasing the ConfigSource

### DIFF
--- a/pkg/component/controller/clusterconfig/apiconfigsource.go
+++ b/pkg/component/controller/clusterconfig/apiconfigsource.go
@@ -49,7 +49,7 @@ func NewAPIConfigSource(kubeClientFactory kubeutil.ClientFactoryInterface) (Conf
 	return a, nil
 }
 
-func (a *apiConfigSource) Release(ctx context.Context) error {
+func (a *apiConfigSource) Release(ctx context.Context) {
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()
@@ -65,7 +65,6 @@ func (a *apiConfigSource) Release(ctx context.Context) error {
 			}
 		}
 	}()
-	return nil
 }
 
 func (a *apiConfigSource) ResultChan() <-chan *v1beta1.ClusterConfig {

--- a/pkg/component/controller/clusterconfig/configsource.go
+++ b/pkg/component/controller/clusterconfig/configsource.go
@@ -24,7 +24,7 @@ import (
 
 type ConfigSource interface {
 	// Release allows the config source to start sending config updates
-	Release(ctx context.Context) error
+	Release(context.Context)
 	// ResultChan provides the result channel where config updates are pushed by the source on it is released
 	ResultChan() <-chan *v1beta1.ClusterConfig
 	// Stop stops sending config events

--- a/pkg/component/controller/clusterconfig/staticsource.go
+++ b/pkg/component/controller/clusterconfig/staticsource.go
@@ -37,10 +37,9 @@ func NewStaticSource(staticConfig *v1beta1.ClusterConfig) (ConfigSource, error) 
 	}, nil
 }
 
-func (s *staticSource) Release(_ context.Context) error {
+func (s *staticSource) Release(context.Context) {
 	logrus.WithField("component", "static-config-source").Debug("sending static config via channel")
 	s.resultChan <- s.staticConfig
-	return nil
 }
 
 func (s *staticSource) ResultChan() <-chan *v1beta1.ClusterConfig {


### PR DESCRIPTION
## Description

All implementations never return an error, hence the return value can be removed and the error handling can be simplified during the controller startup.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings