### PR TITLE
Inline cluster reconcilers

### DIFF
--- a/pkg/component/controller/calico.go
+++ b/pkg/component/controller/calico.go
@@ -42,7 +42,7 @@ var calicoCRDOnce sync.Once
 
 // Calico is the Component interface implementation to manage Calico
 type Calico struct {
-	log *logrus.Entry
+	log logrus.FieldLogger
 
 	crdSaver   manifestsSaver
 	saver      manifestsSaver
@@ -76,15 +76,15 @@ type calicoConfig struct {
 }
 
 // NewCalico creates new Calico reconciler component
-func NewCalico(k0sVars constant.CfgVars, crdSaver manifestsSaver, manifestsSaver manifestsSaver) (*Calico, error) {
-	log := logrus.WithFields(logrus.Fields{"component": "calico"})
+func NewCalico(k0sVars constant.CfgVars, crdSaver manifestsSaver, manifestsSaver manifestsSaver) *Calico {
 	return &Calico{
-		log:        log,
+		log: logrus.WithFields(logrus.Fields{"component": "calico"}),
+
 		crdSaver:   crdSaver,
 		saver:      manifestsSaver,
 		prevConfig: calicoConfig{},
 		k0sVars:    k0sVars,
-	}, nil
+	}
 }
 
 // Init does nothing

--- a/pkg/component/controller/calico_test.go
+++ b/pkg/component/controller/calico_test.go
@@ -40,8 +40,7 @@ func TestCalicoManifests(t *testing.T) {
 	t.Run("must_write_crd_during_bootstrap", func(t *testing.T) {
 		saver := inMemorySaver{}
 		crdSaver := inMemorySaver{}
-		calico, err := NewCalico(k0sVars, crdSaver, saver)
-		require.NoError(t, err)
+		calico := NewCalico(k0sVars, crdSaver, saver)
 		require.NoError(t, calico.Run(context.Background()))
 		require.NoError(t, calico.Stop())
 
@@ -54,8 +53,7 @@ func TestCalicoManifests(t *testing.T) {
 	t.Run("must_write_only_non_crd_on_change", func(t *testing.T) {
 		saver := inMemorySaver{}
 		crdSaver := inMemorySaver{}
-		calico, err := NewCalico(k0sVars, crdSaver, saver)
-		require.NoError(t, err)
+		calico := NewCalico(k0sVars, crdSaver, saver)
 
 		_ = calico.processConfigChanges(calicoConfig{})
 
@@ -69,8 +67,7 @@ func TestCalicoManifests(t *testing.T) {
 		clusterConfig.Spec.Network.Calico.EnableWireguard = true
 		saver := inMemorySaver{}
 		crdSaver := inMemorySaver{}
-		calico, err := NewCalico(k0sVars, crdSaver, saver)
-		require.NoError(t, err)
+		calico := NewCalico(k0sVars, crdSaver, saver)
 		cfg, err := calico.getConfig(clusterConfig)
 		require.NoError(t, err)
 		_ = calico.processConfigChanges(cfg)
@@ -86,8 +83,7 @@ func TestCalicoManifests(t *testing.T) {
 		clusterConfig.Spec.Network.Calico.EnableWireguard = false
 		saver := inMemorySaver{}
 		crdSaver := inMemorySaver{}
-		calico, err := NewCalico(k0sVars, crdSaver, saver)
-		require.NoError(t, err)
+		calico := NewCalico(k0sVars, crdSaver, saver)
 
 		cfg, err := calico.getConfig(clusterConfig)
 		require.NoError(t, err)
@@ -105,8 +101,7 @@ func TestCalicoManifests(t *testing.T) {
 			clusterConfig.Spec.Network.Calico.IPAutodetectionMethod = "somemethod"
 			saver := inMemorySaver{}
 			crdSaver := inMemorySaver{}
-			calico, err := NewCalico(k0sVars, crdSaver, saver)
-			require.NoError(t, err)
+			calico := NewCalico(k0sVars, crdSaver, saver)
 			templateContext, err := calico.getConfig(clusterConfig)
 			require.NoError(t, err)
 			require.Equal(t, clusterConfig.Spec.Network.Calico.IPAutodetectionMethod, templateContext.IPAutodetectionMethod)
@@ -127,8 +122,7 @@ func TestCalicoManifests(t *testing.T) {
 			clusterConfig.Spec.Network.Calico.IPv6AutodetectionMethod = "anothermethod"
 			saver := inMemorySaver{}
 			crdSaver := inMemorySaver{}
-			calico, err := NewCalico(k0sVars, crdSaver, saver)
-			require.NoError(t, err)
+			calico := NewCalico(k0sVars, crdSaver, saver)
 			templateContext, err := calico.getConfig(clusterConfig)
 			require.NoError(t, err)
 			require.Equal(t, clusterConfig.Spec.Network.Calico.IPAutodetectionMethod, templateContext.IPAutodetectionMethod)

--- a/pkg/component/controller/defaultpsp.go
+++ b/pkg/component/controller/defaultpsp.go
@@ -46,12 +46,11 @@ var _ component.Component = (*DefaultPSP)(nil)
 var _ component.ReconcilerComponent = (*DefaultPSP)(nil)
 
 // NewDefaultPSP creates new system level RBAC reconciler
-func NewDefaultPSP(k0sVars constant.CfgVars) (*DefaultPSP, error) {
-	manifestDir := path.Join(k0sVars.ManifestsDir, "defaultpsp")
+func NewDefaultPSP(k0sVars constant.CfgVars) *DefaultPSP {
 	return &DefaultPSP{
 		k0sVars:     k0sVars,
-		manifestDir: manifestDir,
-	}, nil
+		manifestDir: path.Join(k0sVars.ManifestsDir, "defaultpsp"),
+	}
 }
 
 // Init does currently nothing

--- a/pkg/component/controller/kubeletconfig.go
+++ b/pkg/component/controller/kubeletconfig.go
@@ -46,21 +46,21 @@ var _ component.Component = (*KubeletConfig)(nil)
 
 // KubeletConfig is the reconciler for generic kubelet configs
 type KubeletConfig struct {
-	kubeClientFactory k8sutil.ClientFactoryInterface
+	log logrus.FieldLogger
 
-	log              *logrus.Entry
-	k0sVars          constant.CfgVars
-	previousProfiles v1beta1.WorkerProfiles
+	kubeClientFactory k8sutil.ClientFactoryInterface
+	k0sVars           constant.CfgVars
+	previousProfiles  v1beta1.WorkerProfiles
 }
 
 // NewKubeletConfig creates new KubeletConfig reconciler
-func NewKubeletConfig(k0sVars constant.CfgVars, clientFactory k8sutil.ClientFactoryInterface) (*KubeletConfig, error) {
-	log := logrus.WithFields(logrus.Fields{"component": "kubeletconfig"})
+func NewKubeletConfig(k0sVars constant.CfgVars, clientFactory k8sutil.ClientFactoryInterface) *KubeletConfig {
 	return &KubeletConfig{
+		log: logrus.WithFields(logrus.Fields{"component": "kubeletconfig"}),
+
 		kubeClientFactory: clientFactory,
-		log:               log,
 		k0sVars:           k0sVars,
-	}, nil
+	}
 }
 
 // Init does nothing

--- a/pkg/component/controller/kubeletconfig_test.go
+++ b/pkg/component/controller/kubeletconfig_test.go
@@ -34,8 +34,7 @@ var k0sVars = constant.GetConfig("")
 func Test_KubeletConfig(t *testing.T) {
 	dnsAddr, _ := cfg.Spec.Network.DNSAddress()
 	t.Run("default_profile_only", func(t *testing.T) {
-		k, err := NewKubeletConfig(k0sVars, testutil.NewFakeClientFactory())
-		require.NoError(t, err)
+		k := NewKubeletConfig(k0sVars, testutil.NewFakeClientFactory())
 
 		t.Log("starting to run...")
 		buf, err := k.createProfiles(cfg)
@@ -116,8 +115,7 @@ func Test_KubeletConfig(t *testing.T) {
 }
 
 func defaultConfigWithUserProvidedProfiles(t *testing.T) *KubeletConfig {
-	k, err := NewKubeletConfig(k0sVars, testutil.NewFakeClientFactory())
-	require.NoError(t, err)
+	k := NewKubeletConfig(k0sVars, testutil.NewFakeClientFactory())
 
 	cfgProfileX := map[string]interface{}{
 		"authentication": map[string]interface{}{

--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -33,27 +33,27 @@ import (
 
 // KubeProxy is the component implementation to manage kube-proxy
 type KubeProxy struct {
-	log            *logrus.Entry
-	nodeConf       *v1beta1.ClusterConfig
-	K0sVars        constant.CfgVars
+	log logrus.FieldLogger
+
+	nodeConf    *v1beta1.ClusterConfig
+	K0sVars     constant.CfgVars
+	manifestDir string
+
 	previousConfig proxyConfig
-	manifestDir    string
 }
 
 var _ component.Component = (*KubeProxy)(nil)
 var _ component.ReconcilerComponent = (*KubeProxy)(nil)
 
 // NewKubeProxy creates new KubeProxy component
-func NewKubeProxy(configFile string, k0sVars constant.CfgVars, nodeConfig *v1beta1.ClusterConfig) (*KubeProxy, error) {
-	log := logrus.WithFields(logrus.Fields{"component": "kubeproxy"})
-	proxyDir := path.Join(k0sVars.ManifestsDir, "kubeproxy")
+func NewKubeProxy(k0sVars constant.CfgVars, nodeConfig *v1beta1.ClusterConfig) *KubeProxy {
 	return &KubeProxy{
-		log:            log,
-		nodeConf:       nodeConfig,
-		K0sVars:        k0sVars,
-		previousConfig: proxyConfig{},
-		manifestDir:    proxyDir,
-	}, nil
+		log: logrus.WithFields(logrus.Fields{"component": "kubeproxy"}),
+
+		nodeConf:    nodeConfig,
+		K0sVars:     k0sVars,
+		manifestDir: path.Join(k0sVars.ManifestsDir, "kubeproxy"),
+	}
 }
 
 // Init does nothing

--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -30,11 +30,12 @@ import (
 
 // KubeRouter implements the kube-router reconciler component
 type KubeRouter struct {
-	log *logrus.Entry
+	log logrus.FieldLogger
 
-	saver          manifestsSaver
+	saver   manifestsSaver
+	k0sVars constant.CfgVars
+
 	previousConfig kubeRouterConfig
-	k0sVars        constant.CfgVars
 }
 
 var _ component.Component = (*KubeRouter)(nil)
@@ -51,13 +52,13 @@ type kubeRouterConfig struct {
 }
 
 // NewKubeRouter creates new KubeRouter reconciler component
-func NewKubeRouter(k0sVars constant.CfgVars, manifestsSaver manifestsSaver) (*KubeRouter, error) {
-	log := logrus.WithFields(logrus.Fields{"component": "kube-router"})
+func NewKubeRouter(k0sVars constant.CfgVars, manifestsSaver manifestsSaver) *KubeRouter {
 	return &KubeRouter{
+		log: logrus.WithFields(logrus.Fields{"component": "kube-router"}),
+
 		saver:   manifestsSaver,
-		log:     log,
 		k0sVars: k0sVars,
-	}, nil
+	}
 }
 
 // Init does nothing

--- a/pkg/component/controller/kuberouter_test.go
+++ b/pkg/component/controller/kuberouter_test.go
@@ -42,8 +42,7 @@ func TestKubeRouterConfig(t *testing.T) {
 	cfg.Spec.Network.KubeRouter.PeerRouterIPs = "1.2.3.4,4.3.2.1"
 
 	saver := inMemorySaver{}
-	kr, err := NewKubeRouter(k0sVars, saver)
-	require.NoError(t, err)
+	kr := NewKubeRouter(k0sVars, saver)
 	require.NoError(t, kr.Reconcile(context.Background(), cfg))
 	require.NoError(t, kr.Stop())
 
@@ -74,8 +73,7 @@ func TestKubeRouterDefaultManifests(t *testing.T) {
 	cfg.Spec.Network.Provider = "kuberouter"
 	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
 	saver := inMemorySaver{}
-	kr, err := NewKubeRouter(k0sVars, saver)
-	require.NoError(t, err)
+	kr := NewKubeRouter(k0sVars, saver)
 	require.NoError(t, kr.Reconcile(context.Background(), cfg))
 	require.NoError(t, kr.Stop())
 

--- a/pkg/component/controller/metricserver.go
+++ b/pkg/component/controller/metricserver.go
@@ -237,11 +237,13 @@ spec:
 
 // MetricServer is the reconciler implementation for metrics server
 type MetricServer struct {
-	log               *logrus.Entry
-	clusterConfig     *v1beta1.ClusterConfig
-	tickerDone        context.CancelFunc
+	log logrus.FieldLogger
+
 	K0sVars           constant.CfgVars
 	kubeClientFactory k8sutil.ClientFactoryInterface
+
+	clusterConfig *v1beta1.ClusterConfig
+	tickerDone    context.CancelFunc
 }
 
 type metricsConfig struct {
@@ -255,13 +257,13 @@ var _ component.Component = (*MetricServer)(nil)
 var _ component.ReconcilerComponent = (*MetricServer)(nil)
 
 // NewMetricServer creates new MetricServer reconciler
-func NewMetricServer(k0sVars constant.CfgVars, kubeClientFactory k8sutil.ClientFactoryInterface) (*MetricServer, error) {
-	log := logrus.WithFields(logrus.Fields{"component": "metricServer"})
+func NewMetricServer(k0sVars constant.CfgVars, kubeClientFactory k8sutil.ClientFactoryInterface) *MetricServer {
 	return &MetricServer{
-		log:               log,
+		log: logrus.WithFields(logrus.Fields{"component": "metricServer"}),
+
 		K0sVars:           k0sVars,
 		kubeClientFactory: kubeClientFactory,
-	}, nil
+	}
 }
 
 // Init does nothing

--- a/pkg/component/controller/metricserver_test.go
+++ b/pkg/component/controller/metricserver_test.go
@@ -33,8 +33,7 @@ func TestGetConfigWithZeroNodes(t *testing.T) {
 	fakeFactory := testutil.NewFakeClientFactory()
 	ctx := context.Background()
 
-	metrics, err := NewMetricServer(k0sVars, fakeFactory)
-	require.NoError(t, err)
+	metrics := NewMetricServer(k0sVars, fakeFactory)
 	require.NoError(t, metrics.Reconcile(ctx, cfg))
 	cfg, err := metrics.getConfig(ctx)
 	require.NoError(t, err)
@@ -57,8 +56,7 @@ func TestGetConfigWithSomeNodes(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	metrics, err := NewMetricServer(k0sVars, fakeFactory)
-	require.NoError(t, err)
+	metrics := NewMetricServer(k0sVars, fakeFactory)
 	require.NoError(t, metrics.Reconcile(ctx, cfg))
 	cfg, err := metrics.getConfig(ctx)
 	require.NoError(t, err)

--- a/pkg/component/controller/noderole.go
+++ b/pkg/component/controller/noderole.go
@@ -34,20 +34,20 @@ import (
 
 // NodeRole implements the component interface to manage node role labels for worker nodes
 type NodeRole struct {
-	kubeClientFactory k8sutil.ClientFactoryInterface
+	log logrus.FieldLogger
 
-	log     *logrus.Entry
-	k0sVars constant.CfgVars
+	kubeClientFactory k8sutil.ClientFactoryInterface
+	k0sVars           constant.CfgVars
 }
 
 // NewNodeRole creates new NodeRole reconciler
-func NewNodeRole(k0sVars constant.CfgVars, clientFactory k8sutil.ClientFactoryInterface) (*NodeRole, error) {
-	log := logrus.WithFields(logrus.Fields{"component": "noderole"})
+func NewNodeRole(k0sVars constant.CfgVars, clientFactory k8sutil.ClientFactoryInterface) *NodeRole {
 	return &NodeRole{
+		log: logrus.WithFields(logrus.Fields{"component": "noderole"}),
+
 		kubeClientFactory: clientFactory,
-		log:               log,
 		k0sVars:           k0sVars,
-	}, nil
+	}
 }
 
 // Init no-op

--- a/pkg/component/controller/systemrbac.go
+++ b/pkg/component/controller/systemrbac.go
@@ -33,10 +33,8 @@ type SystemRBAC struct {
 }
 
 // NewSystemRBAC creates new system level RBAC reconciler
-func NewSystemRBAC(manifestDir string) (*SystemRBAC, error) {
-	return &SystemRBAC{
-		manifestDir: manifestDir,
-	}, nil
+func NewSystemRBAC(manifestDir string) *SystemRBAC {
+	return &SystemRBAC{manifestDir}
 }
 
 // Init does nothing


### PR DESCRIPTION
## Description

The cluster reconcilers are not special in any way. Just add them directly to the cluster component manager, without an extra method. Also remove unused error return values, which makes quite some error handling unnecessary.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings