### PR TITLE
Remove error return value when stopping the ConfigSource

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -353,22 +353,13 @@ func (c *CmdOpts) startController(ctx context.Context) error {
 	// For backwards compatibility, use file as config source by default
 	if c.EnableDynamicConfig {
 		cfgSource, err = clusterconfig.NewAPIConfigSource(adminClientFactory)
-		if err != nil {
-			return err
-		}
 	} else {
 		cfgSource, err = clusterconfig.NewStaticSource(c.ClusterConfig)
-		if err != nil {
-			return err
-		}
 	}
-	defer func() {
-		if cfgSource != nil {
-			if err := cfgSource.Stop(); err != nil {
-				logrus.Warnf("error while stopping ConfigSource: %s", err.Error())
-			}
-		}
-	}()
+	if err != nil {
+		return err
+	}
+	defer cfgSource.Stop()
 
 	// start Bootstrapping Reconcilers
 	err = c.startBootstrapReconcilers(ctx, adminClientFactory, leaderElector, cfgSource)

--- a/pkg/component/controller/clusterconfig/apiconfigsource.go
+++ b/pkg/component/controller/clusterconfig/apiconfigsource.go
@@ -71,11 +71,10 @@ func (a *apiConfigSource) ResultChan() <-chan *v1beta1.ClusterConfig {
 	return a.resultChan
 }
 
-func (a apiConfigSource) Stop() error {
+func (a apiConfigSource) Stop() {
 	if a.resultChan != nil {
 		close(a.resultChan)
 	}
-	return nil
 }
 
 func (a *apiConfigSource) NeedToStoreInitialConfig() bool {

--- a/pkg/component/controller/clusterconfig/configsource.go
+++ b/pkg/component/controller/clusterconfig/configsource.go
@@ -28,7 +28,7 @@ type ConfigSource interface {
 	// ResultChan provides the result channel where config updates are pushed by the source on it is released
 	ResultChan() <-chan *v1beta1.ClusterConfig
 	// Stop stops sending config events
-	Stop() error
+	Stop()
 	// NeedToStoreInitialConfig tells the configsource user if the initial config should be stored in the api or not
 	NeedToStoreInitialConfig() bool
 }

--- a/pkg/component/controller/clusterconfig/staticsource.go
+++ b/pkg/component/controller/clusterconfig/staticsource.go
@@ -46,10 +46,7 @@ func (s *staticSource) ResultChan() <-chan *v1beta1.ClusterConfig {
 	return s.resultChan
 }
 
-func (s *staticSource) Stop() error {
-	// Nothing to stop
-	return nil
-}
+func (*staticSource) Stop() {}
 
 func (s *staticSource) NeedToStoreInitialConfig() bool {
 	return false


### PR DESCRIPTION
## Description

All implementations never return an error, hence the return value can be removed and the error handling can be simplified.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings