### PR TITLE
Fix default build target (`build` vs. `all`)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,15 +65,15 @@ GO_ENV ?= docker run --rm \
 	k0sbuild.docker-image.k0s
 GO ?= $(GO_ENV) go
 
-.PHONY: all
-all: k0s k0s.exe
-
 .PHONY: build
 ifeq ($(TARGET_OS),windows)
 build: k0s.exe
 else
 build: k0s
 endif
+
+.PHONY: all
+all: k0s k0s.exe
 
 build/cache:
 	mkdir -p -- '$@'


### PR DESCRIPTION
## Description

The previous change moved the 'all' target to be the first target, resulting
in `k0s.exe` being built unnecessarily on linux.

This change moves the `build` target to be first as it was originally.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings