### PR TITLE
Improve kubectl inttest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ LD_FLAGS += -X k8s.io/component-base/version.gitVersion=v$(KUBECTL_VERSION)
 LD_FLAGS += -X k8s.io/component-base/version.gitMajor=$(KUBECTL_MAJOR)
 LD_FLAGS += -X k8s.io/component-base/version.gitMinor=$(KUBECTL_MINOR)
 LD_FLAGS += -X k8s.io/component-base/version.buildDate=$(BUILD_DATE)
-LD_FLAGS += -X k8s.io/component-base/version.gitCommit="not_available"
+LD_FLAGS += -X k8s.io/component-base/version.gitCommit=not_available
 LD_FLAGS += $(BUILD_GO_LDFLAGS_EXTRA)
 
 golint := $(shell which golangci-lint 2>/dev/null)

--- a/inttest/kubectl/kubectl_test.go
+++ b/inttest/kubectl/kubectl_test.go
@@ -17,9 +17,15 @@ limitations under the License.
 package kubectl
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/k0sproject/k0s/pkg/constant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -27,9 +33,9 @@ type KubectlSuite struct {
 	common.FootlooseSuite
 }
 
-const pluginContent = `#!/bin/bash
+const pluginContent = `#!/usr/bin/env sh
 
-echo "foo-plugin"
+echo foo-plugin
 `
 
 func (s *KubectlSuite) TestEmbeddedKubectl() {
@@ -37,7 +43,7 @@ func (s *KubectlSuite) TestEmbeddedKubectl() {
 	s.PutFile(s.ControllerNode(0), "/bin/kubectl-foo", pluginContent)
 
 	ssh, err := s.SSH(s.ControllerNode(0))
-	s.Require().NoError(err)
+	s.Require().NoError(err, "failed to SSH into controller")
 	defer ssh.Disconnect()
 
 	_, err = ssh.ExecWithOutput("chmod +x /bin/kubectl-foo")
@@ -47,93 +53,88 @@ func (s *KubectlSuite) TestEmbeddedKubectl() {
 
 	s.T().Log("Check that different ways to call kubectl subcommand work")
 
-	tests := []struct {
-		Name    string
-		Command string
-		Check   func(output string, err error)
+	callingConventions := []struct {
+		name string
+		cmd  []string
 	}{
-		{
-			Name:    "full subcommand name",
-			Command: "k0s kubectl version",
-			Check: func(output string, e error) {
-				s.Require().NoError(e)
-				s.Require().Contains(output, "Client Version: version.Info")
-			},
-		},
-		{
-			Name:    "short subcommand name",
-			Command: "k0s kc version",
-			Check: func(output string, e error) {
-				s.Require().NoError(e)
-				s.Require().Contains(output, "Client Version: version.Info")
-			},
-		},
-		{
-			Name:    "full command arguments",
-			Command: "k0s kubectl version -v 8",
-			Check: func(output string, e error) {
-				s.Require().NoError(e)
-				// Check for debug log messages
-				s.Require().Contains(output, "round_trippers.go")
-			},
-		},
-		{
-			Name:    "short command arguments",
-			Command: "k0s kc version -v 8",
-			Check: func(output string, e error) {
-				s.Require().NoError(e)
-				// Check for debug log messages
-				s.Require().Contains(output, "round_trippers.go")
-			},
-		},
-		{
-			Name:    "full command plugin loader",
-			Command: "k0s kubectl foo",
-			Check: func(output string, e error) {
-				s.Require().NoError(e)
-				s.Require().Equal("foo-plugin", output, "Unexpected output: %v", output)
-			},
-		},
-		{
-			Name:    "short command plugin loader",
-			Command: "k0s kc foo",
-			Check: func(output string, e error) {
-				s.Require().NoError(e)
-				s.Require().Equal("foo-plugin", output, "Unexpected output: %v", output)
-			},
-		},
+		{"full_subcommand", []string{"k0s", "kubectl"}},
+		{"short_subcommand", []string{"k0s", "kc"}},
+		{"symlink", []string{"/usr/bin/kubectl"}},
+	}
 
-		{
-			Name:    "symlink command",
-			Command: "kubectl version",
-			Check: func(output string, e error) {
-				s.Require().NoError(e)
-				s.Require().Contains(output, "Client Version: version.Info")
-			},
-		},
-		{
-			Name:    "symlink arguments",
-			Command: "kubectl version -v 8",
-			Check: func(output string, e error) {
-				s.Require().NoError(e)
-				// Check for debug log messages
-				s.Require().Contains(output, "round_trippers.go")
-			},
-		},
-		{
-			Name:    "symlink plugin loader",
-			Command: "k0s kubectl foo",
-			Check: func(output string, e error) {
-				s.Require().NoError(e)
-				s.Require().Equal("foo-plugin", output, "Unexpected output: %v", output)
-			},
-		},
+	subcommands := []struct {
+		name  string
+		cmd   []string
+		check func(t *testing.T, output string)
+	}{
+		{"plain", nil, func(t *testing.T, output string) {
+			assert.Contains(t, output, `kubectl controls the Kubernetes cluster manager.`)
+		}},
+
+		{"JSON_version", []string{"version", "--output=json"}, func(t *testing.T, output string) {
+			var versions map[string]any
+			require.NoError(t, json.Unmarshal([]byte(output), &versions))
+			checkClientVersion(t, requiredValue[map[string]any](t, versions, "clientVersion"))
+			checkServerVersion(t, requiredValue[map[string]any](t, versions, "serverVersion"))
+		}},
+
+		{"plugin_loader", []string{"foo"}, func(t *testing.T, output string) {
+			assert.Equal(t, "foo-plugin", output)
+		}},
 	}
-	for _, test := range tests {
-		s.T().Logf("Trying %s with command `%s`", test.Name, test.Command)
-		output, err := ssh.ExecWithOutput(test.Command)
-		test.Check(output, err)
+
+	for _, callingConvention := range callingConventions {
+		for _, subcommand := range subcommands {
+			s.T().Run(fmt.Sprint(callingConvention.name, "_", subcommand.name), func(t *testing.T) {
+				cmd := strings.Join(append(callingConvention.cmd, subcommand.cmd...), " ")
+				t.Log("Executing", cmd)
+				output, err := ssh.ExecWithOutput(cmd)
+				t.Cleanup(func() {
+					if t.Failed() {
+						t.Log("Error: ", err)
+						t.Log("Output: ", output)
+					}
+				})
+				assert.NoError(t, err)
+				subcommand.check(t, output)
+			})
+		}
 	}
+}
+
+func requiredValue[V any](t *testing.T, obj map[string]any, key string) V {
+	value, ok := obj[key]
+	require.True(t, ok, "Key %q not found", key)
+	typedValue, ok := value.(V)
+	require.True(t, ok, "Incompatible type for key %q: %+v", key, value)
+	return typedValue
+}
+
+func checkClientVersion(t *testing.T, v map[string]any) {
+	assert.Equal(t,
+		constant.KubernetesMajorMinorVersion,
+		fmt.Sprintf("%v.%v", requiredValue[string](t, v, "major"), requiredValue[string](t, v, "minor")),
+	)
+	assert.Contains(t,
+		requiredValue[string](t, v, "gitVersion"),
+		fmt.Sprintf("v%s", constant.KubernetesMajorMinorVersion),
+	)
+	assert.Equal(t, "not_available", requiredValue[string](t, v, "gitCommit"))
+	assert.Empty(t, requiredValue[string](t, v, "gitTreeState"))
+}
+
+func checkServerVersion(t *testing.T, v map[string]any) {
+	assert.Equal(t,
+		constant.KubernetesMajorMinorVersion,
+		fmt.Sprintf("%v.%v", requiredValue[string](t, v, "major"), requiredValue[string](t, v, "minor")),
+	)
+	assert.Contains(t,
+		requiredValue[string](t, v, "gitVersion"),
+		fmt.Sprintf("v%s", constant.KubernetesMajorMinorVersion),
+	)
+	assert.Contains(t, requiredValue[string](t, v, "gitVersion"), "+k0s")
+	assert.NotEmpty(t, requiredValue[string](t, v, "gitCommit"))
+	assert.Equal(t, "clean", requiredValue[string](t, v, "gitTreeState"))
 }
 
 func TestKubectlCommand(t *testing.T) {


### PR DESCRIPTION
## Description

* Rollup the different tests into a test matrix.
* Use full path to symlink, so that the symlink is tested, not the standalone kubectl binary in /usr/local/bin.
* Use JSON output for the version command, as the plain version command is deprecated.
* Remove the double quotes around the not_available string for the git commit. It ends up in the compiled binary and looks strange.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings