### PR TITLE
[autopilot] Link unit tests the same way as the k0s binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ GO ?= $(GO_ENV) go
 ifeq ($(TARGET_OS),windows)
 build: k0s.exe
 else
+BUILD_GO_LDFLAGS_EXTRA = -extldflags=-static
 build: k0s
 endif
 
@@ -80,7 +81,7 @@ build/cache:
 
 .k0sbuild.docker-image.k0s: build/Dockerfile embedded-bins/Makefile.variables | build/cache
 	docker build --rm \
-		--build-arg BUILDIMAGE=golang:$(go_version) \
+		--build-arg BUILDIMAGE=golang:$(go_version)-alpine \
 		-f build/Dockerfile \
 		-t k0sbuild.docker-image.k0s build/
 	touch $@
@@ -163,7 +164,6 @@ pkg/assets/zz_generated_offsets_darwin.go:
 
 k0s: TARGET_OS = linux
 k0s: CGO_ENABLED = 1
-k0s: BUILD_GO_LDFLAGS_EXTRA = -extldflags=-static
 k0s: .k0sbuild.docker-image.k0s
 
 k0s.exe: TARGET_OS = windows
@@ -203,7 +203,7 @@ smoketests: $(smoketests)
 .PHONY: check-unit
 check-unit: GO_TEST_RACE ?= -race
 check-unit: go.sum codegen
-	$(GO) test $(GO_TEST_RACE) `$(GO) list $(GO_DIRS)`
+	$(GO) test $(GO_TEST_RACE) -ldflags='$(LD_FLAGS)' `$(GO) list $(GO_DIRS)`
 
 .PHONY: check-image-validity
 check-image-validity: go.sum

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILDIMAGE
 FROM $BUILDIMAGE
-RUN apt-get update && apt-get install -y make gcc musl-dev binutils-gold
+RUN apk add --no-cache make gcc musl-dev binutils-gold
 
 ENV \
   HOME="/run/k0s-build" \


### PR DESCRIPTION
## Description

This addresses a miscompilation on Alpine aarch64, which tries to generate no-pie code using the gold linker, but that produces binaries that segfault instantly.

Also restore Alpine as the Docker base image for compiling everything.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings