### PR TITLE
Improve kubectl kubeconfig detection

### DIFF
--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"syscall"
 
 	"github.com/sirupsen/logrus"
@@ -102,33 +103,60 @@ func NewK0sKubectlCmd() *cobra.Command {
 				}
 			}
 		}
-		c := CmdOpts(config.GetCmdOpts())
-		if os.Getenv("KUBECONFIG") == "" {
-			// Verify we can read the config before pushing it to env
-			file, err := os.OpenFile(c.K0sVars.AdminKubeConfigPath, os.O_RDONLY, 0600)
-			if err != nil {
-				logrus.Errorf("cannot read admin kubeconfig at %s, is the server running?", c.K0sVars.AdminKubeConfigPath)
-				return err
-			}
-			defer file.Close()
-			os.Setenv("KUBECONFIG", c.K0sVars.AdminKubeConfigPath)
+
+		if err := fallbackToK0sKubeconfig(args); err != nil {
+			return err
 		}
 
 		return originalPreRunE(cmd, args)
 	}
 	cmd.PersistentFlags().AddFlagSet(config.GetKubeCtlFlagSet())
 	originalRun := cmd.Run
-	cmd.Run = func(cmd *cobra.Command, args []string) {
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 {
 			if err := kubectl.HandlePluginCommand(&kubectlPluginHandler{}, args); err != nil {
 				// note: the plugin exec will replace the k0s process and exit on it's own,
 				// the error here is a failure to exec, not the error-exit of the plugin.
-				logrus.Fatalf("kubectl plugin handler failed: %v", err)
+				return fmt.Errorf("kubectl plugin handler failed: %w", err)
 			}
 		}
 
 		originalRun(cmd, args)
+		return nil
 	}
+
 	logs.AddFlags(cmd.PersistentFlags())
 	return cmd
+}
+
+func fallbackToK0sKubeconfig(args []string) error {
+	for _, arg := range args {
+		if arg == "--" {
+			// no more options
+			break
+		}
+		if arg == "--kubeconfig" || strings.HasPrefix(arg, "--kubeconfig=") {
+			// kubeconfig set via args, no need to check if k0s kubeconfig is readable
+			return nil
+		}
+	}
+
+	if _, envSet := os.LookupEnv("KUBECONFIG"); envSet {
+		// kubeconfig environment variable set, don't override
+		return nil
+	}
+
+	kubeconfig := config.GetCmdOpts().K0sVars.AdminKubeConfigPath
+	// verify that k0s's kubeconfig is readable before pushing it to the env
+	file, err := os.Open(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("cannot read k0s kubeconfig, is the server running? (%w)", err)
+	}
+	file.Close()
+
+	if err := os.Setenv("KUBECONFIG", kubeconfig); err != nil {
+		return fmt.Errorf("failed to set k0s kubeconfig as default: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Description

The embedded kubectl command checks the k0s kubeconfig for readability, even if another kubeconfig was specified as CLI arg and the k0s kubeconfig wouldn't be used at all. This can be a problem when invoking `k0s kc --kubeconfig ./readable-kubeconfig`, but but the executing user has no rights to read k0s's admin kubeconfig file.

Fix this by improving the kubeconfig detection and only checking the admin kubeconfig for readability if no kubeconfig was specified, neither via OS env nor via CLI args.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings