### PR TITLE
[release-1.22] First start watching bundle dir, then list/add existing dirs

### DIFF
--- a/pkg/applier/manager.go
+++ b/pkg/applier/manager.go
@@ -94,6 +94,22 @@ func (m *Manager) Reconcile() error {
 func (m *Manager) runWatchers(ctx context.Context) error {
 	log := logrus.WithField("component", "applier-manager")
 
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.WithError(err).Error("failed to create watcher")
+		return err
+	}
+	defer watcher.Close()
+
+	err = watcher.Add(m.bundlePath)
+	if err != nil {
+		log.Warnf("Failed to start watcher: %s", err.Error())
+	}
+
+	// Add all directories after the bundle dir has been added to the watcher.
+	// Doing it the other way round introduces a race condition when directories
+	// get created after the initial listing but before the watch starts.
+
 	dirs, err := dir.GetAll(m.bundlePath)
 	if err != nil {
 		return err
@@ -106,17 +122,6 @@ func (m *Manager) runWatchers(ctx context.Context) error {
 		}
 	}
 
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		log.WithError(err).Error("failed to create watcher")
-		return err
-	}
-	defer watcher.Close()
-
-	err = watcher.Add(m.bundlePath)
-	if err != nil {
-		log.Warnf("Failed to start watcher: %s", err.Error())
-	}
 	for {
 		select {
 		case err, ok := <-watcher.Errors:


### PR DESCRIPTION
## Description

Add all directories after the bundle dir has been added to the watcher. Doing it the other way round introduces a race condition when directories get created after the initial listing but before the watch starts.

See #1781.
See #1785.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings