### PR TITLE
Don't run the bind-mounted `/usr/bin/k0s` directly in inttests

### DIFF
--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -58,6 +58,9 @@ const (
 	workerNodeNameFormat     = "worker%d"
 	lbNodeNameFormat         = "lb%d"
 	etcdNodeNameFormat       = "etcd%d"
+
+	defaultK0sBinaryFullPath = "/usr/bin/k0s"
+	k0sBindMountFullPath     = "/dist/k0s"
 )
 
 // FootlooseSuite defines all the common stuff we need to be able to run k0s testing on footloose.
@@ -94,7 +97,7 @@ type FootlooseSuite struct {
 // initializeDefaults initializes any unset configuration knobs to their defaults.
 func (s *FootlooseSuite) initializeDefaults() {
 	if s.K0sFullPath == "" {
-		s.K0sFullPath = "/usr/bin/k0s"
+		s.K0sFullPath = defaultK0sBinaryFullPath
 	}
 	if s.K0sAPIExternalPort == 0 {
 		s.K0sAPIExternalPort = 9443
@@ -860,7 +863,7 @@ func (s *FootlooseSuite) initializeFootlooseClusterInDir(dir string) error {
 		{
 			Type:        "bind",
 			Source:      binPath,
-			Destination: s.K0sFullPath,
+			Destination: k0sBindMountFullPath,
 			ReadOnly:    true,
 		},
 		{

--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -4,6 +4,9 @@ ARG ETCD_ARCH
 ARG ETCD_VERSION
 ARG KUBE_VERSION
 
+# Apply our changes to the image
+COPY root/ /
+
 RUN apk add openrc openssh-server bash busybox-initscripts coreutils curl haproxy
 # enable syslog and sshd
 RUN rc-update add cgroups boot
@@ -11,6 +14,9 @@ RUN rc-update add syslog boot
 RUN rc-update add machine-id boot
 RUN rc-update add sshd default
 RUN rc-update add local default
+# Ensures that /usr/bin/k0s is seeded from /dist at startup
+RUN rc-update add k0s-seed default
+
 # remove -docker keyword so we actually mount cgroups in container
 RUN sed -i -e '/keyword/s/-docker//' /etc/init.d/cgroups
 # disable ttys

--- a/inttest/footloose-alpine/root/etc/init.d/k0s-seed
+++ b/inttest/footloose-alpine/root/etc/init.d/k0s-seed
@@ -1,0 +1,14 @@
+#!/sbin/openrc-run
+
+description="Copy seeded k0s to /usr/bin"
+
+depend() {
+	need root localmount
+}
+
+start() {
+	ebegin "Seeding k0s binary to /usr/bin"
+	/usr/bin/install -D -t /usr/bin /dist/k0s
+
+	eend $?
+}

--- a/inttest/upgrade/upgrade_test.go
+++ b/inttest/upgrade/upgrade_test.go
@@ -138,7 +138,7 @@ func (s *UpgradeSuite) TestK0sGetsUp() {
 				return err
 			}
 			defer ssh.Disconnect()
-			_, err = ssh.ExecWithOutput("rm /usr/local/bin/k0s && cp /usr/bin/k0s.new /usr/local/bin/k0s")
+			_, err = ssh.ExecWithOutput("rm /usr/local/bin/k0s && cp /usr/bin/k0s /usr/local/bin/k0s")
 			if err != nil {
 				return err
 			}
@@ -157,7 +157,7 @@ func (s *UpgradeSuite) TestK0sGetsUp() {
 				return err
 			}
 			defer ssh.Disconnect()
-			_, err = ssh.ExecWithOutput("rm /usr/local/bin/k0s && cp /usr/bin/k0s.new /usr/local/bin/k0s")
+			_, err = ssh.ExecWithOutput("rm /usr/local/bin/k0s && cp /usr/bin/k0s /usr/local/bin/k0s")
 			if err != nil {
 				return err
 			}
@@ -183,7 +183,6 @@ func TestUpgradeSuite(t *testing.T) {
 		common.FootlooseSuite{
 			ControllerCount: 1,
 			WorkerCount:     2,
-			K0sFullPath:     "/usr/bin/k0s.new",
 		},
 	}
 	suite.Run(t, &s)


### PR DESCRIPTION
## Description

Autopilot will be replacing this binary as a part of its upcoming
integration tests, and this is not possible (cleanly) when the `k0s`
is bind-mounted to the host.

Instead, have a startup service in the footloose container seed the
`/usr/bin/k0s` from a bind-mounted location `/dist/k0s`

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings