### PR TITLE
Refactor Debouncer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/docker/libnetwork v0.8.0-dev.2.0.20201031180254-535ef365dc1d
 	github.com/estesp/manifest-tool/v2 v2.0.1-0.20220217152536-f3906340b65e
 	github.com/evanphx/json-patch v4.12.0+incompatible
+	github.com/fsnotify/fsnotify v1.5.4
 	github.com/go-openapi/jsonpointer v0.19.5
 	github.com/gorilla/mux v1.8.0
 	github.com/imdario/mergo v0.3.13
@@ -47,7 +48,6 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150
 	google.golang.org/grpc v1.47.0
-	gopkg.in/fsnotify.v1 v1.4.7
 	helm.sh/helm/v3 v3.9.0
 	sigs.k8s.io/controller-runtime v0.12.1
 	sigs.k8s.io/yaml v1.3.0
@@ -128,7 +128,6 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible // indirect
-	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/fullstorydev/grpcurl v1.8.5 // indirect
 	github.com/fvbommel/sortorder v1.0.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -530,8 +530,8 @@ github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebP
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
-github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
+github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
+github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/fullstorydev/grpcurl v1.8.0/go.mod h1:Mn2jWbdMrQGJQ8UD62uNyMumT2acsZUCkZIqFxsQf1o=
 github.com/fullstorydev/grpcurl v1.8.1/go.mod h1:3BWhvHZwNO7iLXaQlojdg5NA6SxUDePli4ecpK1N7gw=
@@ -1865,6 +1865,7 @@ golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -2175,7 +2176,6 @@ gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qS
 gopkg.in/cheggaaa/pb.v1 v1.0.28 h1:n1tBJnnK2r7g9OW2btFH91V92STTUevLXYFb8gy9EMk=
 gopkg.in/cheggaaa/pb.v1 v1.0.28/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=

--- a/pkg/debounce/debounce_test.go
+++ b/pkg/debounce/debounce_test.go
@@ -17,65 +17,114 @@ package debounce
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/fsnotify.v1"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDebounce(t *testing.T) {
-	eventChan := make(chan fsnotify.Event)
-	var debounceCalled atomic.Value
-	debounceCalled.Store(0)
+	const numEvents = 5
+	eventChan := make(chan int32, numEvents)
+	var debounceCalled uint32
+	var lastItem int32
+	ctx, cancel := context.WithCancel(context.TODO())
 
-	var lastEvent atomic.Value
-	lastEvent.Store("")
-	debouncer := New(context.Background(), 1*time.Second, eventChan, func(arg fsnotify.Event) {
-		val := debounceCalled.Load().(int)
-		val++
-		debounceCalled.Store(val)
-		lastEvent.Store(arg.Name)
-	})
-	go debouncer.Start()
-
-	for i := 0; i < 5; i++ {
-		eventChan <- fsnotify.Event{Name: fmt.Sprintf("event#%d", i)}
+	debouncer := Debouncer[int32]{
+		Input:   eventChan,
+		Timeout: 10 * time.Millisecond,
+		Callback: func(item int32) {
+			atomic.AddUint32(&debounceCalled, 1)
+			atomic.StoreInt32(&lastItem, item)
+		},
 	}
-	time.Sleep(2 * time.Second)
-	debouncer.Stop()
-	assert.Equal(t, 1, debounceCalled.Load())
-	assert.Equal(t, "event#4", lastEvent.Load())
+
+	for i := int32(1); i <= numEvents; i++ {
+		eventChan <- i
+	}
+
+	runReturned := make(chan error)
+	go func() { runReturned <- debouncer.Run(ctx) }()
+
+	for i := 0; i < 1000; i++ {
+		time.Sleep(10 * time.Millisecond)
+		if atomic.LoadInt32(&lastItem) == numEvents {
+			break
+		}
+	}
+
+	cancel()
+
+	select {
+	case <-time.After(1 * time.Second):
+		require.Fail(t, "Debouncer didn't terminate in time")
+	case err := <-runReturned:
+		assert.Same(t, context.Canceled, err)
+	}
+
+	assert.Equal(t, uint32(1), atomic.LoadUint32(&debounceCalled))
+	assert.Equal(t, int32(numEvents), atomic.LoadInt32(&lastItem))
 }
 
 func TestDebounceStopWithoutActuallyDebouncing(t *testing.T) {
-	eventChan := make(chan fsnotify.Event)
-	var debounceCalled atomic.Value
-	debounceCalled.Store(0)
+	const numEvents = 5
+	eventChan := make(chan int, numEvents)
+	var debounceCalled uint32
+	ctx, cancel := context.WithCancel(context.TODO())
 
-	var lastEvent atomic.Value
-	lastEvent.Store("")
-	debouncer := New(context.Background(), 10*time.Second, eventChan, func(arg fsnotify.Event) {
-		val := debounceCalled.Load().(int)
-		val++
-		debounceCalled.Store(val)
-		lastEvent.Store(arg.Name)
-
-	})
-	var startReturned atomic.Value
-	startReturned.Store(false)
-	go func() {
-		debouncer.Start()
-		startReturned.Store(true)
-	}()
-	for i := 0; i < 5; i++ {
-		eventChan <- fsnotify.Event{Name: fmt.Sprintf("event#%d", i)}
+	debouncer := Debouncer[int]{
+		Input:    eventChan,
+		Timeout:  10 * time.Second,
+		Callback: func(int) { atomic.AddUint32(&debounceCalled, 1) },
 	}
-	debouncer.Stop()
+
+	for i := 1; i <= numEvents; i++ {
+		eventChan <- i
+	}
+
+	runReturned := make(chan error)
+	go func() { runReturned <- debouncer.Run(ctx) }()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-time.After(1 * time.Second):
+		require.Fail(t, "Debouncer didn't terminate in time")
+	case err := <-runReturned:
+		assert.Same(t, context.Canceled, err)
+	}
+
+	assert.Equal(t, uint32(0), atomic.LoadUint32(&debounceCalled))
+
+	eventChan <- -1
+	sentinel := <-eventChan
+	assert.Equal(t, -1, sentinel, "Debouncer didn't consume all events")
+}
+
+func TestDebouncerReturnsIfInputIsClosed(t *testing.T) {
+	eventChan := make(chan int)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	debouncer := Debouncer[int]{
+		Input:    eventChan,
+		Timeout:  10 * time.Second,
+		Callback: func(int) {},
+	}
+
+	runReturned := make(chan error)
+	go func() { runReturned <- debouncer.Run(ctx) }()
+
 	time.Sleep(10 * time.Millisecond)
-	assert.True(t, startReturned.Load().(bool))
-	assert.Equal(t, 0, debounceCalled.Load())
-	assert.Equal(t, "", lastEvent.Load())
+	close(eventChan)
+
+	select {
+	case <-time.After(1 * time.Second):
+		assert.Fail(t, "Debouncer didn't return in time")
+	case err := <-runReturned:
+		assert.NoError(t, err)
+	}
 }


### PR DESCRIPTION
## Description

* Make Debouncer a generic struct over its channel items.
* Add a filter function, so that uninteresting items can be suppressed before resetting the debouncing timer.
* Combine the Start/Stop methods into a single Run method that exits when the given context is done. The Start method was blocking anyways, exiting when the Stop method was called. This way, it's also no longer required to have a factory method for Debouncer and it can be created directly as a struct literal.
* Clear potentially pending timer ticks when resetting it.
* Use the new Debouncer in StackApplier. Use a context instad of a "done" channel, so that it's compatible to the new Debouncer API.
* Update to the latest fsnotify library.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings