### PR TITLE
Add configurable k0s launch modes for integration tests

### DIFF
--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -67,6 +67,11 @@ const (
 type FootlooseSuite struct {
 	suite.Suite
 
+	// Provide alternate launch functionalities as-needed.
+
+	LaunchMode     LaunchMode
+	launchDelegate *LaunchDelegate
+
 	/* config knobs (initialized via `initializeDefaults`) */
 
 	ControllerCount       int
@@ -110,6 +115,18 @@ func (s *FootlooseSuite) initializeDefaults() {
 	}
 	if s.KubeAPIExternalPort == 0 {
 		s.KubeAPIExternalPort = 6443
+	}
+	if s.LaunchMode == "" {
+		s.LaunchMode = LaunchModeStandalone
+	}
+
+	switch s.LaunchMode {
+	case LaunchModeStandalone:
+		s.launchDelegate = s.StandaloneLaunchDelegate()
+	case LaunchModeOpenRC:
+		s.launchDelegate = s.OpenRCLaunchDelegate()
+	default:
+		s.Require().Fail("Missing launch delegate (standalone, openrc)")
 	}
 }
 
@@ -412,19 +429,81 @@ func (s *FootlooseSuite) InitController(idx int, k0sArgs ...string) error {
 		return err
 	}
 	defer ssh.Disconnect()
-	umaskCmd := ""
-	if s.ControllerUmask != 0 {
-		umaskCmd = fmt.Sprintf("umask %d;", s.ControllerUmask)
-	}
-	// Allow any arch for etcd in smokes
-	startCmd := fmt.Sprintf("%s ETCD_UNSUPPORTED_ARCH=%s nohup %s controller --debug %s >/tmp/k0s-controller.log 2>&1 &", umaskCmd, runtime.GOARCH, s.K0sFullPath, strings.Join(k0sArgs, " "))
-	_, err = ssh.ExecWithOutput(startCmd)
-	if err != nil {
-		s.T().Logf("failed to execute '%s' on %s", startCmd, controllerNode)
+
+	if err := s.launchDelegate.InitController(ssh, k0sArgs...); err != nil {
+		s.T().Logf("failed to start k0scontroller on %s: %v", controllerNode, err)
 		return err
 	}
 
 	return s.WaitForKubeAPI(controllerNode, getDataDirOpt(k0sArgs))
+}
+
+// initControllerStandalone initializes a controller in 'standalone' mode, meaning that
+// the k0s executable is launched directly (vs. started from a service)
+func (s *FootlooseSuite) initControllerStandalone(conn *SSHConnection, k0sArgs ...string) error {
+	umaskCmd := ""
+	if s.ControllerUmask != 0 {
+		umaskCmd = fmt.Sprintf("umask %d;", s.ControllerUmask)
+	}
+
+	// Allow any arch for etcd in smokes
+	cmd := fmt.Sprintf("%s ETCD_UNSUPPORTED_ARCH=%s nohup %s controller --debug %s >/tmp/k0s-controller.log 2>&1 &", umaskCmd, runtime.GOARCH, s.K0sFullPath, strings.Join(k0sArgs, " "))
+
+	if _, err := conn.ExecWithOutput(cmd); err != nil {
+		return fmt.Errorf("unable to execute '%s': %w", cmd, err)
+	}
+
+	return nil
+}
+
+// initControllerOpenRC initializes a controller in 'openrc' mode, meaning that
+// the k0s executable is launched as a service managed by openrc.
+func (s *FootlooseSuite) initControllerOpenRC(conn *SSHConnection, k0sArgs ...string) error {
+	if err := s.installK0sServiceOpenRC(conn, "controller"); err != nil {
+		return fmt.Errorf("unable to install openrc k0s controller: %w", err)
+	}
+
+	// Configure k0s as a controller w/args
+	controllerArgs := fmt.Sprintf("controller --debug %s", strings.Join(k0sArgs, " "))
+	if err := configureK0sServiceArgs(conn, "controller", controllerArgs); err != nil {
+		return fmt.Errorf("failed to configure k0s with '%s'", controllerArgs)
+	}
+
+	cmd := "/etc/init.d/k0scontroller start"
+	if _, err := conn.ExecWithOutput(cmd); err != nil {
+		return fmt.Errorf("unable to execute '%s': %w", cmd, err)
+	}
+
+	return nil
+}
+
+// installK0sServiceOpenRC will install an openrc k0s-type service (controller/worker)
+// if it does not already exist.
+func (s *FootlooseSuite) installK0sServiceOpenRC(conn *SSHConnection, k0sType string) error {
+	existsCommand := fmt.Sprintf("/usr/bin/file /etc/init.d/k0s%s", k0sType)
+	if _, err := conn.ExecWithOutput(existsCommand); err != nil {
+		cmd := fmt.Sprintf("%s install %s", s.K0sFullPath, k0sType)
+		if _, err := conn.ExecWithOutput(cmd); err != nil {
+			return fmt.Errorf("unable to execute '%s': %w", cmd, err)
+		}
+	}
+
+	return nil
+}
+
+// configureK0sServiceArgs performs some reconfiguring of the `/etc/init.d/k0s[controller|worker]`
+// startup script to allow for different configurations at test time, using the same base
+// image.
+func configureK0sServiceArgs(conn *SSHConnection, k0sType string, args string) error {
+	k0sServiceFile := fmt.Sprintf("/etc/init.d/k0s%s", k0sType)
+	cmd := fmt.Sprintf("sed -i 's#^command_args=.*$#command_args=\"%s\"#g' %s", args, k0sServiceFile)
+
+	_, err := conn.ExecWithOutput(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to execute '%s' on %s: %w", cmd, conn.Address, err)
+	}
+
+	return nil
 }
 
 // GetJoinToken generates join token for the asked role
@@ -460,25 +539,56 @@ func (s *FootlooseSuite) RunWorkers(args ...string) error {
 }
 
 func (s *FootlooseSuite) RunWorkersWithToken(token string, args ...string) error {
-	ssh, err := s.SSH("controller0")
-	s.Require().NoError(err)
-	defer ssh.Disconnect()
-	if token == "" {
-		return fmt.Errorf("got empty token for worker join")
-	}
-	workerCommand := fmt.Sprintf(`nohup %s --debug worker %s "%s" >/tmp/k0s-worker.log 2>&1 &`, s.K0sFullPath, strings.Join(args, " "), token)
-
 	for i := 0; i < s.WorkerCount; i++ {
-		sshWorker, err := s.SSH(s.WorkerNode(i))
+		workerNode := s.WorkerNode(i)
+		sshWorker, err := s.SSH(workerNode)
 		if err != nil {
 			return err
 		}
 		defer sshWorker.Disconnect()
-		_, err = sshWorker.ExecWithOutput(workerCommand)
-		if err != nil {
+
+		if err := s.launchDelegate.InitWorker(sshWorker, token, args...); err != nil {
+			s.T().Logf("failed to start k0sworker on %s: %v", workerNode, err)
 			return err
 		}
 	}
+	return nil
+}
+
+// initWorkerStandalone initializes a worker in 'standalone' mode, meaning that
+// the k0s executable is launched directly (vs. started from a service)
+func (s *FootlooseSuite) initWorkerStandalone(conn *SSHConnection, token string, k0sArgs ...string) error {
+	if token == "" {
+		return fmt.Errorf("got empty token for worker join")
+	}
+
+	cmd := fmt.Sprintf(`nohup %s --debug worker %s "%s" >/tmp/k0s-worker.log 2>&1 &`, s.K0sFullPath, strings.Join(k0sArgs, " "), token)
+	if _, err := conn.ExecWithOutput(cmd); err != nil {
+		return fmt.Errorf("unable to execute '%s': %w", cmd, err)
+	}
+
+	return nil
+}
+
+// initWorkerOpenRC initializes a worker in 'openrc' mode, meaning that
+// the k0s executable is launched as a service managed by openrc.
+func (s *FootlooseSuite) initWorkerOpenRC(conn *SSHConnection, token string, k0sArgs ...string) error {
+	if err := s.installK0sServiceOpenRC(conn, "worker"); err != nil {
+		return fmt.Errorf("unable to install openrc k0s worker: %w", err)
+	}
+
+	// Configure k0s as a worker w/args
+	workerArgs := fmt.Sprintf("worker --debug %s %s", strings.Join(k0sArgs, " "), token)
+
+	if err := configureK0sServiceArgs(conn, "worker", workerArgs); err != nil {
+		return fmt.Errorf("failed to configure k0s with '%s'", workerArgs)
+	}
+
+	cmd := "/etc/init.d/k0sworker start"
+	if _, err := conn.ExecWithOutput(cmd); err != nil {
+		return fmt.Errorf("unable to execute '%s': %w", cmd, err)
+	}
+
 	return nil
 }
 
@@ -533,9 +643,28 @@ func (s *FootlooseSuite) StopController(name string) error {
 	s.Require().NoError(err)
 	defer ssh.Disconnect()
 	s.T().Log("killing k0s")
+
+	return s.launchDelegate.StopController(ssh)
+}
+
+// stopControllerStandalone stops a k0s controller that was started standalone.
+func (s *FootlooseSuite) stopControllerStandalone(conn *SSHConnection) error {
 	stopCommand := fmt.Sprintf("kill $(pidof %s | tr \" \" \"\\n\" | sort -n | head -n1) && while pidof %s; do sleep 0.1s; done", s.K0sFullPath, s.K0sFullPath)
-	_, err = ssh.ExecWithOutput(stopCommand)
-	return err
+	if _, err := conn.ExecWithOutput(stopCommand); err != nil {
+		return fmt.Errorf("unable to execute '%s': %w", stopCommand, err)
+	}
+
+	return nil
+}
+
+// stopControllerOpenRC stops a k0s controller that was started using openrc.
+func (s *FootlooseSuite) stopControllerOpenRC(conn *SSHConnection) error {
+	startCmd := "/etc/init.d/k0scontroller stop"
+	if _, err := conn.ExecWithOutput(startCmd); err != nil {
+		return fmt.Errorf("unable to execute '%s': %w", startCmd, err)
+	}
+
+	return nil
 }
 
 func (s *FootlooseSuite) Reset(name string) error {
@@ -1051,4 +1180,51 @@ func (s *FootlooseSuite) getIPAddress(nodeName string) string {
 	ipAddress, err := ssh.ExecWithOutput("hostname -i")
 	s.Require().NoError(err)
 	return ipAddress
+}
+
+type LaunchMode string
+
+const (
+	LaunchModeStandalone LaunchMode = "standalone"
+	LaunchModeOpenRC     LaunchMode = "openrc"
+)
+
+// LaunchDelegate provides an indirection to the launch operations in footloosesuite
+// so that alternate behaviour can be performed.
+type LaunchDelegate struct {
+	InitController func(conn *SSHConnection, k0sArgs ...string) error
+	StopController func(conn *SSHConnection) error
+	InitWorker     func(conn *SSHConnection, token string, k0sArgs ...string) error
+}
+
+// StandaloneLaunchDelegate creates a footloosesuite LaunchDelegate that starts controllers/workers
+// in a 'standalone' mode, ie. not run from a service.
+func (s *FootlooseSuite) StandaloneLaunchDelegate() *LaunchDelegate {
+	return &LaunchDelegate{
+		InitController: func(conn *SSHConnection, k0sArgs ...string) error {
+			return s.initControllerStandalone(conn, k0sArgs...)
+		},
+		StopController: func(conn *SSHConnection) error {
+			return s.stopControllerStandalone(conn)
+		},
+		InitWorker: func(conn *SSHConnection, token string, k0sArgs ...string) error {
+			return s.initWorkerStandalone(conn, token, k0sArgs...)
+		},
+	}
+}
+
+// OpenRCLaunchDelegate creates a footloosesuite LaunchDelegate that starts controllers/workers
+// via an openrc service.
+func (s *FootlooseSuite) OpenRCLaunchDelegate() *LaunchDelegate {
+	return &LaunchDelegate{
+		InitController: func(conn *SSHConnection, k0sArgs ...string) error {
+			return s.initControllerOpenRC(conn, k0sArgs...)
+		},
+		StopController: func(conn *SSHConnection) error {
+			return s.stopControllerOpenRC(conn)
+		},
+		InitWorker: func(conn *SSHConnection, token string, k0sArgs ...string) error {
+			return s.initWorkerOpenRC(conn, token, k0sArgs...)
+		},
+	}
 }

--- a/inttest/k0scloudprovider/k0scloudprovider_test.go
+++ b/inttest/k0scloudprovider/k0scloudprovider_test.go
@@ -123,6 +123,7 @@ func TestK0sCloudProviderSuite(t *testing.T) {
 		common.FootlooseSuite{
 			ControllerCount: 1,
 			WorkerCount:     2,
+			LaunchMode:      "openrc",
 		},
 	})
 }


### PR DESCRIPTION
## Description

In integration tests, you can now control how `k0s` will be launched,
either `standalone` (the default), or `openrc`.

This new `openrc` launch mode will start `k0s` via an openrc service.
The main motivation behind this is for the enabling of autopilot
integration tests which will need `k0s` to terminate and restart,
all handled by the service.

The `k0scloudprovider` integration test has been updated to use
`openrc` as an example.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings