### PR TITLE
Restart leader election as long as k0s is running

### DIFF
--- a/pkg/leaderelection/lease_pool.go
+++ b/pkg/leaderelection/lease_pool.go
@@ -218,7 +218,12 @@ func (p *LeasePool) Watch(opts ...WatchOpt) (*LeaseEvents, context.CancelFunc, e
 	}
 
 	ctx, cancel := context.WithCancel(p.config.ctx)
-	go le.Run(ctx)
+
+	go func() {
+		for ctx.Err() == nil {
+			le.Run(ctx)
+		}
+	}()
 
 	return p.events, cancel, nil
 }


### PR DESCRIPTION
## Description

The client-go leader elector will return from its run loop whenever the "leader election loop is stopped by ctx or it has stopped holding the leader lease". This means that k0s needs to restart leader election as long as it's running, because the run loop may terminate even if the context is not yet done.

Implement a simple loop over the leader elector's run method that terminates as soon as the context is done. Add a test case that demonstrates a case when leader election will simply stop, even if the lease pool is still active.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings