### PR TITLE
Bump k0sctl version in inttest to 0.13.0

### DIFF
--- a/inttest/k0sctl/k0sctl_test.go
+++ b/inttest/k0sctl/k0sctl_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/k0sproject/k0s/inttest/common"
 )
 
-const k0sctlVersion = "v0.13.0-rc.3"
+const k0sctlVersion = "v0.13.0"
 
 type K0sctlSuite struct {
 	common.FootlooseSuite


### PR DESCRIPTION
## Description

https://github.com/k0sproject/k0sctl/releases/tag/v0.13.0

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings