### PR TITLE
Also publish pre-release docs

### DIFF
--- a/.github/workflows/publish-docs-manual.yml
+++ b/.github/workflows/publish-docs-manual.yml
@@ -9,36 +9,39 @@ on:
 env:
   PYTHON_VERSION: 3.x
   TARGET_VERSION: ${{ github.event.inputs.version }}
-  
+
 jobs:
   build:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout k0s main
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          path: main
+          fetch-depth: 0
+
+      - name: Prepare build environment
+        working-directory: ./main
+        run: .github/workflows/prepare-build-env.sh
+
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies
+        working-directory: ./main
         run: |
           python -m pip install --upgrade pip
-          pip install mkdocs
+          pip install -r docs/requirements_release.txt
           pip install git+https://${{ secrets.GH_TOKEN }}@github.com/lensapp/mkdocs-material-insiders.git
-          pip install mdx-truly-sane-lists
-          pip install mike
 
       - name: Checkout k0s ${{ github.event.inputs.version }}
         uses: actions/checkout@v3
         with:
           ref: '${{ github.event.inputs.version }}'
-          fetch-depth: 0
-
-      - name: Checkout k0s main
-        uses: actions/checkout@v3
-        with:
-          ref: 'main'
-          path: 'main'
           fetch-depth: 0
 
       - name: Copy files from main to ${{ github.event.inputs.version }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -15,7 +15,7 @@ jobs:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
-      - name: checkout k0s release
+      - name: Checkout k0s
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -32,11 +32,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: checkout k0s release
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Install dependencies
         run: |
@@ -60,12 +55,13 @@ jobs:
         run: |
           mike deploy --push head
 
-      # If this is a tag build, deploy as a new version
+      # If a release has been published, deploy it as a new version
       - name: mike deploy new version
-        if: contains(github.ref, 'refs/tags/v') && !github.event.release.prerelease
+        if: github.event_name == 'release' && github.event.action == 'published' && !github.event.release.draft
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
         run: |
-          VERSION=${GITHUB_REF/refs\/tags\//}
-          mike deploy --push "${VERSION}"
+          mike deploy --push "$VERSION"
 
       - name: Update mike version aliases
         id: set_versions


### PR DESCRIPTION
## Description

The current docs workflow will try to set the LATEST alias to any non-draft version in the "Update mike version aliases" step, but the previous step "mike deploy new version" is only targeting non-pre-release versions. This results in all the docs workflows being broken until a new non-pre-release version is released.

Fix this by triggering the deploy step for pre-releases, too. Also sync the manual publish docs workflow with the automatic one.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings