### PR TITLE
Fix single node config loading to force use of kine if no storage config is given in partial config

### DIFF
--- a/inttest/singlenode/singlenode_test.go
+++ b/inttest/singlenode/singlenode_test.go
@@ -34,7 +34,7 @@ const k0sPartialConfig = `
 spec:
   api:
     sans:
-	- 1.2.3.4
+    - 1.2.3.4
 `
 
 type SingleNodeSuite struct {

--- a/inttest/singlenode/singlenode_test.go
+++ b/inttest/singlenode/singlenode_test.go
@@ -30,12 +30,20 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const k0sPartialConfig = `
+spec:
+  api:
+    sans:
+	- 1.2.3.4
+`
+
 type SingleNodeSuite struct {
 	common.FootlooseSuite
 }
 
 func (s *SingleNodeSuite) TestK0sGetsUp() {
-	s.NoError(s.InitController(0, "--single"))
+	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sPartialConfig)
+	s.NoError(s.InitController(0, "--single", "--config=/tmp/k0s.yaml"))
 
 	kc, err := s.KubeClient(s.ControllerNode(0))
 	s.Require().NoError(err)

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
@@ -199,7 +199,7 @@ func (c *ClusterConfig) UnmarshalJSON(data []byte) error {
 	if c.Kind == "" {
 		c.Kind = "ClusterConfig"
 	}
-	c.Spec = DefaultClusterSpec()
+	c.Spec = DefaultClusterSpec(c.Spec.Storage)
 
 	type config ClusterConfig
 	jc := (*config)(c)

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
@@ -199,7 +199,14 @@ func (c *ClusterConfig) UnmarshalJSON(data []byte) error {
 	if c.Kind == "" {
 		c.Kind = "ClusterConfig"
 	}
-	c.Spec = DefaultClusterSpec(c.Spec.Storage)
+
+	// If there's already a storage configured, do not override it with default
+	// etcd config BEFORE unmarshaling
+	var storage *StorageSpec
+	if c.Spec != nil && c.Spec.Storage != nil {
+		storage = c.Spec.Storage
+	}
+	c.Spec = DefaultClusterSpec(storage)
 
 	type config ClusterConfig
 	jc := (*config)(c)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -223,13 +223,20 @@ func TestNodeConfigWithAPIConfig(t *testing.T) {
 }
 
 func TestSingleNodeConfig(t *testing.T) {
+
+	yamlData := `
+spec:
+  api:
+    address: 1.2.3.4`
+
+	CfgFile = writeConfigFile(t, yamlData)
+
 	loadingRules := ClientConfigLoadingRules{
 		RuntimeConfigPath: nonExistentPath(t),
 		Nodeconfig:        true,
 	}
 	k0sVars := constant.GetConfig("")
 	k0sVars.DefaultStorageType = "kine"
-	CfgFile = ""
 
 	err := loadingRules.InitRuntimeConfig(k0sVars)
 	if err != nil {


### PR DESCRIPTION

Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1707 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings