### PR TITLE
Refactor StackApplier

### DIFF
--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -36,6 +36,9 @@ import (
 	"github.com/k0sproject/k0s/pkg/kubernetes"
 )
 
+// manifestFilePattern is the glob pattern that all applicable manifest files need to match.
+const manifestFilePattern = "*.yaml"
+
 // Applier manages all the "static" manifests and applies them on the k8s API
 type Applier struct {
 	Name string
@@ -110,7 +113,7 @@ func (a *Applier) Apply(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	files, err := filepath.Glob(path.Join(a.Dir, "*.yaml"))
+	files, err := filepath.Glob(path.Join(a.Dir, manifestFilePattern))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Part of #1814.

Changes to StackApplier:

* Combine Start/Stop methods into a simple Run method that exits when the given context is done. The start method blocked anyways, exiting when the Stop method was called. The context approach is somewhat more straight forward.
* Only consider fsnotify events for manifest files.
* Also log fsnotify watcher errors in the StackApplier.
* Synchronize access to the internal applier, as calls to it might happen concurrently.
* Remove the unused Healthy method.

Changes to the Manager:

* Always remove a stack from internal map, even if its deletion failed. The directory is gone anyways, and a readdition wouldn't work otherwise, because of the old, stopped stack still being in the map.
* Retry stack running on failure.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings