### PR TITLE
[release-1.23] Remove latest alias from docs

### DIFF
--- a/.github/workflows/publish-docs-manual.yml
+++ b/.github/workflows/publish-docs-manual.yml
@@ -11,35 +11,35 @@ env:
   NODE_VERSION: 12.x
   PYTHON_VERSION: 3.x
   TARGET_VERSION: ${{ github.event.inputs.version }}
-  
+
 jobs:
   build:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout k0s main
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          path: main
+          fetch-depth: 0
+
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies
+        working-directory: ./main
         run: |
           python -m pip install --upgrade pip
-          pip install mkdocs
+          pip install -r docs/requirements_release.txt
           pip install git+https://${{ secrets.GH_TOKEN }}@github.com/lensapp/mkdocs-material-insiders.git
-          pip install mike
 
       - name: Checkout k0s ${{ github.event.inputs.version }}
         uses: actions/checkout@v2
         with:
           ref: '${{ github.event.inputs.version }}'
-          fetch-depth: 0
-
-      - name: Checkout k0s main
-        uses: actions/checkout@v2
-        with:
-          ref: 'main'
-          path: 'main'
           fetch-depth: 0
 
       - name: Copy files from main to ${{ github.event.inputs.version }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -45,7 +45,7 @@ jobs:
           pip install mike
           go install github.com/k0sproject/version/cmd/k0s_sort@v0.2.2
 
-      - name: checkout k0s release
+      - name: Checkout k0s
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -70,12 +70,17 @@ jobs:
         run: |
           mike deploy --push head
 
-      # If this is a tag build, deploy as a new version
+      # If a release has been published, deploy it as a new version
       - name: mike deploy new version
-        if: contains(github.ref, 'refs/tags/v') && !github.event.release.prerelease
+        if: >-
+          github.event_name == 'release' &&
+          github.event.action == 'published' &&
+          !github.event.release.draft &&
+          !github.event.release.prerelease
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
         run: |
-          VERSION=${GITHUB_REF/refs\/tags\//}
-          mike deploy --push "${VERSION}"
+          mike deploy --push "$VERSION"
 
       - name: Update mike version aliases
         id: set_versions
@@ -86,7 +91,6 @@ jobs:
           LATEST=$(echo "${TAGS}" | tail -1)
           STABLE=$(echo "${TAGS}" | grep -v -- "-" | tail -1)
           mike alias -u head main
-          mike alias -u "${LATEST}" latest
           mike alias -u "${STABLE}" stable
           mike set-default --push stable
           echo ::set-output name=LATEST::${LATEST}


### PR DESCRIPTION
## Description

The latest alias was pointing to the latest release, including pre-releases. Pre-releases, on the other hand, won't get their docs published. This resulted in a situation in which the docs workflow was broken as long as the latest version was a pre-release.

Fix this by removing the latest alias from the workflow. Also sync the manual publish docs workflow with the automatic one.

See #1820.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings