### PR TITLE
[release-1.21] Fix kine build script not passed the required CFLAGS

### DIFF
--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -73,6 +73,7 @@ $(addprefix $(bindir)/, $(bins)): | $(bindir)
 		--build-arg BUILDIMAGE=$($(patsubst %/Dockerfile,%,$<)_buildimage) \
 		--build-arg BUILD_GO_TAGS=$($(patsubst %/Dockerfile,%,$<)_build_go_tags) \
 		--build-arg BUILD_GO_CGO_ENABLED=$($(patsubst %/Dockerfile,%,$<)_build_go_cgo_enabled) \
+		--build-arg BUILD_GO_CGO_CFLAGS=$($(patsubst %/Dockerfile,%,$<)_build_go_cgo_cflags) \
 		--build-arg BUILD_SHIM_GO_CGO_ENABLED=$($(patsubst %/Dockerfile,%,$<)_build_shim_go_cgo_enabled) \
 		--build-arg BUILD_GO_FLAGS=$($(patsubst %/Dockerfile,%,$<)_build_go_flags) \
 		--build-arg BUILD_GO_LDFLAGS=$($(patsubst %/Dockerfile,%,$<)_build_go_ldflags) \

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -5,6 +5,7 @@ runc_version = 1.0.3
 runc_buildimage = golang:$(go_version)-alpine
 runc_build_go_tags = "seccomp"
 #runc_build_go_cgo_enabled =
+#runc_build_go_cgo_cflags =
 #runc_build_go_flags =
 #runc_build_go_ldflags =
 runc_build_go_ldflags_extra = "-w -s -extldflags=-static"
@@ -14,6 +15,7 @@ containerd_buildimage = golang:$(go_version15)-alpine
 containerd_build_go_tags = "apparmor,selinux"
 containerd_build_shim_go_cgo_enabled = 0
 #containerd_build_go_cgo_enabled =
+#containerd_build_go_cgo_cflags =
 #containerd_build_go_flags =
 #containerd_build_go_ldflags =
 containerd_build_go_ldflags_extra = "-w -s -extldflags=-static"
@@ -22,6 +24,7 @@ kubernetes_version = 1.21.13
 kubernetes_buildimage = golang:$(go_version)-alpine
 kubernetes_build_go_tags = "providerless"
 #kubernetes_build_go_cgo_enabled =
+#kubernetes_build_go_cgo_cflags =
 kubernetes_build_go_flags = "-v"
 #kubernetes_build_go_ldflags =
 kubernetes_build_go_ldflags_extra = "-w -s -extldflags=-static"
@@ -30,6 +33,7 @@ kine_version = 0.6.5
 kine_buildimage = golang:$(go_version)-alpine
 #kine_build_go_tags =
 #kine_build_go_cgo_enabled =
+kine_build_go_cgo_cflags = "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" # Flags taken from https://github.com/k3s-io/kine/blob/v0.9.1/scripts/build#L16
 #kine_build_go_flags =
 kine_build_go_ldflags = "-w -s"
 kine_build_go_ldflags_extra = "-extldflags=-static"
@@ -38,6 +42,7 @@ etcd_version = 3.4.18
 etcd_buildimage = golang:$(go_version)-alpine
 #etcd_build_go_tags =
 etcd_build_go_cgo_enabled = 0
+#etcd_build_go_cgo_cflags =
 #etcd_build_go_flags =
 etcd_build_go_ldflags = "-w -s"
 #etcd_build_go_ldflags_extra =
@@ -46,6 +51,7 @@ konnectivity_buildimage = golang:$(go_version)-alpine
 konnectivity_version = 0.0.31-k0s
 #konnectivity_build_go_tags =
 konnectivity_build_go_cgo_enabled = 0
+#konnectivity_build_go_cgo_cflags =
 konnectivity_build_go_flags = "-a"
 konnectivity_build_go_ldflags = "-w -s"
 konnectivity_build_go_ldflags_extra = "-extldflags=-static"

--- a/embedded-bins/kine/Dockerfile
+++ b/embedded-bins/kine/Dockerfile
@@ -4,6 +4,7 @@ FROM $BUILDIMAGE AS build
 ARG VERSION
 ARG BUILD_GO_TAGS
 ARG BUILD_GO_CGO_ENABLED
+ARG BUILD_GO_CGO_CFLAGS
 ARG BUILD_GO_FLAGS
 ARG BUILD_GO_LDFLAGS
 ARG BUILD_GO_LDFLAGS_EXTRA
@@ -15,7 +16,7 @@ RUN cd / && git clone -b v$VERSION --depth=1 https://github.com/rancher/kine.git
 WORKDIR /kine
 RUN go version
 RUN CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
-    go build \
+    CGO_CFLAGS=${BUILD_GO_CGO_CFLAGS} go build \
         ${BUILD_GO_FLAGS} \
         -tags="${BUILD_GO_TAGS}" \
         -ldflags="${BUILD_GO_LDFLAGS} ${BUILD_GO_LDFLAGS_EXTRA}" \


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Kine [build script](https://github.com/k3s-io/kine/blob/dc877c3e2003aa6e01f1e35a09a6fb2578aa8a6e/scripts/build#L16) passes two flags when building the SQLite driver. `SQLITE_ENABLE_DBSTAT_VTAB=1` is [required](https://www.sqlite.org/compile.html#enable_dbstat_vtab) to enable `dbstat` on SQLite which [kine depends on](https://github.com/k3s-io/kine/blob/dc877c3e2003aa6e01f1e35a09a6fb2578aa8a6e/pkg/drivers/sqlite/sqlite.go#L66). 

See #1818.
See #1822.
See #1824.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings