### PR TITLE
[release-1.21] Fix formatting errors according to golangci-lint

### DIFF
--- a/pkg/backup/filesystem.go
+++ b/pkg/backup/filesystem.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package backup

--- a/pkg/backup/manager.go
+++ b/pkg/backup/manager.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/backup/sqlitedb.go
+++ b/pkg/backup/sqlitedb.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/backup/util.go
+++ b/pkg/backup/util.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*


### PR DESCRIPTION
## Description

For some strange reason, the golangci-lint binary downloaded from GitHub (which is used in the lint workflow) is claiming that some files are not gofmt-ed. This is not true for Go 1.16, but for Go 1.17+. No idea what causes this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings