### PR TITLE
Added 'forceupdate' to the autopilot schema

### DIFF
--- a/pkg/apis/autopilot.k0sproject.io/v1beta2/types.go
+++ b/pkg/apis/autopilot.k0sproject.io/v1beta2/types.go
@@ -142,6 +142,9 @@ type PlanCommandK0sUpdate struct {
 	// Version is the version that `K0sUpdate` will be upgrading to.
 	Version string `json:"version"`
 
+	// ForceUpdate ensures that version checking is ignored and that all updates are applied.
+	ForceUpdate bool `json:"forceupdate"`
+
 	// Platforms is a map of PlanResourceUrls to platform identifiers, allowing a single k0s version
 	// to have multiple URL resources based on platform.
 	Platforms PlanPlatformResourceURLMap `json:"platforms"`

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable.go
@@ -161,9 +161,10 @@ func signalNodeK0sUpdateCommandBuilder(node crcli.Object, cmd apv1beta2.PlanComm
 		return apsigv2.Command{
 			ID: &cmdStatus.ID,
 			K0sUpdate: &apsigv2.CommandK0sUpdate{
-				URL:     updateContent.URL,
-				Version: cmd.K0sUpdate.Version,
-				Sha256:  updateContent.Sha256,
+				URL:         updateContent.URL,
+				Version:     cmd.K0sUpdate.Version,
+				Sha256:      updateContent.Sha256,
+				ForceUpdate: cmd.K0sUpdate.ForceUpdate,
 			},
 		}
 	}, nil

--- a/pkg/autopilot/controller/signal/k0s/signal.go
+++ b/pkg/autopilot/controller/signal/k0s/signal.go
@@ -112,14 +112,10 @@ func (h *signalControllerHandler) Handle(ctx context.Context, sctx apsigcomm.Sig
 
 	sctx.Log.Infof("Current version of k0s = '%s', requested version = '%s'", k0sVersion, sctx.SignalData.Command.K0sUpdate.Version)
 
-	// Only move to 'Downloading' if the requested version doesn't match the current
-	// installed version. Move to 'Completed' otherwise as there is nothing to do.
-	var status string
-	switch k0sVersion {
-	case sctx.SignalData.Command.K0sUpdate.Version:
+	// Move to 'Completed' if we match versions on a non-forced update. Otherwise, proceed to 'Downloading'
+	var status = Downloading
+	if k0sVersion == sctx.SignalData.Command.K0sUpdate.Version && !sctx.SignalData.Command.K0sUpdate.ForceUpdate {
 		status = apsigcomm.Completed
-	default:
-		status = Downloading
 	}
 
 	// Populate the response into the annotations

--- a/pkg/autopilot/signaling/v2/signaling_v2.go
+++ b/pkg/autopilot/signaling/v2/signaling_v2.go
@@ -141,9 +141,10 @@ type Command struct {
 
 // CommandK0sUpdate describes what an update to `k0s` is.
 type CommandK0sUpdate struct {
-	URL     string `json:"url" validate:"required,url"`
-	Version string `json:"version" validate:"required"`
-	Sha256  string `json:"sha256,omitempty"`
+	URL         string `json:"url" validate:"required,url"`
+	Version     string `json:"version" validate:"required"`
+	Sha256      string `json:"sha256,omitempty"`
+	ForceUpdate bool   `json:"forceupdate,omitempty"`
 }
 
 // CommandAirgapUpdate describes what an update to `airgap` is.

--- a/static/manifests/autopilot/CustomResourceDefinition/autopilot.k0sproject.io_plans.yaml
+++ b/static/manifests/autopilot/CustomResourceDefinition/autopilot.k0sproject.io_plans.yaml
@@ -134,6 +134,10 @@ spec:
                       description: K0sUpdate is the `K0sUpdate` command which is responsible
                         for updating a k0s node (controller/worker)
                       properties:
+                        forceupdate:
+                          description: ForceUpdate ensures that version checking is
+                            ignored and that all updates are applied.
+                          type: boolean
                         platforms:
                           additionalProperties:
                             description: PlanResourceURL is a remote URL resource.
@@ -264,6 +268,7 @@ spec:
                             be upgrading to.
                           type: string
                       required:
+                      - forceupdate
                       - platforms
                       - targets
                       - version

--- a/static/manifests/autopilot/CustomResourceDefinition/autopilot.k0sproject.io_updateconfigs.yaml
+++ b/static/manifests/autopilot/CustomResourceDefinition/autopilot.k0sproject.io_updateconfigs.yaml
@@ -133,6 +133,10 @@ spec:
                           description: K0sUpdate is the `K0sUpdate` command which
                             is responsible for updating a k0s node (controller/worker)
                           properties:
+                            forceupdate:
+                              description: ForceUpdate ensures that version checking
+                                is ignored and that all updates are applied.
+                              type: boolean
                             platforms:
                               additionalProperties:
                                 description: PlanResourceURL is a remote URL resource.
@@ -268,6 +272,7 @@ spec:
                                 will be upgrading to.
                               type: string
                           required:
+                          - forceupdate
                           - platforms
                           - targets
                           - version


### PR DESCRIPTION
## Description

The main motivation for this option is for integration tests where in order to fully complete
an autopilot integration test (of the same k0s binary), we need to be able to 'ignore' the
detected 'k0s' versions.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings