### PR TITLE
In inttests, use `/usr/local/bin/k0s` instead of `/usr/bin/k0s`

### DIFF
--- a/inttest/backup/backup_test.go
+++ b/inttest/backup/backup_test.go
@@ -170,7 +170,7 @@ func (s *BackupSuite) takeBackup() error {
 	}
 	defer ssh.Disconnect()
 
-	out, err := ssh.ExecWithOutput("k0s backup --save-path /root/")
+	out, err := ssh.ExecWithOutput("/usr/local/bin/k0s backup --save-path /root/")
 	if err != nil {
 		s.T().Errorf("backup failed with output:\n%s", out)
 		return err
@@ -186,7 +186,7 @@ func (s *BackupSuite) takeBackupStdout() error {
 	}
 	defer ssh.Disconnect()
 
-	out, err := ssh.ExecWithOutput("k0s backup --save-path - > backup.tar.gz")
+	out, err := ssh.ExecWithOutput("/usr/local/bin/k0s backup --save-path - > backup.tar.gz")
 	if err != nil {
 		s.T().Errorf("backup failed with output:\n%s", out)
 		return err
@@ -211,7 +211,7 @@ func (s *BackupSuite) restoreBackup() error {
 
 	s.T().Log("restoring controller from file")
 
-	out, err := ssh.ExecWithOutput("k0s restore $(ls /root/k0s_backup_*.tar.gz)")
+	out, err := ssh.ExecWithOutput("/usr/local/bin/k0s restore $(ls /root/k0s_backup_*.tar.gz)")
 	if err != nil {
 		s.T().Errorf("restore failed with output:\n%s", out)
 		return err
@@ -230,7 +230,7 @@ func (s *BackupSuite) restoreBackupStdin() error {
 
 	s.T().Log("restoring controller from stdin")
 
-	out, err := ssh.ExecWithOutput("cat backup.tar.gz | k0s restore -")
+	out, err := ssh.ExecWithOutput("cat backup.tar.gz | /usr/local/bin/k0s restore -")
 	if err != nil {
 		s.T().Errorf("restore failed with output:\n%s", out)
 		return err

--- a/inttest/byocri/byocri_test.go
+++ b/inttest/byocri/byocri_test.go
@@ -80,7 +80,7 @@ func (s *BYOCRISuite) runDockerWorker() error {
 		return err
 	}
 
-	workerCommand := fmt.Sprintf(`nohup k0s --debug worker --cri-socket remote:unix:///var/run/cri-dockerd.sock "%s" >/tmp/k0s-worker.log 2>&1 &`, token)
+	workerCommand := fmt.Sprintf(`nohup /usr/local/bin/k0s --debug worker --cri-socket remote:unix:///var/run/cri-dockerd.sock "%s" >/tmp/k0s-worker.log 2>&1 &`, token)
 	_, err = sshWorker.ExecWithOutput(workerCommand)
 	if err != nil {
 		return err

--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -38,19 +38,19 @@ func (s *CliSuite) TestK0sCliCommandNegative() {
 	defer ssh.Disconnect()
 
 	// k0s controller command should fail if non existent path to config is passed
-	_, err = ssh.ExecWithOutput("k0s controller --config /some/fake/path")
+	_, err = ssh.ExecWithOutput("/usr/local/bin/k0s controller --config /some/fake/path")
 	s.Require().Error(err)
 
 	// k0s install command should fail if non existent path to config is passed
-	_, err = ssh.ExecWithOutput("k0s install controller --config /some/fake/path")
+	_, err = ssh.ExecWithOutput("/usr/local/bin/k0s install controller --config /some/fake/path")
 	s.Require().Error(err)
 
 	// k0s start should fail if service is not installed
-	_, err = ssh.ExecWithOutput("k0s start")
+	_, err = ssh.ExecWithOutput("/usr/local/bin/k0s start")
 	s.Require().Error(err)
 
 	// k0s stop should fail if service is not installed
-	_, err = ssh.ExecWithOutput("k0s stop")
+	_, err = ssh.ExecWithOutput("/usr/local/bin/k0s stop")
 	s.Require().Error(err)
 }
 
@@ -73,7 +73,7 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 
 	s.T().Run("k0sInstall", func(t *testing.T) {
 		// Install with some arbitrary kubelet flags so we see those get properly passed to the kubelet
-		out, err := ssh.ExecWithOutput("k0s install controller --enable-worker --disable-components konnectivity-server,metrics-server --kubelet-extra-args='--event-qps=7 --enable-load-reader=true'")
+		out, err := ssh.ExecWithOutput("/usr/local/bin/k0s install controller --enable-worker --disable-components konnectivity-server,metrics-server --kubelet-extra-args='--event-qps=7 --enable-load-reader=true'")
 		assert.NoError(t, err)
 		assert.Equal(t, "", out)
 	})
@@ -82,12 +82,12 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 		assert := assert.New(t)
 		require := require.New(t)
 
-		_, err = ssh.ExecWithOutput("k0s start")
+		_, err = ssh.ExecWithOutput("/usr/local/bin/k0s start")
 		require.NoError(err)
 
 		require.NoError(s.WaitForKubeAPI(s.ControllerNode(0)))
 
-		output, err := ssh.ExecWithOutput("k0s kubectl get namespaces -o json 2>/dev/null")
+		output, err := ssh.ExecWithOutput("/usr/local/bin/k0s kubectl get namespaces -o json 2>/dev/null")
 		require.NoError(err)
 
 		namespaces := &K8sNamespaces{}
@@ -128,14 +128,14 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 	})
 
 	s.T().Log("waiting for k0s to terminate")
-	_, err = ssh.ExecWithOutput("k0s stop")
+	_, err = ssh.ExecWithOutput("/usr/local/bin/k0s stop")
 	s.NoError(err)
 	_, err = ssh.ExecWithOutput("while pidof k0s containerd kubelet; do sleep 0.1s; done")
 	s.Require().NoError(err)
 
 	s.T().Run("k0sReset", func(t *testing.T) {
 		assert := assert.New(t)
-		resetOutput, err := ssh.ExecWithOutput("k0s reset --debug")
+		resetOutput, err := ssh.ExecWithOutput("/usr/local/bin/k0s reset --debug")
 		s.T().Logf("Reset executed with output:\n%s", resetOutput)
 
 		// k0s reset will always exit with an error on footloose, since it's unable to remove /var/lib/k0s

--- a/inttest/cnichange/cnichange_test.go
+++ b/inttest/cnichange/cnichange_test.go
@@ -41,7 +41,7 @@ func (s *CNIChangeSuite) TestK0sGetsUpButRejectsToChangeCNI() {
 
 	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfig)
 	s.T().Log("restarting k0s with new cni, this should fail")
-	_, err = sshC1.ExecWithOutput("k0s controller --debug --config /tmp/k0s.yaml")
+	_, err = sshC1.ExecWithOutput("/usr/local/bin/k0s controller --debug --config /tmp/k0s.yaml")
 	s.Require().Error(err)
 }
 

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -59,7 +59,7 @@ const (
 	lbNodeNameFormat         = "lb%d"
 	etcdNodeNameFormat       = "etcd%d"
 
-	defaultK0sBinaryFullPath = "/usr/bin/k0s"
+	defaultK0sBinaryFullPath = "/usr/local/bin/k0s"
 	k0sBindMountFullPath     = "/dist/k0s"
 )
 

--- a/inttest/ctr/ctr_test.go
+++ b/inttest/ctr/ctr_test.go
@@ -34,10 +34,10 @@ func (s *CtrSuite) TestK0sCtrCommand() {
 	s.Require().NoError(err)
 	defer ssh.Disconnect()
 
-	_, err = ssh.ExecWithOutput("k0s install controller --enable-worker")
+	_, err = ssh.ExecWithOutput("/usr/local/bin/k0s install controller --enable-worker")
 	s.Require().NoError(err)
 
-	_, err = ssh.ExecWithOutput("k0s start")
+	_, err = ssh.ExecWithOutput("/usr/local/bin/k0s start")
 	s.Require().NoError(err)
 
 	err = s.WaitForKubeAPI(s.ControllerNode(0))
@@ -49,7 +49,7 @@ func (s *CtrSuite) TestK0sCtrCommand() {
 	err = s.WaitForNodeReady(s.ControllerNode(0), kc)
 	s.NoError(err)
 
-	output, err := ssh.ExecWithOutput("k0s ctr namespaces list 2>/dev/null")
+	output, err := ssh.ExecWithOutput("/usr/local/bin/k0s ctr namespaces list 2>/dev/null")
 	s.Require().NoError(err)
 
 	flatOutput := removeRedundantSpaces(output)

--- a/inttest/customdomain/customdomain_test.go
+++ b/inttest/customdomain/customdomain_test.go
@@ -62,10 +62,10 @@ func (s *CustomDomainSuite) TestK0sGetsUpWithCustomDomain() {
 		// e.g. execing via client-go is super complex and would require too much wiring
 		ssh, err := s.SSH(s.ControllerNode(0))
 		s.NoError(err)
-		_, err = ssh.ExecWithOutput("k0s kc run nginx --image docker.io/nginx:1-alpine")
+		_, err = ssh.ExecWithOutput("/usr/local/bin/k0s kc run nginx --image docker.io/nginx:1-alpine")
 		s.NoError(err)
 		s.NoError(common.WaitForPod(kc, "nginx", "default"))
-		output, err := ssh.ExecWithOutput("k0s kc exec nginx -- cat /etc/resolv.conf")
+		output, err := ssh.ExecWithOutput("/usr/local/bin/k0s kc exec nginx -- cat /etc/resolv.conf")
 		s.NoError(err)
 		s.Contains(output, "search default.svc.something.local svc.something.local something.local")
 	})

--- a/inttest/customports/customports_test.go
+++ b/inttest/customports/customports_test.go
@@ -143,7 +143,7 @@ func (ds *Suite) TestControllerJoinsWithCustomPort() {
 		ds.Require().NoError(err)
 		defer ssh.Disconnect()
 
-		out, err := ssh.ExecWithOutput("k0s kubeconfig create user | awk '$1 == \"server:\" {print $2}'")
+		out, err := ssh.ExecWithOutput("/usr/local/bin/k0s kubeconfig create user | awk '$1 == \"server:\" {print $2}'")
 		ds.Require().NoError(err)
 		ds.Require().Equal(fmt.Sprintf("https://%s:%d", ipAddress, kubeAPIPort), out)
 	})

--- a/inttest/externaletcd/external_etcd_test.go
+++ b/inttest/externaletcd/external_etcd_test.go
@@ -96,15 +96,15 @@ func (s *ExternalEtcdSuite) TestK0sWithExternalEtcdCluster() {
 	s.Require().NoError(err)
 	s.Require().Contains(output, "/k0s-tenant/services/specs/kube-system/kube-dns")
 
-	etcdLeaveOutput, err := k0sControllerSSH.ExecWithOutput("k0s etcd leave")
+	etcdLeaveOutput, err := k0sControllerSSH.ExecWithOutput("/usr/local/bin/k0s etcd leave")
 	s.Require().Error(err)
 	s.Require().Contains(etcdLeaveOutput, "command 'k0s etcd' does not support external etcd cluster")
 
-	etcdListOutput, err := k0sControllerSSH.ExecWithOutput("k0s etcd member-list")
+	etcdListOutput, err := k0sControllerSSH.ExecWithOutput("/usr/local/bin/k0s etcd member-list")
 	s.Require().Error(err)
 	s.Require().Contains(etcdListOutput, "command 'k0s etcd' does not support external etcd cluster")
 
-	backupOutput, err := k0sControllerSSH.ExecWithOutput("k0s backup")
+	backupOutput, err := k0sControllerSSH.ExecWithOutput("/usr/local/bin/k0s backup")
 	s.Require().Error(err)
 	s.Require().Contains(backupOutput, "command 'k0s backup' does not support external etcd cluster")
 }

--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -14,8 +14,7 @@ RUN rc-update add syslog boot
 RUN rc-update add machine-id boot
 RUN rc-update add sshd default
 RUN rc-update add local default
-RUN rc-update add nginx default
-# Ensures that /usr/bin/k0s is seeded from /dist at startup
+# Ensures that /usr/local/bin/k0s is seeded from /dist at startup
 RUN rc-update add k0s-seed default
 
 # remove -docker keyword so we actually mount cgroups in container

--- a/inttest/footloose-alpine/root/etc/init.d/k0s-seed
+++ b/inttest/footloose-alpine/root/etc/init.d/k0s-seed
@@ -1,14 +1,14 @@
 #!/sbin/openrc-run
 
-description="Copy seeded k0s to /usr/bin"
+description="Copy seeded k0s to /usr/local/bin"
 
 depend() {
 	need root localmount
 }
 
 start() {
-	ebegin "Seeding k0s binary to /usr/bin"
-	/usr/bin/install -D -t /usr/bin /dist/k0s
+	ebegin "Seeding k0s binary to /usr/local/bin"
+	/usr/bin/install -D -t /usr/local/bin /dist/k0s
 
 	eend $?
 }

--- a/inttest/hacontrolplane/hacontrolplane_test.go
+++ b/inttest/hacontrolplane/hacontrolplane_test.go
@@ -37,7 +37,7 @@ func (s *HAControlplaneSuite) getMembers(fromControllerIdx int) map[string]strin
 	sshCon, err := s.SSH(s.ControllerNode(fromControllerIdx))
 	s.NoError(err)
 	defer sshCon.Disconnect()
-	output, err := sshCon.ExecWithOutput("k0s etcd member-list 2>/dev/null")
+	output, err := sshCon.ExecWithOutput("/usr/local/bin/k0s etcd member-list 2>/dev/null")
 	s.T().Logf("k0s etcd member-list output: %s", output)
 	s.NoError(err)
 
@@ -54,7 +54,7 @@ func (s *HAControlplaneSuite) makeNodeLeave(executeOnControllerIdx int, peerAddr
 	s.NoError(err)
 	defer sshCon.Disconnect()
 	for i := 0; i < 20; i++ {
-		_, err := sshCon.ExecWithOutput(fmt.Sprintf("k0s etcd leave --peer-address %s", peerAddress))
+		_, err := sshCon.ExecWithOutput(fmt.Sprintf("/usr/local/bin/k0s etcd leave --peer-address %s", peerAddress))
 		if err == nil {
 			break
 		}
@@ -68,7 +68,7 @@ func (s *HAControlplaneSuite) TestDeregistration() {
 	// Verify that k0s return failure (https://github.com/k0sproject/k0s/issues/790)
 	sshC0, err := s.SSH(s.ControllerNode(0))
 	s.Require().NoError(err)
-	_, err = sshC0.ExecWithOutput("k0s etcd member-list")
+	_, err = sshC0.ExecWithOutput("/usr/local/bin/k0s etcd member-list")
 	s.Require().Error(err)
 
 	s.NoError(s.InitController(0))

--- a/inttest/kubectl/kubectl_test.go
+++ b/inttest/kubectl/kubectl_test.go
@@ -42,7 +42,7 @@ func (s *KubectlSuite) TestEmbeddedKubectl() {
 
 	_, err = ssh.ExecWithOutput("chmod +x /bin/kubectl-foo")
 	s.Require().NoError(err)
-	_, err = ssh.ExecWithOutput("ln -s /usr/bin/k0s /usr/bin/kubectl")
+	_, err = ssh.ExecWithOutput("ln -s /usr/local/bin/k0s /usr/bin/kubectl")
 	s.Require().NoError(err)
 
 	s.T().Log("Check that different ways to call kubectl subcommand work")
@@ -54,7 +54,7 @@ func (s *KubectlSuite) TestEmbeddedKubectl() {
 	}{
 		{
 			Name:    "full subcommand name",
-			Command: "k0s kubectl version",
+			Command: "/usr/local/bin/k0s kubectl version",
 			Check: func(output string, e error) {
 				s.Require().NoError(e)
 				s.Require().Contains(output, "Client Version: version.Info")
@@ -62,7 +62,7 @@ func (s *KubectlSuite) TestEmbeddedKubectl() {
 		},
 		{
 			Name:    "short subcommand name",
-			Command: "k0s kc version",
+			Command: "/usr/local/bin/k0s kc version",
 			Check: func(output string, e error) {
 				s.Require().NoError(e)
 				s.Require().Contains(output, "Client Version: version.Info")
@@ -70,7 +70,7 @@ func (s *KubectlSuite) TestEmbeddedKubectl() {
 		},
 		{
 			Name:    "full command arguments",
-			Command: "k0s kubectl version -v 8",
+			Command: "/usr/local/bin/k0s kubectl version -v 8",
 			Check: func(output string, e error) {
 				s.Require().NoError(e)
 				// Check for debug log messages
@@ -79,7 +79,7 @@ func (s *KubectlSuite) TestEmbeddedKubectl() {
 		},
 		{
 			Name:    "short command arguments",
-			Command: "k0s kc version -v 8",
+			Command: "/usr/local/bin/k0s kc version -v 8",
 			Check: func(output string, e error) {
 				s.Require().NoError(e)
 				// Check for debug log messages
@@ -88,7 +88,7 @@ func (s *KubectlSuite) TestEmbeddedKubectl() {
 		},
 		{
 			Name:    "full command plugin loader",
-			Command: "k0s kubectl foo",
+			Command: "/usr/local/bin/k0s kubectl foo",
 			Check: func(output string, e error) {
 				s.Require().NoError(e)
 				s.Require().Equal("foo-plugin", output, "Unexpected output: %v", output)
@@ -96,7 +96,7 @@ func (s *KubectlSuite) TestEmbeddedKubectl() {
 		},
 		{
 			Name:    "short command plugin loader",
-			Command: "k0s kc foo",
+			Command: "/usr/local/bin/k0s kc foo",
 			Check: func(output string, e error) {
 				s.Require().NoError(e)
 				s.Require().Equal("foo-plugin", output, "Unexpected output: %v", output)
@@ -122,7 +122,7 @@ func (s *KubectlSuite) TestEmbeddedKubectl() {
 		},
 		{
 			Name:    "symlink plugin loader",
-			Command: "k0s kubectl foo",
+			Command: "/usr/local/bin/k0s kubectl foo",
 			Check: func(output string, e error) {
 				s.Require().NoError(e)
 				s.Require().Equal("foo-plugin", output, "Unexpected output: %v", output)

--- a/inttest/upgrade/upgrade_test.go
+++ b/inttest/upgrade/upgrade_test.go
@@ -138,7 +138,7 @@ func (s *UpgradeSuite) TestK0sGetsUp() {
 				return err
 			}
 			defer ssh.Disconnect()
-			_, err = ssh.ExecWithOutput("rm /usr/local/bin/k0s && cp /usr/bin/k0s /usr/local/bin/k0s")
+			_, err = ssh.ExecWithOutput("cp -f /dist/k0s /usr/local/bin/k0s")
 			if err != nil {
 				return err
 			}
@@ -157,7 +157,7 @@ func (s *UpgradeSuite) TestK0sGetsUp() {
 				return err
 			}
 			defer ssh.Disconnect()
-			_, err = ssh.ExecWithOutput("rm /usr/local/bin/k0s && cp /usr/bin/k0s /usr/local/bin/k0s")
+			_, err = ssh.ExecWithOutput("cp -f /dist/k0s /usr/local/bin/k0s")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description

Admin/operator-provided content should typically live under `/usr/local`. This also
helps with the integration of autopilot integration tests which use `/usr/local/bin/k0s`
exclusively.

This also aligns with the default install path used by k0sctl, as well as the 'get' script.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings