### PR TITLE
Updated the `ha3x3` integration test to work with ap-embedded `k0s`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -135,6 +135,7 @@ jobs:
       fail-fast: false
       matrix:
         smoke-suite:
+          - check-ap-ha3x3
           - check-basic
           - check-addons
           - check-byocri

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -1,5 +1,6 @@
 smoketests := \
 	check-addons \
+	check-ap-ha3x3 \
 	check-airgap \
 	check-backup \
 	check-basic \

--- a/inttest/common/defaults.go
+++ b/inttest/common/defaults.go
@@ -1,0 +1,72 @@
+// Copyright 2022 k0s authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"runtime"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	TargetK0sVersion = "v1.23.3+k0s.1"
+)
+
+type K0sVersion string
+type K0sVersionedPlatformResourceMap map[K0sVersion]PlatformedResourceMap
+type PlatformedResourceMap map[string]ResourceMap
+type ResourceMap map[string]AttributeMap
+type AttributeMap map[string]string
+
+var Versions = K0sVersionedPlatformResourceMap{
+	"v1.23.3+k0s.1": {
+		"linux-amd64": {
+			"k0s": {
+				"url":    "https://github.com/k0sproject/k0s/releases/download/v1.23.3%2Bk0s.1/k0s-v1.23.3+k0s.1-amd64",
+				"sha256": "0cd1f7c49ef81e18d3873a77ccabb5e4095db1c3647ca3fa8fc3eb16566e204e",
+			},
+			"airgap": {
+				"url":    "https://github.com/k0sproject/k0s/releases/download/v1.23.3%2Bk0s.1/k0s-airgap-bundle-v1.23.3+k0s.1-amd64",
+				"sha256": "258f3edd0c260a23c579406f5cc04a599a6f59cc1707f9bd523d7a9abc07f0e2",
+			},
+		},
+		"linux-arm64": {
+			"k0s": {
+				"url":    "https://github.com/k0sproject/k0s/releases/download/v1.23.3%2Bk0s.1/k0s-v1.23.3+k0s.1-arm64",
+				"sha256": "350adde6c452abd56a3c8113bf5af254fc17bcc41946e32ae47b580626a9293c",
+			},
+			"airgap": {
+				"url":    "https://github.com/k0sproject/k0s/releases/download/v1.23.3%2Bk0s.1/k0s-airgap-bundle-v1.23.3+k0s.1-arm64",
+				"sha256": "2fe4976a90193e2ec89d3cff4ebf6bd063b38cf23116071689415fd19f251f29",
+			},
+		},
+		"windows-amd64": {
+			"k0s": {
+				"url":    "https://github.com/k0sproject/k0s/releases/download/v1.23.3%2Bk0s.1/k0s-v1.23.3+k0s.1-amd64.exe",
+				"sha256": "f9e064f70c997e55dacbd3b36ca04029bb7995e84be8084d8bbd2cd75601fe30",
+			},
+			// no airgap bundles published for windows
+		},
+	},
+}
+
+// DefaultNodeLabels creates a default map of labels expected to be seen
+// on every signal node.
+func DefaultNodeLabels() map[string]string {
+	return map[string]string{
+		v1.LabelOSStable:   runtime.GOOS,
+		v1.LabelArchStable: runtime.GOARCH,
+	}
+}

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"math"
 	"net/http"
@@ -35,6 +36,9 @@ import (
 	"testing"
 	"text/template"
 	"time"
+
+	apclient "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset"
+	extclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 
 	"github.com/go-openapi/jsonpointer"
 	"github.com/pkg/errors"
@@ -97,6 +101,9 @@ type FootlooseSuite struct {
 	clusterDir    string
 	clusterConfig config.Config
 	cluster       *cluster.Cluster
+
+	ControllerNetworks []string
+	WorkerNetworks     []string
 }
 
 // initializeDefaults initializes any unset configuration knobs to their defaults.
@@ -323,7 +330,7 @@ func (s *FootlooseSuite) startHAProxy() {
 
 	s.Require().NoError(err)
 	_, err = ssh.ExecWithOutput("haproxy -c -f /tmp/haproxy.cfg")
-	s.Require().NoError(err, "LB configuration is broken")
+	s.Require().NoError(err, "LB configuration is broken", err)
 	_, err = ssh.ExecWithOutput("haproxy -f /tmp/haproxy.cfg &")
 	s.Require().NoError(err, "Can't start LB")
 }
@@ -416,7 +423,13 @@ func (s *FootlooseSuite) getControllersIPAddresses() []string {
 	s.Require().NoError(err)
 
 	for i := 0; i < s.ControllerCount; i++ {
-		addresses[i] = machines[i].Status().IP
+		// If a network is supplied, the address will need to be obtained from there.
+		// Note that this currently uses the first network found.
+		if machines[i].Status().IP != "" {
+			addresses[i] = machines[i].Status().IP
+		} else if len(machines[i].Status().RuntimeNetworks) > 0 {
+			addresses[i] = machines[i].Status().RuntimeNetworks[0].IP
+		}
 	}
 	return addresses
 }
@@ -794,6 +807,25 @@ func (s *FootlooseSuite) KubeClient(node string, k0sKubeconfigArgs ...string) (*
 	return kubernetes.NewForConfig(cfg)
 }
 
+// AutopilotClient returns a client for accessing the autopilot schema
+func (s *FootlooseSuite) AutopilotClient(node string, k0sKubeconfigArgs ...string) (apclient.Interface, error) {
+	cfg, err := s.GetKubeConfig(node, k0sKubeconfigArgs...)
+	if err != nil {
+		return nil, err
+	}
+	return apclient.NewForConfig(cfg)
+}
+
+// ExtensionsClient returns a client for accessing the extensions schema
+func (s *FootlooseSuite) ExtensionsClient(node string, k0sKubeconfigArgs ...string) (*extclient.ApiextensionsV1Client, error) {
+	cfg, err := s.GetKubeConfig(node, k0sKubeconfigArgs...)
+	if err != nil {
+		return nil, err
+	}
+
+	return extclient.NewForConfig(cfg)
+}
+
 // WaitForNodeReady wait that we see the given node in "Ready" state in kubernetes API
 func (s *FootlooseSuite) WaitForNodeReady(node string, kc *kubernetes.Clientset) error {
 	s.T().Logf("waiting to see %s ready in kube API", node)
@@ -1071,6 +1103,7 @@ func (s *FootlooseSuite) initializeFootlooseClusterInDir(dir string) error {
 					Privileged:   true,
 					Volumes:      volumes,
 					PortMappings: portMaps,
+					Networks:     s.ControllerNetworks,
 				},
 			},
 			{
@@ -1081,6 +1114,7 @@ func (s *FootlooseSuite) initializeFootlooseClusterInDir(dir string) error {
 					Privileged:   true,
 					Volumes:      volumes,
 					PortMappings: portMaps,
+					Networks:     s.WorkerNetworks,
 				},
 			},
 		},
@@ -1095,6 +1129,7 @@ func (s *FootlooseSuite) initializeFootlooseClusterInDir(dir string) error {
 				Volumes:      volumes,
 				PortMappings: portMaps,
 				Ignite:       nil,
+				Networks:     s.ControllerNetworks,
 			},
 			Count: 1,
 		})
@@ -1227,4 +1262,90 @@ func (s *FootlooseSuite) OpenRCLaunchDelegate() *LaunchDelegate {
 			return s.initWorkerOpenRC(conn, token, k0sArgs...)
 		},
 	}
+}
+
+// CreateNetwork creates a docker network with the provided name, destroying
+// any network that has the same name first.
+func (s *FootlooseSuite) CreateNetwork(name string) error {
+	_ = s.DestroyNetwork(name)
+
+	cmd := exec.Command("/usr/bin/docker", "network", "create", name)
+	return cmd.Run()
+}
+
+// DestroyNetwork removes a docker network with the provided name.
+func (s *FootlooseSuite) DestroyNetwork(name string) error {
+	cmd := exec.Command("/usr/bin/docker", "network", "rm", name)
+	return cmd.Run()
+}
+
+// RunCommandController runs a command via SSH on a specified controller node
+func (s *FootlooseSuite) RunCommandController(idx int, command string) (string, error) {
+	ssh, err := s.SSH(s.ControllerNode(idx))
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	return ssh.ExecWithOutput(command)
+}
+
+// GetK0sVersion returns the `k0s version` output from a specific node.
+func (s *FootlooseSuite) GetK0sVersion(node string) (string, error) {
+	ssh, err := s.SSH(node)
+	if err != nil {
+		return "", err
+	}
+	defer ssh.Disconnect()
+
+	version, err := ssh.ExecWithOutput("/usr/local/bin/k0s version")
+	if err != nil {
+		return "", err
+	}
+
+	return version, nil
+}
+
+// GetMembers returns all of the known etcd members for a given node
+func (s *FootlooseSuite) GetMembers(idx int) map[string]string {
+	// our etcd instances doesn't listen on public IP, so test is performed by calling CLI tools over ssh
+	// which in general even makes sense, we can test tooling as well
+	sshCon, err := s.SSH(s.ControllerNode(idx))
+	s.NoError(err)
+	defer sshCon.Disconnect()
+	output, err := sshCon.ExecWithOutput("/usr/local/bin/k0s etcd member-list")
+	output = lastLine(output)
+	s.NoError(err)
+
+	members := struct {
+		Members map[string]string `json:"members"`
+	}{}
+
+	err = json.Unmarshal([]byte(output), &members)
+	s.NoError(err, err)
+
+	return members.Members
+}
+
+func lastLine(text string) string {
+	if text == "" {
+		return ""
+	}
+	parts := strings.Split(text, "\n")
+	return parts[len(parts)-1]
+}
+
+// WaitForSSH ensures that an SSH connection can be successfully obtained, and retries
+// for up to a specific timeout/delay.
+func (s *FootlooseSuite) WaitForSSH(node string, timeout time.Duration, delay time.Duration) error {
+	s.T().Logf("Waiting for SSH connection to '%s'", node)
+	for start := time.Now(); time.Since(start) < timeout; {
+		if conn, err := s.SSH(node); err == nil {
+			conn.Disconnect()
+			return nil
+		}
+
+		s.T().Logf("Unable to SSH to '%s', waiting %v for retry", node, delay)
+		time.Sleep(delay)
+	}
+
+	return fmt.Errorf("timed out waiting for ssh connection to '%s'", node)
 }

--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -14,6 +14,7 @@ RUN rc-update add syslog boot
 RUN rc-update add machine-id boot
 RUN rc-update add sshd default
 RUN rc-update add local default
+RUN rc-update add nginx default
 # Ensures that /usr/local/bin/k0s is seeded from /dist at startup
 RUN rc-update add k0s-seed default
 

--- a/pkg/autopilot/controller/signal/k0s/init.go
+++ b/pkg/autopilot/controller/signal/k0s/init.go
@@ -70,6 +70,10 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 		return fmt.Errorf("unable to register k0s 'restart' controller: %w", err)
 	}
 
+	if err := registerRestarted(logger, mgr, restartedEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s restarted")), delegate); err != nil {
+		return fmt.Errorf("unable to register k0s 'restarted' controller: %w", err)
+	}
+
 	if err := registerUnCordoning(logger, mgr, unCordoningEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s uncordoning")), delegate); err != nil {
 		return fmt.Errorf("unable to register k0s 'uncordon' controller: %w", err)
 	}

--- a/pkg/autopilot/controller/signal/k0s/restarted_windows.go
+++ b/pkg/autopilot/controller/signal/k0s/restarted_windows.go
@@ -1,0 +1,38 @@
+// Copyright 2022 k0s authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k0s
+
+import (
+	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
+	apsigpred "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common/predicate"
+
+	"github.com/sirupsen/logrus"
+	crman "sigs.k8s.io/controller-runtime/pkg/manager"
+	crpred "sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// restartedEventFilter creates a controller-runtime predicate that governs which
+// objects will make it into reconciliation, and which will be ignored.
+func restartedEventFilter(hostname string, handler apsigpred.ErrorHandler) crpred.Predicate {
+	return nil
+}
+
+// registerRestarted registers the 'restart' controller to the controller-runtime manager.
+//
+// This controller is only interested in changes to signal nodes where its signaling
+// status is marked as `Restart`
+func registerRestarted(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate) error {
+	return nil
+}


### PR DESCRIPTION
## Description

This updates the `ha3x3` integration test to use the new `forceupdate` feature
to force an update of the same `k0s` binary in test. The launch mode for this
integration test is using `openrc` which allows for the binary to be replaced.

To handle the difference in behaviour between ap-emebedded in `k0s` vs standalone,
the `restart` reconciler needed to be split into two pieces. This was necessary
as when ap was running standalone, all controller-runtime events appear as updates
(unless the process dies). When running embedded in `k0s`, our only indication that
the `k0s` binary has restarted is the 'created' event which is used when data is
loaded/cached (ie. on startup)

The previous `ha3x3` test would end by comparing the installed versions of `k0s`,
asserting them to whatever version is mandated in the integration test plan. Since
the same binary is used for testing (same version numbers), this has been expanded
to just assert that all state/status are completed across `controllers` and `workers`.

With this change in place, the remaining ap-integration tests can be ported over.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings