### PR TITLE
Move component.Healthy() into its own interface

### DIFF
--- a/pkg/applier/manager.go
+++ b/pkg/applier/manager.go
@@ -198,6 +198,3 @@ func (m *Manager) removeStack(ctx context.Context, name string) {
 
 	log.Info("Stack deleted successfully")
 }
-
-// Health-check interface
-func (m *Manager) Healthy() error { return nil }

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -44,16 +44,19 @@ type Component interface {
 	// Stop when cancelled. It's merely used to cancel the component's startup.
 	Run(context.Context) error
 
-	// Healthy performs a health check and indicates that the component is
-	// running and functional. Whenever this is not the case, a non-nil error is
-	// returned.
-	Healthy() error
-
 	// Stop stops this component, potentially cleaning up any temporary
 	// resources attached to it. Stop itself may be called in any lifecycle
 	// phase. All other lifecycle methods have to return an error after Stop
 	// returns. Stop may be called more than once.
 	Stop() error
+}
+
+// Healthz represents a component that can be checked for its health.
+type Healthz interface {
+	// Healthy performs a health check and indicates that the component is
+	// running and functional. Whenever this is not the case, a non-nil error is
+	// returned.
+	Healthy() error
 }
 
 // ReconcilerComponent defines the component interface that is reconciled based

--- a/pkg/component/controller/apiendpointreconciler.go
+++ b/pkg/component/controller/apiendpointreconciler.go
@@ -97,9 +97,6 @@ func (a *APIEndpointReconciler) Reconcile(ctx context.Context, cfg *v1beta1.Clus
 	return a.reconcileEndpoints(ctx)
 }
 
-// Healthy dummy implementation
-func (a *APIEndpointReconciler) Healthy() error { return nil }
-
 func (a *APIEndpointReconciler) reconcileEndpoints(ctx context.Context) error {
 	if a.clusterConfig == nil {
 		return nil

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -51,6 +51,7 @@ type APIServer struct {
 }
 
 var _ component.Component = (*APIServer)(nil)
+var _ component.Healthz = (*APIServer)(nil)
 
 var apiDefaultArgs = map[string]string{
 	"allow-privileged":                   "true",

--- a/pkg/component/controller/calico.go
+++ b/pkg/component/controller/calico.go
@@ -238,6 +238,3 @@ func (c *Calico) Reconcile(_ context.Context, cfg *v1beta1.ClusterConfig) error 
 	}
 	return nil
 }
-
-// Health-check interface
-func (c *Calico) Healthy() error { return nil }

--- a/pkg/component/controller/clusterConfig.go
+++ b/pkg/component/controller/clusterConfig.go
@@ -172,10 +172,6 @@ func (r *ClusterConfigReconciler) Stop() error {
 	return nil
 }
 
-func (r *ClusterConfigReconciler) Healthy() error {
-	return nil
-}
-
 func (r *ClusterConfigReconciler) reportStatus(ctx context.Context, config *v1beta1.ClusterConfig, reconcileError error) {
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -158,6 +158,3 @@ func (a *Manager) Stop() error {
 	}
 	return nil
 }
-
-// Health-check interface
-func (a *Manager) Healthy() error { return nil }

--- a/pkg/component/controller/controllersleasecounter.go
+++ b/pkg/component/controller/controllersleasecounter.go
@@ -101,6 +101,3 @@ func (l *K0sControllersLeaseCounter) Stop() error {
 	}
 	return nil
 }
-
-// Healthy is a no-op healchcheck
-func (l *K0sControllersLeaseCounter) Healthy() error { return nil }

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -387,6 +387,3 @@ func (c *CoreDNS) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterC
 	c.lastKnownClusterConfig = clusterConfig
 	return nil
 }
-
-// Health-check interface
-func (c *CoreDNS) Healthy() error { return nil }

--- a/pkg/component/controller/crd.go
+++ b/pkg/component/controller/crd.go
@@ -74,7 +74,3 @@ func (c CRD) Run(_ context.Context) error {
 func (c CRD) Stop() error {
 	return nil
 }
-
-func (c CRD) Healthy() error {
-	return nil
-}

--- a/pkg/component/controller/csrapprover.go
+++ b/pkg/component/controller/csrapprover.go
@@ -74,8 +74,6 @@ func NewCSRApprover(c *v1beta1.ClusterConfig, leaderElector LeaderElector, kubeC
 	}
 }
 
-func (a *CSRApprover) Healthy() error { return nil }
-
 // Stop stops the CSRApprover
 func (a *CSRApprover) Stop() error {
 	a.stop()

--- a/pkg/component/controller/defaultpsp.go
+++ b/pkg/component/controller/defaultpsp.go
@@ -239,6 +239,3 @@ subjects:
   kind: Group
   name: system:serviceaccounts
 `
-
-// Health-check interface
-func (d *DefaultPSP) Healthy() error { return nil }

--- a/pkg/component/controller/dummyleaderelector.go
+++ b/pkg/component/controller/dummyleaderelector.go
@@ -32,7 +32,6 @@ var _ component.Component = (*DummyLeaderElector)(nil)
 func (l *DummyLeaderElector) Init(_ context.Context) error { return nil }
 func (l *DummyLeaderElector) Stop() error                  { return nil }
 func (l *DummyLeaderElector) IsLeader() bool               { return l.Leader }
-func (l *DummyLeaderElector) Healthy() error               { return nil }
 
 func (l *DummyLeaderElector) AddAcquiredLeaseCallback(fn func()) {
 	l.callbacks = append(l.callbacks, fn)

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -55,6 +55,7 @@ type Etcd struct {
 }
 
 var _ component.Component = (*Etcd)(nil)
+var _ component.Healthz = (*Etcd)(nil)
 
 // Init extracts the needed binaries
 func (e *Etcd) Init(_ context.Context) error {

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -361,8 +361,3 @@ func (ec *ExtensionsController) Run(ctx context.Context) error {
 func (ec *ExtensionsController) Stop() error {
 	return nil
 }
-
-// Healthy
-func (ec *ExtensionsController) Healthy() error {
-	return nil
-}

--- a/pkg/component/controller/k0scloudprovider.go
+++ b/pkg/component/controller/k0scloudprovider.go
@@ -84,8 +84,3 @@ func (c *K0sCloudProvider) Stop() error {
 
 	return nil
 }
-
-// Healthy in the k0s-cloud-provider intentionally does nothing.
-func (c *K0sCloudProvider) Healthy() error {
-	return nil
-}

--- a/pkg/component/controller/k0scloudprovider_test.go
+++ b/pkg/component/controller/k0scloudprovider_test.go
@@ -100,12 +100,6 @@ func (suite *K0sCloudProviderSuite) TestRunStop() {
 	assert.Equal(suite.T(), true, suite.cancelled)
 }
 
-// TestHealthy covers the `Healthy()` function post-init.
-func (suite *K0sCloudProviderSuite) TestHealthy() {
-	assert.Nil(suite.T(), suite.ccp.Init(context.TODO()))
-	assert.Nil(suite.T(), suite.ccp.Healthy())
-}
-
 // TestK0sCloudProviderTestSuite sets up the suite for testing.
 func TestK0sCloudProviderTestSuite(t *testing.T) {
 	suite.Run(t, new(K0sCloudProviderSuite))

--- a/pkg/component/controller/k0scontrolapi.go
+++ b/pkg/component/controller/k0scontrolapi.go
@@ -66,6 +66,3 @@ func (m *K0SControlAPI) Run(_ context.Context) error {
 func (m *K0SControlAPI) Stop() error {
 	return m.supervisor.Stop()
 }
-
-// Healthy for health-check interface
-func (m *K0SControlAPI) Healthy() error { return nil }

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -109,6 +109,3 @@ func (k *Kine) Run(_ context.Context) error {
 func (k *Kine) Stop() error {
 	return k.supervisor.Stop()
 }
-
-// Health-check interface
-func (k *Kine) Healthy() error { return nil }

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -379,6 +379,3 @@ spec:
                   path: konnectivity-agent-token
                   audience: system:konnectivity-server
 `
-
-// Healthy is a no-op check
-func (k *Konnectivity) Healthy() error { return nil }

--- a/pkg/component/controller/kubeletconfig.go
+++ b/pkg/component/controller/kubeletconfig.go
@@ -306,6 +306,3 @@ func mergeProfiles(a *unstructuredYamlObject, b unstructuredYamlObject) (unstruc
 	}
 	return *a, nil
 }
-
-// Health-check interface
-func (k *KubeletConfig) Healthy() error { return nil }

--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -325,6 +325,3 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
 `
-
-// Health-check interface
-func (k *KubeProxy) Healthy() error { return nil }

--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -64,9 +64,6 @@ func NewKubeRouter(k0sVars constant.CfgVars, manifestsSaver manifestsSaver) *Kub
 // Init does nothing
 func (k *KubeRouter) Init(_ context.Context) error { return nil }
 
-// Healthy is a no-op check
-func (k *KubeRouter) Healthy() error { return nil }
-
 // Stop no-op as nothing running
 func (k *KubeRouter) Stop() error { return nil }
 

--- a/pkg/component/controller/leaderelector.go
+++ b/pkg/component/controller/leaderelector.go
@@ -124,5 +124,3 @@ func (l *LeasePoolLeaderElector) Stop() error {
 func (l *LeasePoolLeaderElector) IsLeader() bool {
 	return l.leaderStatus.Load().(bool)
 }
-
-func (l *LeasePoolLeaderElector) Healthy() error { return nil }

--- a/pkg/component/controller/metrics.go
+++ b/pkg/component/controller/metrics.go
@@ -149,9 +149,6 @@ func (m *Metrics) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterCon
 	return nil
 }
 
-// Healthy is the health-check interface
-func (m *Metrics) Healthy() error { return nil }
-
 type job struct {
 	log logrus.FieldLogger
 

--- a/pkg/component/controller/metricserver.go
+++ b/pkg/component/controller/metricserver.go
@@ -334,9 +334,6 @@ func (m *MetricServer) Reconcile(_ context.Context, clusterConfig *v1beta1.Clust
 	return nil
 }
 
-// Healthy is the health-check interface
-func (m *MetricServer) Healthy() error { return nil }
-
 // Mostly for calculating the resource needs based on node numbers. From https://github.com/kubernetes-sigs/metrics-server#scaling :
 // Starting from v0.5.0 Metrics Server comes with default resource requests that should guarantee good performance for most cluster configurations up to 100 nodes:
 // - 100m core of CPU

--- a/pkg/component/controller/noderole.go
+++ b/pkg/component/controller/noderole.go
@@ -120,6 +120,3 @@ func (n *NodeRole) addNodeLabel(ctx context.Context, client kubernetes.Interface
 func (n *NodeRole) Stop() error {
 	return nil
 }
-
-// Health-check interface
-func (n *NodeRole) Healthy() error { return nil }

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -120,6 +120,3 @@ func (a *Scheduler) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterC
 	a.previousConfig = args
 	return a.supervisor.Supervise()
 }
-
-// Health-check interface
-func (a *Scheduler) Healthy() error { return nil }

--- a/pkg/component/controller/systemrbac.go
+++ b/pkg/component/controller/systemrbac.go
@@ -109,6 +109,3 @@ subjects:
   kind: Group
   name: system:nodes
 `
-
-// Health-check interface
-func (s *SystemRBAC) Healthy() error { return nil }

--- a/pkg/component/controller/tunneledapiendpointreconciller.go
+++ b/pkg/component/controller/tunneledapiendpointreconciller.go
@@ -66,10 +66,6 @@ func (ter *TunneledEndpointReconciler) Stop() error {
 	return nil
 }
 
-func (ter *TunneledEndpointReconciler) Healthy() error {
-	return nil
-}
-
 func (ter *TunneledEndpointReconciler) Reconcile(ctx context.Context, cfg *v1beta1.ClusterConfig) error {
 	ter.cfg = cfg
 	return nil

--- a/pkg/component/manager.go
+++ b/pkg/component/manager.go
@@ -176,6 +176,11 @@ func isReconcileComponent(component Component) bool {
 
 // waitForHealthy waits until the component is healthy and returns true upon success. If a timeout occurs, it returns false
 func waitForHealthy(ctx context.Context, comp Component, name string, timeout time.Duration) error {
+	healthz, ok := comp.(Healthz)
+	if !ok {
+		return nil
+	}
+
 	ctx, cancelFunction := context.WithTimeout(ctx, timeout)
 
 	// clear up context after timeout
@@ -185,7 +190,7 @@ func waitForHealthy(ctx context.Context, comp Component, name string, timeout ti
 	ticker := time.NewTicker(100 * time.Millisecond)
 	for {
 		logrus.Debugf("checking %s for health", name)
-		if err := comp.Healthy(); err != nil {
+		if err := healthz.Healthy(); err != nil {
 			logrus.Debugf("health-check: %s not yet healthy: %v", name, err)
 		} else {
 			return nil

--- a/pkg/component/status/status.go
+++ b/pkg/component/status/status.go
@@ -40,9 +40,6 @@ type Status struct {
 
 var _ component.Component = (*Status)(nil)
 
-// Healthy dummy implementation
-func (s *Status) Healthy() error { return nil }
-
 // Init initializes component
 func (s *Status) Init(_ context.Context) error {
 	s.L = logrus.WithFields(logrus.Fields{"component": "status"})

--- a/pkg/component/worker/containerd.go
+++ b/pkg/component/worker/containerd.go
@@ -105,6 +105,3 @@ func (c *ContainerD) setupConfig() error {
 func (c *ContainerD) Stop() error {
 	return c.supervisor.Stop()
 }
-
-// Health-check interface
-func (c *ContainerD) Healthy() error { return nil }

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -232,9 +232,6 @@ func (k *Kubelet) Stop() error {
 	return k.supervisor.Stop()
 }
 
-// Health-check interface
-func (k *Kubelet) Healthy() error { return nil }
-
 func (k *Kubelet) prepareLocalKubeletConfig(kubeletconfig string, kubeletConfigData kubeletConfig) (string, error) {
 	var kubeletConfiguration kubeletv1beta1.KubeletConfiguration
 	err := yaml.Unmarshal([]byte(kubeletconfig), &kubeletConfiguration)

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -106,5 +106,3 @@ func (a OCIBundleReconciler) unpackBundle(ctx context.Context, client *container
 func (a *OCIBundleReconciler) Stop() error {
 	return nil
 }
-
-func (a *OCIBundleReconciler) Healthy() error { return nil }

--- a/pkg/component/worker/static_pods.go
+++ b/pkg/component/worker/static_pods.go
@@ -101,6 +101,8 @@ type staticPods struct {
 	stopped     sync.WaitGroup
 }
 
+var _ component.Healthz = (*staticPods)(nil)
+
 // NewStaticPods creates a new static_pods component.
 func NewStaticPods() interface {
 	StaticPods

--- a/pkg/component/worker/static_pods_test.go
+++ b/pkg/component/worker/static_pods_test.go
@@ -176,8 +176,8 @@ func TestStaticPods_Lifecycle(t *testing.T) {
 	log, logs := test.NewNullLogger()
 	log.SetLevel(logrus.DebugLevel)
 
-	underTest := NewStaticPods()
-	underTest.(*staticPods).log = log
+	underTest := NewStaticPods().(*staticPods)
+	underTest.log = log
 	podUnderTest, err := underTest.ClaimStaticPod("default", "dummy-test")
 	require.NoError(t, err)
 	assert.NoError(t, podUnderTest.SetManifest(dummyPod))

--- a/pkg/component/worker/stubs.go
+++ b/pkg/component/worker/stubs.go
@@ -46,10 +46,6 @@ func (c CalicoInstaller) Stop() error {
 	panic("stub component is used: CalicoInstaller")
 }
 
-func (c CalicoInstaller) Healthy() error {
-	panic("stub component is used: CalicoInstaller")
-}
-
 type KubeProxy struct {
 	K0sVars   constant.CfgVars
 	CIDRRange string
@@ -67,9 +63,5 @@ func (k KubeProxy) Run(_ context.Context) error {
 }
 
 func (k KubeProxy) Stop() error {
-	panic("stub component is used: KubeProxy")
-}
-
-func (k KubeProxy) Healthy() error {
 	panic("stub component is used: KubeProxy")
 }

--- a/pkg/telemetry/component.go
+++ b/pkg/telemetry/component.go
@@ -115,11 +115,6 @@ func (c *Component) Reconcile(ctx context.Context, clusterCfg *v1beta1.ClusterCo
 	return nil
 }
 
-// Healthy checks health
-func (c *Component) Healthy() error {
-	return nil
-}
-
 func (c Component) run(ctx context.Context) {
 	c.stopCh = make(chan struct{})
 	ticker := time.NewTicker(interval)


### PR DESCRIPTION
## Description

This allows for removing several dozens of empty method declarations from the code base. In fact, Healthy() is only implemented by APIServer, Etcd and StaticPods.

See #1844.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings