### PR TITLE
The `forceupdate` field should be optional.

### DIFF
--- a/pkg/apis/autopilot.k0sproject.io/v1beta2/types.go
+++ b/pkg/apis/autopilot.k0sproject.io/v1beta2/types.go
@@ -143,7 +143,7 @@ type PlanCommandK0sUpdate struct {
 	Version string `json:"version"`
 
 	// ForceUpdate ensures that version checking is ignored and that all updates are applied.
-	ForceUpdate bool `json:"forceupdate"`
+	ForceUpdate bool `json:"forceupdate,omitempty"`
 
 	// Platforms is a map of PlanResourceUrls to platform identifiers, allowing a single k0s version
 	// to have multiple URL resources based on platform.

--- a/static/manifests/autopilot/CustomResourceDefinition/autopilot.k0sproject.io_plans.yaml
+++ b/static/manifests/autopilot/CustomResourceDefinition/autopilot.k0sproject.io_plans.yaml
@@ -268,7 +268,6 @@ spec:
                             be upgrading to.
                           type: string
                       required:
-                      - forceupdate
                       - platforms
                       - targets
                       - version

--- a/static/manifests/autopilot/CustomResourceDefinition/autopilot.k0sproject.io_updateconfigs.yaml
+++ b/static/manifests/autopilot/CustomResourceDefinition/autopilot.k0sproject.io_updateconfigs.yaml
@@ -272,7 +272,6 @@ spec:
                                 will be upgrading to.
                               type: string
                           required:
-                          - forceupdate
                           - platforms
                           - targets
                           - version


### PR DESCRIPTION
## Description

This was an oversight on the original commit, and shouldn't require people
to explicitly define `forceupdate: false` in their plans.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings