### PR TITLE
Moved `ap-airgap` to use the footloosesuite in `k0s`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -82,6 +82,18 @@ jobs:
           make --touch codegen
           make build
 
+      - name: Build airgap bundle (linux)
+        if: matrix.target == 'linux'
+        run: make image-bundle/bundle.tar
+
+      - name: Cache airgap bundle (linux)
+        if: matrix.target == 'linux'
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-build-airgap-bundle-${{ github.ref_name }}-${{ github.sha }}
+          path: |
+            image-bundle/bundle.tar
+
       - name: Upload compiled binary
         uses: actions/upload-artifact@v3
         with:
@@ -126,7 +138,7 @@ jobs:
 
       - name: Validate OCI images manifests
         run: make check-image-validity
-  
+
   smoketest:
     name: Smoke test
     needs: build
@@ -136,6 +148,8 @@ jobs:
       matrix:
         smoke-suite:
           - check-addons
+          - check-airgap
+          - check-ap-airgap
           - check-ap-ha3x3
           - check-ap-platformselect
           - check-ap-quorum
@@ -190,6 +204,13 @@ jobs:
         with:
           name: k0s
 
+      - name: Restore airgap bundle
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-build-airgap-bundle-${{ github.ref_name }}-${{ github.sha }}
+          path: |
+            image-bundle/bundle.tar
+
       - name: k0s sysinfo
         run: |
           chmod +x k0s
@@ -203,59 +224,6 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: smoketest-${{ matrix.smoke-suite }}-logs
-          path: /tmp/*.log
-
-  smoketest-airgap:
-    name: Smoke test for airgap install
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
-
-      - name: Prepare build environment
-        run: .github/workflows/prepare-build-env.sh
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Download compiled binary
-        uses: actions/download-artifact@v3
-        with:
-          name: k0s
-
-      - name: Create airgap image list
-        run: |
-          # Pretend that k0s has been built by make
-          chmod +x k0s
-          make -C embedded-bins staging/linux/bin
-          make -t k0s
-
-          # actually create the image list
-          make image-bundle/image.list
-
-      - name: Cache airgap image bundle
-        id: cache-bundle
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-airgap-image-bundle-${{ hashFiles('image-bundle/image.list') }}
-          path: image-bundle/bundle.tar
-
-      - name: Create airgap image bundle
-        if: steps.cache-bundle.outputs.cache-hit != 'true'
-        run: make image-bundle/bundle.tar
-
-      - name: Run test
-        run: make -C inttest check-airgap
-
-      - name: Collect test logs
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: smoketest-airgap-check-airgap-logs
           path: /tmp/*.log
 
   smoketest-arm:

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ lint: .k0sbuild.docker-image.k0s go.sum codegen
 	$(GO_ENV) golangci-lint run --verbose $(GO_DIRS)
 
 .PHONY: $(smoketests)
-check-airgap: image-bundle/bundle.tar
+check-airgap check-ap-airgap: image-bundle/bundle.tar
 $(smoketests): k0s
 	$(MAKE) -C inttest $@
 

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -1,6 +1,7 @@
 smoketests := \
 	check-addons \
 	check-airgap \
+	check-ap-airgap \
 	check-ap-ha3x3 \
 	check-ap-platformselect \
 	check-ap-quorum \


### PR DESCRIPTION
## Description

The main difference is the bind-mounting of `K0S_IMAGE_BUNDLE` to `/dist`, and
serving the image bundle from the embedded `nginx`.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings