### PR TITLE
Added the autopilot `platformselect` inttest

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -136,6 +136,7 @@ jobs:
       matrix:
         smoke-suite:
           - check-ap-ha3x3
+          - check-ap-platformselect
           - check-basic
           - check-addons
           - check-byocri

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -1,7 +1,8 @@
 smoketests := \
 	check-addons \
-	check-ap-ha3x3 \
 	check-airgap \
+	check-ap-ha3x3 \
+	check-ap-platformselect \
 	check-backup \
 	check-basic \
 	check-byocri \

--- a/inttest/ap-platformselect/platformselect_test.go
+++ b/inttest/ap-platformselect/platformselect_test.go
@@ -20,17 +20,18 @@ import (
 	"testing"
 	"time"
 
-	apitcomm "github.com/k0sproject/k0s/inttest/autopilot/common"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 
+	"github.com/k0sproject/k0s/inttest/common"
+
 	"github.com/stretchr/testify/suite"
 )
 
 type platformSelectSuite struct {
-	apitcomm.FootlooseSuite
+	common.FootlooseSuite
 }
 
 // SetupTest prepares the controller and filesystem, getting it into a consistent
@@ -40,9 +41,6 @@ func (s *platformSelectSuite) SetupTest() {
 
 	s.Require().NoError(s.InitController(0), "--disable-components=metrics-server")
 	s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(0)))
-
-	// With k0s running, then launch autopilot
-	s.Require().NoError(s.InitControllerAutopilot(0, "--kubeconfig=/var/lib/k0s/pki/admin.conf", "--mode=controller"))
 
 	client, err := s.ExtensionsClient(s.ControllerNode(0))
 	s.Require().NoError(err)
@@ -66,17 +64,15 @@ spec:
   timestamp: now
   commands:
     - k0supdate:
-        version: ` + apitcomm.TargetK0sVersion + `
+        version: v0.0.0
+        forceupdate: true
         platforms:
           windows-amd64:
-            url: ` + apitcomm.Versions[apitcomm.TargetK0sVersion]["windows-amd64"]["k0s"]["url"] + `
-            sha256: ` + apitcomm.Versions[apitcomm.TargetK0sVersion]["windows-amd64"]["k0s"]["sha256"] + `
+            url: http://localhost/dist/k0s-windows-amd64
           linux-amd64:
-            url: ` + apitcomm.Versions[apitcomm.TargetK0sVersion]["linux-amd64"]["k0s"]["url"] + `
-            sha256: ` + apitcomm.Versions[apitcomm.TargetK0sVersion]["linux-amd64"]["k0s"]["sha256"] + `
+            url: http://localhost/dist/k0s
           linux-arm64:
-            url: ` + apitcomm.Versions[apitcomm.TargetK0sVersion]["linux-arm64"]["k0s"]["url"] + `
-            sha256: ` + apitcomm.Versions[apitcomm.TargetK0sVersion]["linux-arm64"]["k0s"]["sha256"] + `
+            url: http://localhost/dist/k0s-arm64
         targets:
           controllers:
             discovery:
@@ -111,18 +107,23 @@ spec:
 	s.NoError(err)
 	s.Equal(appc.PlanCompleted, plan.Status.State)
 
-	k0sVersion, err := s.GetK0sVersion(s.ControllerNode(0))
-	s.NoError(err)
-	s.Equal("v1.23.3+k0s.1", k0sVersion)
+	s.Equal(1, len(plan.Status.Commands))
+	cmd := plan.Status.Commands[0]
+
+	s.NotNil(cmd.K0sUpdate)
+	s.NotNil(cmd.K0sUpdate.Controllers)
+	s.NotEmpty(cmd.K0sUpdate.Controllers)
+	s.Equal(appc.SignalCompleted, cmd.K0sUpdate.Controllers[0].State)
 }
 
 // TestPlatformSelectSuite sets up a suite using a single controller, running various
 // autopilot upgrade scenarios against it.
 func TestPlatformSelectSuite(t *testing.T) {
 	suite.Run(t, &platformSelectSuite{
-		apitcomm.FootlooseSuite{
+		common.FootlooseSuite{
 			ControllerCount: 1,
 			WorkerCount:     0,
+			LaunchMode:      common.LaunchModeOpenRC,
 		},
 	})
 }


### PR DESCRIPTION
## Description

This ensures that the proper platform artifact defined in a plan is used
for the k0s update.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings