### PR TITLE
Added the autopilot `quorumsafety` inttest

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -139,6 +139,7 @@ jobs:
           - check-ap-ha3x3
           - check-ap-platformselect
           - check-ap-quorum
+          - check-ap-quorumsafety
           - check-basic
           - check-byocri
           - check-calico

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -4,6 +4,7 @@ smoketests := \
 	check-ap-ha3x3 \
 	check-ap-platformselect \
 	check-ap-quorum \
+	check-ap-quorumsafety \
 	check-backup \
 	check-basic \
 	check-byocri \


### PR DESCRIPTION
## Description
This covers the scenario of preventing an autopilot plan from applying due
to a quorum failure. All controller nodes need to respond that they are
available before a controller update starts, and in this test we intentionally
leave out a controller.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings