### PR TITLE
Collect k0s logs based on launch mode in inttests

### DIFF
--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -271,7 +271,17 @@ func (s *FootlooseSuite) cleanupSuite() {
 			s.T().Logf("failed to ssh to node %s to get logs", m.Hostname())
 			continue
 		}
-		log, err := ssh.ExecWithOutput("cat /tmp/k0s-*.log")
+		logPathInContainer := ""
+		switch s.LaunchMode {
+		case LaunchModeOpenRC:
+			logPathInContainer = "/var/log/k0s.log"
+		case LaunchModeStandalone:
+			logPathInContainer = "/tmp/k0s-*.log"
+		default:
+			s.T().Logf(`unknown launchmode %s, dunno how to collect logs ¯\_(ツ)_/¯`, s.LaunchMode)
+		}
+
+		log, err := ssh.ExecWithOutput(fmt.Sprintf("cat %s", logPathInContainer))
 		if err != nil {
 			s.T().Logf("failed to cat logs on machine %s: %s", m.Hostname(), err)
 		}


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

## Description

If we hit a test timeout, we automatically collect k0s logs from all test nodes. This is however broken in case of `LaunchModeOpenRC` as the logs path was hardcoded to `/tmp/k0s-*.log`. This PR fixes it to be based of test suites `LaunchMode`

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test: Tested by running ha3x3 test with 1m timeout. Logs got properly collected.
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings