### PR TITLE
Raise ap-ha3x3 inttest timeout to 6m

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -68,6 +68,9 @@ check-noderole: TIMEOUT=6m
 # Backup check runs two scenarios
 check-backup: TIMEOUT=6m
 
+# Autopilot 3x3 HA test can take a while to run
+check-ap-ha3x3: TIMEOUT=6m
+
 .PHONY: $(smoketests)
 include Makefile.variables
 


### PR DESCRIPTION
## Description

The smokes have default timeout of 4 minutes. Checking few of the ha3x3 runs it's around 225-230 sec range. This is dangerously close to the 4m timeout and I'd expect us to see "flakes" just based on it hitting the timeout while it's still working on the update.

I actually saw it hitting a timeout locally while I had some unexpected load on my dev box. (quite a few leftover footloose clusters doing random stuff...)

Hence bump up the timeout for this specific case a bit.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings