### PR TITLE
k0s binaries for autopilot integration tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -100,6 +100,18 @@ jobs:
           name: k0s${{ matrix.binary-suffix }}
           path: k0s${{ matrix.binary-suffix }}
 
+      - name: Build test binaries
+        if: matrix.target == 'linux'
+        run: |
+          make test-bin
+
+      - name: Upload test binaries
+        if: matrix.target == 'linux'
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-k0s
+          path: test-k0s-*
+
   unittest:
     name: Unit test
     needs: build
@@ -204,6 +216,11 @@ jobs:
         with:
           name: k0s
 
+      - name: Download test binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: test-k0s
+
       - name: Restore airgap bundle
         uses: actions/cache@v3
         with:
@@ -215,6 +232,11 @@ jobs:
         run: |
           chmod +x k0s
           ./k0s sysinfo
+
+      - name: Copy test binary
+        run: |
+          cp ./test-k0s-0.0.1 k0s
+          chmod +x k0s
 
       - name: Run inttest
         run: make -C inttest ${{ matrix.smoke-suite }}

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,12 @@ k0s: .k0sbuild.docker-image.k0s
 k0s.exe: TARGET_OS = windows
 k0s.exe: CGO_ENABLED = 0
 
-k0s.exe k0s: $(GO_SRCS) $(codegen_targets) go.sum
+test-k0s-0.0.1: VERSION=v0.0.1-test
+test-k0s-0.0.2: VERSION=v0.0.2-test
+
+test-bin: test-k0s-0.0.1 test-k0s-0.0.2
+
+k0s.exe k0s test-k0s-0.0.1 test-k0s-0.0.2: $(GO_SRCS) $(codegen_targets) go.sum
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(TARGET_OS) $(GO) build $(BUILD_GO_FLAGS) -ldflags='$(LD_FLAGS)' -o $@.code main.go
 	cat $@.code bindata_$(TARGET_OS) > $@.tmp \
 		&& rm -f $@.code \

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -81,7 +81,7 @@ check-ap-updater: .update-server.stamp
 include Makefile.variables
 
 $(smoketests): .footloose-alpine.stamp
-	K0S_IMAGES_BUNDLE="$(realpath ../image-bundle/bundle.tar)" K0S_PATH="$(realpath ../k0s)" go test -count=1 -v -timeout $(TIMEOUT) github.com/k0sproject/k0s/inttest/$(subst check-,,$@)
+	K0S_IMAGES_BUNDLE="$(realpath ../image-bundle/bundle.tar)" K0S_PATH="$(realpath ../k0s)" K0S_NEW_PATH="$(realpath ../test-k0s-0.0.2)" go test -count=1 -v -timeout $(TIMEOUT) github.com/k0sproject/k0s/inttest/$(subst check-,,$@)
 
 .PHONY: clean
 clean:

--- a/inttest/ap-ha3x3/ha3x3_test.go
+++ b/inttest/ap-ha3x3/ha3x3_test.go
@@ -117,26 +117,17 @@ spec:
   timestamp: now
   commands:
     - k0supdate:
-        version: v0.0.0
-        forceupdate: true
+        version: v0.0.2-test
         platforms:
           linux-amd64:
-            url: http://localhost/dist/k0s
+            url: http://localhost/dist/test-k0s-0.0.2
         targets:
           controllers:
             discovery:
-              static:
-                nodes:
-                  - controller0
-                  - controller1
-                  - controller2
+              selector: {}
           workers:
             discovery:
-              static:
-                nodes:
-                  - worker0
-                  - worker1
-                  - worker2
+              selector: {}
 `
 
 	manifestFile := "/tmp/happy.yaml"

--- a/inttest/ap-updater/updater_test.go
+++ b/inttest/ap-updater/updater_test.go
@@ -72,17 +72,7 @@ spec:
   planSpec:
     id: id123
     timestamp: now
-    commands:
-    - k0supdate:
-        version: v0.0.0
-        forceupdate: true
-        platforms:
-          linux-amd64:
-            url: http://localhost/dist/k0s
-        targets:
-          controllers:
-            discovery:
-              selector: {}
+    commands: []
 `
 
 	vars := struct {

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -64,9 +64,10 @@ const (
 	etcdNodeNameFormat         = "etcd%d"
 	updateServerNodeNameFormat = "updateserver%d"
 
-	defaultK0sBinaryFullPath   = "/usr/local/bin/k0s"
-	k0sBindMountFullPath       = "/dist/k0s"
-	k0sAirgapBindMountFullPath = "/dist/bundle.tar"
+	defaultK0sBinaryFullPath       = "/usr/local/bin/k0s"
+	k0sBindMountFullPath           = "/dist/k0s"
+	newK0sVersionBindMountFullPath = "/dist/test-k0s-0.0.2"
+	k0sAirgapBindMountFullPath     = "/dist/bundle.tar"
 )
 
 // FootlooseSuite defines all the common stuff we need to be able to run k0s testing on footloose.
@@ -1053,6 +1054,16 @@ func (s *FootlooseSuite) initializeFootlooseClusterInDir(dir string) error {
 			Type:        "bind",
 			Source:      airgapPath,
 			Destination: k0sAirgapBindMountFullPath,
+			ReadOnly:    true,
+		})
+	}
+
+	newK0sVersionPath := os.Getenv("K0S_NEW_PATH")
+	if newK0sVersionPath != "" {
+		volumes = append(volumes, config.Volume{
+			Type:        "bind",
+			Source:      newK0sVersionPath,
+			Destination: newK0sVersionBindMountFullPath,
 			ReadOnly:    true,
 		})
 	}

--- a/inttest/update-server/html/stable/index.yaml
+++ b/inttest/update-server/html/stable/index.yaml
@@ -1,10 +1,10 @@
 name: stable
-version: v0.0.0
+version: v0.0.2-test
 downloadURLs:
   k0s:
-    linux-amd64: http://localhost/dist/k0s
-    linux-arm64: http://localhost/dist/k0s
-    linux-arm: http://localhost/dist/k0s
+    linux-amd64: http://localhost/dist/test-k0s-0.0.2
+    linux-arm64: http://localhost/dist/test-k0s-0.0.2
+    linux-arm: http://localhost/dist/test-k0s-0.0.2
   airgap:
     linux-amd64: ..../k0s-images-amd64
     linux-arm64: ..../k0s-images-arm64


### PR DESCRIPTION
Signed-off-by: Alexey Makhov <amakhov@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

`k0s  version` returns an empty string in integration tests and autopilot can't finish the update because the desired version doesn't match the actual one. We have to use `forceUpdate: true` to fix the tests.

In this change we generate "old" and "new" versions of k0s for tests by changing `build.Version` var using compile-time flags.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings