### PR TITLE
Autopilot updater plan generation improved

### DIFF
--- a/pkg/autopilot/controller/updates/updater.go
+++ b/pkg/autopilot/controller/updates/updater.go
@@ -166,25 +166,36 @@ func (u *updater) toPlan(nextVersion *uc.Update) apv1beta2.Plan {
 
 	p.Spec.ID = strconv.FormatInt(time.Now().Unix(), 10)
 	p.Spec.Timestamp = strconv.FormatInt(time.Now().Unix(), 10)
-	p.Spec.Commands = append(p.Spec.Commands, apv1beta2.PlanCommand{
-		K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{
-			Version:   string(nextVersion.Version),
-			Platforms: platforms,
-			Targets: apv1beta2.PlanCommandTargets{
-				Controllers: apv1beta2.PlanCommandTarget{
-					Discovery: apv1beta2.PlanCommandTargetDiscovery{
-						Selector: &apv1beta2.PlanCommandTargetDiscoverySelector{},
+
+	var updateCommandFound bool
+	for _, cmd := range p.Spec.Commands {
+		if cmd.K0sUpdate != nil || cmd.AirgapUpdate != nil {
+			updateCommandFound = true
+			break
+		}
+	}
+
+	// If update command is not specified, we add a default one to update all controller and workers in the cluster
+	if !updateCommandFound {
+		p.Spec.Commands = append(p.Spec.Commands, apv1beta2.PlanCommand{
+			K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{
+				Version:   string(nextVersion.Version),
+				Platforms: platforms,
+				Targets: apv1beta2.PlanCommandTargets{
+					Controllers: apv1beta2.PlanCommandTarget{
+						Discovery: apv1beta2.PlanCommandTargetDiscovery{
+							Selector: &apv1beta2.PlanCommandTargetDiscoverySelector{},
+						},
 					},
-				},
-				Workers: apv1beta2.PlanCommandTarget{
-					Discovery: apv1beta2.PlanCommandTargetDiscovery{
-						Selector: &apv1beta2.PlanCommandTargetDiscoverySelector{},
+					Workers: apv1beta2.PlanCommandTarget{
+						Discovery: apv1beta2.PlanCommandTargetDiscovery{
+							Selector: &apv1beta2.PlanCommandTargetDiscoverySelector{},
+						},
 					},
 				},
 			},
-			// TODO: Targets
-		},
-	})
+		})
+	}
 
 	return p
 }


### PR DESCRIPTION
Signed-off-by: Alexey Makhov <amakhov@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently, the autopilot updater creates a Plan with `K0sUpdate` command to update all members of the cluster and doesn't respect commands in the `spec.planSpec.commands` section of the UpdaterConfig

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings