### PR TITLE
Another ctr version warning fix and add inttest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ LD_FLAGS += -X k8s.io/component-base/version.gitMajor=$(KUBECTL_MAJOR)
 LD_FLAGS += -X k8s.io/component-base/version.gitMinor=$(KUBECTL_MINOR)
 LD_FLAGS += -X k8s.io/component-base/version.buildDate=$(BUILD_DATE)
 LD_FLAGS += -X k8s.io/component-base/version.gitCommit=not_available
-LD_FLAGS += -X github.com/containerd/containerd/version.Version=v$(containerd_version)
+LD_FLAGS += -X github.com/containerd/containerd/version.Version=$(containerd_version)
 ifeq ($(EMBEDDED_BINS_BUILDMODE), docker)
 LD_FLAGS += -X github.com/containerd/containerd/version.Revision=$(shell ./embedded-bins/staging/linux/bin/containerd --version | awk '{print $$4}')
 endif

--- a/inttest/ctr/ctr_test.go
+++ b/inttest/ctr/ctr_test.go
@@ -55,6 +55,10 @@ func (s *CtrSuite) TestK0sCtrCommand() {
 	flatOutput := removeRedundantSpaces(output)
 	errMsg := fmt.Sprintf("returned output of command 'k0s ctr namespaces list' is different than expected: %s", output)
 	s.Equal("NAME LABELS k8s.io", flatOutput, errMsg)
+
+	output, err = ssh.ExecWithOutput("/usr/local/bin/k0s ctr version")
+	s.Require().NoError(err)
+	s.Require().NotContains(output, "WARNING")
 }
 
 func TestCtrCommandSuite(t *testing.T) {


### PR DESCRIPTION
Apparently ctr expects the containerd's version string to be without
the 'v' prefix. Add integration test to verify that `ctr version` happy.

fixes commit f3aeb3aed1ea (Set containerd/version.Version during linktime)

Ref https://github.com/k0sproject/k0s/issues/1840

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings