### PR TITLE
Fix the overriding of `GOLANG_IMAGE`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ LD_FLAGS += -X github.com/containerd/containerd/version.Revision=$(shell ./embed
 endif
 LD_FLAGS += $(BUILD_GO_LDFLAGS_EXTRA)
 
+GOLANG_IMAGE ?= golang:$(go_version)-alpine3.16
 GO_ENV ?= docker run --rm \
 	-v '$(CURDIR)/build/cache':/run/k0s-build \
 	-v '$(CURDIR)':/go/src/github.com/k0sproject/k0s \
@@ -85,7 +86,7 @@ build/cache:
 
 .k0sbuild.docker-image.k0s: build/Dockerfile embedded-bins/Makefile.variables | build/cache
 	docker build --rm \
-		--build-arg BUILDIMAGE=golang:$(go_version)-alpine3.16 \
+		--build-arg BUILDIMAGE=$(GOLANG_IMAGE) \
 		-f build/Dockerfile \
 		-t k0sbuild.docker-image.k0s build/
 	touch $@
@@ -175,7 +176,6 @@ k0s: .k0sbuild.docker-image.k0s
 
 k0s.exe: TARGET_OS = windows
 k0s.exe: BUILD_GO_CGO_ENABLED = 0
-k0s.exe: GOLANG_IMAGE = golang:$(go_version)-alpine3.16
 
 k0s.exe k0s: $(GO_SRCS) $(codegen_targets) go.sum
 	CGO_ENABLED=$(BUILD_GO_CGO_ENABLED) GOOS=$(TARGET_OS) $(GO) build $(BUILD_GO_FLAGS) -ldflags='$(LD_FLAGS)' -o $@.code main.go


### PR DESCRIPTION
## Description

It looks like a mismerge from the autopilot branch caused this variable
to get lost + incorrectly used. This restores the ability to override
the variable for specialized builds.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings