### PR TITLE
Bump the `check-backup` timeout to 10m

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -70,7 +70,7 @@ check-configchange: TIMEOUT=8m
 check-noderole: TIMEOUT=6m
 
 # Backup check runs two scenarios
-check-backup: TIMEOUT=6m
+check-backup: TIMEOUT=10m
 
 # Autopilot 3x3 HA test can take a while to run
 check-ap-ha3x3: TIMEOUT=6m


### PR DESCRIPTION
## Description

The current timeout value is 6m, and successful runs locally seem
to be around the 5m30s mark. This is an effort to reduce the occasional
failures of this test in CI

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings