### PR TITLE
Ensure `schedulablewait` reconcilation is aware of planid

### DIFF
--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Schedulable handles the provider state 'schedulable'
-func (aup *airgapupdate) Schedulable(ctx context.Context, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+func (aup *airgapupdate) Schedulable(ctx context.Context, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 	logger := aup.logger.WithField("state", "schedulable")
 	logger.Info("Processing")
 
@@ -67,7 +67,7 @@ func (aup *airgapupdate) Schedulable(ctx context.Context, cmd apv1beta2.PlanComm
 		return appc.PlanIncompleteTargets, false, nil
 	}
 
-	if err := appku.UpdateSignalNode(signalNodeCopy, signalNodeCommandBuilder); err != nil {
+	if err := appku.UpdateSignalNode(signalNodeCopy, planID, signalNodeCommandBuilder); err != nil {
 		logger.Warnf("Unable to update signal node: %v", err)
 		return appc.PlanIncompleteTargets, false, nil
 	}

--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable_test.go
@@ -199,7 +199,7 @@ func TestSchedulable(t *testing.T) {
 			)
 
 			ctx := context.TODO()
-			nextState, retry, err := provider.Schedulable(ctx, test.command, &test.status)
+			nextState, retry, err := provider.Schedulable(ctx, "id123", test.command, &test.status)
 
 			assert.Equal(t, test.expectedNextState, nextState)
 			assert.Equal(t, test.expectedRetry, retry)

--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulablewait.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulablewait.go
@@ -26,7 +26,7 @@ import (
 )
 
 // SchedulableWait handles the provider state 'schedulablewait'
-func (aup *airgapupdate) SchedulableWait(ctx context.Context, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+func (aup *airgapupdate) SchedulableWait(ctx context.Context, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 	logger := aup.logger.WithField("state", "schedulablewait")
 	logger.Info("Processing")
 

--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulablewait_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulablewait_test.go
@@ -186,6 +186,7 @@ func TestSchedulableWait(t *testing.T) {
 						Name: "worker0",
 						Annotations: signalNodeStatusDataAnnotations(
 							apsigv2.SignalData{
+								PlanID:  "id123",
 								Created: "now",
 								Command: apsigv2.Command{
 									AirgapUpdate: &apsigv2.CommandAirgapUpdate{
@@ -245,7 +246,7 @@ func TestSchedulableWait(t *testing.T) {
 			)
 
 			ctx := context.TODO()
-			nextState, retry, err := provider.SchedulableWait(ctx, test.command, &test.status)
+			nextState, retry, err := provider.SchedulableWait(ctx, "id123", test.command, &test.status)
 
 			assert.Equal(t, test.expectedNextState, nextState)
 			assert.Equal(t, test.expectedRetry, retry)

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Schedulable handles the provider state 'schedulable'
-func (kp *k0supdate) Schedulable(ctx context.Context, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+func (kp *k0supdate) Schedulable(ctx context.Context, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 	logger := kp.logger.WithField("state", "schedulable")
 	logger.Info("Processing")
 
@@ -93,7 +93,7 @@ func (kp *k0supdate) Schedulable(ctx context.Context, cmd apv1beta2.PlanCommand,
 		return appc.PlanIncompleteTargets, false, nil
 	}
 
-	if err := appku.UpdateSignalNode(signalNodeCopy, signalNodeCommandBuilder); err != nil {
+	if err := appku.UpdateSignalNode(signalNodeCopy, planID, signalNodeCommandBuilder); err != nil {
 		logger.Warnf("Unable to update signal node: %v", err)
 		return appc.PlanIncompleteTargets, false, nil
 	}

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable_test.go
@@ -206,7 +206,7 @@ func TestSchedulable(t *testing.T) {
 			)
 
 			ctx := context.TODO()
-			nextState, retry, err := provider.Schedulable(ctx, test.command, &test.status)
+			nextState, retry, err := provider.Schedulable(ctx, "id123", test.command, &test.status)
 
 			assert.Equal(t, test.expectedNextState, nextState)
 			assert.Equal(t, test.expectedRetry, retry)

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/update.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/update.go
@@ -28,8 +28,9 @@ import (
 type SignalNodeCommandBuilder func() apsigv2.Command
 
 // UpdateSignalNode builds a signalling update request, and adds it to the provided node
-func UpdateSignalNode(node crcli.Object, cb SignalNodeCommandBuilder) error {
+func UpdateSignalNode(node crcli.Object, planID string, cb SignalNodeCommandBuilder) error {
 	signalData := apsigv2.SignalData{
+		PlanID:  planID,
 		Created: time.Now().Format(time.RFC3339),
 		Command: cb(),
 	}

--- a/pkg/autopilot/controller/plans/core/fakes.go
+++ b/pkg/autopilot/controller/plans/core/fakes.go
@@ -25,8 +25,8 @@ import (
 type fakePlanCommandProvider struct {
 	commandID              string
 	handlerNewPlan         func(context.Context, apv1beta2.PlanCommand, *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error)
-	handlerSchedulable     func(context.Context, apv1beta2.PlanCommand, *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error)
-	handlerSchedulableWait func(context.Context, apv1beta2.PlanCommand, *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error)
+	handlerSchedulable     func(context.Context, string, apv1beta2.PlanCommand, *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error)
+	handlerSchedulableWait func(context.Context, string, apv1beta2.PlanCommand, *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error)
 }
 
 var _ PlanCommandProvider = (*fakePlanCommandProvider)(nil)
@@ -39,10 +39,10 @@ func (f fakePlanCommandProvider) NewPlan(ctx context.Context, cmd apv1beta2.Plan
 	return f.handlerNewPlan(ctx, cmd, status)
 }
 
-func (f fakePlanCommandProvider) Schedulable(ctx context.Context, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
-	return f.handlerSchedulable(ctx, cmd, status)
+func (f fakePlanCommandProvider) Schedulable(ctx context.Context, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+	return f.handlerSchedulable(ctx, planID, cmd, status)
 }
 
-func (f fakePlanCommandProvider) SchedulableWait(ctx context.Context, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
-	return f.handlerSchedulableWait(ctx, cmd, status)
+func (f fakePlanCommandProvider) SchedulableWait(ctx context.Context, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+	return f.handlerSchedulableWait(ctx, planID, cmd, status)
 }

--- a/pkg/autopilot/controller/plans/core/initprovidershandler.go
+++ b/pkg/autopilot/controller/plans/core/initprovidershandler.go
@@ -70,7 +70,7 @@ func (ah *initProvidersHandler) Handle(ctx context.Context, plan *apv1beta2.Plan
 		// It is the adapters implementation who is responsible for providing the proper status
 		// for executing the command.
 
-		nextState, _, err := ah.adapter(ctx, cmdHandler, cmd, &plan.Status.Commands[len(plan.Status.Commands)-1])
+		nextState, _, err := ah.adapter(ctx, cmdHandler, plan.Spec.ID, cmd, &plan.Status.Commands[len(plan.Status.Commands)-1])
 
 		// Given that this is a fixed-initialization, we expect that all of the command initialization should
 		// succeed, but in the case that it doesn't make the caller aware.

--- a/pkg/autopilot/controller/plans/core/initprovidershandler_test.go
+++ b/pkg/autopilot/controller/plans/core/initprovidershandler_test.go
@@ -68,7 +68,7 @@ func TestInitProvidersHandle(t *testing.T) {
 			},
 			NewInitProvidersHandler(
 				logger,
-				func(ctx context.Context, provider PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+				func(ctx context.Context, provider PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 					return provider.NewPlan(ctx, cmd, status)
 				},
 				PlanSchedulableWait,
@@ -79,10 +79,10 @@ func TestInitProvidersHandle(t *testing.T) {
 
 						return PlanSchedulableWait, false, nil
 					},
-					handlerSchedulable: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					handlerSchedulable: func(ctx context.Context, planID string, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						return PlanSchedulableWait, false, fmt.Errorf("should not have reached schedulable")
 					},
-					handlerSchedulableWait: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					handlerSchedulableWait: func(ctx context.Context, planID string, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						return PlanSchedulableWait, false, fmt.Errorf("should not have reached schedulablewait")
 					},
 				},
@@ -114,8 +114,8 @@ func TestInitProvidersHandle(t *testing.T) {
 			},
 			NewInitProvidersHandler(
 				logger,
-				func(ctx context.Context, provider PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
-					return provider.Schedulable(ctx, cmd, status)
+				func(ctx context.Context, provider PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					return provider.Schedulable(ctx, planID, cmd, status)
 				},
 				PlanSchedulableWait,
 				fakePlanCommandProvider{
@@ -146,8 +146,8 @@ func TestInitProvidersHandle(t *testing.T) {
 			},
 			NewInitProvidersHandler(
 				logger,
-				func(ctx context.Context, provider PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
-					return provider.Schedulable(ctx, cmd, status)
+				func(ctx context.Context, provider PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					return provider.Schedulable(ctx, planID, cmd, status)
 				},
 				PlanSchedulableWait,
 				fakePlanCommandProvider{
@@ -176,7 +176,7 @@ func TestInitProvidersHandle(t *testing.T) {
 			},
 			NewInitProvidersHandler(
 				logger,
-				func(ctx context.Context, provider PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+				func(ctx context.Context, provider PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 					return PlanSchedulableWait, false, fmt.Errorf("intentional error")
 				},
 				PlanSchedulableWait,

--- a/pkg/autopilot/controller/plans/core/planstatehandler.go
+++ b/pkg/autopilot/controller/plans/core/planstatehandler.go
@@ -75,7 +75,7 @@ func (h *planStateHandler) Handle(ctx context.Context, plan *apv1beta2.Plan) (Pr
 		// for executing the command.
 
 		originalPlanCommandState := cmdStatus.State
-		nextState, retry, err := h.adapter(ctx, cmdHandler, cmd, cmdStatus)
+		nextState, retry, err := h.adapter(ctx, cmdHandler, plan.Spec.ID, cmd, cmdStatus)
 
 		// If we're asked to retry, we can ignore any errors and state transition as this is an effective
 		// 'redo' of the operation.

--- a/pkg/autopilot/controller/plans/core/planstatehandler_test.go
+++ b/pkg/autopilot/controller/plans/core/planstatehandler_test.go
@@ -64,21 +64,21 @@ func TestHandle(t *testing.T) {
 			},
 			NewPlanStateHandler(
 				logger,
-				func(ctx context.Context, provider PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
-					return provider.Schedulable(ctx, cmd, status)
+				func(ctx context.Context, provider PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					return provider.Schedulable(ctx, planID, cmd, status)
 				},
 				fakePlanCommandProvider{
 					commandID: "K0sUpdate",
 					handlerNewPlan: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						return PlanSchedulableWait, false, fmt.Errorf("should not have reached newplan")
 					},
-					handlerSchedulable: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					handlerSchedulable: func(ctx context.Context, planID string, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						assert.Equal(t, "v1.2.3", pc.K0sUpdate.Version)
 						pcs.K0sUpdate = &apv1beta2.PlanCommandK0sUpdateStatus{}
 
 						return PlanCompleted, false, nil
 					},
-					handlerSchedulableWait: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					handlerSchedulableWait: func(ctx context.Context, planID string, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						return PlanSchedulableWait, false, fmt.Errorf("should not have reached schedulablewait")
 					},
 				},
@@ -106,8 +106,8 @@ func TestHandle(t *testing.T) {
 			},
 			NewPlanStateHandler(
 				logger,
-				func(ctx context.Context, provider PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
-					return provider.Schedulable(ctx, cmd, status)
+				func(ctx context.Context, provider PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					return provider.Schedulable(ctx, planID, cmd, status)
 				},
 				fakePlanCommandProvider{
 					commandID: "UnknownProvider",
@@ -137,8 +137,8 @@ func TestHandle(t *testing.T) {
 			},
 			NewPlanStateHandler(
 				logger,
-				func(ctx context.Context, provider PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
-					return provider.Schedulable(ctx, cmd, status)
+				func(ctx context.Context, provider PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					return provider.Schedulable(ctx, planID, cmd, status)
 				},
 				fakePlanCommandProvider{
 					commandID: "UnknownProvider",
@@ -205,7 +205,7 @@ func TestHandle(t *testing.T) {
 			},
 			NewPlanStateHandler(
 				logger,
-				func(ctx context.Context, provider PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+				func(ctx context.Context, provider PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 					return PlanSchedulableWait, false, fmt.Errorf("intentional error")
 				},
 				fakePlanCommandProvider{
@@ -253,15 +253,15 @@ func TestHandle(t *testing.T) {
 			},
 			NewPlanStateHandler(
 				logger,
-				func(ctx context.Context, provider PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
-					return provider.Schedulable(ctx, cmd, status)
+				func(ctx context.Context, provider PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					return provider.Schedulable(ctx, planID, cmd, status)
 				},
 				fakePlanCommandProvider{
 					commandID: "K0sUpdate",
 					handlerNewPlan: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						return pcs.State, false, fmt.Errorf("should not have reached newplan")
 					},
-					handlerSchedulable: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					handlerSchedulable: func(ctx context.Context, planID string, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						// Ensures that only the second command makes it here
 						assert.Equal(t, "v2", pc.K0sUpdate.Version)
 
@@ -269,7 +269,7 @@ func TestHandle(t *testing.T) {
 
 						return PlanCompleted, false, nil
 					},
-					handlerSchedulableWait: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					handlerSchedulableWait: func(ctx context.Context, planID string, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						return pcs.State, false, fmt.Errorf("should not have reached schedulablewait")
 					},
 				},
@@ -307,19 +307,19 @@ func TestHandle(t *testing.T) {
 			},
 			NewPlanStateHandler(
 				logger,
-				func(ctx context.Context, provider PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
-					return provider.Schedulable(ctx, cmd, status)
+				func(ctx context.Context, provider PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					return provider.Schedulable(ctx, planID, cmd, status)
 				},
 				fakePlanCommandProvider{
 					commandID: "K0sUpdate",
 					handlerNewPlan: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						return pcs.State, false, fmt.Errorf("should not have reached newplan")
 					},
-					handlerSchedulable: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					handlerSchedulable: func(ctx context.Context, planID string, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						pcs.K0sUpdate = &apv1beta2.PlanCommandK0sUpdateStatus{}
 						return PlanCompleted, false, nil
 					},
-					handlerSchedulableWait: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					handlerSchedulableWait: func(ctx context.Context, planID string, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						return pcs.State, false, fmt.Errorf("should not have reached schedulablewait")
 					},
 				},
@@ -358,19 +358,19 @@ func TestHandle(t *testing.T) {
 			},
 			NewPlanStateHandler(
 				logger,
-				func(ctx context.Context, provider PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
-					return provider.Schedulable(ctx, cmd, status)
+				func(ctx context.Context, provider PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					return provider.Schedulable(ctx, planID, cmd, status)
 				},
 				fakePlanCommandProvider{
 					commandID: "K0sUpdate",
 					handlerNewPlan: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						return pcs.State, false, fmt.Errorf("should not have reached newplan")
 					},
-					handlerSchedulable: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					handlerSchedulable: func(ctx context.Context, planID string, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						pcs.K0sUpdate = &apv1beta2.PlanCommandK0sUpdateStatus{}
 						return PlanCompleted, false, nil
 					},
-					handlerSchedulableWait: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					handlerSchedulableWait: func(ctx context.Context, planID string, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						return pcs.State, false, fmt.Errorf("should not have reached schedulablewait")
 					},
 				},
@@ -414,19 +414,19 @@ func TestHandle(t *testing.T) {
 			},
 			NewPlanStateHandler(
 				logger,
-				func(ctx context.Context, provider PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
-					return provider.Schedulable(ctx, cmd, status)
+				func(ctx context.Context, provider PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					return provider.Schedulable(ctx, planID, cmd, status)
 				},
 				fakePlanCommandProvider{
 					commandID: "K0sUpdate",
 					handlerNewPlan: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						return pcs.State, false, fmt.Errorf("should not have reached newplan")
 					},
-					handlerSchedulable: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					handlerSchedulable: func(ctx context.Context, planID string, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						pcs.K0sUpdate = &apv1beta2.PlanCommandK0sUpdateStatus{}
 						return pcs.State, true, nil
 					},
-					handlerSchedulableWait: func(ctx context.Context, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+					handlerSchedulableWait: func(ctx context.Context, planID string, pc apv1beta2.PlanCommand, pcs *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 						return pcs.State, false, fmt.Errorf("should not have reached schedulablewait")
 					},
 				},

--- a/pkg/autopilot/controller/plans/core/types.go
+++ b/pkg/autopilot/controller/plans/core/types.go
@@ -59,7 +59,7 @@ type PlanStateHandler interface {
 
 // PlanStateHandlerAdapter defines an adapter function between the `PlanStateController`, and the
 // specific function to call in the resolved `PlanCommandProvider`.
-type PlanStateHandlerAdapter func(ctx context.Context, provider PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error)
+type PlanStateHandlerAdapter func(ctx context.Context, provider PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error)
 
 // PlanCommandProviderMap is a mapping of command names to `PlanCommandProvider` instances.
 type PlanCommandProviderMap map[string]PlanCommandProvider
@@ -77,8 +77,8 @@ type PlanCommandProvider interface {
 	NewPlan(ctx context.Context, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error)
 
 	// Schedulable handles the provider state 'schedulable'
-	Schedulable(ctx context.Context, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error)
+	Schedulable(ctx context.Context, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error)
 
 	// SchedulableWait handles the provider state 'schedulablewait'
-	SchedulableWait(ctx context.Context, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error)
+	SchedulableWait(ctx context.Context, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error)
 }

--- a/pkg/autopilot/controller/plans/init.go
+++ b/pkg/autopilot/controller/plans/init.go
@@ -65,7 +65,7 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 func registerNewPlanStateController(logger *logrus.Entry, mgr crman.Manager, providers []appc.PlanCommandProvider) error {
 	handler := appc.NewInitProvidersHandler(
 		logger,
-		func(ctx context.Context, provider appc.PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+		func(ctx context.Context, provider appc.PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
 			return provider.NewPlan(ctx, cmd, status)
 		},
 		appc.PlanSchedulableWait,
@@ -80,8 +80,8 @@ func registerNewPlanStateController(logger *logrus.Entry, mgr crman.Manager, pro
 func registerSchedulableWaitStateController(logger *logrus.Entry, mgr crman.Manager, providers []appc.PlanCommandProvider) error {
 	handler := appc.NewPlanStateHandler(
 		logger,
-		func(ctx context.Context, provider appc.PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
-			return provider.SchedulableWait(ctx, cmd, status)
+		func(ctx context.Context, provider appc.PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+			return provider.SchedulableWait(ctx, planID, cmd, status)
 		},
 		providers...,
 	)
@@ -94,8 +94,8 @@ func registerSchedulableWaitStateController(logger *logrus.Entry, mgr crman.Mana
 func registerSchedulableStateController(logger *logrus.Entry, mgr crman.Manager, providers []appc.PlanCommandProvider) error {
 	handler := appc.NewPlanStateHandler(
 		logger,
-		func(ctx context.Context, provider appc.PlanCommandProvider, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
-			return provider.Schedulable(ctx, cmd, status)
+		func(ctx context.Context, provider appc.PlanCommandProvider, planID string, cmd apv1beta2.PlanCommand, status *apv1beta2.PlanCommandStatus) (apv1beta2.PlanStateType, bool, error) {
+			return provider.Schedulable(ctx, planID, cmd, status)
 		},
 		providers...,
 	)

--- a/pkg/autopilot/controller/signal/k0s/signal_test.go
+++ b/pkg/autopilot/controller/signal/k0s/signal_test.go
@@ -562,6 +562,7 @@ func TestCheckExpiredInvalid(t *testing.T) {
 		{
 			"Downloading in progress + not-expired",
 			&apsigv2.SignalData{
+				PlanID:  "id123",
 				Created: "now",
 				Command: apsigv2.Command{
 					ID: new(int),
@@ -585,6 +586,7 @@ func TestCheckExpiredInvalid(t *testing.T) {
 		{
 			"Processing in ApplyingUpdate + expired",
 			&apsigv2.SignalData{
+				PlanID:  "id123",
 				Created: "now",
 				Command: apsigv2.Command{
 					ID: new(int),
@@ -608,6 +610,7 @@ func TestCheckExpiredInvalid(t *testing.T) {
 		{
 			"Invalid status timestamp",
 			&apsigv2.SignalData{
+				PlanID:  "id123",
 				Created: "now",
 				Command: apsigv2.Command{
 					ID: new(int),

--- a/pkg/autopilot/signaling/v2/signaling_v2.go
+++ b/pkg/autopilot/signaling/v2/signaling_v2.go
@@ -57,6 +57,7 @@ func NewStatus(status string) *Status {
 // SignalData provides all of the details of the requested `autopilot` operation,
 // as well as its current status.
 type SignalData struct {
+	PlanID  string  `json:"planId" validate:"required"`
 	Created string  `json:"created" validate:"required"`
 	Command Command `json:"command" validate:"required"`
 	Status  *Status `json:"status,omitempty"`

--- a/pkg/autopilot/signaling/v2/signaling_v2_test.go
+++ b/pkg/autopilot/signaling/v2/signaling_v2_test.go
@@ -58,10 +58,11 @@ func TestSignalDataValid(t *testing.T) {
 		successful bool
 	}{
 		// K0s data
-		{"Happy", SignalData{"now", commandK0s, status}, true},
-		{"MissingTimestamp", SignalData{"", commandK0s, status}, false},
-		{"MissingStatus", SignalData{"now", commandK0s, nil}, true},
-		{"MissingCommand", SignalData{"now", Command{}, status}, false},
+		{"Happy", SignalData{"id123", "now", commandK0s, status}, true},
+		{"MissingPlanID", SignalData{"", "now", commandK0s, status}, false},
+		{"MissingTimestamp", SignalData{"id123", "", commandK0s, status}, false},
+		{"MissingStatus", SignalData{"id123", "now", commandK0s, nil}, true},
+		{"MissingCommand", SignalData{"id123", "now", Command{}, status}, false},
 	}
 
 	for _, test := range tests {
@@ -77,6 +78,7 @@ func TestSignalDataValid(t *testing.T) {
 func TestSignalDataUpdateK0sValid(t *testing.T) {
 	makeSignalData := func(url, version, sha256 string) SignalData {
 		return SignalData{
+			PlanID:  "id123",
 			Created: "now",
 			Command: Command{
 				ID: new(int),
@@ -121,6 +123,7 @@ func TestSignalDataUpdateK0sValid(t *testing.T) {
 		{
 			"K0sRequired",
 			SignalData{
+				PlanID:  "id123",
 				Created: "now",
 				Command: Command{
 					ID:        new(int),
@@ -141,6 +144,7 @@ func TestSignalDataUpdateK0sValid(t *testing.T) {
 
 func TestMarshaling(t *testing.T) {
 	signalData1 := SignalData{
+		PlanID:  "id123",
 		Created: "now",
 		Command: Command{
 			ID: new(int),


### PR DESCRIPTION
## Description

The reconciliation that `schedulablewait` performs against the state of
`ControlNode` and `Node` was not taking into consideration the planid.

If any previously completed `ControlNode` or `Node` instances were included
in a new plan, those would be incorrectly marked as 'Completed'.

Ultimately, this plumbs the planid down through the various PlanStateHandler
API functions to make it available at reconcilation time.

Fixes #1902

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings