### PR TITLE
Move controller `autopilot` creation into a `Component` + `--enable-worker` fix

### DIFF
--- a/pkg/component/controller/autopilot.go
+++ b/pkg/component/controller/autopilot.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	apcli "github.com/k0sproject/k0s/pkg/autopilot/client"
+	apcont "github.com/k0sproject/k0s/pkg/autopilot/controller"
+	aproot "github.com/k0sproject/k0s/pkg/autopilot/controller/root"
+
+	"github.com/k0sproject/k0s/pkg/component"
+	"github.com/k0sproject/k0s/pkg/constant"
+	"github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/sirupsen/logrus"
+)
+
+var _ component.Component = (*Autopilot)(nil)
+
+type Autopilot struct {
+	K0sVars            constant.CfgVars
+	AdminClientFactory kubernetes.ClientFactoryInterface
+}
+
+func (a *Autopilot) Init(ctx context.Context) error {
+	return nil
+}
+
+func (a *Autopilot) Run(ctx context.Context) error {
+	log := logrus.WithFields(logrus.Fields{"component": "autopilot"})
+
+	autopilotClientFactory, err := apcli.NewClientFactory(a.AdminClientFactory.GetRESTConfig())
+	if err != nil {
+		return fmt.Errorf("creating autopilot client factory error: %w", err)
+	}
+
+	autopilotRoot, err := apcont.NewRootController(aproot.RootConfig{
+		KubeConfig:          a.K0sVars.AdminKubeConfigPath,
+		K0sDataDir:          a.K0sVars.DataDir,
+		Mode:                "controller",
+		ManagerPort:         8899,
+		MetricsBindAddr:     "0",
+		HealthProbeBindAddr: "0",
+	}, logrus.WithFields(logrus.Fields{"component": "autopilot"}), autopilotClientFactory)
+	if err != nil {
+		return fmt.Errorf("failed to create autopilot controller: %w", err)
+	}
+
+	go func() {
+		if err := autopilotRoot.Run(ctx); err != nil {
+			log.WithError(err).Error("Error while running autopilot")
+		}
+	}()
+
+	return nil
+}
+
+func (a *Autopilot) Stop() error {
+	return nil
+}
+
+func (a *Autopilot) Healthy() error {
+	return nil
+}


### PR DESCRIPTION
## Description

All of the logic for creating + starting autopilot on Controllers was
inline with the controller initialization. This has been moved into
its own `autopilot.go`, similar to what was done in workers.

This did uncover + fix a bug where autopilot would not be started
if `--enable-worker` was provided. The current expectation for
controllers with `--enable-worker` is that the default autopilot
`controller` behavior will be used.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings