### PR TITLE
Added a generic 'apply failed' status to plans + nodes.

### DIFF
--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/compare.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/compare.go
@@ -52,3 +52,16 @@ func IsCompleted(targets []apv1beta2.PlanCommandTargetStatus) bool {
 
 	return true
 }
+
+// IsNotRecoverable determines if any of the PlanCommandTargetStatus is considered non-recoverable.
+func IsNotRecoverable(groups ...[]apv1beta2.PlanCommandTargetStatus) bool {
+	for _, group := range groups {
+		for _, target := range group {
+			if target.State == appc.SignalApplyFailed {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/autopilot/controller/plans/core/types.go
+++ b/pkg/autopilot/controller/plans/core/types.go
@@ -30,6 +30,7 @@ var (
 	PlanIncompleteTargets   apv1beta2.PlanStateType = "IncompleteTargets"
 	PlanRestricted          apv1beta2.PlanStateType = "Restricted"
 	PlanMissingSignalNode   apv1beta2.PlanStateType = "MissingSignalNode"
+	PlanApplyFailed         apv1beta2.PlanStateType = "ApplyFailed"
 )
 
 // PlanCommandStatusType
@@ -39,6 +40,7 @@ var (
 	SignalCompleted       apv1beta2.PlanCommandTargetStateType = "SignalCompleted"
 	SignalMissingNode     apv1beta2.PlanCommandTargetStateType = "SignalMissingNode"
 	SignalMissingPlatform apv1beta2.PlanCommandTargetStateType = "SignalMissingPlatform"
+	SignalApplyFailed     apv1beta2.PlanCommandTargetStateType = "SignalApplyFailed"
 )
 
 type ProviderResult int


### PR DESCRIPTION
## Description

Previously, when an update failed at the signal node level, the state in
the plan would stay at 'SignalSent', which implies that something is
processing, despite the Plan being technically "done"

This change adds a 'PlanApplyFailed' to the plan states, and a new
`SignalApplyFailed` to signal node states.

If any signal node reports a `SignalApplyFailed`, the plan will switch
to `PlanApplyFailed`, and the plan will terminate.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings