### PR TITLE
More context propagation

### DIFF
--- a/pkg/autopilot/controller/leases.go
+++ b/pkg/autopilot/controller/leases.go
@@ -83,7 +83,7 @@ func (lw *leaseWatcher) StartWatcher(ctx context.Context, namespace string, name
 					leaderelection.WithNamespace(namespace),
 				}
 
-				leasePool, err := leaderelection.NewLeasePool(lw.client, name, leasePoolOpts...)
+				leasePool, err := leaderelection.NewLeasePool(ctx, lw.client, name, leasePoolOpts...)
 				if err != nil {
 					errorCh <- fmt.Errorf("failed to create lease pool: %w", err)
 					cancel()

--- a/pkg/component/controller/controllersleasecounter.go
+++ b/pkg/component/controller/controllersleasecounter.go
@@ -62,7 +62,7 @@ func (l *K0sControllersLeaseCounter) Run(ctx context.Context) error {
 	}
 	leaseID := fmt.Sprintf("k0s-ctrl-%s", holderIdentity)
 
-	leasePool, err := leaderelection.NewLeasePool(client, leaseID,
+	leasePool, err := leaderelection.NewLeasePool(ctx, client, leaseID,
 		leaderelection.WithLogger(log),
 		leaderelection.WithContext(ctx))
 	if err != nil {

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -52,6 +52,7 @@ type Etcd struct {
 	supervisor supervisor.Supervisor
 	uid        int
 	gid        int
+	ctx        context.Context
 }
 
 var _ component.Component = (*Etcd)(nil)
@@ -129,6 +130,7 @@ func (e *Etcd) syncEtcdConfig(peerURL, etcdCaCert, etcdCaCertKey string) ([]stri
 
 // Run runs etcd if external cluster is not configured
 func (e *Etcd) Run(ctx context.Context) error {
+	e.ctx = ctx
 	if e.Config.IsExternalClusterUsed() {
 		return nil
 	}
@@ -281,7 +283,7 @@ func (e *Etcd) setupCerts(ctx context.Context) error {
 // Health-check interface
 func (e *Etcd) Healthy() error {
 	logrus.WithField("component", "etcd").Debug("checking etcd endpoint for health")
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(e.ctx, 1*time.Second)
 	defer cancel()
 	err := etcd.CheckEtcdReady(ctx, e.K0sVars.CertRootDir, e.K0sVars.EtcdCertDir, e.Config)
 	return err

--- a/pkg/component/controller/leaderelector.go
+++ b/pkg/component/controller/leaderelector.go
@@ -69,7 +69,7 @@ func (l *LeasePoolLeaderElector) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("can't create kubernetes rest client for lease pool: %v", err)
 	}
-	leasePool, err := leaderelection.NewLeasePool(client, "k0s-endpoint-reconciler",
+	leasePool, err := leaderelection.NewLeasePool(ctx, client, "k0s-endpoint-reconciler",
 		leaderelection.WithLogger(l.log),
 		leaderelection.WithContext(ctx))
 	if err != nil {

--- a/pkg/leaderelection/lease_pool.go
+++ b/pkg/leaderelection/lease_pool.go
@@ -113,14 +113,14 @@ func WithNamespace(namespace string) LeaseOpt {
 }
 
 // NewLeasePool creates a new LeasePool struct to interact with a lease
-func NewLeasePool(client kubernetes.Interface, name string, opts ...LeaseOpt) (*LeasePool, error) {
+func NewLeasePool(ctx context.Context, client kubernetes.Interface, name string, opts ...LeaseOpt) (*LeasePool, error) {
 
 	leaseConfig := LeaseConfiguration{
 		log:           logrus.NewEntry(logrus.StandardLogger()),
 		duration:      60 * time.Second,
 		renewDeadline: 15 * time.Second,
 		retryPeriod:   5 * time.Second,
-		ctx:           context.TODO(),
+		ctx:           ctx,
 		namespace:     "kube-node-lease",
 		name:          name,
 	}

--- a/pkg/leaderelection/lease_pool_test.go
+++ b/pkg/leaderelection/lease_pool_test.go
@@ -40,7 +40,7 @@ func TestLeasePoolWatcherTriggersOnLeaseAcquisition(t *testing.T) {
 	expectCreateNamespace(t, fakeClient)
 	expectCreateLease(t, fakeClient, identity)
 
-	pool, err := NewLeasePool(fakeClient, "test", WithIdentity(identity), WithNamespace("test"))
+	pool, err := NewLeasePool(context.TODO(), fakeClient, "test", WithIdentity(identity), WithNamespace("test"))
 	require.NoError(t, err)
 
 	output := &LeaseEvents{
@@ -81,7 +81,7 @@ func TestLeasePoolTriggersLostLeaseWhenCancelled(t *testing.T) {
 	expectCreateNamespace(t, fakeClient)
 	expectCreateLease(t, fakeClient, identity)
 
-	pool, err := NewLeasePool(fakeClient, "test", WithIdentity(identity), WithNamespace("test"))
+	pool, err := NewLeasePool(context.TODO(), fakeClient, "test", WithIdentity(identity), WithNamespace("test"))
 	require.NoError(t, err)
 
 	output := &LeaseEvents{
@@ -120,7 +120,7 @@ func TestLeasePoolWatcherReacquiresLostLease(t *testing.T) {
 		}
 	}()
 
-	pool, err := NewLeasePool(fakeClient, "test",
+	pool, err := NewLeasePool(context.TODO(), fakeClient, "test",
 		WithIdentity(identity), WithNamespace("test"),
 		WithRetryPeriod(650*time.Millisecond),
 		WithRenewDeadline(1*time.Second),
@@ -163,7 +163,7 @@ func TestSecondWatcherAcquiresReleasedLease(t *testing.T) {
 	expectCreateNamespace(t, fakeClient)
 	expectCreateLease(t, fakeClient, identity)
 
-	pool, err := NewLeasePool(fakeClient, "test", WithIdentity(identity), WithNamespace("test"))
+	pool, err := NewLeasePool(context.TODO(), fakeClient, "test", WithIdentity(identity), WithNamespace("test"))
 	require.NoError(t, err)
 
 	events, cancel, err := pool.Watch(WithOutputChannels(&LeaseEvents{
@@ -173,7 +173,7 @@ func TestSecondWatcherAcquiresReleasedLease(t *testing.T) {
 	require.NoError(t, err)
 	defer cancel()
 
-	pool2, err := NewLeasePool(fakeClient, "test", WithIdentity(identity2), WithNamespace("test"))
+	pool2, err := NewLeasePool(context.TODO(), fakeClient, "test", WithIdentity(identity2), WithNamespace("test"))
 	require.NoError(t, err)
 
 	events2, cancel2, err := pool2.Watch(WithOutputChannels(&LeaseEvents{

--- a/pkg/leaderelection/lease_pool_test.go
+++ b/pkg/leaderelection/lease_pool_test.go
@@ -122,8 +122,8 @@ func TestLeasePoolWatcherReacquiresLostLease(t *testing.T) {
 
 	pool, err := NewLeasePool(context.TODO(), fakeClient, "test",
 		WithIdentity(identity), WithNamespace("test"),
-		WithRetryPeriod(650*time.Millisecond),
-		WithRenewDeadline(1*time.Second),
+		WithRetryPeriod(350*time.Millisecond),
+		WithRenewDeadline(500*time.Millisecond),
 	)
 	require.NoError(t, err)
 
@@ -163,7 +163,12 @@ func TestSecondWatcherAcquiresReleasedLease(t *testing.T) {
 	expectCreateNamespace(t, fakeClient)
 	expectCreateLease(t, fakeClient, identity)
 
-	pool, err := NewLeasePool(context.TODO(), fakeClient, "test", WithIdentity(identity), WithNamespace("test"))
+	pool, err := NewLeasePool(context.TODO(), fakeClient, "test",
+		WithIdentity(identity), WithNamespace("test"),
+		WithRetryPeriod(350*time.Millisecond),
+		WithRenewDeadline(500*time.Millisecond),
+	)
+
 	require.NoError(t, err)
 
 	events, cancel, err := pool.Watch(WithOutputChannels(&LeaseEvents{
@@ -173,7 +178,12 @@ func TestSecondWatcherAcquiresReleasedLease(t *testing.T) {
 	require.NoError(t, err)
 	defer cancel()
 
-	pool2, err := NewLeasePool(context.TODO(), fakeClient, "test", WithIdentity(identity2), WithNamespace("test"))
+	pool2, err := NewLeasePool(context.TODO(), fakeClient, "test",
+		WithIdentity(identity2),
+		WithNamespace("test"),
+		WithRetryPeriod(350*time.Millisecond),
+		WithRenewDeadline(500*time.Millisecond),
+	)
 	require.NoError(t, err)
 
 	events2, cancel2, err := pool2.Watch(WithOutputChannels(&LeaseEvents{


### PR DESCRIPTION
## Description

- Pass a context to lease pool so it can be cancelled during shut down.
- Pass context to etcd health check so we cancel the health check early on shutdown.
- minor optimization to leas pool unit tests. Shorten the timeouts.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings