### PR TITLE
Change kube-proxy metrics address to 0.0.0.0

### DIFF
--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -245,7 +245,7 @@ data:
       tcpTimeout: 0s
       udpTimeout: 0s
     kind: KubeProxyConfiguration
-    metricsBindAddress: ""
+    metricsBindAddress: "0.0.0.0:10249"
     nodePortAddresses: null
     oomScoreAdj: null
     portRange: ""


### PR DESCRIPTION
Signed-off-by: Karen Almog <kalmog@mirantis.com>

## Description

This PR changes the default metricsAddress for kube-proxy from 127.0.0.1:10249 to 0.0.0.0:10249 (https://github.com/helm/charts/tree/master/stable/prometheus-operator#kubeproxy).
This allows prometheus to fetch metrics and monitor kibe-proxy

Fixes #1904

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings