### PR TITLE
Add a warning about unique machine-ids

### DIFF
--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -10,6 +10,10 @@ You should plan to allocate the control plane nodes into different zones. This w
 
 For etcd high availability it's recommended to configure 3 or 5 controller nodes. For more information, refer to the [etcd documentation](https://etcd.io/docs/latest/faq/#why-an-odd-number-of-cluster-members).
 
+## System considerations
+
+If your controllers are cloned virtual machines or deployed from a template, make sure that `/etc/machine-id` is unique on every controller. If not you may get unexpected results with some components, e.g. Konnectivity connections).
+
 ## Load Balancer
 
 Control plane high availability requires a tcp load balancer, which acts as a single point of contact to access the controllers. The load balancer needs to allow and route traffic to each controller through the following ports:


### PR DESCRIPTION
No machines, especially controllers, should ever share machine-ids.

Cfr. https://github.com/k0sproject/k0s/issues/1547#issuecomment-1046789907

"The root cause seems to be that the controllers have matching machine IDs which k0s adds as --server-id."

Signed-off-by: pvdputte <pvdputte@users.noreply.github.com>

## Description

I've been bitten by intermittent timeouts and general instability in my k0s testing with a HA control plane. It took me a long time to troubleshoot it. Eventually I found out that both my vagrant boxes and VMware templates were not resetting machine-id properly. A warning about the importance of having unique machine-ids when setting up HA could be helpful to others.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings