### PR TITLE
Fix a `SIGTERM` shutdown issue in supervisor

### DIFF
--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -115,7 +115,13 @@ func (s *Supervisor) Supervise() error {
 	var ctx context.Context
 	ctx, s.cancel = context.WithCancel(context.Background())
 	started := make(chan error)
+	s.done = make(chan bool)
+
 	go func() {
+		defer func() {
+			close(s.done)
+		}()
+
 		s.log.Info("Starting to supervise")
 		restarts := 0
 		for {
@@ -142,10 +148,6 @@ func (s *Supervisor) Supervise() error {
 			} else {
 				if restarts == 0 {
 					s.log.Info("Started successfully, go nuts")
-					s.done = make(chan bool)
-					defer func() {
-						s.done <- true
-					}()
 					started <- nil
 				} else {
 					s.log.Infof("Restarted (%d)", restarts)


### PR DESCRIPTION
## Description
This cleans up the creation/closure of a channel used to indicate
that the supervisor goroutine is 'done'. The `defer` in the for-loop
wasn't being invoked per-iteration (due to the goroutine function
not exiting).

Also, this `done` channel has been changed to notify on `close()`
instead of sending data into it.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings