### PR TITLE
A number of fixes to the `airgapupdate` command in autopilot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ include embedded-bins/Makefile.variables
 include inttest/Makefile.variables
 include hack/tools/Makefile.variables
 
+K0S_GO_BUILD_CACHE ?= build/cache
+
 GO_SRCS := $(shell find . -type f -name '*.go' -not -path './$(K0S_GO_BUILD_CACHE)/*' -not -path './inttest/*' -not -name '*_test.go' -not -name 'zz_generated*')
 GO_DIRS := . ./cmd/... ./pkg/... ./internal/... ./static/... ./hack/...
 
@@ -10,7 +12,6 @@ GO_DIRS := . ./cmd/... ./pkg/... ./internal/... ./static/... ./hack/...
 #   none	does not embed any binaries
 
 EMBEDDED_BINS_BUILDMODE ?= docker
-K0S_GO_BUILD_CACHE ?= build/cache
 # k0s runs on linux even if its built on mac or windows
 TARGET_OS ?= linux
 BUILD_UID ?= $(shell id -u)

--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulablewait_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulablewait_test.go
@@ -226,6 +226,96 @@ func TestSchedulableWait(t *testing.T) {
 			},
 		},
 
+		// Covers the scenario of a v1.Node that contains autopilot state that indicates that
+		// an update has completed, with a different plan ID from the test data. This should
+		// result in the v1.Node autopilot state NOT getting reconciled as current, and ignored.
+		{
+			"WorkerNoPlanIDMatch",
+			[]crcli.Object{
+				&v1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker0",
+						Annotations: map[string]string{
+							"k0sproject.io/autopilot-signal-version": apsigv2.Version,
+							"k0sproject.io/autopilot-signal-data":    `{"planId":"id999","created":"2022-07-01T00:56:19Z","command":{"id":0,"airgapupdate":{"url":"http://localhost/dist/k0s","version":"v0.0.0","forceupdate":true}},"status":{"status":"Completed","timestamp":"2022-07-01T00:56:27Z"}}`,
+						},
+					},
+				},
+			},
+			apv1beta2.PlanCommand{
+				AirgapUpdate: &apv1beta2.PlanCommandAirgapUpdate{
+					Workers: apv1beta2.PlanCommandTarget{
+						Limits: apv1beta2.PlanCommandTargetLimits{
+							Concurrent: 1,
+						},
+					},
+				},
+			},
+			apv1beta2.PlanCommandStatus{
+				State: appc.PlanSchedulableWait,
+				AirgapUpdate: &apv1beta2.PlanCommandAirgapUpdateStatus{
+					Workers: []apv1beta2.PlanCommandTargetStatus{
+						apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalPending),
+					},
+				},
+			},
+			appc.PlanSchedulable,
+			false,
+			false,
+			[]apv1beta2.PlanCommandTargetStatus{
+				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalPending),
+			},
+		},
+
+		// Covers the scenario of a v1.Node that contains autopilot state that indicates that
+		// an update has completed, with the same plan ID as the test data. This should result
+		// in the v1.Node autopilot state getting reconciled as current.
+		{
+			"WorkerPlanIDMatch",
+			[]crcli.Object{
+				&v1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker0",
+						Annotations: map[string]string{
+							"k0sproject.io/autopilot-signal-version": apsigv2.Version,
+							"k0sproject.io/autopilot-signal-data":    `{"planId":"id123","created":"2022-07-01T00:56:19Z","command":{"id":0,"airgapupdate":{"url":"http://localhost/dist/k0s","version":"v0.0.0","forceupdate":true}},"status":{"status":"Completed","timestamp":"2022-07-01T00:56:27Z"}}`,
+						},
+					},
+				},
+			},
+			apv1beta2.PlanCommand{
+				AirgapUpdate: &apv1beta2.PlanCommandAirgapUpdate{
+					Workers: apv1beta2.PlanCommandTarget{
+						Limits: apv1beta2.PlanCommandTargetLimits{
+							Concurrent: 1,
+						},
+					},
+				},
+			},
+			apv1beta2.PlanCommandStatus{
+				State: appc.PlanSchedulableWait,
+				AirgapUpdate: &apv1beta2.PlanCommandAirgapUpdateStatus{
+					Workers: []apv1beta2.PlanCommandTargetStatus{
+						apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalPending),
+					},
+				},
+			},
+			appc.PlanCompleted,
+			false,
+			false,
+			[]apv1beta2.PlanCommandTargetStatus{
+				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalCompleted),
+			},
+		},
+
 		// Cover the scenario where a node fails to apply an update, and that the failure
 		// is propagated back up to the plan state, resulting in the plan terminating.
 		{

--- a/pkg/autopilot/controller/signal/airgap/signal.go
+++ b/pkg/autopilot/controller/signal/airgap/signal.go
@@ -81,6 +81,12 @@ func registerSignalController(logger *logrus.Entry, mgr crman.Manager, eventFilt
 // Handle will move the status to `Downloading` in order to start the airgap bundle download.
 // At this time, there is no reliable version information on airgap bundles.
 func (h *signalControllerHandler) Handle(ctx context.Context, sctx apsigcomm.SignalControllerContext) (cr.Result, error) {
+	// A nil SignalData indicates that the request is completed, or invalid. Either way,
+	// there is nothing to process.
+	if sctx.SignalData == nil {
+		return cr.Result{}, nil
+	}
+
 	sctx.Log.Infof("Found available signaling update request")
 
 	// We have no way at the moment to identify what version an airgap bundle is, or what version is


### PR DESCRIPTION
## Description
This is a rollup of a number of fixes to the `airgapupdate` command, specifically regressions and gaps in testing.

Specifically:
* Fix `airgapupdate` not being aware of planid
* Added the generic 'apply failed' to `airgapupdate`
* Avoid nil-pointer dereference on completed airgap commands

Also, there is a `Makefile` change that fixes some incorrect files being added into `GO_SRCS`

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings