### PR TITLE
Cordoning controller node for autopilot update

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -470,6 +470,7 @@ func (c *CmdOpts) startController(ctx context.Context) error {
 	c.ClusterComponents.Add(ctx, &controller.Autopilot{
 		K0sVars:            c.K0sVars,
 		AdminClientFactory: adminClientFactory,
+		EnableWorker:       c.EnableWorker,
 	})
 
 	perfTimer.Checkpoint("starting-cluster-components-init")

--- a/pkg/autopilot/constant/static.go
+++ b/pkg/autopilot/constant/static.go
@@ -15,11 +15,14 @@
 package constant
 
 const (
-	AutopilotName       = "autopilot"
-	AutopilotNamespace  = "k0s-autopilot"
-	AutopilotConfigName = AutopilotName
-	K0sBinaryDir        = "/usr/local/bin"
-	K0sDefaultDataDir   = "/var/lib/k0s"
-	K0sManifestSubDir   = "manifests"
-	K0sImagesDir        = "images"
+	AutopilotName                      = "autopilot"
+	AutopilotNamespace                 = "k0s-autopilot"
+	AutopilotConfigName                = AutopilotName
+	K0sBinaryDir                       = "/usr/local/bin"
+	K0sDefaultDataDir                  = "/var/lib/k0s"
+	K0sManifestSubDir                  = "manifests"
+	K0sImagesDir                       = "images"
+	K0SControlNodeModeAnnotation       = "autopilot.k0sproject.io/mode"
+	K0SControlNodeModeController       = "controller"
+	K0SControlNodeModeControllerWorker = "controller+worker"
 )

--- a/pkg/autopilot/controller/root_controller.go
+++ b/pkg/autopilot/controller/root_controller.go
@@ -57,7 +57,7 @@ type rootController struct {
 var _ aproot.Root = (*rootController)(nil)
 
 // NewRootController builds a root for autopilot "controller" operations.
-func NewRootController(cfg aproot.RootConfig, logger *logrus.Entry, cf apcli.FactoryInterface) (aproot.Root, error) {
+func NewRootController(cfg aproot.RootConfig, logger *logrus.Entry, enableWorker bool, cf apcli.FactoryInterface) (aproot.Root, error) {
 	c := &rootController{
 		cfg:           cfg,
 		log:           logger,
@@ -70,7 +70,7 @@ func NewRootController(cfg aproot.RootConfig, logger *logrus.Entry, cf apcli.Fac
 	c.stopSubHandler = c.stopSubControllers
 	c.leaseWatcherCreator = NewLeaseWatcher
 	c.setupHandler = func(ctx context.Context, cf apcli.FactoryInterface) error {
-		setupController := NewSetupController(c.log, cf, cfg.K0sDataDir)
+		setupController := NewSetupController(c.log, cf, cfg.K0sDataDir, enableWorker)
 		return setupController.Run(ctx)
 	}
 

--- a/pkg/autopilot/controller/root_controller_test.go
+++ b/pkg/autopilot/controller/root_controller_test.go
@@ -59,7 +59,7 @@ func TestModeSwitch(t *testing.T) {
 	logger := logrus.New().WithField("app", "autopilot-test")
 	clientFactory := aptu.NewFakeClientFactory()
 
-	rootControllerInterface, err := NewRootController(aproot.RootConfig{}, logger, clientFactory)
+	rootControllerInterface, err := NewRootController(aproot.RootConfig{}, logger, false, clientFactory)
 	assert.NoError(t, err)
 
 	rootController, ok := rootControllerInterface.(*rootController)

--- a/pkg/autopilot/controller/signal/k0s/cordon.go
+++ b/pkg/autopilot/controller/signal/k0s/cordon.go
@@ -105,10 +105,8 @@ func (r *cordoning) Reconcile(ctx context.Context, req cr.Request) (cr.Result, e
 	if err := signalData.Unmarshal(signalNode.GetAnnotations()); err != nil {
 		return cr.Result{}, fmt.Errorf("unable to unmarshal signal data for node='%s': %w", req.NamespacedName.Name, err)
 	}
-
-	kind := signalNode.GetObjectKind().GroupVersionKind().Kind
-	if kind != "Node" {
-		logger.Infof("ignoring non Node kind: %s", kind)
+	if !needsCordoning(signalNode) {
+		logger.Infof("ignoring non worker node")
 
 		return cr.Result{}, r.moveToNextState(ctx, signalNode, ApplyingUpdate)
 	}

--- a/pkg/autopilot/controller/signal/k0s/uncordon.go
+++ b/pkg/autopilot/controller/signal/k0s/uncordon.go
@@ -106,9 +106,8 @@ func (r *uncordoning) Reconcile(ctx context.Context, req cr.Request) (cr.Result,
 		return cr.Result{}, fmt.Errorf("unable to unmarshal signal data for node='%s': %w", req.NamespacedName.Name, err)
 	}
 
-	kind := signalNode.GetObjectKind().GroupVersionKind().Kind
-	if kind != "Node" {
-		logger.Infof("ignoring non Node kind: %s", kind)
+	if !needsCordoning(signalNode) {
+		logger.Infof("ignoring non worker node")
 
 		return cr.Result{}, r.moveToNextState(ctx, signalNode, apsigcomm.Completed)
 	}

--- a/pkg/component/controller/autopilot.go
+++ b/pkg/component/controller/autopilot.go
@@ -34,6 +34,7 @@ var _ component.Component = (*Autopilot)(nil)
 type Autopilot struct {
 	K0sVars            constant.CfgVars
 	AdminClientFactory kubernetes.ClientFactoryInterface
+	EnableWorker       bool
 }
 
 func (a *Autopilot) Init(ctx context.Context) error {
@@ -55,7 +56,7 @@ func (a *Autopilot) Run(ctx context.Context) error {
 		ManagerPort:         8899,
 		MetricsBindAddr:     "0",
 		HealthProbeBindAddr: "0",
-	}, logrus.WithFields(logrus.Fields{"component": "autopilot"}), autopilotClientFactory)
+	}, logrus.WithFields(logrus.Fields{"component": "autopilot"}), a.EnableWorker, autopilotClientFactory)
 	if err != nil {
 		return fmt.Errorf("failed to create autopilot controller: %w", err)
 	}


### PR DESCRIPTION
Signed-off-by: Alexey Makhov <amakhov@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1894

When a controller is running with `--single` or `--enable-worker` flags, we'd like to cordon nodes during updates.
During the startup, the controller adds the `autopilot.k0sproject.io/mode` annotation. We can check is during the update and decide if we want to cordon the node or not.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings