### PR TITLE
Do not use timeouted context as an argument to the GetRestConfig. Get…

### DIFF
--- a/pkg/component/worker/autopilot.go
+++ b/pkg/component/worker/autopilot.go
@@ -58,7 +58,7 @@ func (a *Autopilot) Run(ctx context.Context) error {
 	// needed by autopilot.
 
 	var restConfig *rest.Config
-	if err := wait.PollUntilWithContext(timeout, defaultPollDuration, func(ctx context.Context) (done bool, err error) {
+	if err := wait.PollUntilWithContext(timeout, defaultPollDuration, func(_ context.Context) (done bool, err error) {
 		log.Debugf("Attempting to load autopilot client config")
 		if restConfig, err = GetRestConfig(ctx, a.K0sVars.KubeletAuthConfigPath); err != nil {
 			log.WithError(err).Warnf("Failed to load autopilot client config, retrying in %v", defaultPollDuration)


### PR DESCRIPTION
GetRestConfig sets up the long-living goroutine which rotates the certificates based on a certificate TTL. If timeouted context is given it cancels the long-living goroutine

Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>

## Description

GetRestConfig sets up the long-living goroutine which rotates the certificates based on a certificate TTL. If timeouted context is given it cancels the long-living goroutine



## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings