### PR TITLE
Fix GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,15 +58,15 @@ jobs:
       - name: Prepare build environment
         run: .github/workflows/prepare-build-env.sh
 
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - name: Build
         run: make EMBEDDED_BINS_BUILDMODE=docker
         env:
           VERSION: ${{ needs.release.outputs.tag_name }}
+
+      - name: Set up Go for smoke tests
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Run basic smoke test
         run: make check-basic
@@ -108,12 +108,12 @@ jobs:
           asset_path: ./image-bundle/bundle.tar
           asset_name: k0s-airgap-bundle-${{ needs.release.outputs.tag_name }}-amd64
           asset_content_type: application/octet-stream
-      
+
       - name: Clean Docker after build
         if: always()
         run: |
           docker system prune --all --volumes --force
-      
+
       # https://github.com/actions/checkout/issues/273#issuecomment-642908752
       # Golang mod cache tends to set directories to read-only, which breaks any
       # attempts to simply remove those directories. The `make clean-gocache`
@@ -193,15 +193,15 @@ jobs:
         run: .github/workflows/prepare-build-env.sh
         working-directory: ./
 
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - name: Build
         run: make EMBEDDED_BINS_BUILDMODE=docker
         env:
           VERSION: ${{ needs.release.outputs.tag_name }}
+
+      - name: Set up Go for smoke tests
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Run basic smoke test
         run: make check-basic
@@ -271,18 +271,35 @@ jobs:
       - name: "Pre: Fixup directories"
         run: find . -type d -not -perm /u+w -exec chmod u+w '{}' \;
 
-      - name: Install GoLang for ARMHF
-        run: "echo $HOME/.local/go/bin >> $GITHUB_PATH; rm -rf $HOME/.local/go && mkdir -p $HOME/.local/go && curl --silent -L https://golang.org/dl/$(curl --silent -L 'https://golang.org/VERSION?m=text').linux-armv6l.tar.gz | tar -C $HOME/.local -xz"
-      - name: Go Version
-        run: go version
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
+
+      - name: Prepare build environment
+        run: .github/workflows/prepare-build-env.sh
+        working-directory: ./
 
       - name: Build
         run: make EMBEDDED_BINS_BUILDMODE=docker
         env:
           VERSION: ${{ needs.release.outputs.tag_name }}
+
+      # Need to install Go manually: https://github.com/actions/setup-go/issues/106
+      - name: Set up Go for smoke tests (armv6l)
+        run: |
+          echo "Setup go stable version $GO_VERSION"
+          rm -rf -- "$HOME/.local/go"
+          mkdir -p -- "$HOME/.local/go"
+          curl --silent -L "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar -C "$HOME/.local" -xz
+
+          echo "$HOME/.local/go/bin" >>"$GITHUB_PATH"
+          export PATH="$PATH:$HOME/.local/go/bin"
+          echo Added go to the path
+
+          echo "Successfully setup go version $GO_VERSION"
+          go version
+          echo ::group::go env
+          go env
+          echo ::endgroup::
 
       - name: Run basic smoke test
         run: make check-basic
@@ -389,7 +406,6 @@ jobs:
             docker.io/k0sproject/k0s:${{ needs.release.outputs.image_tag }}
           push: true
 
-
   conformance-test:
     needs:
       - release
@@ -470,4 +486,3 @@ jobs:
 
           terraform destroy -auto-approve
         if: ${{ always() }}
-

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,6 @@ ifeq ($(DEBUG), false)
 LD_FLAGS ?= -w -s
 endif
 
-KUBECTL_VERSION = $(shell go mod graph |  grep "github.com/k0sproject/k0s" |  grep kubectl  | cut -d "@" -f 2 | sed "s/v0\./1./")
-KUBECTL_MAJOR= $(shell echo ${KUBECTL_VERSION} | cut -d "." -f 1)
-KUBECTL_MINOR= $(shell echo ${KUBECTL_VERSION} | cut -d "." -f 2)
-
 # https://reproducible-builds.org/docs/source-date-epoch/#makefile
 # https://reproducible-builds.org/docs/source-date-epoch/#git
 # https://stackoverflow.com/a/15103333
@@ -48,9 +44,9 @@ LD_FLAGS += -X github.com/k0sproject/k0s/pkg/build.EtcdVersion=$(etcd_version)
 LD_FLAGS += -X github.com/k0sproject/k0s/pkg/build.KonnectivityVersion=$(konnectivity_version)
 LD_FLAGS += -X "github.com/k0sproject/k0s/pkg/build.EulaNotice=$(EULA_NOTICE)"
 LD_FLAGS += -X github.com/k0sproject/k0s/pkg/telemetry.segmentToken=$(SEGMENT_TOKEN)
-LD_FLAGS += -X k8s.io/component-base/version.gitVersion=v$(KUBECTL_VERSION)
-LD_FLAGS += -X k8s.io/component-base/version.gitMajor=$(KUBECTL_MAJOR)
-LD_FLAGS += -X k8s.io/component-base/version.gitMinor=$(KUBECTL_MINOR)
+LD_FLAGS += -X k8s.io/component-base/version.gitVersion=v$(kubernetes_version)
+LD_FLAGS += -X k8s.io/component-base/version.gitMajor=$(shell echo '$(kubernetes_version)' | cut -d. -f1)
+LD_FLAGS += -X k8s.io/component-base/version.gitMinor=$(shell echo '$(kubernetes_version)' | cut -d. -f2)
 LD_FLAGS += -X k8s.io/component-base/version.buildDate=$(BUILD_DATE)
 LD_FLAGS += -X k8s.io/component-base/version.gitCommit=not_available
 LD_FLAGS += -X github.com/containerd/containerd/version.Version=$(containerd_version)

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150
+	golang.org/x/tools v0.1.10-0.20220218145154-897bd77cd717
 	google.golang.org/grpc v1.48.0
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.9.1
@@ -262,7 +263,6 @@ require (
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306 // indirect
-	golang.org/x/tools v0.1.10-0.20220218145154-897bd77cd717 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/pkg/constant/constant_shared_test.go
+++ b/pkg/constant/constant_shared_test.go
@@ -23,22 +23,107 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"golang.org/x/tools/go/packages"
 )
 
-func TestKonnectivityVersion(t *testing.T) {
-	assert.Equal(t, getVersion(t, "konnectivity"), strings.TrimPrefix(KonnectivityImageVersion, "v"))
+func TestConstants(t *testing.T) {
+	for _, test := range []struct{ name, constant, varName string }{
+		{"KonnectivityImageVersion", "v" + KonnectivityImageVersion, "konnectivity"},
+		{"KubeProxyImageVersion", KubeProxyImageVersion, "kubernetes"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, "v"+getVersion(t, test.varName), test.constant)
+		})
+	}
+
+	t.Run("KubernetesMajorMinorVersion", func(t *testing.T) {
+		ver := strings.Split(getVersion(t, "kubernetes"), ".")
+		require.GreaterOrEqual(t, len(ver), 2, "failed to spilt Kubernetes version %q", ver)
+		kubeMajorMinor := ver[0] + "." + ver[1]
+		assert.Equal(t, kubeMajorMinor, KubernetesMajorMinorVersion)
+	})
 }
 
-func TestKubeProxyVersion(t *testing.T) {
-	assert.Equal(t, getVersion(t, "kubernetes"), strings.TrimPrefix(KubeProxyImageVersion, "v"))
+func TestKubernetesModuleVersions(t *testing.T) {
+	kubernetesVersion := getVersion(t, "kubernetes")
+
+	checkPackageModules(t,
+		func(modulePath string) bool {
+			switch modulePath {
+			// Don't report any version mismatches on the following modules.
+			// They have a release cycle which is decoupled from k8s itself.
+			case "k8s.io/klog/v2", "k8s.io/kube-openapi", "k8s.io/utils":
+				return false
+
+			default:
+				return strings.HasPrefix(modulePath, "k8s.io/")
+			}
+		},
+		func(t *testing.T, pkgPath string, module *packages.Module) bool {
+			modVer := module.Version
+			if module.Path != "k8s.io/kubernetes" {
+				// All modules besides Kubernetes itself use v0 instead of v1.
+				modVer = strings.Replace(modVer, "v0.", "v1.", 1)
+			}
+
+			return !assert.Equal(t, "v"+kubernetesVersion, modVer,
+				"Module version for package %s doesn't match: %+#v",
+				pkgPath, module,
+			)
+		},
+	)
 }
 
-func TestKubernetesMajorMinorVersion(t *testing.T) {
-	ver := strings.Split(getVersion(t, "kubernetes"), ".")
-	require.GreaterOrEqual(t, len(ver), 2, "failed to spilt Kubernetes version %q", ver)
-	kubeMinorMajor := ver[0] + "." + ver[1]
+func TestEtcdModuleVersions(t *testing.T) {
+	etcdVersion := getVersion(t, "etcd")
+	etcdVersionParts := strings.Split(etcdVersion, ".")
+	require.GreaterOrEqual(t, len(etcdVersionParts), 1, "failed to spilt etcd version %q", etcdVersion)
 
-	assert.Equal(t, kubeMinorMajor, KubernetesMajorMinorVersion)
+	checkPackageModules(t,
+		func(modulePath string) bool {
+			return strings.HasPrefix(modulePath, "go.etcd.io/etcd/") &&
+				strings.HasSuffix(modulePath, "/v"+etcdVersionParts[0])
+		},
+		func(t *testing.T, pkgPath string, module *packages.Module) bool {
+			return !assert.Equal(t, "v"+etcdVersion, module.Version,
+				"Module version for package %s doesn't match: %+#v",
+				pkgPath, module,
+			)
+		},
+	)
+}
+
+func TestContainerdModuleVersions(t *testing.T) {
+	containerdVersion := getVersion(t, "containerd")
+
+	checkPackageModules(t,
+		func(modulePath string) bool {
+			return modulePath == "github.com/containerd/containerd"
+		},
+		func(t *testing.T, pkgPath string, module *packages.Module) bool {
+			return !assert.Equal(t, "v"+containerdVersion, module.Version,
+				"Module version for package %s doesn't match: %+#v",
+				pkgPath, module,
+			)
+		},
+	)
+}
+
+func TestRuncModuleVersions(t *testing.T) {
+	runcVersion := getVersion(t, "runc")
+
+	checkPackageModules(t,
+		func(modulePath string) bool {
+			return modulePath == "github.com/opencontainers/runc"
+		},
+		func(t *testing.T, pkgPath string, module *packages.Module) bool {
+			return !assert.Equal(t, "v"+runcVersion, module.Version,
+				"Module version for package %s doesn't match: %+#v",
+				pkgPath, module,
+			)
+		},
+	)
 }
 
 func getVersion(t *testing.T, component string) string {
@@ -50,4 +135,35 @@ func getVersion(t *testing.T, component string) string {
 	require.NotEmpty(t, out, "failed to get %s version", component)
 
 	return strings.TrimSuffix(string(out), "\n")
+}
+
+func checkPackageModules(t *testing.T, filter func(modulePath string) bool, check func(t *testing.T, pkgPath string, module *packages.Module) bool) {
+	pkgs, err := packages.Load(&packages.Config{
+		Mode: packages.NeedName | packages.NeedModule | packages.NeedImports | packages.NeedDeps,
+		Logf: t.Logf,
+	}, "github.com/k0sproject/k0s")
+	require.NoError(t, err)
+
+	failedModules := make(map[string]bool)
+	checkCalledAtLeastOnce := false
+
+	packages.Visit(pkgs, func(p *packages.Package) bool {
+		if p.Module != nil && filter(p.Module.Path) {
+			actual := p.Module
+			for actual.Replace != nil {
+				actual = actual.Replace
+			}
+
+			if !failedModules[actual.Path] {
+				checkCalledAtLeastOnce = true
+				if !check(t, p.PkgPath, actual) {
+					failedModules[actual.Path] = true
+				}
+			}
+		}
+
+		return true
+	}, nil)
+
+	assert.True(t, checkCalledAtLeastOnce, "Not a single package passed the filter.")
 }


### PR DESCRIPTION
## Description

The build of the k0s binary aims to not rely on the Go toolchain installed on the build host. The toolchain installation was removed from the GitHub workflow that builds the Windows binary under that assumption in fe4f1948d.

However, that assumption does not hold, as there's still one invocation of the go binary inside a Makefile shell function. Building k0s when there's no go binary in the path doesn't break the build, but produces a binary that panics at runtime, since some of the variables set at link time have invalid values.

Fix this by determining the link time variables via another mechanism that doesn't rely on the go binary. Add additional tests that check for consistency between the binary versions of the embedded binaries with their respective Go module dependencies, so that it's safe to assume that they are in sync.

Move down the toolchain installation in the other release builds just before the smoke tests, as they are the only ones which require it.

Copy over the ARM toolchain installation procedure from the PR workflow to the release workflow, which also ensures that the ARM release actually uses a fixed Go version to execute the smokes.

Fixes #1922.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings