### PR TITLE
Add config option to enable hairpin mode in kube-router

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -171,6 +171,7 @@ jobs:
           - check-externaletcd
           - check-hacontrolplane
           - check-kine
+          - check-kuberouter
           - check-kubeletcertrotate
           - check-metrics
           - check-multicontroller

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,6 +63,7 @@ spec:
       peerRouterIPs: ""
       peerRouterASNs: ""
       autoMTU: true
+      hairpinMode: false
     kubeProxy:
       disabled: false
       mode: iptables
@@ -171,6 +172,7 @@ spec:
 | `mtu`            | Override MTU setting, if `autoMTU` must be set to `false`).                                                                                        |
 | `peerRouterIPs`  | Comma-separated list of [global peer addresses](https://github.com/cloudnativelabs/kube-router/blob/master/docs/bgp.md#global-external-bgp-peers). |
 | `peerRouterASNs` | Comma-separated list of [global peer ASNs](https://github.com/cloudnativelabs/kube-router/blob/master/docs/bgp.md#global-external-bgp-peers).      |
+| `hairpinMode`    | Activate hairpinMode (default: `false`) (https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md#hairpin-mode)               |
 
 **Note**: Kube-router allows many networking aspects to be configured per node, service, and pod (for more information, refer to the [Kube-router user guide](https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md)).
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -17,6 +17,7 @@ Kube-router is built into k0s, and so by default the distribution uses it for ne
 - Uses bit less resources (~15%)
 - Does NOT support dual-stack (IPv4/IPv6) networking
 - Does NOT support Windows nodes
+- Does NOT activate hairpin mode by default
 
 ### Calico
 

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -26,6 +26,7 @@ smoketests := \
 	check-hacontrolplane \
 	check-k0scloudprovider \
 	check-kine \
+	check-kuberouter \
 	check-kubeletcertrotate \
 	check-metrics \
 	check-multicontroller \

--- a/inttest/common/util.go
+++ b/inttest/common/util.go
@@ -128,14 +128,24 @@ func waitForDeployment(kc *kubernetes.Clientset, name string) wait.ConditionWith
 
 // WaitForPod waits for pod be running
 func WaitForPod(kc *kubernetes.Clientset, name, namespace string) error {
-	return fallbackPoll(func(ctx context.Context) (done bool, err error) {
+	return fallbackPoll(waitForPod(kc, name, namespace))
+}
+
+// WaitForPod waits until a pod is running as long as the given context isn't
+// canceled.
+func WaitForPodWithContext(ctx context.Context, kc *kubernetes.Clientset, name, namespace string) error {
+	return Poll(ctx, waitForPod(kc, name, namespace))
+}
+
+func waitForPod(kc *kubernetes.Clientset, name, namespace string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (done bool, err error) {
 		ds, err := kc.CoreV1().Pods(namespace).Get(ctx, name, v1.GetOptions{})
 		if err != nil {
 			return false, nil
 		}
 
 		return ds.Status.Phase == "Running", nil
-	})
+	}
 }
 
 // WaitForPodLogs picks the first Ready pod from the list of pods in given namespace and gets the logs of it

--- a/inttest/kuberouter/kuberouter_hairpin_test.go
+++ b/inttest/kuberouter/kuberouter_hairpin_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package kuberouter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/k0sproject/k0s/inttest/common"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type KubeRouterHairpinSuite struct {
+	common.FootlooseSuite
+}
+
+func (s *KubeRouterHairpinSuite) TestK0sGetsUp() {
+	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfigWithHairpinning)
+	s.Require().NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
+	s.MakeDir(s.ControllerNode(0), "/var/lib/k0s/manifests/test")
+	s.PutFile(s.ControllerNode(0), "/var/lib/k0s/manifests/test/pod.yaml", podManifest)
+	s.PutFile(s.ControllerNode(0), "/var/lib/k0s/manifests/test/service.yaml", serviceManifest)
+	s.Require().NoError(s.RunWorkers())
+
+	kc, err := s.KubeClient("controller0", "")
+	s.NoError(err)
+
+	err = s.WaitForNodeReady("worker0", kc)
+	s.NoError(err)
+
+	err = s.WaitForNodeReady("worker1", kc)
+	s.NoError(err)
+
+	s.T().Log("waiting to see kube-router pods ready")
+	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "kube-router did not start")
+
+	s.T().Log("waiting to see hairpin pod ready")
+	err = common.WaitForPodWithContext(s.Context(), kc, "hairpin-pod", "default")
+	s.NoError(err)
+
+	s.T().Run("check hairpin mode", func(t *testing.T) {
+		// All done via SSH as it's much simpler :)
+		// e.g. execing via client-go is super complex and would require too much wiring
+		ssh, err := s.SSH(s.ControllerNode(0))
+		require.NoError(t, err)
+		defer ssh.Disconnect()
+
+		const curl = "k0s kc exec -n default hairpin-pod -c curl -- curl"
+		for _, test := range []struct {
+			dnsName string
+			desc    string
+		}{
+			{
+				"localhost",
+				"pod can reach itself via loopback",
+			},
+			{
+				"hairpin",
+				"pod can reach itself via service name",
+			},
+		} {
+			t.Run(test.desc, func(t *testing.T) {
+				output, err := ssh.ExecWithOutput(fmt.Sprintf("%s --connect-timeout 5 -sS http://%s", curl, test.dnsName))
+				if !assert.NoError(t, err) || !assert.Contains(t, output, "Thank you for using nginx.") {
+					t.Log(output)
+				}
+			})
+		}
+	})
+}
+
+func TestKubeRouterHairpinSuite(t *testing.T) {
+	s := KubeRouterHairpinSuite{
+		common.FootlooseSuite{
+			ControllerCount: 1,
+			WorkerCount:     2,
+		},
+	}
+	suite.Run(t, &s)
+}
+
+const k0sConfigWithHairpinning = `
+spec:
+  network:
+    provider: kuberouter
+    kuberouter:
+      hairpinMode: true
+`
+
+const podManifest = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hairpin-pod
+  namespace: default
+  labels:
+    app.kubernetes.io/name: hairpin
+spec:
+  containers:
+  - name: nginx
+    image: docker.io/library/nginx:1.23.1-alpine
+    ports:
+    - containerPort: 80
+  - name: curl
+    image: docker.io/curlimages/curl:7.84.0
+    command: ["/bin/sh", "-c"]
+    args: ["tail -f /dev/null"]
+`
+
+const serviceManifest = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: hairpin
+  namespace: default
+spec:
+  selector:
+    app.kubernetes.io/name: hairpin
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+`

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/kuberouter.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/kuberouter.go
@@ -21,6 +21,8 @@ type KubeRouter struct {
 	AutoMTU bool `json:"autoMTU"`
 	// Override MTU setting (autoMTU must be set to false)
 	MTU int `json:"mtu"`
+	// Activate Hairpin Mode (allow a Pod behind a Service to communicate to its own ClusterIP:Port)
+	HairpinMode bool `json:"hairpinMode"`
 	// Comma-separated list of global peer addresses
 	PeerRouterASNs string `json:"peerRouterASNs"`
 	// Comma-separated list of global peer ASNs

--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -46,6 +46,7 @@ type kubeRouterConfig struct {
 	AutoMTU           bool
 	CNIInstallerImage string
 	CNIImage          string
+	HairpinMode       bool
 	PeerRouterIPs     string
 	PeerRouterASNs    string
 	PullPolicy        string
@@ -87,6 +88,7 @@ func (k *KubeRouter) Reconcile(_ context.Context, clusterConfig *v1beta1.Cluster
 		MTU:               clusterConfig.Spec.Network.KubeRouter.MTU,
 		PeerRouterIPs:     clusterConfig.Spec.Network.KubeRouter.PeerRouterIPs,
 		PeerRouterASNs:    clusterConfig.Spec.Network.KubeRouter.PeerRouterASNs,
+		HairpinMode:       clusterConfig.Spec.Network.KubeRouter.HairpinMode,
 		CNIImage:          clusterConfig.Spec.Images.KubeRouter.CNI.URI(),
 		CNIInstallerImage: clusterConfig.Spec.Images.KubeRouter.CNIInstaller.URI(),
 		PullPolicy:        clusterConfig.Spec.Images.DefaultPullPolicy,
@@ -147,6 +149,7 @@ data:
              "auto-mtu": {{ .AutoMTU }},
              "bridge":"kube-bridge",
              "isDefaultGateway":true,
+             "hairpinMode": {{ .HairpinMode }},
              "ipam":{
                 "type":"host-local"
              }
@@ -253,6 +256,7 @@ spec:
         - "--run-service-proxy=false"
         - "--bgp-graceful-restart=true"
         - "--metrics-port=8080"
+        - "--hairpin-mode={{ .HairpinMode }}"
         {{- if .PeerRouterIPs }}
         - "--peer-router-ips={{ .PeerRouterIPs }}"
         {{- end }}

--- a/static/manifests/v1beta1/CustomResourceDefinition/k0s.k0sproject.io_clusterconfigs.yaml
+++ b/static/manifests/v1beta1/CustomResourceDefinition/k0s.k0sproject.io_clusterconfigs.yaml
@@ -343,6 +343,10 @@ spec:
                       autoMTU:
                         description: 'Auto-detection of used MTU (default: true)'
                         type: boolean
+                      hairpinMode:
+                        description: Activate Hairpin Mode (allow a Pod behind a Service
+                          to communicate to its own ClusterIP:Port)
+                        type: boolean
                       mtu:
                         description: Override MTU setting (autoMTU must be set to
                           false)


### PR DESCRIPTION
## Description

Kube-router doesn't support hairpinning by default - it needs to be activated explicitly. Hairpinnig is needed whenever a pod behind a service needs to communicate with the service.
This PR adds a config option to enable hairpinning in kube-router.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

I created a k0s-cluster and verified the configuration changes documented in https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md#hairpin-mode were active. Next i successfully checked the communication between a pod and its 'own' service. 

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings