### PR TITLE
Fix multi-arch images build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,12 +371,12 @@ jobs:
       - name: Fetch k0s arm64
         uses: actions/download-artifact@v3
         with:
-          name: k0s-amd64
+          name: k0s-arm64
           path: ./k0s-arm64
       - name: Fetch k0s arm
         uses: actions/download-artifact@v3
         with:
-          name: k0s-amd64
+          name: k0s-arm
           path: ./k0s-arm
 
       - name: Build image and push to Docker Hub and GitHub image registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,15 @@ ARG ARCH
 FROM ${ARCH}alpine:3.16
 ARG TARGETARCH
 
-RUN apk add --no-cache bash coreutils findutils curl tini
+RUN apk add --no-cache bash coreutils findutils iptables curl tini
 
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
 ADD docker-entrypoint.sh /entrypoint.sh
 ADD ./k0s-${TARGETARCH}/k0s /usr/local/bin/k0s
 
-ENTRYPOINT ["/sbin/tini", "--", "/bin/sh", "/entrypoint.sh" ]
+RUN chmod +x /usr/local/bin/k0s
 
+ENTRYPOINT ["/sbin/tini", "--", "/bin/sh", "/entrypoint.sh" ]
 
 CMD ["k0s", "controller", "--enable-worker"]


### PR DESCRIPTION
Signed-off-by: Alexey Makhov <amakhov@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1936

There are several bugs in the multi-arch images build:  
- `iptables` was removed from the docker image since k0s doesn't need it. But the `entrypoint.sh` needs it, so I brought it back
- wrong artifacts are downloaded for arm64 and armv7 images. 
- execution permission is missing for the binary 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings