### PR TITLE
Add missing pid file to openrc init close #1775

### DIFF
--- a/pkg/install/linux_openrc.go
+++ b/pkg/install/linux_openrc.go
@@ -26,6 +26,7 @@ command={{.Path|cmdEscape}}
 command_args="{{range .Arguments}}'{{.}}' {{end}}"
 {{- end }}
 name=$(basename $(readlink -f $command))
+pidfile="/run/${name}.pid"
 supervise_daemon_args="--stdout /var/log/${name}.log --stderr /var/log/${name}.err"
 
 : "${rc_ulimit=-n 1048576 -u unlimited}"


### PR DESCRIPTION
Fix

```
INFO ==> Running phase: Initialize the k0s cluster 
INFO [ssh] ip:22: installing k0s controller 
INFO * Running clean-up for phase: Initialize the k0s cluster 
ERRO apply failed - log file saved to /home/karen/.cache/k0sctl/k0sctl.log 
FATA Process exited with status 1
```
