### PR TITLE
Fix airgap arm64 build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -342,6 +342,9 @@ jobs:
       - name: Run smoketest
         run: make -C inttest check-basic
 
+      - name: Run airgap test
+        run: make check-airgap TARGET_PLATFORM=linux/${{ matrix.arch }}
+
       - name: Collect test logs
         if: failure()
         uses: actions/upload-artifact@v3

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/avast/retry-go"
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/platforms"
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
@@ -61,7 +62,7 @@ func (a *OCIBundleReconciler) Run(ctx context.Context) error {
 	var client *containerd.Client
 	sock := filepath.Join(a.k0sVars.RunDir, "containerd.sock")
 	err = retry.Do(func() error {
-		client, err = containerd.New(sock, containerd.WithDefaultNamespace("k8s.io"))
+		client, err = containerd.New(sock, containerd.WithDefaultNamespace("k8s.io"), containerd.WithDefaultPlatform(platforms.OnlyStrict(platforms.DefaultSpec())))
 		if err != nil {
 			logrus.WithError(err).Errorf("can't connect to containerd socket %s", sock)
 			return err


### PR DESCRIPTION
Signed-off-by: Alexey Makhov <amakhov@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1939

For airgap bundles, we export images for the platform into the tar archive and then try to import them on k0s startup. 
The problem here is that by default during import containerd matches platforms not strictly, so for arm64 it tries to import both arm64 and armv7 images, but there are no armv7 blobs in the archive.

So, the actual fix is to change the `Only` matcher to the `OnlyStrict` one.

There is the PR with a similar fix for `ctr import` command: https://github.com/containerd/containerd/pull/6906

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings