### PR TITLE
fix(docs): feature gates are of type bool

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -243,9 +243,9 @@ spec:
     - name: custom-feature-gate      # name of the worker profile
       values:
          featureGates:        # feature gates mapping
-            DevicePlugins: "true"
-            Accelerators: "true"
-            AllowExtTrafficLocalEndpoints: "false"
+            DevicePlugins: true
+            Accelerators: true
+            AllowExtTrafficLocalEndpoints: false
 ```
 
 ##### Custom volumePluginDir


### PR DESCRIPTION
Signed-off-by: danmx <daniel@iziourov.info>

## Description

Fixing documentation to match what's expected by `kubelet`.

When using strings instead of booleans kubelet raised a JSONparsing error:

```
Jul 29 08:22:10 hostname k0s[1953]: #9: can't unmarshal kubelet config: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go struct field KubeletConfiguration.featureGates of type bool                                                                                                                                                                                                  
```

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings