### PR TITLE
Use a custom GitHub token for checkouts in the backport action

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -30,6 +30,7 @@ jobs:
         with:
           # required to find all branches
           fetch-depth: 0
+          token: ${{ secrets.GH_BACKPORT_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Create backport PRs
         # should be kept in sync with `version`


### PR DESCRIPTION
## Description

The default GitHub token is not entitled to make changes to GitHub workflows. Hence, backporting changes to workflows will fail, since the git push operation that touches the workflow files will be rejected with a permission error:

> ! [remote rejected]   backport-1954-to-release-1.23 -> backport-1954-to-release-1.23 (refusing to allow a GitHub App to create or update workflow `.github/workflows/go.yml` without `workflows` permission)

Use the same token for git pull/push that is used for GitHub API access. This one will have the appropriate permissions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings