### PR TITLE
[Backport release-1.24] Bump Calico to v3.23.3

### DIFF
--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -86,7 +86,7 @@ const (
 	CoreDNSImage                       = "k8s.gcr.io/coredns/coredns"
 	CoreDNSImageVersion                = "v1.7.0"
 	CalicoImage                        = "docker.io/calico/cni"
-	CalicoComponentImagesVersion       = "v3.23.1"
+	CalicoComponentImagesVersion       = "v3.23.3"
 	CalicoNodeImage                    = "docker.io/calico/node"
 	KubeControllerImage                = "docker.io/calico/kube-controllers"
 	KubeRouterCNIImage                 = "docker.io/cloudnativelabs/kube-router"

--- a/static/manifests/calico/ClusterRole/calico-node.yaml
+++ b/static/manifests/calico/ClusterRole/calico-node.yaml
@@ -69,6 +69,14 @@ rules:
       - pods/status
     verbs:
       - patch
+  # Used for creating service account tokens to be used by the CNI plugin
+  - apiGroups: [""]
+    resources:
+      - serviceaccounts/token
+    resourceNames:
+      - calico-node
+    verbs:
+      - create
   # Calico monitors various CRDs for config.
   - apiGroups: ["crd.projectcalico.org"]
     resources:
@@ -154,4 +162,3 @@ rules:
       - daemonsets
     verbs:
       - get
-


### PR DESCRIPTION
Automated backport to `release-1.24`, triggered by a label in #1897.
See .