### PR TITLE
[Backport release-1.24] Use a custom GitHub token for checkouts in the backport action

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -30,6 +30,7 @@ jobs:
         with:
           # required to find all branches
           fetch-depth: 0
+          token: ${{ secrets.GH_BACKPORT_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Create backport PRs
         # should be kept in sync with `version`


### PR DESCRIPTION
Automated backport to `release-1.24`, triggered by a label in #1963.
See .