### PR TITLE
[Backport release-1.22] [Backport release-1.23] Use a custom GitHub token in the backport action

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: zeebe-io/backport-action@v0.0.8
         with:
           # Config README: https://github.com/zeebe-io/backport-action#backport-action
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_BACKPORT_TOKEN }}
           github_workspace: ${{ github.workspace }}
           # should be kept in sync with `uses`
           version: v0.0.8


### PR DESCRIPTION
Automated backport to `release-1.22`, triggered by a label in #1961.
See .