### PR TITLE
fix(docs): official way to enable nvidia-container-runtime

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -122,26 +122,18 @@ Finally, if you want to change CRI look into:
 By default, CRI is set to runC. As such, you must configure Nvidia GPU support by replacing `runc` with `nvidia-container-runtime`:
 
 ```toml
-[plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
-runtime_type = "io.containerd.runtime.v1.linux"
-runtime_engine = ""
-runtime_root = ""
-privileged_without_host_devices = false
-base_runtime_spec = ""
-[plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
-Runtime = "nvidia-container-runtime"
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvdia]
-runtime_type = "io.containerd.runtime.v1.linux"
-runtime_engine = ""
-runtime_root = ""
-privileged_without_host_devices = false
-base_runtime_spec = ""
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvdia.options]
-Runtime = "nvidia-container-runtime"
+[plugins."io.containerd.grpc.v1.cri".containerd]
+    default_runtime_name = "nvidia"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+    privileged_without_host_devices = false
+    runtime_engine = ""
+    runtime_root = ""
+    runtime_type = "io.containerd.runc.v1"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
+    BinaryName = "/usr/bin/nvidia-container-runtime"
 ```
 
-**Note** Detailed instruction on how to run `nvidia-container-runtime` on your node is available [here](https://josephb.org/blog/containerd-nvidia/).
+**Note** Detailed instruction on how to run `nvidia-container-runtime` on your node is available [here](https://docs.nvidia.com/datacenter/cloud-native/kubernetes/install-k8s.html#install-nvidia-container-toolkit-nvidia-docker2).
 
 After editing the configuration, restart `k0s` to get containerd using the newly configured runtime.
 


### PR DESCRIPTION
Signed-off-by: danmx <daniel@iziourov.info>

## Description

Updating documentation to follow NVIDIA's recommended `containerd` configuration to enable `nvidia-container-runtime`.

https://docs.nvidia.com/datacenter/cloud-native/kubernetes/install-k8s.html#install-nvidia-container-toolkit-nvidia-docker2

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings