### PR TITLE
Bump Go to v1.19.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -312,7 +312,7 @@ jobs:
           echo "Setup go stable version $GO_VERSION"
           rm -rf -- "$HOME/.local/go"
           mkdir -p -- "$HOME/.local/go"
-          curl --silent -L "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar -C "$HOME/.local" -xz
+          curl --silent -L "https://go.dev/dl/go${GO_VERSION%%.0}.linux-armv6l.tar.gz" | tar -C "$HOME/.local" -xz
 
           echo "$HOME/.local/go/bin" >>"$GITHUB_PATH"
           export PATH="$PATH:$HOME/.local/go/bin"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
           echo "Setup go stable version $GO_VERSION"
           rm -rf -- "$HOME/.local/go"
           mkdir -p -- "$HOME/.local/go"
-          curl --silent -L "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar -C "$HOME/.local" -xz
+          curl --silent -L "https://go.dev/dl/go${GO_VERSION%%.0}.linux-armv6l.tar.gz" | tar -C "$HOME/.local" -xz
 
           echo "$HOME/.local/go/bin" >>"$GITHUB_PATH"
           export PATH="$PATH:$HOME/.local/go/bin"

--- a/cmd/airgap/airgap.go
+++ b/cmd/airgap/airgap.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package airgap
 
 import (

--- a/cmd/airgap/listimages.go
+++ b/cmd/airgap/listimages.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package airgap
 
 import (

--- a/cmd/airgap/listimages_test.go
+++ b/cmd/airgap/listimages_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package airgap
 
 import (

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package api
 
 import (

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -275,13 +275,13 @@ func (c *CmdOpts) caHandler() http.Handler {
 	})
 }
 
-/** The token is in form of xyz.foobar where:
-- xyz: the token "ID" in kube api
-- foobar: the token itself
-We need to validate:
-- that we find a secret with the ID
-- that the token matches whats inside the secret
-*/
+// The token is in form of xyz.foobar where:
+//   - xyz: the token "ID" in kube api
+//   - foobar: the token itself
+//
+// We need to validate:
+//   - that we find a secret with the ID
+//   - that the token matches whats inside the secret
 func (c *CmdOpts) isValidToken(ctx context.Context, token string, role string) bool {
 	parts := strings.Split(token, ".")
 	logrus.Debugf("token parts: %v", parts)

--- a/cmd/api/util.go
+++ b/cmd/api/util.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package api
 
 import (

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 import (

--- a/cmd/config/create.go
+++ b/cmd/config/create.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 import (

--- a/cmd/config/edit.go
+++ b/cmd/config/edit.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 import (

--- a/cmd/config/status.go
+++ b/cmd/config/status.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 import (

--- a/cmd/config/validate.go
+++ b/cmd/config/validate.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 import (

--- a/cmd/controller/certificates.go
+++ b/cmd/controller/certificates.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/cmd/ctr/ctr.go
+++ b/cmd/ctr/ctr.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ctr
 
 import (

--- a/cmd/etcd/etcd.go
+++ b/cmd/etcd/etcd.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package etcd
 
 import (

--- a/cmd/etcd/leave.go
+++ b/cmd/etcd/leave.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package etcd
 
 import (

--- a/cmd/etcd/list.go
+++ b/cmd/etcd/list.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package etcd
 
 import (

--- a/cmd/install/controller.go
+++ b/cmd/install/controller.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package install
 
 import (

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package install
 
 import (

--- a/cmd/install/util.go
+++ b/cmd/install/util.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package install
 
 import (

--- a/cmd/install/worker.go
+++ b/cmd/install/worker.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package install
 
 import (

--- a/cmd/kubeconfig/admin.go
+++ b/cmd/kubeconfig/admin.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubeconfig
 
 import (

--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubeconfig
 
 import (

--- a/cmd/kubeconfig/kubeconfig.go
+++ b/cmd/kubeconfig/kubeconfig.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubeconfig
 
 import (

--- a/cmd/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeconfig/kubeconfig_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubeconfig
 
 import (

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubectl
 
 import (

--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package reset
 
 import (

--- a/cmd/restore/restore_windows.go
+++ b/cmd/restore/restore_windows.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package restore
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package start
 
 import (

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package status
 
 import (

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package stop
 
 import (

--- a/cmd/sysinfo/sysinfo.go
+++ b/cmd/sysinfo/sysinfo.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sysinfo
 
 import (

--- a/cmd/token/create.go
+++ b/cmd/token/create.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package token
 
 import (

--- a/cmd/token/invalidate.go
+++ b/cmd/token/invalidate.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package token
 
 import (

--- a/cmd/token/list.go
+++ b/cmd/token/list.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package token
 
 import (

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package token
 
 import (

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package validate
 
 import (

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package version
 
 import (

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package worker
 
 import (

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,4 +1,4 @@
-go_version = 1.18.5
+go_version = 1.19.0
 
 runc_version = 1.1.3
 runc_buildimage = golang:$(go_version)-alpine3.16

--- a/hack/validate-images/main.go
+++ b/hack/validate-images/main.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import (

--- a/internal/autopilot/pkg/random/random.go
+++ b/internal/autopilot/pkg/random/random.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package random
 
 import (

--- a/internal/autopilot/pkg/templatewriter/templatewriter.go
+++ b/internal/autopilot/pkg/templatewriter/templatewriter.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package templatewriter
 
 import (

--- a/internal/pkg/archive/archive.go
+++ b/internal/pkg/archive/archive.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package archive
 
 import (

--- a/internal/pkg/dir/dir.go
+++ b/internal/pkg/dir/dir.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package dir
 
 import (

--- a/internal/pkg/dir/dir_test.go
+++ b/internal/pkg/dir/dir_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package dir
 
 import (

--- a/internal/pkg/file/file_test.go
+++ b/internal/pkg/file/file_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package file
 
 import (

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package flags
 
 import (

--- a/internal/pkg/flags/flags_test.go
+++ b/internal/pkg/flags/flags_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package flags
 
 import (

--- a/internal/pkg/iface/iface.go
+++ b/internal/pkg/iface/iface.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package iface
 
 import (

--- a/internal/pkg/random/random.go
+++ b/internal/pkg/random/random.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package random
 
 import "crypto/rand"

--- a/internal/pkg/strictyaml/strictyaml.go
+++ b/internal/pkg/strictyaml/strictyaml.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package strictyaml
 
 import (

--- a/internal/pkg/strictyaml/strictyaml_test.go
+++ b/internal/pkg/strictyaml/strictyaml_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package strictyaml
 
 import (

--- a/internal/pkg/stringmap/stringmap.go
+++ b/internal/pkg/stringmap/stringmap.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package stringmap
 
 import "fmt"

--- a/internal/pkg/stringmap/stringmap_test.go
+++ b/internal/pkg/stringmap/stringmap_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package stringmap
 
 import (

--- a/internal/pkg/stringslice/stringslice.go
+++ b/internal/pkg/stringslice/stringslice.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package stringslice
 
 import (

--- a/internal/pkg/stringslice/stringslice_test.go
+++ b/internal/pkg/stringslice/stringslice_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package stringslice
 
 import (

--- a/internal/pkg/sysinfo/machineid/machineid.go
+++ b/internal/pkg/sysinfo/machineid/machineid.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package machineid
 
 import (

--- a/internal/pkg/sysinfo/machineid/machineid_test.go
+++ b/internal/pkg/sysinfo/machineid/machineid_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package machineid
 
 import (

--- a/internal/pkg/sysinfo/probes/linux/cgroup_v2.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroup_v2.go
@@ -22,7 +22,7 @@ package linux
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -60,7 +60,7 @@ func (s *cgroupV2) loadControllers(seen func(string, string)) error {
 		return err
 	}
 
-	controllerData, err := ioutil.ReadFile(filepath.Join(s.mountPoint, "cgroup.controllers"))
+	controllerData, err := os.ReadFile(filepath.Join(s.mountPoint, "cgroup.controllers"))
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/templatewriter/templatewriter.go
+++ b/internal/pkg/templatewriter/templatewriter.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package templatewriter
 
 import (

--- a/internal/pkg/users/users.go
+++ b/internal/pkg/users/users.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package users
 
 import (

--- a/internal/pkg/users/users_test.go
+++ b/internal/pkg/users/users_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package users
 
 import (

--- a/internal/testutil/kube_client.go
+++ b/internal/testutil/kube_client.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package testutil
 
 import (

--- a/internal/testutil/manifest_parser.go
+++ b/internal/testutil/manifest_parser.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package testutil
 
 import (

--- a/internal/testutil/runtime_config.go
+++ b/internal/testutil/runtime_config.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package testutil
 
 import (

--- a/inttest/airgap/airgap_test.go
+++ b/inttest/airgap/airgap_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package airgap
 
 import (

--- a/inttest/autopilot/common/footloosesuite.go
+++ b/inttest/autopilot/common/footloosesuite.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package common
 
 import (

--- a/inttest/backup/backup_test.go
+++ b/inttest/backup/backup_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package basic
 
 import (

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package basic
 
 import (

--- a/inttest/byocri/byocri_test.go
+++ b/inttest/byocri/byocri_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package byocri
 
 import (

--- a/inttest/calico/calico_test.go
+++ b/inttest/calico/calico_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package calico
 
 import (

--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cli
 
 import (

--- a/inttest/cnichange/cnichange_test.go
+++ b/inttest/cnichange/cnichange_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cnichange
 
 import (

--- a/inttest/common/filetools.go
+++ b/inttest/common/filetools.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package common
 
 import (

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package common
 
 import (

--- a/inttest/common/ssh.go
+++ b/inttest/common/ssh.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package common
 
 import (

--- a/inttest/common/util.go
+++ b/inttest/common/util.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package common
 
 import (

--- a/inttest/common/vmsuite.go
+++ b/inttest/common/vmsuite.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package common
 
 import (

--- a/inttest/configchange/config_test.go
+++ b/inttest/configchange/config_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package configchange
 
 import (

--- a/inttest/ctr/ctr_test.go
+++ b/inttest/ctr/ctr_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ctr
 
 import (

--- a/inttest/customdomain/customdomain_test.go
+++ b/inttest/customdomain/customdomain_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package customdomain
 
 import (

--- a/inttest/defaultstorage/defaultstorage_test.go
+++ b/inttest/defaultstorage/defaultstorage_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package defaultstorage
 
 import (

--- a/inttest/disabledcomponents/disabled_components_test.go
+++ b/inttest/disabledcomponents/disabled_components_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package disabledcomponents
 
 import (

--- a/inttest/externaletcd/external_etcd_test.go
+++ b/inttest/externaletcd/external_etcd_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package externaletcd
 
 import (

--- a/inttest/extraargs/extraargs_test.go
+++ b/inttest/extraargs/extraargs_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package extraargs
 
 import (

--- a/inttest/hacontrolplane/hacontrolplane_test.go
+++ b/inttest/hacontrolplane/hacontrolplane_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package hacontrolplane
 
 import (

--- a/inttest/k0scloudprovider/k0scloudprovider_test.go
+++ b/inttest/k0scloudprovider/k0scloudprovider_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package k0scloudprovider
 
 import (

--- a/inttest/k0sctl/k0sctl_test.go
+++ b/inttest/k0sctl/k0sctl_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package k0sctl
 
 import (

--- a/inttest/kine/kine_test.go
+++ b/inttest/kine/kine_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kine
 
 import (

--- a/inttest/kuberouter/kuberouter_hairpin_test.go
+++ b/inttest/kuberouter/kuberouter_hairpin_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kuberouter
 
 import (

--- a/inttest/metrics/metrics_test.go
+++ b/inttest/metrics/metrics_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package metrics
 
 import (

--- a/inttest/metricscraper/metricscraper_test.go
+++ b/inttest/metricscraper/metricscraper_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package metricscraper
 
 import (

--- a/inttest/multicontroller/multicontroller_test.go
+++ b/inttest/multicontroller/multicontroller_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package multicontroller
 
 import (

--- a/inttest/noderole/noderole_no_taints_test.go
+++ b/inttest/noderole/noderole_no_taints_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package noderole
 
 import (

--- a/inttest/noderole/noderole_single_test.go
+++ b/inttest/noderole/noderole_single_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package noderole
 
 import (

--- a/inttest/noderole/noderole_test.go
+++ b/inttest/noderole/noderole_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package noderole
 
 import (

--- a/inttest/psp/psp_test.go
+++ b/inttest/psp/psp_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package psp
 
 import (

--- a/inttest/singlenode/singlenode_test.go
+++ b/inttest/singlenode/singlenode_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package singlenode
 
 import (

--- a/inttest/sonobuoy/cncf_conformance_test.go
+++ b/inttest/sonobuoy/cncf_conformance_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sonobuoy
 
 import (

--- a/inttest/sonobuoy/results.go
+++ b/inttest/sonobuoy/results.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sonobuoy
 
 import (

--- a/inttest/sonobuoy/results_test.go
+++ b/inttest/sonobuoy/results_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sonobuoy
 
 import (

--- a/inttest/sonobuoy/signetwork_test.go
+++ b/inttest/sonobuoy/signetwork_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sonobuoy
 
 import (

--- a/inttest/statussocket/statussocket_test.go
+++ b/inttest/statussocket/statussocket_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package statussocket
 
 import (

--- a/inttest/tunneledkas/suite_test.go
+++ b/inttest/tunneledkas/suite_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package tunneledkas
 
 import (

--- a/inttest/upgrade/upgrade_test.go
+++ b/inttest/upgrade/upgrade_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package basic
 
 import (

--- a/inttest/workerrestart/workerrestart_test.go
+++ b/inttest/workerrestart/workerrestart_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package workerrestart
 
 import (

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import (

--- a/pkg/airgap/images.go
+++ b/pkg/airgap/images.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package airgap
 
 import (

--- a/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset/fake/register.go
+++ b/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset/scheme/register.go
+++ b/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/apis/autopilot.k0sproject.io/v1beta2/info.go
+++ b/pkg/apis/autopilot.k0sproject.io/v1beta2/info.go
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 // Package v1beta2 contains API Schema definitions for the v1beta2 API group
-//+kubebuilder:object:generate=true
-//+groupName=autopilot.k0sproject.io
+// +kubebuilder:object:generate=true
+// +groupName=autopilot.k0sproject.io
 package v1beta2
 
 import (

--- a/pkg/apis/autopilot.k0sproject.io/v1beta2/types.go
+++ b/pkg/apis/autopilot.k0sproject.io/v1beta2/types.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+groupName=autopilot.k0sproject.io
+// +groupName=autopilot.k0sproject.io
 package v1beta2
 
 import (
@@ -32,12 +32,12 @@ func init() {
 // ControlNode is a node which behaves as a controller, able to receive autopilot
 // signaling updates.
 //
-//+kubebuilder:object:root=true
-//+kubebuilder:resource:scope=Cluster
-//+kubebuilder:subresource:status
-//+genclient
-//+genclient:onlyVerbs=create,delete,list,get,watch,update,updateStatus
-//+genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+// +genclient
+// +genclient:onlyVerbs=create,delete,list,get,watch,update,updateStatus
+// +genclient:nonNamespaced
 // +groupName=autopilot.k0sproject.io
 type ControlNode struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -62,11 +62,11 @@ func (c *ControlNodeStatus) GetInternalIP() string {
 
 // ControlNodeList is a list of ControlNode instances.
 //
-//+kubebuilder:object:root=true
-//+kubebuilder:resource:scope=Cluster
-//+genclient
-//+genclient:onlyVerbs=create
-//+genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +genclient
+// +genclient:onlyVerbs=create
+// +genclient:nonNamespaced
 type ControlNodeList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -77,14 +77,14 @@ type ControlNodeList struct {
 // Plan provides all details of what to execute as a part of the plan, and
 // the current status of its execution.
 //
-//+kubebuilder:object:root=true
-//+kubebuilder:resource:scope=Cluster
-//+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
-//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-//+genclient
-//+genclient:onlyVerbs=create,delete,list,get,watch,update
-//+genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +genclient
+// +genclient:onlyVerbs=create,delete,list,get,watch,update
+// +genclient:nonNamespaced
 type Plan struct {
 	metav1.TypeMeta `json:",omitempty,inline"`
 	// Standard object's metadata.
@@ -99,11 +99,11 @@ type Plan struct {
 
 // PlanList is a list of Plan instances.
 //
-//+kubebuilder:object:root=true
-//+kubebuilder:resource:scope=Cluster
-//+genclient
-//+genclient:onlyVerbs=create
-//+genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +genclient
+// +genclient:onlyVerbs=create
+// +genclient:nonNamespaced
 type PlanList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/apis/autopilot.k0sproject.io/v1beta2/updateconfig.go
+++ b/pkg/apis/autopilot.k0sproject.io/v1beta2/updateconfig.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+groupName=autopilot.k0sproject.io
+// +groupName=autopilot.k0sproject.io
 package v1beta2
 
 import (
@@ -26,11 +26,11 @@ func init() {
 	)
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:resource:scope=Cluster
-//+genclient
-//+genclient:onlyVerbs=create,delete,list,get,watch,update
-//+genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +genclient
+// +genclient:onlyVerbs=create,delete,list,get,watch,update
+// +genclient:nonNamespaced
 // +groupName=autopilot.k0sproject.io
 type UpdateConfig struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -50,11 +50,11 @@ type UpgradeStrategy struct {
 	Cron string `json:"cron"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:resource:scope=Cluster
-//+genclient
-//+genclient:onlyVerbs=create
-//+genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +genclient
+// +genclient:onlyVerbs=create
+// +genclient:nonNamespaced
 type UpdateConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/apis/helm.k0sproject.io/v1beta1/chart_types.go
+++ b/pkg/apis/helm.k0sproject.io/v1beta1/chart_types.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/helm.k0sproject.io/v1beta1/generic_hash.go
+++ b/pkg/apis/helm.k0sproject.io/v1beta1/generic_hash.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import "fmt"

--- a/pkg/apis/k0s.k0sproject.io/clientset/fake/register.go
+++ b/pkg/apis/k0s.k0sproject.io/clientset/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/apis/k0s.k0sproject.io/clientset/scheme/register.go
+++ b/pkg/apis/k0s.k0sproject.io/clientset/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/api.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/api.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/api_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/api_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/calico.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/calico.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import "encoding/json"

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
@@ -135,7 +135,7 @@ func DefaultSchedulerSpec() *SchedulerSpec {
 	}
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 // +genclient
 // +genclient:onlyVerbs=create
 // ClusterConfigList contains a list of ClusterConfig

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/controltypes.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/controltypes.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import "fmt"

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/dualstack.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/dualstack.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 // DualStack defines network configuration for ipv4\ipv6 mixed cluster setup

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/extensions.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/extensions.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/extenstions_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/extenstions_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/feature_gates.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/feature_gates.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/feature_gates_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/feature_gates_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/groupversion_info.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta1 contains API Schema definitions for the  v1beta1 API group
-//+kubebuilder:object:generate=true
-//+groupName=k0s.k0sproject.io
+// +kubebuilder:object:generate=true
+// +groupName=k0s.k0sproject.io
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/images.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/images.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/images_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/images_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/kubeproxy.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/kubeproxy.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/kuberouter.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/kuberouter.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 // KubeRouter defines the kube-router related config options

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/network.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/network.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/network_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/network_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/psp.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/psp.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/psp_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/psp_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/storage.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/storage.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/storage_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/storage_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/storageextensions.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/storageextensions.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import "fmt"

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/system.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/system.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import "github.com/k0sproject/k0s/pkg/constant"

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/telemetry.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/telemetry.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 var _ Validateable = (*ClusterTelemetry)(nil)

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/workerprofile.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/workerprofile.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/workerprofile_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/workerprofile_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1beta1
 
 import (

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package applier
 
 import (

--- a/pkg/applier/applier_test.go
+++ b/pkg/applier/applier_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package applier
 
 import (

--- a/pkg/applier/manager.go
+++ b/pkg/applier/manager.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package applier
 
 import (

--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package applier
 
 import (

--- a/pkg/applier/stackapplier.go
+++ b/pkg/applier/stackapplier.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package applier
 
 import (

--- a/pkg/assets/stage.go
+++ b/pkg/assets/stage.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package assets
 
 import (

--- a/pkg/autopilot/build/version.go
+++ b/pkg/autopilot/build/version.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package build
 
 // Version gets overridden at build time using -X build.Version=$VERSION

--- a/pkg/backup/config.go
+++ b/pkg/backup/config.go
@@ -16,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package backup
 
 import (

--- a/pkg/backup/etcd.go
+++ b/pkg/backup/etcd.go
@@ -16,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package backup
 
 import (

--- a/pkg/backup/filesystem.go
+++ b/pkg/backup/filesystem.go
@@ -16,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package backup
 
 import (

--- a/pkg/backup/sqlitedb.go
+++ b/pkg/backup/sqlitedb.go
@@ -16,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package backup
 
 import (

--- a/pkg/backup/util.go
+++ b/pkg/backup/util.go
@@ -16,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package backup
 
 import (

--- a/pkg/build/eulanotice.go
+++ b/pkg/build/eulanotice.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package build
 
 // EulaNotice allows one to inject custom Eula during build time

--- a/pkg/build/version.go
+++ b/pkg/build/version.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package build
 
 // Version gets overridden at build time using -X main.Version=$VERSION

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package certificate
 
 import (

--- a/pkg/cleanup/bridge_darwin.go
+++ b/pkg/cleanup/bridge_darwin.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cleanup
 
 type bridge struct {

--- a/pkg/cleanup/bridge_linux.go
+++ b/pkg/cleanup/bridge_linux.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cleanup
 
 import (

--- a/pkg/cleanup/cleanup_windows.go
+++ b/pkg/cleanup/cleanup_windows.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cleanup
 
 // no need to build unix specific funcs into windows

--- a/pkg/cleanup/cni.go
+++ b/pkg/cleanup/cni.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cleanup
 
 import (

--- a/pkg/cleanup/containers.go
+++ b/pkg/cleanup/containers.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cleanup
 
 import (

--- a/pkg/cleanup/directories.go
+++ b/pkg/cleanup/directories.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cleanup
 
 import (

--- a/pkg/cleanup/services.go
+++ b/pkg/cleanup/services.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cleanup
 
 import (

--- a/pkg/cleanup/users.go
+++ b/pkg/cleanup/users.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cleanup
 
 import (

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package component
 
 import (

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -24,12 +24,12 @@ import (
 
 // Component defines the lifecycle of managed components.
 //
-//    Created ――――――――――――――――――――――►(Stop)―――╮
-//    ╰―(Init)―► Initialized ―――――――►(Stop)――╮│
-//               ╰―(Run)―► Running ―►(Stop)―╮││
-//                  ╭(Healthy)╯▲            ▼▼▼
-//                  ╰――――――――――╯         ╭► Terminated╮
-//                                       ╰――――(Stop)――╯
+//	Created ――――――――――――――――――――――►(Stop)―――╮
+//	╰―(Init)―► Initialized ―――――――►(Stop)――╮│
+//	           ╰―(Run)―► Running ―►(Stop)―╮││
+//	              ╭(Healthy)╯▲            ▼▼▼
+//	              ╰――――――――――╯         ╭► Terminated╮
+//	                                   ╰――――(Stop)――╯
 type Component interface {
 	// Init initializes the component and prepares it for execution. This should
 	// include any fallible operations that can be performed without actually
@@ -63,12 +63,12 @@ type Healthz interface {
 // ReconcilerComponent defines the component interface that is reconciled based
 // on changes on the global config CR object changes.
 //
-//    Created ――――――――――――――――――――――――►(Stop)―――――╮
-//    ╰―(Init)―► Initialized ―――――――――►(Stop)――――╮│
-//   ╭(Reconcile)╯▲╰―(Run)―► Running ―►(Stop)―――╮││
-//   ╰――――――――――――╯╭(Reconcile)╯▲▲╰(Healthy)╮   ▼▼▼
-//                 ╰――――――――――――╯╰――――――――――╯╭► Terminated╮
-//                                           ╰――――(Stop)――╯
+//	 Created ――――――――――――――――――――――――►(Stop)―――――╮
+//	 ╰―(Init)―► Initialized ―――――――――►(Stop)――――╮│
+//	╭(Reconcile)╯▲╰―(Run)―► Running ―►(Stop)―――╮││
+//	╰――――――――――――╯╭(Reconcile)╯▲▲╰(Healthy)╮   ▼▼▼
+//	              ╰――――――――――――╯╰――――――――――╯╭► Terminated╮
+//	                                        ╰――――(Stop)――╯
 type ReconcilerComponent interface {
 	Component
 

--- a/pkg/component/controller/apiendpointreconciler.go
+++ b/pkg/component/controller/apiendpointreconciler.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/apiendpointreconciler_test.go
+++ b/pkg/component/controller/apiendpointreconciler_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/apiserver_test.go
+++ b/pkg/component/controller/apiserver_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/autopilot.go
+++ b/pkg/component/controller/autopilot.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/calico.go
+++ b/pkg/component/controller/calico.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/calico_test.go
+++ b/pkg/component/controller/calico_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/clusterConfig.go
+++ b/pkg/component/controller/clusterConfig.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/cniutil.go
+++ b/pkg/component/controller/cniutil.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/controllersleasecounter.go
+++ b/pkg/component/controller/controllersleasecounter.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/coredns_test.go
+++ b/pkg/component/controller/coredns_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import "testing"

--- a/pkg/component/controller/csrapprover.go
+++ b/pkg/component/controller/csrapprover.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/csrapprover_test.go
+++ b/pkg/component/controller/csrapprover_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/defaultpsp.go
+++ b/pkg/component/controller/defaultpsp.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/dummyleaderelector.go
+++ b/pkg/component/controller/dummyleaderelector.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/k0scloudprovider.go
+++ b/pkg/component/controller/k0scloudprovider.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/k0scloudprovider_test.go
+++ b/pkg/component/controller/k0scloudprovider_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/k0scontrolapi.go
+++ b/pkg/component/controller/k0scontrolapi.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/kubeletconfig.go
+++ b/pkg/component/controller/kubeletconfig.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/kubeletconfig_test.go
+++ b/pkg/component/controller/kubeletconfig_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/kuberouter_test.go
+++ b/pkg/component/controller/kuberouter_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/leaderelector.go
+++ b/pkg/component/controller/leaderelector.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/metrics.go
+++ b/pkg/component/controller/metrics.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/metricserver.go
+++ b/pkg/component/controller/metricserver.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/metricserver_test.go
+++ b/pkg/component/controller/metricserver_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/noderole.go
+++ b/pkg/component/controller/noderole.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/systemrbac.go
+++ b/pkg/component/controller/systemrbac.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/controller/tunneledapiendpointreconciller.go
+++ b/pkg/component/controller/tunneledapiendpointreconciller.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/component/manager.go
+++ b/pkg/component/manager.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package component
 
 import (

--- a/pkg/component/manager_test.go
+++ b/pkg/component/manager_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package component
 
 import (

--- a/pkg/component/status/status.go
+++ b/pkg/component/status/status.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package status
 
 import (

--- a/pkg/component/worker/autopilot.go
+++ b/pkg/component/worker/autopilot.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package worker
 
 import (

--- a/pkg/component/worker/client.go
+++ b/pkg/component/worker/client.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package worker
 
 import (

--- a/pkg/component/worker/containerd.go
+++ b/pkg/component/worker/containerd.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package worker
 
 import (

--- a/pkg/component/worker/cri_runtime.go
+++ b/pkg/component/worker/cri_runtime.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package worker
 
 import (

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package worker
 
 import (

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -211,7 +210,7 @@ func (k *Kubelet) Run(ctx context.Context) error {
 			logrus.Warnf("failed to prepare local kubelet config: %s", err.Error())
 			return err
 		}
-		err = ioutil.WriteFile(kubeletConfigPath, []byte(kubeletconfig), 0644)
+		err = os.WriteFile(kubeletConfigPath, []byte(kubeletconfig), 0644)
 		if err != nil {
 			return fmt.Errorf("failed to write kubelet config: %w", err)
 		}

--- a/pkg/component/worker/kubelet_test.go
+++ b/pkg/component/worker/kubelet_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package worker
 
 import (

--- a/pkg/component/worker/kubeletconfigclient.go
+++ b/pkg/component/worker/kubeletconfigclient.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package worker
 
 import (

--- a/pkg/component/worker/kubeproxy_windows.go
+++ b/pkg/component/worker/kubeproxy_windows.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package worker
 
 import (

--- a/pkg/component/worker/localproxy.go
+++ b/pkg/component/worker/localproxy.go
@@ -13,4 +13,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package worker

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package worker
 
 import (

--- a/pkg/component/worker/static_pods_test.go
+++ b/pkg/component/worker/static_pods_test.go
@@ -19,7 +19,7 @@ package worker
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -292,7 +292,7 @@ func TestStaticPods_Lifecycle(t *testing.T) {
 
 		assert.Equal(t, resp.StatusCode, http.StatusOK)
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
 		assert.JSONEq(t, expectedContent, string(body))

--- a/pkg/component/worker/stubs.go
+++ b/pkg/component/worker/stubs.go
@@ -16,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package worker
 
 import (

--- a/pkg/component/worker/utils.go
+++ b/pkg/component/worker/utils.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package worker
 
 import (

--- a/pkg/config/api_config.go
+++ b/pkg/config/api_config.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 import (

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 import (

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 import (

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 import (

--- a/pkg/config/file_config.go
+++ b/pkg/config/file_config.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 import (

--- a/pkg/constant/constant_posix.go
+++ b/pkg/constant/constant_posix.go
@@ -16,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package constant
 
 import "fmt"

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package constant
 
 import (

--- a/pkg/constant/constant_shared_test.go
+++ b/pkg/constant/constant_shared_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package constant
 
 import (

--- a/pkg/constant/constant_windows.go
+++ b/pkg/constant/constant_windows.go
@@ -16,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package constant
 
 import "fmt"

--- a/pkg/container/runtime/cri.go
+++ b/pkg/container/runtime/cri.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package runtime
 
 import (

--- a/pkg/container/runtime/docker.go
+++ b/pkg/container/runtime/docker.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package runtime
 
 import (

--- a/pkg/container/runtime/runtime.go
+++ b/pkg/container/runtime/runtime.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package runtime
 
 type ContainerRuntime interface {

--- a/pkg/debounce/debounce_test.go
+++ b/pkg/debounce/debounce_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package debounce
 
 import (

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package etcd
 
 import (

--- a/pkg/etcd/health.go
+++ b/pkg/etcd/health.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package etcd
 
 import (

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package helm
 
 import (

--- a/pkg/install/darwin_launchd.go
+++ b/pkg/install/darwin_launchd.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package install
 
 const launchdConfig = `<?xml version='1.0' encoding='UTF-8'?>

--- a/pkg/install/linux_openrc.go
+++ b/pkg/install/linux_openrc.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package install
 
 const openRCScript = `#!/sbin/openrc-run

--- a/pkg/install/linux_sysv.go
+++ b/pkg/install/linux_sysv.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package install
 
 const sysvScript = `#!/bin/sh

--- a/pkg/install/linux_upstart.go
+++ b/pkg/install/linux_upstart.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package install
 
 const upstartScript = `# {{.Description}}

--- a/pkg/install/process.go
+++ b/pkg/install/process.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package install
 
 import (

--- a/pkg/install/service.go
+++ b/pkg/install/service.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package install
 
 import (

--- a/pkg/install/users.go
+++ b/pkg/install/users.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package install
 
 import (

--- a/pkg/k0scloudprovider/addresses.go
+++ b/pkg/k0scloudprovider/addresses.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package k0scloudprovider
 
 import (

--- a/pkg/k0scloudprovider/addresses_test.go
+++ b/pkg/k0scloudprovider/addresses_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package k0scloudprovider
 
 import (

--- a/pkg/k0scloudprovider/command.go
+++ b/pkg/k0scloudprovider/command.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package k0scloudprovider
 
 import (

--- a/pkg/k0scloudprovider/instances.go
+++ b/pkg/k0scloudprovider/instances.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package k0scloudprovider
 
 import (

--- a/pkg/k0scloudprovider/provider.go
+++ b/pkg/k0scloudprovider/provider.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package k0scloudprovider
 
 import (

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubernetes
 
 import (

--- a/pkg/kubernetes/lease.go
+++ b/pkg/kubernetes/lease.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubernetes
 
 import (

--- a/pkg/kubernetes/lease_test.go
+++ b/pkg/kubernetes/lease_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubernetes
 
 import (

--- a/pkg/leaderelection/lease_pool.go
+++ b/pkg/leaderelection/lease_pool.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package leaderelection
 
 import (

--- a/pkg/leaderelection/lease_pool_test.go
+++ b/pkg/leaderelection/lease_pool_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package leaderelection
 
 import (

--- a/pkg/performance/timer.go
+++ b/pkg/performance/timer.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package performance
 
 import (

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package supervisor
 
 import (

--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package supervisor
 
 import (

--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -18,7 +18,6 @@ package supervisor
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -154,7 +153,7 @@ func TestRespawn(t *testing.T) {
 	}
 
 	// wait til process starts up. fifo will block the write til process reads it
-	err = ioutil.WriteFile(pingFifoPath, []byte("ping 1"), 0644)
+	err = os.WriteFile(pingFifoPath, []byte("ping 1"), 0644)
 	if err != nil {
 		t.Errorf("Failed to write to fifo %s: %v", pingFifoPath, err)
 	}
@@ -163,10 +162,10 @@ func TestRespawn(t *testing.T) {
 	process := s.GetProcess()
 
 	// read the pong to unblock the process so it can exit
-	_, _ = ioutil.ReadFile(pongFifoPath)
+	_, _ = os.ReadFile(pongFifoPath)
 
 	// wait til the respawned process again reads the ping fifo
-	err = ioutil.WriteFile(pingFifoPath, []byte("ping 2"), 0644)
+	err = os.WriteFile(pingFifoPath, []byte("ping 2"), 0644)
 	if err != nil {
 		t.Errorf("Failed to write to fifo %s: %v", pingFifoPath, err)
 	}

--- a/pkg/telemetry/component.go
+++ b/pkg/telemetry/component.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package telemetry
 
 import (

--- a/pkg/telemetry/segment.go
+++ b/pkg/telemetry/segment.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package telemetry
 
 import (

--- a/pkg/telemetry/sysinfo.go
+++ b/pkg/telemetry/sysinfo.go
@@ -16,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package telemetry
 
 import (

--- a/pkg/telemetry/sysinfo_linux.go
+++ b/pkg/telemetry/sysinfo_linux.go
@@ -16,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package telemetry
 
 import (

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package telemetry
 
 import (

--- a/pkg/token/joinclient.go
+++ b/pkg/token/joinclient.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package token
 
 import (

--- a/pkg/token/joindecode.go
+++ b/pkg/token/joindecode.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package token
 
 import (

--- a/pkg/token/joinencode.go
+++ b/pkg/token/joinencode.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package token
 
 import (

--- a/pkg/token/kubeconfig.go
+++ b/pkg/token/kubeconfig.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package token
 
 import (

--- a/pkg/token/manager.go
+++ b/pkg/token/manager.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package token
 
 import (


### PR DESCRIPTION
## Description

https://go.dev/doc/go1.19

* Fix Go armv6l download link
* Replace usages of deprecated io/ioutil package
* Run codegen  
  Whitespace changes due to the Go 1.19 update.
* Several changes to comments due to the new go doc format
  * Add a newline between license header and package decl  
    So that go fmt doesn't treat the license header as a package
    documentation and tries to format it.
  * Convert doc comment to new list style
  * Go fmt wants to have a space in front of some comments
  * Go fmt doesn't want to have leading spaces any more

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings