### PR TITLE
Actually leverage image bundle caching on ARM CIs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -383,8 +383,10 @@ jobs:
         id: cache-airgap-image-bundle
         uses: actions/cache@v3
         with:
-          key: airgap-image-bundle-linux-${{ matrix.arch }}.tar-${{ hashFiles('Makefile', 'airgap-images.txt', 'hack/image-bundler/*') }}
-          path: airgap-image-bundle-linux-${{ matrix.arch }}.tar
+          key: airgap-image-bundle-linux-${{ matrix.arch }}-${{ hashFiles('Makefile', 'airgap-images.txt', 'hack/image-bundler/*') }}
+          path: |
+            airgap-images.txt
+            airgap-image-bundle-linux-${{ matrix.arch }}.tar
 
       - name: Create airgap image bundle if not cached
         if: steps.cache-airgap-image-bundle.outputs.cache-hit != 'true'
@@ -392,7 +394,7 @@ jobs:
 
       - name: Run airgap test
         run: |
-          touch --no-create airgap-image-bundle-linux-${{ matrix.arch }}.tar
+          make --touch airgap-image-bundle-linux-${{ matrix.arch }}.tar
           make check-airgap
 
       - name: Collect test logs


### PR DESCRIPTION
## Description

Follow-up to #1969:

The touch wasn't enough, since some prerequisites were missing, which triggered the rebuild of the image bundle file. Change that by using `make --touch` instead. Put the images text file into the cache, too. It's not really required, but better have the real file there than a zero-byte one that's generated by make. That's also the reason for renaming the cache by stripping the ".tar" from its name.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings