### PR TITLE
Authenticate Docker Hub pulls on self-hosted build jobs.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -285,6 +285,14 @@ jobs:
       - ${{ matrix.arch }}
 
     steps:
+      # Our self-hosted runners are one static VMs and will hit docker rate limits easily as all traffic is coming from same IP
+      # By authenticating we can get 200 pulls / 6 hours
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       # https://github.com/actions/checkout/issues/273#issuecomment-642908752 (see below)
       - name: "Pre: Fixup directories"
         run: find . -type d -not -perm /u+w -exec chmod u+w '{}' \;


### PR DESCRIPTION
By authing we can double the rate limits and hopefully will not hit limits too often.

Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

## Description

Our self hosted runner have been hitting Docker Hub rate limits quite often in last week or so. By authenticating we will double the rate limits and thus hopefully will not hit limits too often.
