### PR TITLE
Increase check-airgap timeout on ARM runners

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -379,22 +379,22 @@ jobs:
       - name: Create airgap image list
         run: make airgap-images.txt
 
-      - name: Cache airgap image bundle
-        id: cache-airgap-image-bundle
-        uses: actions/cache@v3
-        with:
-          key: airgap-image-bundle-linux-${{ matrix.arch }}-${{ hashFiles('Makefile', 'airgap-images.txt', 'hack/image-bundler/*') }}
-          path: |
-            airgap-images.txt
-            airgap-image-bundle-linux-${{ matrix.arch }}.tar
+      # - name: Cache airgap image bundle
+      #   id: cache-airgap-image-bundle
+      #   uses: actions/cache@v3
+      #   with:
+      #     key: airgap-image-bundle-linux-${{ matrix.arch }}-${{ hashFiles('Makefile', 'airgap-images.txt', 'hack/image-bundler/*') }}
+      #     path: |
+      #       airgap-images.txt
+      #       airgap-image-bundle-linux-${{ matrix.arch }}.tar
 
-      - name: Create airgap image bundle if not cached
-        if: steps.cache-airgap-image-bundle.outputs.cache-hit != 'true'
-        run: make airgap-image-bundle-linux-${{ matrix.arch }}.tar
+      # - name: Create airgap image bundle if not cached
+      #   if: steps.cache-airgap-image-bundle.outputs.cache-hit != 'true'
+      #   run: make airgap-image-bundle-linux-${{ matrix.arch }}.tar
 
       - name: Run airgap test
         run: |
-          make --touch airgap-image-bundle-linux-${{ matrix.arch }}.tar
+          #make --touch airgap-image-bundle-linux-${{ matrix.arch }}.tar
           make check-airgap TIMEOUT=10m
 
       - name: Collect test logs

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -395,7 +395,7 @@ jobs:
       - name: Run airgap test
         run: |
           make --touch airgap-image-bundle-linux-${{ matrix.arch }}.tar
-          make check-airgap
+          make check-airgap TIMEOUT=10m
 
       - name: Collect test logs
         if: failure()


### PR DESCRIPTION
## Description

The ARMv7 airgap tests failed a lot due to timeouts in the last days. Increase it to mitigate this. Strictly speaking, this is only required for ARMv7, but just do it unconditionally for all builds, for simplicity.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings