### PR TITLE
Enable authentication for Airgap image-bundler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,17 +220,24 @@ airgap-images.txt: k0s
 	  exit $$code ; \
 	}
 
-airgap-image-bundle-linux-amd64.tar: TARGET_PLATFORM := linux/amd64
-airgap-image-bundle-linux-arm64.tar: TARGET_PLATFORM := linux/arm64
-airgap-image-bundle-linux-arm.tar:   TARGET_PLATFORM := linux/arm/v7
 airgap-image-bundle-linux-amd64.tar \
 airgap-image-bundle-linux-arm64.tar \
-airgap-image-bundle-linux-arm.tar: .k0sbuild.image-bundler.stamp airgap-images.txt
+airgap-image-bundle-linux-arm.tar :
 	docker run --rm -i --privileged \
 	  -e TARGET_PLATFORM='$(TARGET_PLATFORM)' \
+	  -e DOCKER_USER='$(DOCKER_USER)' \
+	  -e DOCKER_PASSWORD='$(DOCKER_PASSWORD)' \
 	  k0sbuild.image-bundler < airgap-images.txt > '$@' || { \
 	    code=$$? && rm -f -- '$@' && exit $$code ; \
 	  }
+
+airgap-image-bundle-linux-amd64.tar: TARGET_PLATFORM := linux/amd64
+airgap-image-bundle-linux-arm64.tar: TARGET_PLATFORM := linux/arm64
+airgap-image-bundle-linux-arm.tar:   TARGET_PLATFORM := linux/arm/v7
+
+airgap-image-bundle-linux-arm64.tar: .k0sbuild.image-bundler.stamp airgap-images.txt airgap-image-bundle-linux-arm64.tar
+airgap-image-bundle-linux-arm.tar: .k0sbuild.image-bundler.stamp airgap-images.txt airgap-image-bundle-linux-arm.tar 
+airgap-image-bundle-linux-amd64.tar: .k0sbuild.image-bundler.stamp airgap-images.txt airgap-image-bundle-linux-arm.tar 
 
 .k0sbuild.image-bundler.stamp: hack/image-bundler/*
 	docker build -t k0sbuild.image-bundler hack/image-bundler

--- a/hack/image-bundler/Dockerfile
+++ b/hack/image-bundler/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.16
 
-RUN apk add containerd
+RUN apk add bash containerd
 COPY bundler.sh /
 CMD /bundler.sh


### PR DESCRIPTION
Signed-off-by: Karen Almog <kalmog@mirantis.com>

## Description

This PR will allow authenticating against docker.io for building airgap image bundles on our arm runners. Currently we suffer from rate limitations for unauthenticated docker pulls.
The secrets can later be fed into the build process by updating the relevant build workflows.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings