### PR TITLE
Bring back supervised process logging

### DIFF
--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -142,8 +142,8 @@ func (s *Supervisor) Supervise() error {
 			// get signals sent directly to parent.
 			s.cmd.SysProcAttr = DetachAttr(s.UID, s.GID)
 
-			// s.cmd.Stdout = s.log.Writer()
-			// s.cmd.Stderr = s.log.Writer()
+			s.cmd.Stdout = s.log.Writer()
+			s.cmd.Stderr = s.log.Writer()
 
 			err := s.cmd.Start()
 			s.mutex.Unlock()


### PR DESCRIPTION
Got accidentally removed in https://github.com/k0sproject/k0s/pull/1899

Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

