### PR TITLE
Build smoke test matrix from Makefile variable

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,6 +43,7 @@ jobs:
             binary-suffix: .exe
 
     outputs:
+      smoke-test-matrix: ${{ steps.list-smoke-tests.outputs.linux-matrix }}
       airgap-image-bundle-hash-linux: ${{ steps.create-airgap-image-list.outputs.linux-hash }}
 
     steps:
@@ -95,6 +96,12 @@ jobs:
         with:
           name: k0s${{ matrix.binary-suffix }}
           path: k0s${{ matrix.binary-suffix }}
+
+      - name: List smoke tests
+        id: list-smoke-tests
+        run: |
+          ./vars.sh FROM=inttest smoketests | jq --raw-input --raw-output \
+              'split(" ") | [ .[] | select(. != "") ] | "::set-output name=${{ matrix.target }}-matrix::" + tojson'
 
       - name: Create airgap image list
         id: create-airgap-image-list
@@ -175,48 +182,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        smoke-suite:
-          - check-addons
-          - check-airgap
-          - check-ap-airgap
-          - check-ap-ha3x3
-          - check-ap-platformselect
-          - check-ap-quorum
-          - check-ap-quorumsafety
-          - check-ap-selector
-          - check-ap-single
-          - check-ap-updater
-          - check-basic
-          - check-byocri
-          - check-calico
-          - check-cnichange
-          - check-ctr
-          - check-customports
-          - check-dualstack
-          - check-externaletcd
-          - check-hacontrolplane
-          - check-kine
-          - check-kuberouter
-          - check-kubeletcertrotate
-          - check-metrics
-          - check-multicontroller
-          - check-noderole
-          - check-singlenode
-          - check-backup
-          - check-k0scloudprovider
-          - check-cli
-          - check-disabledcomponents
-          - check-extraargs
-          - check-configchange
-          - check-upgrade
-          - check-psp
-          - check-statussocket
-          - check-tunneledkas
-          - check-workerrestart
-          - check-kubectl
-          - check-k0sctl
-          - check-metricscraper
-          - check-customdomain
+        smoke-suite: ${{ fromJson(needs.build.outputs.smoke-test-matrix) }}
 
     steps:
       - name: Check out code into the Go module directory


### PR DESCRIPTION
## Description

Since the CI can treat all the smoke tests in a single matrix nowadays, there's no need to specify the test names both in the Makefile and in the workflow.

Use `vars.sh` and `jq` to capture the smoke tests and feed them into the smoke test job.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings