### PR TITLE
Fix kine/SQLite database open mode

### DIFF
--- a/pkg/apis/k0s.k0sproject.io/v1beta1/storage.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/storage.go
@@ -18,9 +18,10 @@ package v1beta1
 import (
 	"encoding/json"
 	"fmt"
-	"k8s.io/utils/strings/slices"
 	"path/filepath"
 	"strings"
+
+	"k8s.io/utils/strings/slices"
 
 	"github.com/sirupsen/logrus"
 
@@ -153,7 +154,7 @@ func DefaultEtcdConfig() *EtcdConfig {
 // DefaultKineConfig creates KineConfig with sane defaults
 func DefaultKineConfig(dataDir string) *KineConfig {
 	return &KineConfig{
-		DataSource: "sqlite://" + dataDir + "/db/state.db?more=rwc&_journal=WAL&cache=shared",
+		DataSource: "sqlite://" + dataDir + "/db/state.db?mode=rwc&_journal=WAL&cache=shared",
 	}
 }
 

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/storage_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/storage_test.go
@@ -109,7 +109,7 @@ spec:
 	assert.NoError(t, err)
 	assert.Equal(t, "kine", c.Spec.Storage.Type)
 	assert.NotNil(t, c.Spec.Storage.Kine)
-	assert.Equal(t, "sqlite:///var/lib/k0s/db/state.db?more=rwc&_journal=WAL&cache=shared", c.Spec.Storage.Kine.DataSource)
+	assert.Equal(t, "sqlite:///var/lib/k0s/db/state.db?mode=rwc&_journal=WAL&cache=shared", c.Spec.Storage.Kine.DataSource)
 }
 
 type storageSuite struct {


### PR DESCRIPTION
Apparently `rwc` is the [default mode](https://github.com/mattn/go-sqlite3/blob/ae2a61f847e10e6dd771ecd4e1c55e0421cdc7f9/sqlite3.go#L1454-L1456) but to make sure we use the "right" mode even if upstream changes it let's use correct param for that. :)

Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings