### PR TITLE
[Backport release-1.23] Use "object name safe" hostnames for leases

### DIFF
--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -28,4 +28,5 @@ smoketests := \
 	check-upgrade \
 	check-workerrestart \
 	check-kubectl \
-	check-k0sctl
+	check-k0sctl \
+	check-capitalhostnames \

--- a/inttest/capitalhostnames/capitalhostnames_test.go
+++ b/inttest/capitalhostnames/capitalhostnames_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package basic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type CapitalHostnamesSuite struct {
+	common.FootlooseSuite
+}
+
+func (s *CapitalHostnamesSuite) TestK0sGetsUp() {
+
+	s.NoError(s.setHostname(s.ControllerNode(0), "k0s-CONTROLLER"))
+	s.NoError(s.setHostname(s.WorkerNode(0), "k0s-WORKER"))
+
+	s.NoError(s.InitController(0))
+
+	token, err := s.GetJoinToken("worker")
+	s.NoError(err)
+	s.NoError(s.RunWorkersWithToken(token))
+
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	if err != nil {
+		s.FailNow("failed to obtain Kubernetes client", err)
+	}
+
+	err = s.WaitForNodeReady("k0s-worker", kc)
+	s.NoError(err)
+
+	pods, err := kc.CoreV1().Pods("kube-system").List(s.Context(), v1.ListOptions{
+		Limit: 100,
+	})
+	s.NoError(err)
+
+	podCount := len(pods.Items)
+
+	s.T().Logf("found %d pods in kube-system", podCount)
+	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+
+	s.T().Log("waiting to see kube-router pods ready")
+	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "kube-router did not start")
+
+	// Test that we get logs, it's a signal that konnectivity tunnels work
+	s.T().Log("waiting to get logs from pods")
+	s.Require().NoError(common.WaitForPodLogs(kc, "kube-system"))
+
+	// Verify API that we get proper controller counter lease
+	_, err = kc.CoordinationV1().Leases("kube-node-lease").Get(s.Context(), "k0s-ctrl-k0s-controller", v1.GetOptions{})
+	s.NoError(err)
+
+	// Verify the autopilot controller node is created
+	apClient, err := s.AutopilotClient(s.ControllerNode(0))
+	s.NoError(err)
+	s.NotEmpty(apClient)
+	_, err = apClient.AutopilotV1beta2().ControlNodes().Get(s.Context(), "k0s-controller", v1.GetOptions{})
+	s.NoError(err)
+}
+
+func (s *CapitalHostnamesSuite) setHostname(node, hostname string) error {
+	ssh, err := s.SSH(node)
+	if err != nil {
+		return err
+	}
+	defer ssh.Disconnect()
+
+	_, err = ssh.ExecWithOutput("hostname " + hostname)
+	return err
+}
+
+func TestCapitalHostnamesSuite(t *testing.T) {
+	s := CapitalHostnamesSuite{
+		common.FootlooseSuite{
+			ControllerCount: 1,
+			WorkerCount:     1,
+		},
+	}
+	suite.Run(t, &s)
+}

--- a/inttest/capitalhostnames/capitalhostnames_test.go
+++ b/inttest/capitalhostnames/capitalhostnames_test.go
@@ -67,13 +67,6 @@ func (s *CapitalHostnamesSuite) TestK0sGetsUp() {
 	// Verify API that we get proper controller counter lease
 	_, err = kc.CoordinationV1().Leases("kube-node-lease").Get(s.Context(), "k0s-ctrl-k0s-controller", v1.GetOptions{})
 	s.NoError(err)
-
-	// Verify the autopilot controller node is created
-	apClient, err := s.AutopilotClient(s.ControllerNode(0))
-	s.NoError(err)
-	s.NotEmpty(apClient)
-	_, err = apClient.AutopilotV1beta2().ControlNodes().Get(s.Context(), "k0s-controller", v1.GetOptions{})
-	s.NoError(err)
 }
 
 func (s *CapitalHostnamesSuite) setHostname(node, hostname string) error {

--- a/pkg/component/controller/controllersleasecounter.go
+++ b/pkg/component/controller/controllersleasecounter.go
@@ -18,6 +18,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 
@@ -25,8 +27,6 @@ import (
 
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/pkg/leaderelection"
-
-	nodeutil "k8s.io/kubernetes/pkg/util/node"
 )
 
 // K0sControllersLeaseCounter implements a component that manages a lease per controller.
@@ -55,7 +55,7 @@ func (l *K0sControllersLeaseCounter) Run(ctx context.Context) error {
 
 	// hostname used to make the lease names be clear to which controller they belong to
 	// follow kubelet convention for naming so we e.g. use lowercase hostname etc.
-	holderIdentity, err := nodeutil.GetHostname("")
+	holderIdentity, err := getHostname()
 	if err != nil {
 		return nil
 	}
@@ -109,3 +109,21 @@ func (l *K0sControllersLeaseCounter) Reconcile() error {
 
 // Healthy is a no-op healchcheck
 func (l *K0sControllersLeaseCounter) Healthy() error { return nil }
+
+// Adapted from https://github.com/kubernetes/kubernetes/blob/v1.24.3/pkg/util/node/node.go#L46
+// We have our own helper func so we don't need to manage whole kubernetes/kubernetes deps in go.mod
+func getHostname() (string, error) {
+	nodeName, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("couldn't determine hostname: %v", err)
+	}
+	hostName := nodeName
+
+	// Trim whitespaces first to avoid getting an empty hostname
+	// For linux, the hostname is read from file /proc/sys/kernel/hostname directly
+	hostName = strings.TrimSpace(hostName)
+	if len(hostName) == 0 {
+		return "", fmt.Errorf("empty hostname is invalid")
+	}
+	return strings.ToLower(hostName), nil
+}

--- a/pkg/component/controller/controllersleasecounter.go
+++ b/pkg/component/controller/controllersleasecounter.go
@@ -18,7 +18,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 
@@ -26,6 +25,8 @@ import (
 
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/pkg/leaderelection"
+
+	nodeutil "k8s.io/kubernetes/pkg/util/node"
 )
 
 // K0sControllersLeaseCounter implements a component that manages a lease per controller.
@@ -53,7 +54,8 @@ func (l *K0sControllersLeaseCounter) Run(ctx context.Context) error {
 	}
 
 	// hostname used to make the lease names be clear to which controller they belong to
-	holderIdentity, err := os.Hostname()
+	// follow kubelet convention for naming so we e.g. use lowercase hostname etc.
+	holderIdentity, err := nodeutil.GetHostname("")
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
Backport of #2044 to `release-1.23`. See #2011.