### PR TITLE
Fix spelling of GitHub

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -33,7 +33,7 @@ jobs:
             exit 0
           else
             # PR number was not set manually
-            echo "no manual override: leaving Github reference unchanged."
+            echo "no manual override: leaving GitHub reference unchanged."
             echo "github_ref=$GITHUB_REF" >> $GITHUB_ENV
           fi
         working-directory: ./

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you'd like to try k0s, please jump in to our:
 ## Join the Community
 
 - [Community Slack](https://join.slack.com/t/k8slens/shared_invite/zt-wcl8jq3k-68R5Wcmk1o95MLBE5igUDQ) - Request for support and help from the k0s community via Slack (shared Slack channel with Lens).
-- [Github Issues](https://github.com/k0sproject/k0s/issues) - Submit your issues and feature requests via Github.
+- [GitHub Issues](https://github.com/k0sproject/k0s/issues) - Submit your issues and feature requests via GitHub.
 
 We welcome your help in building k0s! If you are interested, we invite you to check out the [Contributing Guide](https://docs.k0sproject.io/latest/contributors/overview/) and the [Code of Conduct](https://docs.k0sproject.io/latest/contributors/CODE_OF_CONDUCT/).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ We try to follow the practice of releasing often. That allows us to have smaller
 
 ## Creating a release
 
-Creating a release happens via Github Actions by creating an [annotated](https://git-scm.com/book/en/v2/Git-Basics-Tagging#_creating_tags) git tag. Tag creation triggers the release workflow which will do most of the heavy-lifting:
+Creating a release happens via GitHub Actions by creating an [annotated](https://git-scm.com/book/en/v2/Git-Basics-Tagging#_creating_tags) git tag. Tag creation triggers the release workflow which will do most of the heavy-lifting:
 
 - Create the actual release in [releases](https://github.com/k0sproject/k0s/releases/)
 - Build `k0s` binary on both AMD64 and ARM64 architectures

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ k0s is distributed as a single binary with zero host OS dependencies besides the
 ## Community Support
 
 - [Community Slack](https://join.slack.com/t/k8slens/shared_invite/zt-wcl8jq3k-68R5Wcmk1o95MLBE5igUDQ) - Request for support and help from the k0s community via Slack (shared Slack channel with Lens).
-- [Github Issues](https://github.com/k0sproject/k0s/issues) - Submit your issues and feature requests via Github.
+- [GitHub Issues](https://github.com/k0sproject/k0s/issues) - Submit your issues and feature requests via GitHub.
 
 We welcome your help in building k0s! If you are interested, we invite you to check out the [Contributing Guide](contributors/overview.md) and the [Code of Conduct](contributors/CODE_OF_CONDUCT.md).
 

--- a/docs/contributors/github_workflow.md
+++ b/docs/contributors/github_workflow.md
@@ -1,4 +1,4 @@
-# Github Workflow
+# GitHub Workflow
 
 This guide assumes you have already cloned the upstream repo to your system via git clone, or via `go get github.com/k0sproject/k0s`.
 
@@ -115,7 +115,7 @@ git push --set-upstream my_fork my_feature_branch
 
 ## Open a Pull Request
 
-[Github Docs](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork)
+[GitHub Docs](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork)
 
 ### Get a code review
 

--- a/docs/contributors/overview.md
+++ b/docs/contributors/overview.md
@@ -10,12 +10,12 @@ Our code of conduct can be found in the link below. Please follow it in all your
 
 - [Code Of Conduct](./CODE_OF_CONDUCT.md)
 
-## Github Workflow
+## GitHub Workflow
 
-We Use [Github Flow](https://guides.github.com/introduction/flow/index.html), so all code changes are tracked via Pull Requests.
+We Use [GitHub Flow](https://guides.github.com/introduction/flow/index.html), so all code changes are tracked via Pull Requests.
 A detailed guide on the recommended workflow can be found below:
 
-- [Github Workflow](./github_workflow.md)
+- [GitHub Workflow](./github_workflow.md)
 
 ## Code Testing
 


### PR DESCRIPTION
## Description

The correct spelling uses a capital H.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings