### PR TITLE
Move Dockerfile args down to where they are used

### DIFF
--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -59,11 +59,11 @@ $(addprefix $(bindir)/, $(bins)): | $(bindir)
 	docker export $$(cat $<) | tar -C $(dir $(bindir)) -xv bin/$(notdir $@) && touch $@
 
 .container.%: .docker-image.%.stamp
-	docker create k0sbuild$(basename $<) > $@.tmp
+	docker create --entrypoint /dev/null k0sbuild$(basename $<) > $@.tmp
 	mv $@.tmp $@
 
 .container.%.windows: .docker-image.%.windows.stamp
-	docker create k0sbuild$(basename $<) > $@.tmp
+	docker create --entrypoint /dev/null k0sbuild$(basename $<) > $@.tmp
 	mv $@.tmp $@
 
 .docker-image.%.stamp: %/Dockerfile Makefile.variables

--- a/embedded-bins/containerd/Dockerfile
+++ b/embedded-bins/containerd/Dockerfile
@@ -1,13 +1,6 @@
 ARG BUILDIMAGE
 FROM $BUILDIMAGE AS build
 
-ARG VERSION
-ARG BUILD_GO_TAGS
-ARG BUILD_GO_CGO_ENABLED
-ARG BUILD_SHIM_GO_CGO_ENABLED
-ARG BUILD_GO_FLAGS
-ARG BUILD_GO_LDFLAGS
-ARG BUILD_GO_LDFLAGS_EXTRA
 ENV GOPATH=/go
 
 RUN apk upgrade -U -a && apk add \
@@ -15,9 +8,18 @@ RUN apk upgrade -U -a && apk add \
 	btrfs-progs-dev btrfs-progs-static \
 	protoc
 
+ARG VERSION
 RUN mkdir -p $GOPATH/src/github.com/containerd/containerd
 RUN git -c advice.detachedHead=false clone -b v$VERSION --depth=1 https://github.com/containerd/containerd.git $GOPATH/src/github.com/containerd/containerd
 WORKDIR /go/src/github.com/containerd/containerd
+
+ARG BUILD_GO_TAGS \
+  BUILD_GO_CGO_ENABLED \
+  BUILD_SHIM_GO_CGO_ENABLED \
+  BUILD_GO_FLAGS \
+  BUILD_GO_LDFLAGS \
+  BUILD_GO_LDFLAGS_EXTRA
+
 RUN go version
 RUN make \
 	CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
@@ -29,4 +31,3 @@ RUN make \
 
 FROM scratch
 COPY --from=build /go/src/github.com/containerd/containerd/bin/* /bin/
-CMD ["/bin/containerd"]

--- a/embedded-bins/etcd/Dockerfile
+++ b/embedded-bins/etcd/Dockerfile
@@ -1,18 +1,19 @@
 ARG BUILDIMAGE
 FROM $BUILDIMAGE AS build
 
-ARG VERSION
-ARG BUILD_GO_TAGS
-ARG BUILD_GO_CGO_ENABLED
-ARG BUILD_GO_FLAGS
-ARG BUILD_GO_LDFLAGS
-ARG BUILD_GO_LDFLAGS_EXTRA
-
 RUN apk add build-base git
 
+ARG VERSION
 RUN cd / && git -c advice.detachedHead=false clone -b v$VERSION --depth=1 https://github.com/etcd-io/etcd.git
 WORKDIR /etcd/server
 RUN go version
+
+ARG BUILD_GO_TAGS \
+  BUILD_GO_CGO_ENABLED \
+  BUILD_GO_FLAGS \
+  BUILD_GO_LDFLAGS \
+  BUILD_GO_LDFLAGS_EXTRA
+
 RUN CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
     go build \
         ${BUILD_GO_FLAGS} \
@@ -23,4 +24,3 @@ RUN CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
 
 FROM scratch
 COPY --from=build /bin/etcd /bin/etcd
-CMD ["/bin/etcd"]

--- a/embedded-bins/iptables/Dockerfile
+++ b/embedded-bins/iptables/Dockerfile
@@ -1,10 +1,10 @@
 ARG BUILDIMAGE=alpine:3.16
 FROM $BUILDIMAGE AS build
 
-ARG VERSION
 RUN apk add build-base git file curl \
 	linux-headers pkgconf libnftnl-dev bison flex
 
+ARG VERSION
 RUN curl -L https://www.netfilter.org/projects/iptables/files/iptables-$VERSION.tar.bz2 \
 	| tar -C / -jx
 
@@ -19,5 +19,3 @@ RUN scanelf -Rn /usr/local && file /usr/local/sbin/*
 FROM scratch
 COPY --from=build /usr/local/sbin/xtables-legacy-multi \
 	/bin/xtables-legacy-multi
-
-CMD ["/bin/xtables-legacy-multi"]

--- a/embedded-bins/kine/Dockerfile
+++ b/embedded-bins/kine/Dockerfile
@@ -1,20 +1,20 @@
 ARG BUILDIMAGE
 FROM $BUILDIMAGE AS build
 
-ARG VERSION
-ARG BUILD_GO_TAGS
-ARG BUILD_GO_CGO_ENABLED
-ARG BUILD_GO_CGO_CFLAGS
-ARG BUILD_GO_FLAGS
-ARG BUILD_GO_LDFLAGS
-ARG BUILD_GO_LDFLAGS_EXTRA
-
 RUN apk add build-base git
 
-
+ARG VERSION
 RUN cd / && git -c advice.detachedHead=false clone -b v$VERSION --depth=1 https://github.com/rancher/kine.git
 WORKDIR /kine
 RUN go version
+
+ARG BUILD_GO_TAGS \
+  BUILD_GO_CGO_ENABLED \
+  BUILD_GO_CGO_CFLAGS \
+  BUILD_GO_FLAGS \
+  BUILD_GO_LDFLAGS \
+  BUILD_GO_LDFLAGS_EXTRA
+
 RUN CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
     CGO_CFLAGS=${BUILD_GO_CGO_CFLAGS} go build \
         ${BUILD_GO_FLAGS} \
@@ -24,4 +24,3 @@ RUN CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
 
 FROM scratch
 COPY --from=build /kine/kine /bin/kine
-CMD ["/bin/kine"]

--- a/embedded-bins/konnectivity/Dockerfile
+++ b/embedded-bins/konnectivity/Dockerfile
@@ -1,17 +1,18 @@
 ARG BUILDIMAGE
 FROM $BUILDIMAGE AS build
 
-ARG VERSION
-ARG BUILD_GO_TAGS
-ARG BUILD_GO_CGO_ENABLED
-ARG BUILD_GO_FLAGS
-ARG BUILD_GO_LDFLAGS
-ARG BUILD_GO_LDFLAGS_EXTRA
-
 RUN apk add build-base git make protoc
 
+ARG VERSION
 RUN git -c advice.detachedHead=false clone -b v$VERSION --depth=1 https://github.com/k0sproject/apiserver-network-proxy.git /apiserver-network-proxy
 WORKDIR /apiserver-network-proxy
+
+ARG BUILD_GO_TAGS \
+  BUILD_GO_CGO_ENABLED \
+  BUILD_GO_FLAGS \
+  BUILD_GO_LDFLAGS \
+  BUILD_GO_LDFLAGS_EXTRA
+
 RUN go version
 RUN go install github.com/golang/mock/mockgen@v1.4.4 && \
     go install github.com/golang/protobuf/protoc-gen-go@v1.4.3 && \
@@ -26,4 +27,3 @@ RUN go install github.com/golang/mock/mockgen@v1.4.4 && \
 
 FROM scratch
 COPY --from=build /apiserver-network-proxy/bin/proxy-server /bin/konnectivity-server
-CMD ["/bin/konnectivity-server"]

--- a/embedded-bins/kubernetes/Dockerfile
+++ b/embedded-bins/kubernetes/Dockerfile
@@ -1,20 +1,21 @@
 ARG BUILDIMAGE
 FROM $BUILDIMAGE AS build
 
-ARG VERSION
-ARG BUILD_GO_TAGS
-ARG BUILD_GO_CGO_ENABLED
-ARG BUILD_GO_FLAGS
-ARG BUILD_GO_LDFLAGS
-ARG BUILD_GO_LDFLAGS_EXTRA
 ENV GOPATH=/go
 ENV COMMANDS="kubelet kube-apiserver kube-scheduler kube-controller-manager"
 
 RUN apk add build-base git go-bindata linux-headers rsync grep coreutils bash
 
+ARG VERSION
 RUN mkdir -p $GOPATH/src/github.com/kubernetes/kubernetes
 RUN git -c advice.detachedHead=false clone -b v$VERSION --depth=1 https://github.com/kubernetes/kubernetes.git $GOPATH/src/github.com/kubernetes/kubernetes
 WORKDIR /go/src/github.com/kubernetes/kubernetes
+
+ARG BUILD_GO_TAGS \
+  BUILD_GO_CGO_ENABLED \
+  BUILD_GO_FLAGS \
+  BUILD_GO_LDFLAGS \
+  BUILD_GO_LDFLAGS_EXTRA
 
 RUN go version
 RUN \
@@ -35,4 +36,3 @@ COPY --from=build \
 	/go/src/github.com/kubernetes/kubernetes/_output/local/bin/linux/*/kube-scheduler \
 	/go/src/github.com/kubernetes/kubernetes/_output/local/bin/linux/*/kube-controller-manager \
 	/bin/
-CMD ["/bin/kubelet"]

--- a/embedded-bins/kubernetes/Dockerfile.windows
+++ b/embedded-bins/kubernetes/Dockerfile.windows
@@ -1,12 +1,12 @@
 ARG BUILDIMAGE
 FROM $BUILDIMAGE AS build
 
+RUN apk add build-base git go-bindata linux-headers rsync grep coreutils bash
+
 ARG VERSION
 ENV GOPATH=/go
 ENV COMMANDS="kubelet kube-proxy"
 ENV KUBE_BUILD_PLATFORMS=windows/amd64
-
-RUN apk add build-base git go-bindata linux-headers rsync grep coreutils bash
 
 RUN mkdir -p $GOPATH/src/github.com/kubernetes/kubernetes
 RUN git -c advice.detachedHead=false clone -b v$VERSION --depth=1 https://github.com/kubernetes/kubernetes.git $GOPATH/src/github.com/kubernetes/kubernetes
@@ -22,4 +22,3 @@ COPY --from=build \
 	/go/src/github.com/kubernetes/kubernetes/_output/local/bin/windows/*/kubelet.exe \
 	/go/src/github.com/kubernetes/kubernetes/_output/local/bin/windows/*/kube-proxy.exe \
 	/bin/
-CMD ["/bin/kubelet.exe"]

--- a/embedded-bins/runc/Dockerfile
+++ b/embedded-bins/runc/Dockerfile
@@ -1,19 +1,13 @@
 ARG BUILDIMAGE
 FROM $BUILDIMAGE AS build
 
-ARG VERSION
-ARG LIBSECCOMP_VERSION=2.5.1
-ARG BUILD_GO_TAGS
-ARG BUILD_GO_CGO_ENABLED
-ARG BUILD_GO_FLAGS
-ARG BUILD_GO_LDFLAGS
-ARG BUILD_GO_LDFLAGS_EXTRA
-
-ENV GOPATH=/go
 
 RUN apk add build-base git \
 	curl linux-headers gperf bash pkgconf
 
+ENV GOPATH=/go
+
+ARG LIBSECCOMP_VERSION=2.5.1
 RUN curl -L https://github.com/seccomp/libseccomp/releases/download/v$LIBSECCOMP_VERSION/libseccomp-$LIBSECCOMP_VERSION.tar.gz \
 	| tar -C / -zx
 
@@ -23,9 +17,17 @@ RUN make -j$(nproc) -C /libseccomp-$LIBSECCOMP_VERSION
 RUN make -j$(nproc) -C /libseccomp-$LIBSECCOMP_VERSION check
 RUN make -C /libseccomp-$LIBSECCOMP_VERSION install
 
+ARG VERSION
 RUN mkdir -p $GOPATH/src/github.com/opencontainers/runc
 RUN git -c advice.detachedHead=false clone -b v$VERSION --depth=1 https://github.com/opencontainers/runc.git $GOPATH/src/github.com/opencontainers/runc
 WORKDIR /go/src/github.com/opencontainers/runc
+
+ARG BUILD_GO_TAGS \
+  BUILD_GO_CGO_ENABLED \
+  BUILD_GO_FLAGS \
+  BUILD_GO_LDFLAGS \
+  BUILD_GO_LDFLAGS_EXTRA
+
 RUN go version
 RUN make \
 	CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
@@ -35,4 +37,3 @@ RUN make \
 
 FROM scratch
 COPY --from=build /go/src/github.com/opencontainers/runc/runc /bin/runc
-CMD ["/bin/runc"]


### PR DESCRIPTION
## Description

This improves the layer caching a bit, i.e. the dependencies don't need to be reinstalled when the binary versions change, or the upstream sources don't need to be cloned when the build flags change.

Moreover: remove the CMD stanzas from the Dockerfiles. The images are never meant to be run anyways. Just provide a dummy entrypoint in order to create containers for exporting the binaries.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings