### PR TITLE
Use GNU Make 3.81 as baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ else
   endif
   HOST_ARCH := amd64
 endif
-undefine HOST_HARDWARE
 endif
 
 K0S_GO_BUILD_CACHE ?= build/cache

--- a/README.md
+++ b/README.md
@@ -85,18 +85,36 @@ With strong enough arguments we might take in new addons, but in general those s
 
 ## Build
 
-`k0s` can be built in two different ways:
+The requirements for building k0s from source are as follows:
 
-Build Kubernetes components from source as static binaries (requires docker):
+- GNU Make (v3.81 or newer)
+- coreutils
+- findutils
+- Docker
+
+All of the compilation steps are performed inside Docker containers, no
+installation of Go is required.
+
+The k0s binary can be built in two different ways:
+
+The "k0s" way, self-contained, all binaries compiled from source, statically
+linked and embedded:
 
 ```shell
-make EMBEDDED_BINS_BUILDMODE=docker
+make
 ```
 
-Build k0s without any embedded binaries (requires that Kubernetes binaries are pre-installed on the runtime system):
+The "package maintainer" way, without any embedded binaries (requires that the
+required binaries are provided separately at runtime):
 
 ```shell
 make EMBEDDED_BINS_BUILDMODE=none
+```
+
+The embedded binaries can be built on their own:
+
+```shell
+make -C embedded-bins
 ```
 
 Builds can be done in parallel:
@@ -107,7 +125,12 @@ make -j$(nproc)
 
 ## Smoke test
 
-To run a smoke test after build:
+Additionally to the requirements for building k0s, the smoke tests _do_ require
+a local Go installation. you can run `./vars.sh go_version` in a terminal to
+find out the version that's being used to build k0s. It will print the
+corresponding Go version to stdout.
+
+To run a basic smoke test after build:
 
 ```shell
 make check-basic

--- a/docs/contributors/github_workflow.md
+++ b/docs/contributors/github_workflow.md
@@ -1,6 +1,6 @@
 # GitHub Workflow
 
-This guide assumes you have already cloned the upstream repo to your system via git clone, or via `go get github.com/k0sproject/k0s`.
+This guide assumes you have already cloned the upstream repo to your system via `git clone`, or via `go get github.com/k0sproject/k0s`.
 
 ## Fork The Project
 
@@ -56,7 +56,7 @@ git fetch origin && \
 Current branch my_feature_branch is up to date.
 ```
 
-Please don't use `git pull` instead of the above `fetch / rebase`. `git pull` does a merge, which leaves merge commits. These make the commit history messy and violate the principle that commits ought to be individually understandable and useful.
+Please don't use `git pull` instead of the above `fetch` / `rebase`. `git pull` does a merge, which leaves merge commits. These make the commit history messy and violate the principle that commits ought to be individually understandable and useful.
 
 ## Commit & Push
 
@@ -115,7 +115,9 @@ git push --set-upstream my_fork my_feature_branch
 
 ## Open a Pull Request
 
-[GitHub Docs](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork)
+See GitHub's docs on how to [create a pull request from a fork][pr-from-fork].
+
+[pr-from-fork]: https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork
 
 ### Get a code review
 

--- a/docs/contributors/overview.md
+++ b/docs/contributors/overview.md
@@ -12,10 +12,12 @@ Our code of conduct can be found in the link below. Please follow it in all your
 
 ## GitHub Workflow
 
-We Use [GitHub Flow](https://guides.github.com/introduction/flow/index.html), so all code changes are tracked via Pull Requests.
-A detailed guide on the recommended workflow can be found below:
+We use [GitHub flow], so all code changes are tracked via Pull Requests. A
+detailed guide on the recommended workflow can be found below:
 
 - [GitHub Workflow](./github_workflow.md)
+
+[GitHub flow]: https://docs.github.com/get-started/quickstart/github-flow
 
 ## Code Testing
 

--- a/docs/contributors/testing.md
+++ b/docs/contributors/testing.md
@@ -1,20 +1,23 @@
-## Testing Your Code
+# Testing Your Code
 
 k0s uses github actions to run automated tests on any PR, before merging.
 However, a PR will not be reviewed before all tests are green, so to save time and prevent your PR from going stale, it is best to test it before submitting the PR.
 
-### Run Local Verifications
+## Run Local Verifications
 
 Please run the following style and formatting commands and fix/check-in any changes:
 
 1. Linting
 
-    We use [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) for style verification.
+    We use [`golangci-lint`](https://golangci-lint.run/) for style verification.
     In the repository's root directory, simply run:
 
     ```shell
     make lint
     ```
+
+    There's no need to install `golangci-lint` manually. The build system will
+    take care of that.
 
 2. Go fmt
 
@@ -31,28 +34,33 @@ Please run the following style and formatting commands and fix/check-in any chan
 
     In the repository root directory, make sure that:
 
-    * `make build && git diff --exit-code` runs successfully.
-    * `make check-basic` runs successfully.
-    * `make check-unit` has no errors.
-    * `make check-hacontrolplane` runs successfully.
+    * `make build && git diff --exit-code` runs successfully.  
+      Verifies that the build is working and that the generated source code
+      matches the one that's checked into source control.
+    * `make check-unit` runs successfully.
+      Verifies that all the unit tests pass.
+    * `make check-basic` runs successfully.  
+      Verifies basic cluster functionality using one controller and two workers.
+    * `make check-hacontrolplane` runs successfully.  
+      Verifies that joining of controllers works.
 
     Please note that this last test is prone to "flakiness", so it might fail on occasion. If it fails constantly, take a deeper look at your code to find the source of the problem.
 
     If you find that all tests passed, you may open a pull request upstream.
 
-### Opening A Pull Request
+## Opening A Pull Request
 
-#### Draft Mode
+### Draft Mode
 
 You may open a pull request in [draft mode](https://github.blog/2019-02-14-introducing-draft-pull-requests).
 All automated tests will still run against the PR, but the PR will not be assigned for review.
 Once a PR is ready for review, transition it from Draft mode, and code owners will be notified.
 
-#### Conformance Testing
+### Conformance Testing
 
 Once a PR has been reviewed and all other tests have passed, a code owner will run a full end-to-end conformance test against the PR. This is usually the last step before merging.
 
-#### Pre-Requisites for PR Merge
+### Pre-Requisites for PR Merge
 
 In order for a PR to be merged, the following conditions should exist:
 
@@ -61,7 +69,7 @@ In order for a PR to be merged, the following conditions should exist:
 3. PR was reviewed and approved by a code owner.
 4. PR is rebased against upstream's main branch.
 
-### Cleanup the local workspace
+## Cleanup the local workspace
 
 In order to clean up the local workspace, run `make clean`. It will clean up all
 of the intermediate files and directories created during the k0s build. Note

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -75,7 +75,7 @@ check-backup: TIMEOUT=10m
 
 # Autopilot 3x3 HA test can take a while to run
 check-ap-ha3x3: K0S_UPDATE_FROM_BIN ?= ../k0s
-check-ap-ha3x3: K0S_UPDATE_FROM_PATH ?= $(shell realpath $(K0S_UPDATE_FROM_BIN))
+check-ap-ha3x3: K0S_UPDATE_FROM_PATH ?= $(realpath $(K0S_UPDATE_FROM_BIN))
 check-ap-ha3x3: TIMEOUT=6m
 
 check-kubeletcertrotate: TIMEOUT=15m


### PR DESCRIPTION
## Description

Document the build requirements of k0s a bit and explicitly specify the requirement of GNU Make at a minimum version of 3.81. This seems to be the common baseline on vanilla macOS installs, so being compatible with that version reduces a bit of friction when starting to hack on k0s on macs.

Take care of some old links, too.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings