### PR TITLE
Add the output of k0s sysinfo to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -22,6 +22,15 @@ body:
         - label: You're looking at docs for the released version, "main" branch docs are usually ahead of released versions.
           required: true
 
+  # Should actually be included in `k0s sysinfo` or something like `k0s version --full`
+  - type: textarea
+    attributes:
+      label: Platform
+      description: >-
+        Which platform did you run k0s on?
+        Use: `uname -srvmo; cat /etc/os-release || lsb_release -a`
+      render: shell
+
   - type: input
     attributes:
       label: Version
@@ -29,9 +38,14 @@ body:
 
   - type: textarea
     attributes:
-      label: Platform
-      description: "Which platform did you run k0s on? Use: `lsb_release -a`"
-      render: shell
+      label: Sysinfo
+      description: "Use: `k0s sysinfo`"
+      value: |
+        <details><summary>`k0s sysinfo`</summary>
+        ```text
+        ➡️ Please replace this text with the output of `k0s sysinfo`. ⬅️
+        ```
+        </details>
 
   - type: textarea
     attributes:
@@ -63,7 +77,7 @@ body:
       description: |
         If applicable, add screenshots to help explain your problem.
         Also add any output from kubectl if applicable.
-        Use: `kubectl logs --kubeconfig /var/lib/k0s/pki/admin.conf`
+        Use: `k0s kubectl logs`
 
   - type: textarea
     attributes:


### PR DESCRIPTION
## Description

Oftentimes k0s version and operating system name and version aren't enough context to judge about the problems that people report. Moreover, the OS release doesn't include the architecture, so we cannot tell if it's on arm or amd.

k0s already features `k0s sysinfo` that prints some diagnostics about the system. Include this as a separate form field and provide a default value that allows for collapsing the output. (Sadly, there's no way to make a form field collapsible by default, so this is less convenient to use as it should be.)

Also extend the suggested command to get the platform information by also including uname (whose info should probably be included into k0s's diagnostic commands.)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings