### PR TITLE
Let Dependabot ignore the Kubernetes Go dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
       - dependency-name: k8s.io/kube-scheduler
       - dependency-name: k8s.io/kubectl
       - dependency-name: k8s.io/kubelet
+      - dependency-name: k8s.io/kubernetes
       - dependency-name: k8s.io/legacy-cloud-providers
       - dependency-name: k8s.io/metrics
       - dependency-name: k8s.io/mount-utils


### PR DESCRIPTION
## Description

It requires additional adjustments besides just bumping the versions in go.mod/go.sum, as most of the other k8s.io/* dependencies.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings