### PR TITLE
Bump iptables to v1.8.8

### DIFF
--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -77,7 +77,7 @@ $(addprefix $(bindir)/, $(bins)): | $(bindir)
 		--build-arg BUILD_GO_FLAGS=$($(patsubst %/Dockerfile,%,$<)_build_go_flags) \
 		--build-arg BUILD_GO_LDFLAGS=$($(patsubst %/Dockerfile,%,$<)_build_go_ldflags) \
 		--build-arg BUILD_GO_LDFLAGS_EXTRA=$($(patsubst %/Dockerfile,%,$<)_build_go_ldflags_extra) \
-		-f $< .
+		$(dir $<)
 	touch $@
 
 .docker-image.%.windows.stamp: %/Dockerfile.windows Makefile.variables

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -55,5 +55,5 @@ konnectivity_build_go_flags = "-a"
 konnectivity_build_go_ldflags = "-w -s"
 konnectivity_build_go_ldflags_extra = "-extldflags=-static"
 
-iptables_version = 1.8.7
+iptables_version = 1.8.8
 iptables_buildimage = alpine:3.16

--- a/embedded-bins/iptables/Dockerfile
+++ b/embedded-bins/iptables/Dockerfile
@@ -8,7 +8,14 @@ ARG VERSION
 RUN curl -L https://www.netfilter.org/projects/iptables/files/iptables-$VERSION.tar.bz2 \
 	| tar -C / -jx
 
-RUN cd /iptables-$VERSION && CFLAGS="-Os" ./configure --sysconfdir=/etc --disable-shared --disable-nftables --without-kernel --disable-devel
+COPY \
+  use-uint-instead-of-u_int.patch \
+  revert-fix-eth-alen.patch \
+  /
+RUN cd /iptables-$VERSION && \
+  git apply /use-uint-instead-of-u_int.patch && \
+  git apply /revert-fix-eth-alen.patch && \
+  CFLAGS="-Os" ./configure --sysconfdir=/etc --disable-shared --disable-nftables --without-kernel --disable-devel
 
 RUN make -j$(nproc) -C /iptables-$VERSION LDFLAGS=-all-static
 RUN make -j$(nproc) -C /iptables-$VERSION install

--- a/embedded-bins/iptables/revert-fix-eth-alen.patch
+++ b/embedded-bins/iptables/revert-fix-eth-alen.patch
@@ -1,0 +1,65 @@
+From 0e7cf0ad306cdf95dc3c28d15a254532206a888e Mon Sep 17 00:00:00 2001
+From: Phil Sutter <phil@nwl.cc>
+Date: Wed, 18 May 2022 16:04:09 +0200
+Subject: Revert "fix build for missing ETH_ALEN definition"
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This reverts commit c5d9a723b5159a28f547b577711787295a14fd84 as it broke
+compiling against musl libc. Might be a bug in the latter, but for the
+time being try to please both by avoiding the include and instead
+defining ETH_ALEN if unset.
+
+While being at it, move netinet/ether.h include up.
+
+Fixes: 1bdb5535f561a ("libxtables: Extend MAC address printing/parsing support")
+Signed-off-by: Phil Sutter <phil@nwl.cc>
+Reviewed-by: Maciej Żenczykowski <maze@google.com>
+---
+ libxtables/xtables.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/libxtables/xtables.c b/libxtables/xtables.c
+index 96fd783a..0638f927 100644
+--- a/libxtables/xtables.c
++++ b/libxtables/xtables.c
+@@ -28,6 +28,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <unistd.h>
++#include <netinet/ether.h>
+ #include <sys/socket.h>
+ #include <sys/stat.h>
+ #include <sys/statfs.h>
+@@ -45,7 +46,6 @@
+ 
+ #include <xtables.h>
+ #include <limits.h> /* INT_MAX in ip_tables.h/ip6_tables.h */
+-#include <linux/if_ether.h> /* ETH_ALEN */
+ #include <linux/netfilter_ipv4/ip_tables.h>
+ #include <linux/netfilter_ipv6/ip6_tables.h>
+ #include <libiptc/libxtc.h>
+@@ -72,6 +72,10 @@
+ #define PROC_SYS_MODPROBE "/proc/sys/kernel/modprobe"
+ #endif
+ 
++#ifndef ETH_ALEN
++#define ETH_ALEN 6
++#endif
++
+ /* we need this for ip6?tables-restore.  ip6?tables-restore.c sets line to the
+  * current line of the input file, in order  to give a more precise error
+  * message.  ip6?tables itself doesn't need this, so it is initialized to the
+@@ -2245,8 +2249,6 @@ void xtables_print_num(uint64_t number, unsigned int format)
+ 	printf(FMT("%4lluT ","%lluT "), (unsigned long long)number);
+ }
+ 
+-#include <netinet/ether.h>
+-
+ static const unsigned char mac_type_unicast[ETH_ALEN] =   {};
+ static const unsigned char msk_type_unicast[ETH_ALEN] =   {1};
+ static const unsigned char mac_type_multicast[ETH_ALEN] = {1};
+-- 
+cgit v1.2.3
+

--- a/embedded-bins/iptables/use-uint-instead-of-u_int.patch
+++ b/embedded-bins/iptables/use-uint-instead-of-u_int.patch
@@ -1,0 +1,163 @@
+From f319389525b066b7dc6d389c88f16a0df3b8f189 Mon Sep 17 00:00:00 2001
+From: Nick Hainke <vincent@systemli.org>
+Date: Mon, 16 May 2022 18:16:41 +0200
+Subject: treewide: use uint* instead of u_int*
+
+Gcc complains about missing types. Some commits introduced u_int* instead
+of uint*. Use uint treewide.
+
+Fixes errors in the form of:
+In file included from xtables-legacy-multi.c:5:
+xshared.h:83:56: error: unknown type name 'u_int16_t'; did you mean 'uint16_t'?
+    83 | set_option(unsigned int *options, unsigned int option, u_int16_t *invflg,
+        |                                                        ^~~~~~~~~
+        |                                                        uint16_t
+make[6]: *** [Makefile:712: xtables_legacy_multi-xtables-legacy-multi.o] Error 1
+
+Avoid libipq API breakage by adjusting libipq.h include accordingly. For
+arpt_mangle.h kernel uAPI header, apply same change as in kernel commit
+e91ded8db5747 ("uapi: netfilter_arp: use __u8 instead of u_int8_t").
+
+Signed-off-by: Nick Hainke <vincent@systemli.org>
+Signed-off-by: Phil Sutter <phil@nwl.cc>
+---
+ extensions/libxt_conntrack.c              | 2 +-
+ include/libipq/libipq.h                   | 8 ++++----
+ include/libiptc/libxtc.h                  | 2 +-
+ include/linux/netfilter_arp/arpt_mangle.h | 2 +-
+ iptables/xshared.c                        | 2 +-
+ iptables/xshared.h                        | 2 +-
+ libipq/ipq_create_handle.3                | 2 +-
+ libipq/ipq_set_mode.3                     | 2 +-
+ 8 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/extensions/libxt_conntrack.c b/extensions/libxt_conntrack.c
+index 64018ce1..234085c5 100644
+--- a/extensions/libxt_conntrack.c
++++ b/extensions/libxt_conntrack.c
+@@ -778,7 +778,7 @@ matchinfo_print(const void *ip, const struct xt_entry_match *match, int numeric,
+ 
+ static void
+ conntrack_dump_ports(const char *prefix, const char *opt,
+-		     u_int16_t port_low, u_int16_t port_high)
++		     uint16_t port_low, uint16_t port_high)
+ {
+ 	if (port_high == 0 || port_low == port_high)
+ 		printf(" %s%s %u", prefix, opt, port_low);
+diff --git a/include/libipq/libipq.h b/include/libipq/libipq.h
+index 3cd13292..dd0cb205 100644
+--- a/include/libipq/libipq.h
++++ b/include/libipq/libipq.h
+@@ -24,7 +24,7 @@
+ #include <errno.h>
+ #include <unistd.h>
+ #include <fcntl.h>
+-#include <sys/types.h>
++#include <stdint.h>
+ #include <sys/socket.h>
+ #include <sys/uio.h>
+ #include <asm/types.h>
+@@ -48,19 +48,19 @@ typedef unsigned long ipq_id_t;
+ struct ipq_handle
+ {
+ 	int fd;
+-	u_int8_t blocking;
++	uint8_t blocking;
+ 	struct sockaddr_nl local;
+ 	struct sockaddr_nl peer;
+ };
+ 
+-struct ipq_handle *ipq_create_handle(u_int32_t flags, u_int32_t protocol);
++struct ipq_handle *ipq_create_handle(uint32_t flags, uint32_t protocol);
+ 
+ int ipq_destroy_handle(struct ipq_handle *h);
+ 
+ ssize_t ipq_read(const struct ipq_handle *h,
+                 unsigned char *buf, size_t len, int timeout);
+ 
+-int ipq_set_mode(const struct ipq_handle *h, u_int8_t mode, size_t len);
++int ipq_set_mode(const struct ipq_handle *h, uint8_t mode, size_t len);
+ 
+ ipq_packet_msg_t *ipq_get_packet(const unsigned char *buf);
+ 
+diff --git a/include/libiptc/libxtc.h b/include/libiptc/libxtc.h
+index 37010188..a1d16ef9 100644
+--- a/include/libiptc/libxtc.h
++++ b/include/libiptc/libxtc.h
+@@ -10,7 +10,7 @@ extern "C" {
+ #endif
+ 
+ #ifndef XT_MIN_ALIGN
+-/* xt_entry has pointers and u_int64_t's in it, so if you align to
++/* xt_entry has pointers and uint64_t's in it, so if you align to
+    it, you'll also align to any crazy matches and targets someone
+    might write */
+ #define XT_MIN_ALIGN (__alignof__(struct xt_entry))
+diff --git a/include/linux/netfilter_arp/arpt_mangle.h b/include/linux/netfilter_arp/arpt_mangle.h
+index 250f5029..8c2b16a1 100644
+--- a/include/linux/netfilter_arp/arpt_mangle.h
++++ b/include/linux/netfilter_arp/arpt_mangle.h
+@@ -13,7 +13,7 @@ struct arpt_mangle
+ 	union {
+ 		struct in_addr tgt_ip;
+ 	} u_t;
+-	u_int8_t flags;
++	__u8 flags;
+ 	int target;
+ };
+ 
+diff --git a/iptables/xshared.c b/iptables/xshared.c
+index a8512d38..9b5e5b5b 100644
+--- a/iptables/xshared.c
++++ b/iptables/xshared.c
+@@ -1025,7 +1025,7 @@ static const int inverse_for_options[NUMBER_OF_OPT] =
+ };
+ 
+ void
+-set_option(unsigned int *options, unsigned int option, u_int16_t *invflg,
++set_option(unsigned int *options, unsigned int option, uint16_t *invflg,
+ 	   bool invert)
+ {
+ 	if (*options & option)
+diff --git a/iptables/xshared.h b/iptables/xshared.h
+index 14568bb0..f8212988 100644
+--- a/iptables/xshared.h
++++ b/iptables/xshared.h
+@@ -80,7 +80,7 @@ struct xtables_target;
+ #define IPT_INV_ARPHRD		0x0800
+ 
+ void
+-set_option(unsigned int *options, unsigned int option, u_int16_t *invflg,
++set_option(unsigned int *options, unsigned int option, uint16_t *invflg,
+ 	   bool invert);
+ 
+ /**
+diff --git a/libipq/ipq_create_handle.3 b/libipq/ipq_create_handle.3
+index 11ef95c4..ebe46daa 100644
+--- a/libipq/ipq_create_handle.3
++++ b/libipq/ipq_create_handle.3
+@@ -24,7 +24,7 @@ ipq_create_handle, ipq_destroy_handle \(em create and destroy libipq handles.
+ .br
+ .B #include <libipq.h>
+ .sp
+-.BI "struct ipq_handle *ipq_create_handle(u_int32_t " flags ", u_int32_t " protocol ");"
++.BI "struct ipq_handle *ipq_create_handle(uint32_t " flags ", uint32_t " protocol ");"
+ .br
+ .BI "int ipq_destroy_handle(struct ipq_handle *" h );
+ .SH DESCRIPTION
+diff --git a/libipq/ipq_set_mode.3 b/libipq/ipq_set_mode.3
+index 0edd3c00..e206886c 100644
+--- a/libipq/ipq_set_mode.3
++++ b/libipq/ipq_set_mode.3
+@@ -24,7 +24,7 @@ ipq_set_mode \(em set the ip_queue queuing mode
+ .br
+ .B #include <libipq.h>
+ .sp
+-.BI "int ipq_set_mode(const struct ipq_handle *" h ", u_int8_t " mode ", size_t " range );
++.BI "int ipq_set_mode(const struct ipq_handle *" h ", uint8_t " mode ", size_t " range );
+ .SH DESCRIPTION
+ The
+ .B ipq_set_mode
+-- 
+cgit v1.2.3
+


### PR DESCRIPTION
## Description

https://www.netfilter.org/projects/iptables/files/changes-iptables-1.8.8.txt

Also include some unreleased patches to fix compilation issues:

* https://git.netfilter.org/iptables/commit/?id=f319389525b066b7dc6d389c88f16a0df3b8f189
  Gcc complains about missing types. Some commits introduced u_int* instead of uint*.
* https://git.netfilter.org/iptables/commit/?id=0e7cf0ad306cdf95dc3c28d15a254532206a888e
  Revert "fix build for missing ETH_ALEN definition"

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings