### PR TITLE
[Backport release-1.22] Add embedded-bins vs. go.mod consistency tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	go.uber.org/zap v1.19.0
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/tools v0.1.10-0.20220218145154-897bd77cd717
 	google.golang.org/grpc v1.38.0
 	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1114,6 +1114,7 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43 h1:+lm10QQTNSBd8DVTNGHx7o/IKu9HYDvLMffDhbyLccI=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50 h1:hlE8//ciYMztlGpl/VA+Zm1AcTPHYkHJPbHqE6WJUXE=
@@ -1235,6 +1236,7 @@ golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWP
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
+golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 h1:kUhD7nTDoI3fVd9G4ORWrbV5NY0liEs/Jg2pv5f+bBA=
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
@@ -1273,6 +1275,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 h1:kQgndtyPBW/JIYERgdxfwMYh3AVStj88WQTlNDi2a+o=
+golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1325,6 +1329,7 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63 h1:iocB37TsdFuN6IBRZ+ry36wrkoV51/tl5vOWqkcPGvY=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -1450,6 +1455,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
@@ -1531,6 +1537,8 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.10-0.20220218145154-897bd77cd717 h1:hI3jKY4Hpf63ns040onEbB3dAkR/H/P83hw1TG8dD3Y=
+golang.org/x/tools v0.1.10-0.20220218145154-897bd77cd717/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/constant/constant_shared_test.go
+++ b/pkg/constant/constant_shared_test.go
@@ -23,21 +23,108 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"golang.org/x/tools/go/packages"
 )
 
-func TestKonnectivityVersion(t *testing.T) {
-	assert.Equal(t, getVersion(t, "konnectivity"), strings.TrimPrefix(KonnectivityImageVersion, "v"))
+func TestConstants(t *testing.T) {
+	for _, test := range []struct{ name, constant, varName string }{
+		{"KonnectivityImageVersion", "v" + KonnectivityImageVersion, "konnectivity"},
+		{"KubeProxyImageVersion", KubeProxyImageVersion, "kubernetes"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, "v"+getVersion(t, test.varName), test.constant)
+		})
+	}
+
+	t.Run("KubernetesMajorMinorVersion", func(t *testing.T) {
+		ver := strings.Split(getVersion(t, "kubernetes"), ".")
+		require.GreaterOrEqual(t, len(ver), 2, "failed to spilt Kubernetes version %q", ver)
+		kubeMajorMinor := ver[0] + "." + ver[1]
+		assert.Equal(t, kubeMajorMinor, KubernetesMajorMinorVersion)
+	})
 }
 
-func TestKubeProxyVersion(t *testing.T) {
-	assert.Equal(t, getVersion(t, "kubernetes"), strings.TrimPrefix(KubeProxyImageVersion, "v"))
+func TestKubernetesModuleVersions(t *testing.T) {
+	kubernetesVersion := getVersion(t, "kubernetes")
+
+	checkPackageModules(t,
+		func(modulePath string) bool {
+			switch modulePath {
+			// Don't report any version mismatches on the following modules.
+			// They have a release cycle which is decoupled from k8s itself.
+			case "k8s.io/klog/v2", "k8s.io/kube-openapi", "k8s.io/system-validators", "k8s.io/utils":
+				return false
+
+			default:
+				return strings.HasPrefix(modulePath, "k8s.io/")
+			}
+		},
+		func(t *testing.T, pkgPath string, module *packages.Module) bool {
+			modVer := module.Version
+			if module.Path != "k8s.io/kubernetes" {
+				// All modules besides Kubernetes itself use v0 instead of v1.
+				modVer = strings.Replace(modVer, "v0.", "v1.", 1)
+			}
+
+			return !assert.Equal(t, "v"+kubernetesVersion, modVer,
+				"Module version for package %s doesn't match: %+#v",
+				pkgPath, module,
+			)
+		},
+	)
 }
 
-func TestKubernetesMajorMinorVersion(t *testing.T) {
-	ver := strings.Split(getVersion(t, "kubernetes"), ".")
-	kubeMinorMajor := ver[0] + "." + ver[1]
+func TestEtcdModuleVersions(t *testing.T) {
+	etcdVersion := getVersion(t, "etcd")
+	etcdVersionParts := strings.Split(etcdVersion, ".")
+	require.GreaterOrEqual(t, len(etcdVersionParts), 1, "failed to spilt etcd version %q", etcdVersion)
 
-	assert.Equal(t, kubeMinorMajor, KubernetesMajorMinorVersion)
+	checkPackageModules(t,
+		func(modulePath string) bool {
+			return strings.HasPrefix(modulePath, "go.etcd.io/etcd/") &&
+				strings.HasSuffix(modulePath, "/v"+etcdVersionParts[0])
+		},
+		func(t *testing.T, pkgPath string, module *packages.Module) bool {
+			return !assert.Equal(t, "v"+etcdVersion, module.Version,
+				"Module version for package %s doesn't match: %+#v",
+				pkgPath, module,
+			)
+		},
+	)
+}
+
+func TestContainerdModuleVersions(t *testing.T) {
+	containerdVersion := getVersion(t, "containerd")
+
+	checkPackageModules(t,
+		func(modulePath string) bool {
+			return modulePath == "github.com/containerd/containerd"
+		},
+		func(t *testing.T, pkgPath string, module *packages.Module) bool {
+			return !assert.Equal(t, "v"+containerdVersion, module.Version,
+				"Module version for package %s doesn't match: %+#v",
+				pkgPath, module,
+			)
+		},
+	)
+}
+
+func TestRuncModuleVersions(t *testing.T) {
+	runcVersion := getVersion(t, "runc")
+
+	checkPackageModules(t,
+		func(modulePath string) bool {
+			return modulePath == "github.com/opencontainers/runc"
+		},
+		func(t *testing.T, pkgPath string, module *packages.Module) bool {
+			return !assert.Equal(t, "v"+runcVersion, module.Version,
+				"Module version for package %s doesn't match: %+#v",
+				pkgPath, module,
+			)
+		},
+	)
 }
 
 func getVersion(t *testing.T, component string) string {
@@ -56,3 +143,34 @@ include ../../embedded-bins/Makefile.variables
 print-%:
 	@echo $($*)
 `
+
+func checkPackageModules(t *testing.T, filter func(modulePath string) bool, check func(t *testing.T, pkgPath string, module *packages.Module) bool) {
+	pkgs, err := packages.Load(&packages.Config{
+		Mode: packages.NeedName | packages.NeedModule | packages.NeedImports | packages.NeedDeps,
+		Logf: t.Logf,
+	}, "github.com/k0sproject/k0s")
+	require.NoError(t, err)
+
+	failedModules := make(map[string]bool)
+	checkCalledAtLeastOnce := false
+
+	packages.Visit(pkgs, func(p *packages.Package) bool {
+		if p.Module != nil && filter(p.Module.Path) {
+			actual := p.Module
+			for actual.Replace != nil {
+				actual = actual.Replace
+			}
+
+			if !failedModules[actual.Path] {
+				checkCalledAtLeastOnce = true
+				if !check(t, p.PkgPath, actual) {
+					failedModules[actual.Path] = true
+				}
+			}
+		}
+
+		return true
+	}, nil)
+
+	assert.True(t, checkCalledAtLeastOnce, "Not a single package passed the filter.")
+}


### PR DESCRIPTION
Backport of #2084. See #2063.