### PR TITLE
Helm extensions debug logging

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -23,9 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/k0sproject/k0s/internal/pkg/dir"
-	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
-	"github.com/k0sproject/k0s/pkg/constant"
+	"github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -35,6 +33,10 @@ import (
 	"helm.sh/helm/v3/pkg/repo"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/yaml"
+
+	"github.com/k0sproject/k0s/internal/pkg/dir"
+	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/constant"
 )
 
 // Commands run different helm command in the same way as CLI tool
@@ -42,6 +44,11 @@ type Commands struct {
 	repoFile     string
 	helmCacheDir string
 	kubeConfig   string
+}
+
+func logFn(format string, args ...interface{}) {
+	log := logrus.WithField("component", "helm")
+	log.Debugf(format, args...)
 }
 
 var getters = getter.Providers{
@@ -76,7 +83,7 @@ func (hc *Commands) getActionCfg(namespace string) (*action.Configuration, error
 		ImpersonateGroup: &impersonateGroup,
 	}
 	actionConfig := &action.Configuration{}
-	if err := actionConfig.Init(cfg, namespace, "secret", func(format string, v ...interface{}) {}); err != nil {
+	if err := actionConfig.Init(cfg, namespace, "secret", logFn); err != nil {
 		return nil, err
 	}
 	return actionConfig, nil


### PR DESCRIPTION
Signed-off-by: Alexey Makhov <amakhov@mirantis.com>

## Description

Once you have any issues with a helm chart it would never be deployed and it's almost impossible to understand what's wrong. The change introduces logging for helm releases to add observability and make debugging easier. 
Works the same way as `helm install/upgrade --debug`

ATM, it prints out logs only in case the k0s running with the `--debug` flag.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings