### PR TITLE
Bump kubernetes release versions for the autopilot update tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -256,7 +256,7 @@ jobs:
 
       - id: set-matrix
         run: |
-          matrix=$(./hack/tools/gen-matrix.sh 1.24.2 1.24.3)
+          matrix=$(./hack/tools/gen-matrix.sh 1.24.3 1.24.4)
           echo "::set-output name=matrix::$matrix"
 
   autopilot-smoketest:


### PR DESCRIPTION
Signed-off-by: Alexey Makhov <amakhov@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

We currently only have autopilot for Kubernetes 1.24.*, so updating the version list for testing requires manual work each release. 
Once we will have Kubernetes 1.25 released, we can get rid of patch versions and use minor ones (eg `./gen-matrix.sh 1.24 1.25`). It will allow us to run the test against the latest releases of the supported Kubernetes versions.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings