### PR TITLE
Set proper version when building kine

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -35,7 +35,7 @@ kine_buildimage = golang:$(go_version)-alpine3.16
 kine_build_go_cgo_cflags = "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" # Flags taken from https://github.com/k3s-io/kine/blob/v0.9.3/scripts/build#L16
 #kine_build_go_flags =
 kine_build_go_ldflags = "-w -s"
-kine_build_go_ldflags_extra = "-extldflags=-static"
+kine_build_go_ldflags_extra = "-extldflags=-static -X github.com/k3s-io/kine/pkg/version.Version=${kine_version}"
 
 etcd_version = 3.5.4
 etcd_buildimage = golang:$(go_version)-alpine3.16

--- a/embedded-bins/kine/Dockerfile
+++ b/embedded-bins/kine/Dockerfile
@@ -20,7 +20,7 @@ RUN CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
     CGO_CFLAGS=${BUILD_GO_CGO_CFLAGS} go build \
         ${BUILD_GO_FLAGS} \
         -tags="${BUILD_GO_TAGS}" \
-        -ldflags="${BUILD_GO_LDFLAGS} ${BUILD_GO_LDFLAGS_EXTRA}" \
+        -ldflags="${BUILD_GO_LDFLAGS} ${BUILD_GO_LDFLAGS_EXTRA} -X github.com/k3s-io/kine/pkg/version.GitCommit=$(git rev-parse --short HEAD)" \
         -o kine
 
 FROM scratch


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

## Description

Currently we build kine without setting the version & commit detail. This results into:
```
root@lima-lens-vm:~# /var/lib/k0s/bin/kine -v    
kine version dev (HEAD)
```

With this change, it'll look more correct:
```
 ./staging/linux/bin/kine -v
kine version 0.9.3 (1c94e77)
```

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings