### PR TITLE
Use Kubernetes API to create Kubelet kubeconfig

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -538,7 +538,7 @@ func (c *CmdOpts) startControllerWorker(ctx context.Context, profile string) err
 			// we use retry.Do with 10 attempts, back-off delay and delay duration 500 ms which gives us
 			// 225 seconds here
 			tokenAge := time.Second * 225
-			cfg, err := token.CreateKubeletBootstrapConfig(ctx, c.NodeConfig.Spec.API, c.K0sVars, token.RoleWorker, tokenAge)
+			cfg, err := token.CreateKubeletBootstrapToken(ctx, c.NodeConfig.Spec.API, c.K0sVars, token.RoleWorker, tokenAge)
 			if err != nil {
 				return err
 			}

--- a/cmd/token/create.go
+++ b/cmd/token/create.go
@@ -70,7 +70,7 @@ k0s token create --role worker --expiry 10m  //sets expiration time to 10 minute
 					return err
 				}
 
-				bootstrapConfig, err = token.CreateKubeletBootstrapConfig(cmd.Context(), c.NodeConfig.Spec.API, c.K0sVars, createTokenRole, expiry)
+				bootstrapConfig, err = token.CreateKubeletBootstrapToken(cmd.Context(), c.NodeConfig.Spec.API, c.K0sVars, createTokenRole, expiry)
 				return err
 			})
 			if err != nil {

--- a/pkg/token/joinencode.go
+++ b/pkg/token/joinencode.go
@@ -23,15 +23,15 @@ import (
 	"io"
 )
 
-// JoinEncode compresses and base64 encodes a join token
-func JoinEncode(inBuf *bytes.Buffer) (string, error) {
+// joinEncode compresses and base64 encodes a join token
+func joinEncode(in io.Reader) (string, error) {
 	var outBuf bytes.Buffer
 	gz, err := gzip.NewWriterLevel(&outBuf, gzip.BestCompression)
 	if err != nil {
 		return "", err
 	}
 
-	_, err = io.Copy(gz, inBuf)
+	_, err = io.Copy(gz, in)
 	gzErr := gz.Close()
 	if err != nil {
 		return "", err

--- a/pkg/token/kubeconfig_test.go
+++ b/pkg/token/kubeconfig_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package token
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateKubeconfig(t *testing.T) {
+	expected := `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: dGhlIGNlcnQ=
+    server: the join URL
+  name: k0s
+contexts:
+- context:
+    cluster: k0s
+    user: the user
+  name: k0s
+current-context: k0s
+kind: Config
+preferences: {}
+users:
+- name: the user
+  user:
+    token: the token
+`
+
+	kubeconfig, err := generateKubeconfig("the join URL", []byte("the cert"), "the user", "the token")
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(kubeconfig))
+}


### PR DESCRIPTION
## Description

Replace the use of the string template by structs and APIs provided by client-go.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings