### PR TITLE
Allow adding callbacks after starting the leader elector

### DIFF
--- a/pkg/component/controller/dummyleaderelector.go
+++ b/pkg/component/controller/dummyleaderelector.go
@@ -24,7 +24,7 @@ import (
 
 type DummyLeaderElector struct {
 	Leader    bool
-	callbacks []func()
+	callbacks []CallbackFn
 }
 
 var _ LeaderElector = (*DummyLeaderElector)(nil)
@@ -34,7 +34,10 @@ func (l *DummyLeaderElector) Init(_ context.Context) error { return nil }
 func (l *DummyLeaderElector) Stop() error                  { return nil }
 func (l *DummyLeaderElector) IsLeader() bool               { return l.Leader }
 
-func (l *DummyLeaderElector) AddAcquiredLeaseCallback(fn func()) {
+func (l *DummyLeaderElector) AddCallback(name string, cb LeaseCallback) {}
+func (l *DummyLeaderElector) RemoveCallback(string)                     {}
+
+func (l *DummyLeaderElector) AddAcquiredLeaseCallback(fn CallbackFn) {
 	l.callbacks = append(l.callbacks, fn)
 }
 

--- a/pkg/component/controller/leaderelector_test.go
+++ b/pkg/component/controller/leaderelector_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/k0sproject/k0s/pkg/leaderelection"
+	"github.com/stretchr/testify/require"
+)
+
+type fakePoolWatcher struct {
+	events *leaderelection.LeaseEvents
+}
+
+func (p *fakePoolWatcher) Watch(...leaderelection.WatchOpt) (*leaderelection.LeaseEvents, context.CancelFunc, error) {
+	p.events = &leaderelection.LeaseEvents{
+		AcquiredLease: make(chan struct{}),
+		LostLease:     make(chan struct{}),
+	}
+	go func() {
+		p.events.AcquiredLease <- struct{}{}
+	}()
+
+	return p.events, nil, nil
+}
+
+func (p *fakePoolWatcher) lose() {
+	go func() {
+		p.events.LostLease <- struct{}{}
+	}()
+}
+
+func TestLeaderElector(t *testing.T) {
+	t.Run("acquired_and_lost_callback_called_if_registrated_before_starting_working_loop", func(t *testing.T) {
+		firstCalled := make(chan bool)
+		firstStopped := make(chan bool)
+		ctx := context.Background()
+		watcher := &fakePoolWatcher{}
+		elector := NewLeasePoolLeaderElector(func() (LeasePoolWatcher, error) {
+			return watcher, nil
+		})
+		elector.AddCallback("first", LeaseCallback{
+			OnAcquired: func() {
+				firstCalled <- true
+			},
+			OnLost: func() {
+				firstStopped <- true
+			},
+		})
+
+		require.NoError(t, elector.Start(ctx))
+		watcher.lose()
+		require.True(t, <-firstCalled, "Must call all start callbacks registrated before start")
+		require.True(t, <-firstStopped, "Must call all lost callbacks registrated before start")
+	})
+
+	t.Run("acquired_and_lost_callback_called_if_registrated_after_starting_working_loop", func(t *testing.T) {
+		firstCalled := make(chan bool)
+		firstStopped := make(chan bool)
+		ctx := context.Background()
+		watcher := &fakePoolWatcher{}
+		elector := NewLeasePoolLeaderElector(func() (LeasePoolWatcher, error) {
+			return watcher, nil
+		})
+
+		require.NoError(t, elector.Start(ctx))
+		elector.AddCallback("first", LeaseCallback{
+			OnAcquired: func() {
+				firstCalled <- true
+			},
+			OnLost: func() {
+				firstStopped <- true
+			},
+		})
+		watcher.lose()
+		require.True(t, <-firstCalled, "Must call all start callbacks registrated before start")
+		require.True(t, <-firstStopped, "Must call all lost callbacks registrated before start")
+	})
+
+	t.Run("lost_callback_is_called_on_deregestritration_even_if_elector_is_still_leader", func(t *testing.T) {
+		firstCalled := make(chan bool)
+		firstStopped := make(chan bool)
+		ctx := context.Background()
+		watcher := &fakePoolWatcher{}
+		elector := NewLeasePoolLeaderElector(func() (LeasePoolWatcher, error) {
+			return watcher, nil
+		})
+		elector.AddCallback("first", LeaseCallback{
+			OnAcquired: func() {
+				firstCalled <- true
+			},
+			OnLost: func() {
+				firstStopped <- true
+			},
+		})
+		require.NoError(t, elector.Start(ctx))
+		require.True(t, <-firstCalled, "Must call all start callbacks registrated before start")
+		elector.RemoveCallback("first")
+		require.True(t, <-firstStopped, "Must call all lost callbacks registrated before start")
+		require.True(t, elector.IsLeader(), "elector is still leader")
+	})
+}

--- a/pkg/leaderelection/lease_pool.go
+++ b/pkg/leaderelection/lease_pool.go
@@ -219,7 +219,7 @@ func (p *LeasePool) Watch(opts ...WatchOpt) (*LeaseEvents, context.CancelFunc, e
 	}
 
 	ctx, cancel := context.WithCancel(p.config.ctx)
-
+	// TODO: never ending goroutine on each watch, possible leak
 	go func() {
 		for ctx.Err() == nil {
 			le.Run(ctx)


### PR DESCRIPTION
Allow adding callbacks after starting the leader elector
Allow de-registrating callbacks from running elector
Unit-tests

Covers #1845 

Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings