### PR TITLE
Add validation message for the TunneledNetworkingMode

### DIFF
--- a/inttest/tunneledkas/suite_test.go
+++ b/inttest/tunneledkas/suite_test.go
@@ -35,6 +35,7 @@ type Suite struct {
 const config = `
 spec:
   api:
+    port: 7443
     tunneledNetworkingMode: true
 `
 
@@ -87,8 +88,9 @@ func (s *Suite) TestK0sTunneledKasMode() {
 func TestK0sTunneledKasModeSuite(t *testing.T) {
 	s := Suite{
 		common.FootlooseSuite{
-			ControllerCount: 1,
-			WorkerCount:     2,
+			ControllerCount:     1,
+			WorkerCount:         2,
+			KubeAPIExternalPort: 7443,
 		},
 	}
 	suite.Run(t, &s)

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/api.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/api.go
@@ -48,13 +48,15 @@ type APISpec struct {
 	SANs []string `json:"sans"`
 }
 
+const defaultKasPort = 6443
+
 // DefaultAPISpec default settings for api
 func DefaultAPISpec() *APISpec {
 	// Collect all nodes addresses for sans
 	addresses, _ := iface.AllAddresses()
 	publicAddress, _ := iface.FirstPublicAddress()
 	return &APISpec{
-		Port:                   6443,
+		Port:                   defaultKasPort,
 		K0sAPIPort:             9443,
 		SANs:                   addresses,
 		Address:                publicAddress,
@@ -127,6 +129,8 @@ func (a *APISpec) Validate() []error {
 	if !govalidator.IsIP(a.Address) {
 		errors = append(errors, fmt.Errorf("spec.api.address: %q is not IP address", a.Address))
 	}
-
+	if a.TunneledNetworkingMode && a.Port == defaultKasPort {
+		errors = append(errors, fmt.Errorf("can't use default kubeapi port if TunneledNetworkingMode is enabled"))
+	}
 	return errors
 }

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/api_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/api_test.go
@@ -66,6 +66,14 @@ func (s *APISuite) TestValidation() {
 		s.Len(errors, 1)
 		s.Contains(errors[0].Error(), "is not a valid address for sans")
 	})
+	s.T().Run("TunneledNetworkingMode_and_default_kas_port_is_invalid", func(t *testing.T) {
+		a := DefaultAPISpec()
+		a.TunneledNetworkingMode = true
+		errors := a.Validate()
+		s.NotNil(errors)
+		s.Len(errors, 1)
+		s.Contains(errors[0].Error(), "can't use default kubeapi port if TunneledNetworkingMode is enabled")
+	})
 }
 
 func TestApiSuite(t *testing.T) {


### PR DESCRIPTION
Config field spec.api.tunneledNetworkingMode set to true and
node role equals to controller+worker mode leads to running
konnectivity-agent and kube-api on the same port.
Due to the fact, that konnectivity-agent runs in host network, in case
of enabled tunneledNetworkingMode, it leads to panic during the
bootstrap.
There is no way to validate spec.api with respect to node role,
so it is easier to just disallow running kube-api with default port
in case if we have tunneledNetworkingMode enabled.

Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings