### PR TITLE
[Backport release-1.23] Bump etcd binary to v3.5.5

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -37,7 +37,7 @@ kine_build_go_cgo_cflags = "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1"
 kine_build_go_ldflags = "-w -s"
 kine_build_go_ldflags_extra = "-extldflags=-static"
 
-etcd_version = 3.5.4
+etcd_version = 3.5.5
 etcd_buildimage = golang:$(go_version)-alpine
 #etcd_build_go_tags =
 etcd_build_go_cgo_enabled = 0

--- a/pkg/constant/constant_shared_test.go
+++ b/pkg/constant/constant_shared_test.go
@@ -87,12 +87,23 @@ func TestEtcdModuleVersions(t *testing.T) {
 				strings.HasSuffix(modulePath, "/v"+etcdVersionParts[0])
 		},
 		func(t *testing.T, pkgPath string, module *packages.Module) bool {
-			return !assert.Equal(t, "v"+etcdVersion, module.Version,
-				"Module version for package %s doesn't match: %+#v",
+			// TODO: Restore the old test behavior once the Go dependencies can
+			// be updated to the current etcd version without opening
+			// dependora's box.
+
+			return !assert.NotEqual(t, "v"+etcdVersion, module.Version,
+				"Module version for package %s matches, consider restoring the old test behavior: %+#v",
 				pkgPath, module,
 			)
+
+			// return !assert.Equal(t, "v"+etcdVersion, module.Version,
+			// 	"Module version for package %s doesn't match: %+#v",
+			// 	pkgPath, module,
+			// )
 		},
 	)
+
+	t.Skip("This test is skipped until the etcd Go dependencies can be updated to the current version.")
 }
 
 func TestContainerdModuleVersions(t *testing.T) {


### PR DESCRIPTION
Backport of #2174. See #2164.