### PR TITLE
Remove gen_manifests.go before its recreation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ pkg/apis/%/.client-gen.stamp: .k0sbuild.docker-image.k0s hack/tools/boilerplate.
 codegen_targets += static/gen_manifests.go
 static/gen_manifests.go: .k0sbuild.docker-image.k0s hack/tools/Makefile.variables
 static/gen_manifests.go: $(shell find static/manifests -type f)
+	-rm -f -- '$@'
 	CGO_ENABLED=0 $(GO) install github.com/kevinburke/go-bindata/go-bindata@v$(go-bindata_version)
 	$(GO_ENV) go-bindata -o static/gen_manifests.go -pkg static -prefix static static/...
 


### PR DESCRIPTION
## Description

This prevents the file to contain itself if gen-bindata is invoked when the file is already present. Otherwise, it would blow up into Gigabytes.

Fixes #2182.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings