### PR TITLE
Don't load cluster config automatically

### DIFF
--- a/cmd/airgap/listimages.go
+++ b/cmd/airgap/listimages.go
@@ -32,7 +32,11 @@ func NewAirgapListImagesCmd() *cobra.Command {
 		Example: `k0s airgap list-images`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := config.GetCmdOpts()
-			uris := airgap.GetImageURIs(c.ClusterConfig.Spec.Images)
+			clusterConfig, err := config.LoadClusterConfig(c.K0sVars)
+			if err != nil {
+				return fmt.Errorf("failed to load cluster config: %w", err)
+			}
+			uris := airgap.GetImageURIs(clusterConfig.Spec.Images)
 			for _, uri := range uris {
 				fmt.Println(uri)
 			}

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -306,7 +306,12 @@ func (c *command) start(ctx context.Context) error {
 	if c.EnableDynamicConfig {
 		configSource, err = clusterconfig.NewAPIConfigSource(adminClientFactory)
 	} else {
-		configSource, err = clusterconfig.NewStaticSource(c.ClusterConfig)
+		var clusterConfig *v1beta1.ClusterConfig
+		clusterConfig, err = config.LoadClusterConfig(c.K0sVars)
+		if err != nil {
+			return fmt.Errorf("failed to load cluster config: %w", err)
+		}
+		configSource, err = clusterconfig.NewStaticSource(clusterConfig)
 	}
 	if err != nil {
 		return err

--- a/cmd/etcd/etcd.go
+++ b/cmd/etcd/etcd.go
@@ -35,10 +35,10 @@ func NewEtcdCmd() *cobra.Command {
 			}
 
 			c := config.GetCmdOpts()
-			if c.ClusterConfig.Spec.Storage.Type != v1beta1.EtcdStorageType {
-				return fmt.Errorf("wrong storage type: %s", c.ClusterConfig.Spec.Storage.Type)
+			if c.NodeConfig.Spec.Storage.Type != v1beta1.EtcdStorageType {
+				return fmt.Errorf("wrong storage type: %s", c.NodeConfig.Spec.Storage.Type)
 			}
-			if c.ClusterConfig.Spec.Storage.Etcd.IsExternalClusterUsed() {
+			if c.NodeConfig.Spec.Storage.Etcd.IsExternalClusterUsed() {
 				return fmt.Errorf("command 'k0s etcd' does not support external etcd cluster")
 			}
 			return nil

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -168,6 +168,11 @@ func (c *Command) Start(ctx context.Context) error {
 
 	certManager := worker.NewCertificateManager(ctx, c.K0sVars.KubeletAuthConfigPath)
 	if !c.SingleNode && !c.EnableWorker {
+		clusterConfig, err := config.LoadClusterConfig(c.K0sVars)
+		if err != nil {
+			return fmt.Errorf("failed to load cluster config: %w", err)
+		}
+
 		componentManager.Add(ctx, &status.Status{
 			StatusInformation: install.K0sStatus{
 				Pid:           os.Getpid(),
@@ -177,7 +182,7 @@ func (c *Command) Start(ctx context.Context) error {
 				Workloads:     true,
 				SingleNode:    false,
 				K0sVars:       c.K0sVars,
-				ClusterConfig: c.ClusterConfig,
+				ClusterConfig: clusterConfig,
 			},
 			CertManager: certManager,
 			Socket:      config.StatusSocket,

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -54,7 +54,6 @@ type CLIOptions struct {
 	WorkerOptions
 	ControllerOptions
 	CfgFile          string
-	ClusterConfig    *v1beta1.ClusterConfig
 	NodeConfig       *v1beta1.ClusterConfig
 	Debug            bool
 	DebugListenOn    string
@@ -231,7 +230,6 @@ func GetCmdOpts() CLIOptions {
 		WorkerOptions:     workerOpts,
 
 		CfgFile:          CfgFile,
-		ClusterConfig:    getClusterConfig(K0sVars),
 		NodeConfig:       getNodeConfig(K0sVars),
 		Debug:            Debug,
 		Verbose:          Verbose,
@@ -281,6 +279,7 @@ func PreRunValidateConfig(k0sVars constant.CfgVars) error {
 	}
 	return nil
 }
+
 func getNodeConfig(k0sVars constant.CfgVars) *v1beta1.ClusterConfig {
 	loadingRules := ClientConfigLoadingRules{Nodeconfig: true, K0sVars: k0sVars}
 	cfg, err := loadingRules.Load()
@@ -290,11 +289,7 @@ func getNodeConfig(k0sVars constant.CfgVars) *v1beta1.ClusterConfig {
 	return cfg
 }
 
-func getClusterConfig(k0sVars constant.CfgVars) *v1beta1.ClusterConfig {
+func LoadClusterConfig(k0sVars constant.CfgVars) (*v1beta1.ClusterConfig, error) {
 	loadingRules := ClientConfigLoadingRules{K0sVars: k0sVars}
-	cfg, err := loadingRules.Load()
-	if err != nil {
-		return nil
-	}
-	return cfg
+	return loadingRules.Load()
 }


### PR DESCRIPTION
## Description

The cluster-wide config is only required in a few cases, but is eagerly loaded for every subcommand. This is unnecessary and leads to a situation in which a controller started with `--enable-dynamic-config` tries to connect to itself to load the config, hanging in a [retry loop](https://github.com/k0sproject/k0s/blob/v1.24.4%2Bk0s.0/pkg/config/api_config.go#L47-L54) for several minutes. The logging configuration to [enable debug logging](https://github.com/k0sproject/k0s/blob/v1.24.4%2Bk0s.0/cmd/controller/controller.go#L72-L77) is evaluated later than that retry loop, so it seems that the controller is dead, with no log output whatsoever.

Remove the `ClusterConfig` field from the `CLIOptions` struct and make the private loading function public. Use that function to load the config on demand in places that require it.

Also replace the usage of `ClusterConfig` with `NodeConfig` in the etcd command. The storage spec is a node-local configuration and shouldn't be read from the cluster config in the first place.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings