### PR TITLE
Add cluster domain to bootstrapping config

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -269,7 +269,7 @@ func (c *command) start(ctx context.Context) error {
 
 	perfTimer.Checkpoint("starting-certificates-init")
 	certs := &Certificates{
-		ClusterSpec: c.ClusterConfig.Spec,
+		ClusterSpec: c.NodeConfig.Spec,
 		CertManager: certificateManager,
 		K0sVars:     c.K0sVars,
 	}

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -269,7 +269,7 @@ func (c *command) start(ctx context.Context) error {
 
 	perfTimer.Checkpoint("starting-certificates-init")
 	certs := &Certificates{
-		ClusterSpec: c.NodeConfig.Spec,
+		ClusterSpec: c.ClusterConfig.Spec,
 		CertManager: certificateManager,
 		K0sVars:     c.K0sVars,
 	}

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
@@ -335,8 +335,9 @@ func (c *ClusterConfig) GetBootstrappingConfig(storageSpec *StorageSpec) *Cluste
 			API:     c.Spec.API,
 			Storage: storageSpec,
 			Network: &Network{
-				ServiceCIDR: c.Spec.Network.ServiceCIDR,
-				DualStack:   c.Spec.Network.DualStack,
+				ServiceCIDR:   c.Spec.Network.ServiceCIDR,
+				DualStack:     c.Spec.Network.DualStack,
+				ClusterDomain: c.Spec.Network.ClusterDomain,
 			},
 			Install: c.Spec.Install,
 		},


### PR DESCRIPTION
## Description

The copying part is merely a temporary fix we need to properly sort out the whole usage of ClusterConfig vs. NodeConfig in whole codebase with good refactoring.

This fixes a case where the cluster domain was omitted from api-server certificates SANs:
```
DNS:kubernetes, DNS:kubernetes.default, DNS:kubernetes.default.svc, DNS:kubernetes.default.svc.cluster, DNS:kubernetes.svc., DNS:localhost, DNS:konnectivity-server.kube-system.svc., IP Address:127.0.0.1, IP Address:172.17.0.2, IP Address:10.96.0.1
```

After this fix the domain is properly added:
```
DNS:kubernetes, DNS:kubernetes.default, DNS:kubernetes.default.svc, DNS:kubernetes.default.svc.cluster, DNS:kubernetes.svc.cluster.local, DNS:localhost, DNS:konnectivity-server.kube-system.svc.cluster.local, IP Address:127.0.0.1, IP Address:172.17.0.2, IP Address:10.96.0.1
```

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings