### PR TITLE
Early logging configuration

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -63,15 +63,13 @@ func NewAPICmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "api",
 		Short: "Run the controller API",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			c := command{CLIOptions: config.GetCmdOpts()}
-
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			logrus.SetOutput(os.Stdout)
-			if !c.Debug {
-				logrus.SetLevel(logrus.InfoLevel)
-			}
-
-			return c.start()
+			logrus.SetLevel(logrus.InfoLevel)
+			return config.CallParentPersistentPreRun(cmd, args)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return (&command{CLIOptions: config.GetCmdOpts()}).start()
 		},
 	}
 	cmd.SilenceUsage = true

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -71,7 +71,7 @@ func NewControllerCmd() *cobra.Command {
 	$ k0s controller --token-file [path_to_file]
 	Note: Token can be passed either as a CLI argument or as a flag`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			logrus.SetOutput(os.Stdout)
+			logrus.SetOutput(cmd.OutOrStdout())
 			logrus.SetLevel(logrus.InfoLevel)
 			return config.CallParentPersistentPreRun(cmd, args)
 		},

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -70,13 +70,13 @@ func NewControllerCmd() *cobra.Command {
 	or CLI flag:
 	$ k0s controller --token-file [path_to_file]
 	Note: Token can be passed either as a CLI argument or as a flag`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			logrus.SetOutput(os.Stdout)
+			logrus.SetLevel(logrus.InfoLevel)
+			return config.CallParentPersistentPreRun(cmd, args)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := command(config.GetCmdOpts())
-
-			logrus.SetOutput(os.Stdout)
-			if !c.Debug {
-				logrus.SetLevel(logrus.InfoLevel)
-			}
 
 			if len(args) > 0 {
 				c.TokenArg = args[0]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,18 +56,16 @@ func NewRootCmd() *cobra.Command {
 		Use:   "k0s",
 		Short: "k0s - Zero Friction Kubernetes",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c := config.GetCmdOpts()
-
-			if c.Verbose {
+			if config.Verbose {
 				logrus.SetLevel(logrus.InfoLevel)
 			}
 
-			if c.Debug {
+			if config.Debug {
 				logrus.SetLevel(logrus.DebugLevel)
 				go func() {
-					log := logrus.WithField("debug_server", c.DebugListenOn)
+					log := logrus.WithField("debug_server", config.DebugListenOn)
 					log.Debug("Starting debug server")
-					if err := http.ListenAndServe(c.DebugListenOn, nil); err != http.ErrServerClosed {
+					if err := http.ListenAndServe(config.DebugListenOn, nil); err != http.ErrServerClosed {
 						log.WithError(err).Debug("Failed to start debug server")
 					} else {
 						log.Debug("Debug server closed")

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -54,7 +54,7 @@ func NewWorkerCmd() *cobra.Command {
 	$ k0s worker --token-file [path_to_file]
 	Note: Token can be passed either as a CLI argument or as a flag`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			logrus.SetOutput(os.Stdout)
+			logrus.SetOutput(cmd.OutOrStdout())
 			logrus.SetLevel(logrus.InfoLevel)
 			return config.CallParentPersistentPreRun(cmd, args)
 		},

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -53,14 +53,13 @@ func NewWorkerCmd() *cobra.Command {
 	or CLI flag:
 	$ k0s worker --token-file [path_to_file]
 	Note: Token can be passed either as a CLI argument or as a flag`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			logrus.SetOutput(os.Stdout)
+			logrus.SetLevel(logrus.InfoLevel)
+			return config.CallParentPersistentPreRun(cmd, args)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command(config.GetCmdOpts())
-
-			logrus.SetOutput(os.Stdout)
-			if !c.Debug {
-				logrus.SetLevel(logrus.InfoLevel)
-			}
-
 			if len(args) > 0 {
 				c.TokenArg = args[0]
 			}


### PR DESCRIPTION
## Description

The long-running subcommands `controller`, `worker` and `api` use stdout and info logging by default. The current setup activates those settings quite late in the Cobra pipeline, potentially logging to the wrong destination, or slurping away interesting debug logs.

Fix this by setting the defaults early for those subcommands via Cobra's `PersistentPreRun` facility. Don't call `config.GetCmdOpts()` unnecessarily in the root command's `PersistentPreRun`, but simply use the global variables directly.

This relates to #2189 in order to help making problems in the early execution stages more visible.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings