### PR TITLE
Fix missing pod/container labels

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -141,3 +141,11 @@ To add custom linker flags use `LDFLAGS` variable.
 ```shell
 LD_FLAGS="--custom-flag=value" make k0s
 ```
+
+## I'm using custom CRI and missing some labels in Prometheus metrics
+
+Due to removal of the embedded docker-shim from Kubelet, the Kubelets embedded [cadvisor](https://github.com/google/cadvisor) metrics got slightly broken. If your container runtime is a custom containerd you can add `--kubelet-extra-flags="--containerd=<path/to/containerd.sock>"` into k0s worker startup. That configures the kubelet embedded cadvisor to talk directly with containerd to gather the metrics and thus gets the expected labels in place.
+
+Unfortunately this does not work on when using Docker via cri-dockerd shim. There's currently no easy workarounds for this.
+
+In the future kubelet will be refactored to get the container metrics from CRI interface rather than from the runtime directly. This work is specified and followed up in [KEP-2371](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2371-cri-pod-container-stats/README.md) but until that work completes the only option is to run a standalone cAdvisor. There's ongoing [effort](https://github.com/kubernetes/website/issues/30681) to both document the current shortcomings and how to run standalone cAdvisor in Kubernetes community.

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -87,6 +87,10 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	s.Require().NoError(s.verifyKubeletAddressFlag(s.WorkerNode(1)))
 	s.Require().NoError(common.WaitForLease(s.Context(), kc, "kube-scheduler", "kube-system"))
 	s.Require().NoError(common.WaitForLease(s.Context(), kc, "kube-controller-manager", "kube-system"))
+
+	for i := 0; i < s.WorkerCount; i++ {
+		s.Require().NoError(common.VerifyKubeletMetrics(s.Context(), kc, s.WorkerNode(i)))
+	}
 }
 
 func (s *BasicSuite) checkCertPerms(node string) error {

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -88,6 +88,9 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	s.Require().NoError(common.WaitForLease(s.Context(), kc, "kube-scheduler", "kube-system"))
 	s.Require().NoError(common.WaitForLease(s.Context(), kc, "kube-controller-manager", "kube-system"))
 
+	// We need to first wait till we see pod logs, that's a signal that konnectivity tunnels are up and thus we can then connect to kubelet
+	// via the API.
+	s.Require().NoError(common.WaitForPodLogs(kc, "kube-system"))
 	for i := 0; i < s.WorkerCount; i++ {
 		s.Require().NoError(common.VerifyKubeletMetrics(s.Context(), kc, s.WorkerNode(i)))
 	}

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -92,7 +92,9 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	// via the API.
 	s.Require().NoError(common.WaitForPodLogs(kc, "kube-system"))
 	for i := 0; i < s.WorkerCount; i++ {
-		s.Require().NoError(common.VerifyKubeletMetrics(s.Context(), kc, s.WorkerNode(i)))
+		node := s.WorkerNode(i)
+		s.T().Logf("checking that we can connect to kubelet metrics on %s", node)
+		s.Require().NoError(common.VerifyKubeletMetrics(s.Context(), kc, node))
 	}
 }
 

--- a/inttest/common/util.go
+++ b/inttest/common/util.go
@@ -17,9 +17,14 @@ limitations under the License.
 package common
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"fmt"
+	"regexp"
 	"time"
 
+	"github.com/k0sproject/k0s/pkg/constant"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -189,4 +194,25 @@ func WaitForLease(ctx context.Context, kc *kubernetes.Clientset, name string, na
 		// Verify that there's a valid holder on the lease
 		return *lease.Spec.HolderIdentity != "", nil
 	})
+}
+
+// VerifyKubeletMetrics checks whether we see container and image labels in kubelet metrics.
+func VerifyKubeletMetrics(ctx context.Context, kc *kubernetes.Clientset, node string) error {
+	metrics, err := kc.CoreV1().RESTClient().Get().AbsPath("/api/v1/nodes/worker0/proxy/metrics/cadvisor").Param("format", "text").DoRaw(ctx)
+	if err != nil {
+		return err
+	}
+
+	image := fmt.Sprintf("%s:%s", constant.KubeRouterCNIImage, constant.KubeRouterCNIImageVersion)
+	containerRegex := regexp.MustCompile(fmt.Sprintf(`container_cpu_usage_seconds_total{container="kube-router".*image="%s"`, image))
+
+	scanner := bufio.NewScanner(bytes.NewReader(metrics))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if containerRegex.MatchString(line) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("container and image label not found in kubelet metrics")
 }

--- a/inttest/common/util.go
+++ b/inttest/common/util.go
@@ -202,7 +202,8 @@ func VerifyKubeletMetrics(ctx context.Context, kc *kubernetes.Clientset, node st
 
 	return Poll(ctx, func(ctx context.Context) (done bool, err error) {
 
-		metrics, err := kc.CoreV1().RESTClient().Get().AbsPath("/api/v1/nodes/worker0/proxy/metrics/cadvisor").Param("format", "text").DoRaw(ctx)
+		path := fmt.Sprintf("/api/v1/nodes/%s/proxy/metrics/cadvisor", node)
+		metrics, err := kc.CoreV1().RESTClient().Get().AbsPath(path).Param("format", "text").DoRaw(ctx)
 		if err != nil {
 			return false, nil // do not return the error so we keep on polling
 		}

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -190,6 +190,7 @@ func (k *Kubelet) Start(ctx context.Context) error {
 	} else {
 		sockPath := path.Join(k.K0sVars.RunDir, "containerd.sock")
 		args["--container-runtime-endpoint"] = fmt.Sprintf("unix://%s", sockPath)
+		args["--containerd"] = sockPath
 	}
 
 	// We only support external providers


### PR DESCRIPTION
## Description

Due to dockershim removal the kubelets embedded cadvisor got slightly broken. Fix this by forcing cavisor to talk directly to containerd.

Unfortunately there's no way to make this universally working for any custom CRI, hence some troubleshooting docs for that case.

Fixes #2187

Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings