### PR TITLE
Fix k0s kubectl --kubeconfig flag

### DIFF
--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -130,12 +130,11 @@ func fallbackToK0sKubeconfig(cmd *cobra.Command) error {
 		return nil
 	}
 
-	kubeconfig, envSet := os.LookupEnv("KUBECONFIG")
-	if envSet {
-		_ = os.Unsetenv("KUBECONFIG")
-	} else {
-		kubeconfig = config.GetCmdOpts().K0sVars.AdminKubeConfigPath
+	if _, ok := os.LookupEnv("KUBECONFIG"); ok {
+		return nil
 	}
+
+	kubeconfig := config.GetCmdOpts().K0sVars.AdminKubeConfigPath
 
 	// verify that k0s's kubeconfig is readable before pushing it to the env
 	if _, err := os.Stat(kubeconfig); err != nil {

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 	"syscall"
 
 	"github.com/k0sproject/k0s/pkg/config"
@@ -90,11 +89,11 @@ func NewK0sKubectlCmd() *cobra.Command {
 	// Get handle on the original kubectl prerun so we can call it later
 	originalPreRunE := cmd.PersistentPreRunE
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		if err := config.CallParentPersistentPreRun(cmd, args); err != nil {
+		if err := fallbackToK0sKubeconfig(cmd); err != nil {
 			return err
 		}
 
-		if err := fallbackToK0sKubeconfig(args); err != nil {
+		if err := config.CallParentPersistentPreRun(cmd, args); err != nil {
 			return err
 		}
 
@@ -119,34 +118,32 @@ func NewK0sKubectlCmd() *cobra.Command {
 	return cmd
 }
 
-func fallbackToK0sKubeconfig(args []string) error {
-	for _, arg := range args {
-		if arg == "--" {
-			// no more options
-			break
-		}
-		if arg == "--kubeconfig" || strings.HasPrefix(arg, "--kubeconfig=") {
-			// kubeconfig set via args, no need to check if k0s kubeconfig is readable
-			return nil
-		}
+func fallbackToK0sKubeconfig(cmd *cobra.Command) error {
+	kubeconfigFlag := cmd.Flags().Lookup("kubeconfig")
+	if kubeconfigFlag == nil {
+		return fmt.Errorf("kubeconfig flag not found")
 	}
 
-	if _, envSet := os.LookupEnv("KUBECONFIG"); envSet {
-		// kubeconfig environment variable set, don't override
+	if kubeconfigFlag.Changed {
+		// prioritize flag over env
+		_ = os.Unsetenv("KUBECONFIG")
 		return nil
 	}
 
-	kubeconfig := config.GetCmdOpts().K0sVars.AdminKubeConfigPath
+	kubeconfig, envSet := os.LookupEnv("KUBECONFIG")
+	if envSet {
+		_ = os.Unsetenv("KUBECONFIG")
+	} else {
+		kubeconfig = config.GetCmdOpts().K0sVars.AdminKubeConfigPath
+	}
+
 	// verify that k0s's kubeconfig is readable before pushing it to the env
-	file, err := os.Open(kubeconfig)
-	if err != nil {
-		return fmt.Errorf("cannot read k0s kubeconfig, is the server running? (%w)", err)
-	}
-	file.Close()
-
-	if err := os.Setenv("KUBECONFIG", kubeconfig); err != nil {
-		return fmt.Errorf("failed to set k0s kubeconfig as default: %w", err)
+	if _, err := os.Stat(kubeconfig); err != nil {
+		return fmt.Errorf("cannot stat k0s kubeconfig, is the server running?: %w", err)
 	}
 
+	if err := kubeconfigFlag.Value.Set(kubeconfig); err != nil {
+		return fmt.Errorf("failed to set kubeconfig flag: %w", err)
+	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

## Description

It was noticed in https://github.com/k0sproject/k0sctl/issues/327 that the `k0s kubectl --kubeconfig` flag does not seem to work.

This PR addresses that.

The `fallbackToK0sKubeconfig` function was going through `args []string`, which at that point should not contain any flags as they have been parsed already. The fallback is now changed to look at the flag value directly through `cmd.Flags().Lookup("kubeconfig")`. The k0s admin kubeconfig path is set using `flag.Value.Set` instead of putting it into os env.

## Type of change

<!-- check the related options -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [X] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [X] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings