### PR TITLE
Use only one kubeconfig loading function in inttests

### DIFF
--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -50,7 +50,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/yaml"
 
 	"github.com/go-openapi/jsonpointer"
@@ -626,42 +625,6 @@ func (s *FootlooseSuite) Reset(name string) error {
 	resetCommand := fmt.Sprintf("%s reset --debug", s.K0sFullPath)
 	_, err = ssh.ExecWithOutput(resetCommand)
 	return err
-}
-
-// GetKubeClientConfig returns the kubeconfig as clientcmdapi.Config struct so it can be used and loaded with clientsets directly
-func (s *FootlooseSuite) GetKubeClientConfig(node string, k0sKubeconfigArgs ...string) (*clientcmdapi.Config, error) {
-	machine, err := s.MachineForName(node)
-	if err != nil {
-		return nil, err
-	}
-	ssh, err := s.SSH(node)
-	if err != nil {
-		return nil, err
-	}
-	defer ssh.Disconnect()
-
-	kubeConfigCmd := fmt.Sprintf("%s kubeconfig admin %s 2>/dev/null", s.K0sFullPath, strings.Join(k0sKubeconfigArgs, " "))
-	kubeConf, err := ssh.ExecWithOutput(kubeConfigCmd)
-	if err != nil {
-		return nil, err
-	}
-	cfg, err := clientcmd.Load([]byte(kubeConf))
-	s.Require().NoError(err)
-
-	hostURL, err := url.Parse(cfg.Clusters["local"].Server)
-	if err != nil {
-		return nil, fmt.Errorf("can't parse port value `%s`: %w", cfg.Clusters["local"].Server, err)
-	}
-	port, err := strconv.ParseInt(hostURL.Port(), 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("can't parse port value `%s`: %w", hostURL.Port(), err)
-	}
-	hostPort, err := machine.HostPort(int(port))
-	if err != nil {
-		return nil, fmt.Errorf("footloose machine has to have %d port mapped: %w", port, err)
-	}
-	cfg.Clusters["local"].Server = fmt.Sprintf("https://localhost:%d", hostPort)
-	return cfg, nil
 }
 
 // KubeClient return kube client by loading the admin access config from given node

--- a/inttest/configchange/config_test.go
+++ b/inttest/configchange/config_test.go
@@ -19,23 +19,21 @@ package configchange
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/suite"
-
-	"github.com/k0sproject/k0s/inttest/common"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	cfgClient "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/clientset/typed/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/stretchr/testify/suite"
 )
 
 type ConfigSuite struct {
@@ -148,7 +146,7 @@ func (s *ConfigSuite) TestK0sGetsUp() {
 		timeout := time.After(20 * time.Second)
 		select {
 		case e := <-w.ResultChan():
-			cm := e.Object.(*v1.ConfigMap)
+			cm := e.Object.(*corev1.ConfigMap)
 			cniConf := cm.Data["cni-conf.json"]
 			s.Contains(cniConf, `"mtu": 1300`)
 			s.Contains(cniConf, `"auto-mtu": false`)
@@ -158,11 +156,11 @@ func (s *ConfigSuite) TestK0sGetsUp() {
 	})
 }
 
-func (s *ConfigSuite) waitForReconcileEvent(eventWatch watch.Interface) (*v1.Event, error) {
+func (s *ConfigSuite) waitForReconcileEvent(eventWatch watch.Interface) (*corev1.Event, error) {
 	timeout := time.After(20 * time.Second)
 	select {
 	case e := <-eventWatch.ResultChan():
-		event := e.Object.(*v1.Event)
+		event := e.Object.(*corev1.Event)
 		return event, nil
 	case <-timeout:
 		return nil, fmt.Errorf("timeout waiting for reconcile event")
@@ -173,32 +171,15 @@ func (s *ConfigSuite) clearConfigEvents(kc *kubernetes.Clientset) error {
 	return kc.CoreV1().Events("kube-system").DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{FieldSelector: "involvedObject.name=k0s"})
 }
 
-// Helper to dump the kubeconfig into temp file so we can load the clusterconfig client with it
+// Get the ClusterConfig client from the controller node's kubeconfig.
 func (s *ConfigSuite) getConfigClient() (cfgClient.ClusterConfigInterface, error) {
-	kubeConfig, err := s.GetKubeClientConfig(s.ControllerNode(0))
+	config, err := s.GetKubeConfig(s.ControllerNode(0))
 	if err != nil {
-		return nil, err
-	}
-
-	f, err := os.CreateTemp("", "kubeconfig-*")
-	if err != nil {
-		return nil, err
-	}
-
-	s.T().Logf("temp kubeconfig at %s", f.Name())
-
-	err = clientcmd.WriteToFile(*kubeConfig, f.Name())
-	if err != nil {
-		return nil, err
-	}
-
-	config, err := clientcmd.BuildConfigFromFlags("", f.Name())
-	if err != nil {
-		return nil, fmt.Errorf("can't read kubeconfig: %v", err)
+		return nil, fmt.Errorf("can't get kubeconfig: %w", err)
 	}
 	c, err := cfgClient.NewForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("can't create kubernetes typed client for cluster config: %v", err)
+		return nil, fmt.Errorf("can't create kubernetes typed client for cluster config: %w", err)
 	}
 	return c.ClusterConfigs(constant.ClusterConfigNamespace), nil
 }


### PR DESCRIPTION
## Description

They were doing nearly the same, so there's no need to have both.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings