### PR TITLE
Use built-in SSH client to wait for SSH connections in inttests

### DIFF
--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -47,6 +47,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -207,29 +208,31 @@ func (s *FootlooseSuite) waitForSSH() {
 		nodes = append(nodes, s.LBNode(0))
 	}
 
-	s.T().Logf("total of %d nodes: %v", len(nodes), nodes)
+	s.T().Logf("Waiting for SSH connections to %d nodes: %v", len(nodes), nodes)
 
-	g := errgroup.Group{}
+	g, ctx := errgroup.WithContext(s.Context())
 	for _, node := range nodes {
 		nodeName := node
 		g.Go(func() error {
-			for i := 0; i < 30; i++ {
-				err := s.cluster.SSH(nodeName, "root", "hostname")
-				if err == nil {
-					return nil
+			return wait.PollUntilWithContext(ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+				ssh, err := s.SSH(nodeName)
+				if err != nil {
+					return false, nil
 				}
-				s.T().Logf("retrying ssh to %s", nodeName)
-				time.Sleep(1 * time.Second)
-			}
-			return fmt.Errorf("failed to get working SSH connection to %s", nodeName)
+				defer ssh.Disconnect()
+
+				_, err = ssh.ExecWithOutput("hostname")
+				if err != nil {
+					return false, nil
+				}
+
+				s.T().Logf("SSH connection to %s successful", nodeName)
+				return true, nil
+			})
 		})
 	}
 
-	err := g.Wait()
-	if err != nil {
-		s.FailNow("failed to ssh one or many nodes", err)
-		return
-	}
+	s.Require().NoError(g.Wait(), "Failed to ssh into all nodes")
 }
 
 // Context returns this suite's context, which should be passed to all blocking operations.


### PR DESCRIPTION
## Description

This is the only place where the footloose SSH facility was used instead of Go's built-in SSH client. Change that in order to have more symmetry to the rest of the test suite.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings