### PR TITLE
Add simple Kubernetes watch facility

### DIFF
--- a/inttest/ap-airgap/airgap_test.go
+++ b/inttest/ap-airgap/airgap_test.go
@@ -127,12 +127,8 @@ spec:
 	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(context.TODO(), client, apconst.AutopilotName, 10*time.Minute, func(obj interface{}) bool {
-		if plan, ok := obj.(*apv1beta2.Plan); ok {
-			return plan.Status.State == appc.PlanCompleted
-		}
-
-		return false
+	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
+		return plan.Status.State == appc.PlanCompleted
 	})
 
 	s.NoError(err)

--- a/inttest/ap-ha3x3/ha3x3_test.go
+++ b/inttest/ap-ha3x3/ha3x3_test.go
@@ -159,12 +159,8 @@ spec:
 	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(context.TODO(), client, apconst.AutopilotName, 10*time.Minute, func(obj interface{}) bool {
-		if plan, ok := obj.(*apv1beta2.Plan); ok {
-			return plan.Status.State == appc.PlanCompleted
-		}
-
-		return false
+	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
+		return plan.Status.State == appc.PlanCompleted
 	})
 
 	// Ensure all state/status are completed

--- a/inttest/ap-platformselect/platformselect_test.go
+++ b/inttest/ap-platformselect/platformselect_test.go
@@ -96,12 +96,8 @@ spec:
 	// as the binary would fail to run.
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(context.TODO(), client, apconst.AutopilotName, 10*time.Minute, func(obj interface{}) bool {
-		if plan, ok := obj.(*apv1beta2.Plan); ok {
-			return plan.Status.State == appc.PlanCompleted
-		}
-
-		return false
+	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
+		return plan.Status.State == appc.PlanCompleted
 	})
 
 	s.NoError(err)

--- a/inttest/ap-quorum/quorum_test.go
+++ b/inttest/ap-quorum/quorum_test.go
@@ -131,12 +131,8 @@ spec:
 	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(context.TODO(), client, apconst.AutopilotName, 10*time.Minute, func(obj interface{}) bool {
-		if plan, ok := obj.(*apv1beta2.Plan); ok {
-			return plan.Status.State == appc.PlanCompleted
-		}
-
-		return false
+	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
+		return plan.Status.State == appc.PlanCompleted
 	})
 
 	s.NoError(err)

--- a/inttest/ap-quorumsafety/quorumsafety_test.go
+++ b/inttest/ap-quorumsafety/quorumsafety_test.go
@@ -154,12 +154,8 @@ spec:
 
 	// The plan should fail with "InconsistentTargets" due to autopilot detecting that `controller2`
 	// despite existing as a `ControlNode`, does not resolve.
-	plan, err := apcomm.WaitForPlanByName(context.TODO(), client, apconst.AutopilotName, 10*time.Minute, func(obj interface{}) bool {
-		if plan, ok := obj.(*apv1beta2.Plan); ok {
-			return plan.Status.State == appc.PlanInconsistentTargets
-		}
-
-		return false
+	plan, err := apcomm.WaitForPlanByName(context.TODO(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
+		return plan.Status.State == appc.PlanInconsistentTargets
 	})
 
 	s.NoError(err)

--- a/inttest/ap-selector/selector_test.go
+++ b/inttest/ap-selector/selector_test.go
@@ -154,12 +154,8 @@ spec:
 	s.NotEmpty(apc)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(context.TODO(), apc, apconst.AutopilotName, 10*time.Minute, func(obj interface{}) bool {
-		if plan, ok := obj.(*apv1beta2.Plan); ok {
-			return plan.Status.State == appc.PlanCompleted
-		}
-
-		return false
+	plan, err := apcomm.WaitForPlanByName(s.Context(), apc, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
+		return plan.Status.State == appc.PlanCompleted
 	})
 
 	s.NoError(err)

--- a/inttest/ap-single/single_test.go
+++ b/inttest/ap-single/single_test.go
@@ -93,12 +93,8 @@ spec:
 	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(context.TODO(), client, apconst.AutopilotName, 10*time.Minute, func(obj interface{}) bool {
-		if plan, ok := obj.(*apv1beta2.Plan); ok {
-			return plan.Status.State == appc.PlanCompleted
-		}
-
-		return false
+	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
+		return plan.Status.State == appc.PlanCompleted
 	})
 
 	s.NoError(err)

--- a/inttest/ap-updater/updater_test.go
+++ b/inttest/ap-updater/updater_test.go
@@ -104,12 +104,8 @@ spec:
 	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(context.TODO(), client, apconst.AutopilotName, 10*time.Minute, func(obj interface{}) bool {
-		if plan, ok := obj.(*apv1beta2.Plan); ok {
-			return plan.Status.State == appc.PlanCompleted
-		}
-
-		return false
+	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
+		return plan.Status.State == appc.PlanCompleted
 	})
 
 	s.NoError(err)

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -90,7 +90,7 @@ func (s *BasicSuite) TestK0sGetsUp() {
 
 	// We need to first wait till we see pod logs, that's a signal that konnectivity tunnels are up and thus we can then connect to kubelet
 	// via the API.
-	s.Require().NoError(common.WaitForPodLogs(kc, "kube-system"))
+	s.Require().NoError(common.WaitForPodLogs(s.Context(), kc, "kube-system"))
 	for i := 0; i < s.WorkerCount; i++ {
 		node := s.WorkerNode(i)
 		s.T().Logf("checking that we can connect to kubelet metrics on %s", node)

--- a/inttest/calico/calico_test.go
+++ b/inttest/calico/calico_test.go
@@ -55,7 +55,7 @@ func (s *CalicoSuite) TestK0sGetsUp() {
 	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 	s.T().Log("waiting to see calico pods ready")
-	s.NoError(common.WaitForCalicoReady(kc), "calico did not start")
+	s.NoError(common.WaitForDaemonSet(s.Context(), kc, "calico-node"), "calico did not start")
 }
 
 func TestCalicoSuite(t *testing.T) {

--- a/inttest/capitalhostnames/capitalhostnames_test.go
+++ b/inttest/capitalhostnames/capitalhostnames_test.go
@@ -62,7 +62,7 @@ func (s *CapitalHostnamesSuite) TestK0sGetsUp() {
 
 	// Test that we get logs, it's a signal that konnectivity tunnels work
 	s.T().Log("waiting to get logs from pods")
-	s.Require().NoError(common.WaitForPodLogs(kc, "kube-system"))
+	s.Require().NoError(common.WaitForPodLogs(s.Context(), kc, "kube-system"))
 
 	// Verify API that we get proper controller counter lease
 	_, err = kc.CoordinationV1().Leases("kube-node-lease").Get(s.Context(), "k0s-ctrl-k0s-controller", v1.GetOptions{})

--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -117,7 +117,7 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 		s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 		// Wait till we see all pods running, otherwise we get into weird timing issues and high probability of leaked containerd shim processes
-		require.NoError(common.WaitForDaemonSetWithContext(s.Context(), kc, "kube-proxy"))
+		require.NoError(common.WaitForDaemonSet(s.Context(), kc, "kube-proxy"))
 		require.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc))
 		require.NoError(common.WaitForDeploymentWithContext(s.Context(), kc, "coredns"))
 

--- a/inttest/common/util.go
+++ b/inttest/common/util.go
@@ -25,13 +25,18 @@ import (
 	"time"
 
 	"github.com/k0sproject/k0s/pkg/constant"
+	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
+
+	appsv1 "k8s.io/api/apps/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 )
 
 // Poll tries a condition func until it returns true, an error or the specified
@@ -40,79 +45,74 @@ func Poll(ctx context.Context, condition wait.ConditionWithContextFunc) error {
 	return wait.PollImmediateUntilWithContext(ctx, 100*time.Millisecond, condition)
 }
 
-func fallbackPoll(condition wait.ConditionWithContextFunc) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-	return Poll(ctx, condition)
-}
-
-// WaitForCalicoReady waits to see all calico pods healthy
-func WaitForCalicoReady(kc *kubernetes.Clientset) error {
-	return WaitForDaemonSet(kc, "calico-node")
+func fallbackContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.TODO(), 5*time.Minute)
 }
 
 // WaitForKubeRouterReady waits to see all kube-router pods healthy.
 func WaitForKubeRouterReady(kc *kubernetes.Clientset) error {
-	return fallbackPoll(waitForKubeRouterReady(kc))
+	ctx, cancel := fallbackContext()
+	defer cancel()
+	return WaitForKubeRouterReadyWithContext(ctx, kc)
 }
 
 // WaitForKubeRouterReady waits to see all kube-router pods healthy as long as
 // the context isn't canceled.
 func WaitForKubeRouterReadyWithContext(ctx context.Context, kc *kubernetes.Clientset) error {
-	return Poll(ctx, waitForKubeRouterReady(kc))
+	return WaitForDaemonSet(ctx, kc, "kube-router")
 }
 
-func waitForKubeRouterReady(kc *kubernetes.Clientset) wait.ConditionWithContextFunc {
-	return waitForDaemonSet(kc, "kube-router")
-}
-
-func WaitForMetricsReady(c *rest.Config) error {
-	apiServiceClientset, err := clientset.NewForConfig(c)
+func WaitForMetricsReady(ctx context.Context, c *rest.Config) error {
+	clientset, err := aggregatorclient.NewForConfig(c)
 	if err != nil {
 		return err
 	}
 
-	return fallbackPoll(func(ctx context.Context) (done bool, err error) {
-		apiService, err := apiServiceClientset.ApiregistrationV1().APIServices().Get(ctx, "v1beta1.metrics.k8s.io", v1.GetOptions{})
-		if err != nil {
-			return false, nil
-		}
+	watchAPIServices := watch.FromClient[*apiregistrationv1.APIServiceList, apiregistrationv1.APIService]
+	return watchAPIServices(clientset.ApiregistrationV1().APIServices()).
+		WithObjectName("v1beta1.metrics.k8s.io").
+		Until(ctx, func(service *apiregistrationv1.APIService) (bool, error) {
+			for _, c := range service.Status.Conditions {
+				if c.Type == apiregistrationv1.Available {
+					if c.Status == apiregistrationv1.ConditionTrue {
+						return true, nil
+					}
 
-		for _, c := range apiService.Status.Conditions {
-			if c.Type == "Available" && c.Status == "True" {
-				return true, nil
+					break
+				}
 			}
-		}
 
-		return false, nil
-	})
+			return false, nil
+		})
 }
 
 // WaitForDaemonSet waits for daemon set be ready.
-func WaitForDaemonSet(kc *kubernetes.Clientset, name string) error {
-	return fallbackPoll(waitForDaemonSet(kc, name))
+func WaitForDaemonSet(ctx context.Context, kc *kubernetes.Clientset, name string) error {
+	return watch.DaemonSets(kc.AppsV1().DaemonSets("kube-system")).
+		WithObjectName(name).
+		Until(ctx, func(ds *appsv1.DaemonSet) (bool, error) {
+			return ds.Status.NumberAvailable == ds.Status.DesiredNumberScheduled, nil
+		})
 }
 
-// WaitForDaemonSetWithContext waits for daemon set be ready as long as the
-// given context isn't canceled.
-func WaitForDaemonSetWithContext(ctx context.Context, kc *kubernetes.Clientset, name string) error {
-	return Poll(ctx, waitForDaemonSet(kc, name))
-}
+// WaitForDeployment waits for the Deployment with the given name to become
+// available as long as the given context isn't canceled.
+func WaitForDeployment(ctx context.Context, kc *kubernetes.Clientset, name string) error {
+	return watch.Deployments(kc.AppsV1().Deployments("kube-system")).
+		WithObjectName(name).
+		Until(ctx, func(deployment *appsv1.Deployment) (bool, error) {
+			for _, c := range deployment.Status.Conditions {
+				if c.Type == appsv1.DeploymentAvailable {
+					if c.Status == corev1.ConditionTrue {
+						return true, nil
+					}
 
-func waitForDaemonSet(kc *kubernetes.Clientset, name string) wait.ConditionWithContextFunc {
-	return func(ctx context.Context) (done bool, err error) {
-		ds, err := kc.AppsV1().DaemonSets("kube-system").Get(ctx, name, v1.GetOptions{})
-		if err != nil {
+					break
+				}
+			}
+
 			return false, nil
-		}
-
-		return ds.Status.NumberAvailable == ds.Status.DesiredNumberScheduled, nil
-	}
-}
-
-// WaitForDeployment waits for a deployment to become ready.
-func WaitForDeployment(kc *kubernetes.Clientset, name string) error {
-	return fallbackPoll(waitForDeployment(kc, name))
+		})
 }
 
 // WaitForDeploymentWithContext waits for a deployment to become ready as long
@@ -123,7 +123,7 @@ func WaitForDeploymentWithContext(ctx context.Context, kc *kubernetes.Clientset,
 
 func waitForDeployment(kc *kubernetes.Clientset, name string) wait.ConditionWithContextFunc {
 	return func(ctx context.Context) (done bool, err error) {
-		dep, err := kc.AppsV1().Deployments("kube-system").Get(ctx, name, v1.GetOptions{})
+		dep, err := kc.AppsV1().Deployments("kube-system").Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, nil
 		}
@@ -132,68 +132,61 @@ func waitForDeployment(kc *kubernetes.Clientset, name string) wait.ConditionWith
 	}
 }
 
-// WaitForPod waits for pod be running
-func WaitForPod(kc *kubernetes.Clientset, name, namespace string) error {
-	return fallbackPoll(waitForPod(kc, name, namespace))
-}
+// WaitForPod waits for the given pod to become ready as long as the given
+// context isn't canceled.
+func WaitForPod(ctx context.Context, kc *kubernetes.Clientset, name, namespace string) error {
+	return watch.Pods(kc.CoreV1().Pods(namespace)).
+		WithObjectName(name).
+		Until(ctx, func(pod *corev1.Pod) (bool, error) {
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == corev1.PodReady {
+					if cond.Status == corev1.ConditionTrue {
+						return true, nil
+					}
 
-// WaitForPod waits until a pod is running as long as the given context isn't
-// canceled.
-func WaitForPodWithContext(ctx context.Context, kc *kubernetes.Clientset, name, namespace string) error {
-	return Poll(ctx, waitForPod(kc, name, namespace))
-}
+					break
+				}
+			}
 
-func waitForPod(kc *kubernetes.Clientset, name, namespace string) wait.ConditionWithContextFunc {
-	return func(ctx context.Context) (done bool, err error) {
-		ds, err := kc.CoreV1().Pods(namespace).Get(ctx, name, v1.GetOptions{})
-		if err != nil {
 			return false, nil
-		}
-
-		return ds.Status.Phase == "Running", nil
-	}
+		})
 }
 
-// WaitForPodLogs picks the first Ready pod from the list of pods in given namespace and gets the logs of it
-func WaitForPodLogs(kc *kubernetes.Clientset, namespace string) error {
-	return fallbackPoll(func(ctx context.Context) (done bool, err error) {
-		pods, err := kc.CoreV1().Pods(namespace).List(ctx, v1.ListOptions{
-			Limit: 100,
+// WaitForPodLogs waits until it can stream the logs of the first running pod
+// that comes along in the given namespace as long as the given context isn't
+// canceled.
+func WaitForPodLogs(ctx context.Context, kc *kubernetes.Clientset, namespace string) error {
+	return Poll(ctx, func(ctx context.Context) (done bool, err error) {
+		pods, err := kc.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			Limit:         100,
+			FieldSelector: fields.OneTermEqualSelector("status.phase", string(corev1.PodRunning)).String(),
 		})
 		if err != nil {
 			return false, err // stop polling with error in case the pod listing fails
 		}
-		var readyPod *corev1.Pod
-		for _, p := range pods.Items {
-			if p.Status.Phase == "Running" {
-				readyPod = &p
-			}
+		if len(pods.Items) < 1 {
+			return false, nil
 		}
-		if readyPod == nil {
-			return false, nil // do not return the error so we keep on polling
-		}
-		_, err = kc.CoreV1().Pods(readyPod.Namespace).GetLogs(readyPod.Name, &corev1.PodLogOptions{Container: readyPod.Spec.Containers[0].Name}).Stream(context.Background())
+
+		pod := &pods.Items[0]
+		logs, err := kc.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Container: pod.Spec.Containers[0].Name}).Stream(ctx)
 		if err != nil {
 			return false, nil // do not return the error so we keep on polling
 		}
+		defer logs.Close()
 
 		return true, nil
 	})
 }
 
 func WaitForLease(ctx context.Context, kc *kubernetes.Clientset, name string, namespace string) error {
-
-	return Poll(ctx, func(ctx context.Context) (done bool, err error) {
-		lease, err := kc.CoordinationV1().Leases(namespace).Get(ctx, name, v1.GetOptions{})
-		if err != nil && apierrors.IsNotFound(err) {
-			return false, nil // Not found, keep polling
-		} else if err != nil {
-			return false, err
-		}
-
-		// Verify that there's a valid holder on the lease
-		return *lease.Spec.HolderIdentity != "", nil
-	})
+	watchLeases := watch.FromClient[*coordinationv1.LeaseList, coordinationv1.Lease]
+	return watchLeases(kc.CoordinationV1().Leases(namespace)).WithObjectName(name).Until(
+		ctx, func(lease *coordinationv1.Lease) (bool, error) {
+			// Verify that there's a valid holder on the lease
+			return *lease.Spec.HolderIdentity != "", nil
+		},
+	)
 }
 
 // VerifyKubeletMetrics checks whether we see container and image labels in kubelet metrics.

--- a/inttest/customdomain/customdomain_test.go
+++ b/inttest/customdomain/customdomain_test.go
@@ -65,7 +65,7 @@ func (s *CustomDomainSuite) TestK0sGetsUpWithCustomDomain() {
 		s.NoError(err)
 		_, err = ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s kc run nginx --image docker.io/nginx:1-alpine")
 		s.NoError(err)
-		s.NoError(common.WaitForPod(kc, "nginx", "default"))
+		s.NoError(common.WaitForPod(s.Context(), kc, "nginx", "default"))
 		output, err := ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s kc exec nginx -- cat /etc/resolv.conf")
 		s.NoError(err)
 		s.Contains(output, "search default.svc.something.local svc.something.local something.local")

--- a/inttest/customports/customports_test.go
+++ b/inttest/customports/customports_test.go
@@ -132,10 +132,10 @@ func (ds *Suite) TestControllerJoinsWithCustomPort() {
 	ds.T().Log("waiting to see CNI pods ready")
 	ds.Require().NoError(common.WaitForKubeRouterReady(kc), "calico did not start")
 	ds.T().Log("waiting to see konnectivity-agent pods ready")
-	ds.Require().NoError(common.WaitForDaemonSet(kc, "konnectivity-agent"), "konnectivity-agent did not start")
+	ds.Require().NoError(common.WaitForDaemonSet(ds.Context(), kc, "konnectivity-agent"), "konnectivity-agent did not start")
 
 	ds.T().Log("waiting to get logs from pods")
-	ds.Require().NoError(common.WaitForPodLogs(kc, "kube-system"))
+	ds.Require().NoError(common.WaitForPodLogs(ds.Context(), kc, "kube-system"))
 
 	// https://github.com/k0sproject/k0s/issues/1202
 	ds.T().Run("kubeconfigIncludesExternalAddress", func(t *testing.T) {

--- a/inttest/defaultstorage/defaultstorage_test.go
+++ b/inttest/defaultstorage/defaultstorage_test.go
@@ -44,7 +44,7 @@ func (s *DefaultStorageSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
 	s.NoError(err)
 
-	err = common.WaitForDeployment(kc, "nginx")
+	err = common.WaitForDeployment(s.Context(), kc, "nginx")
 	s.NoError(err)
 
 	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{

--- a/inttest/kubeletcertrotate/kubeletcertrotate_test.go
+++ b/inttest/kubeletcertrotate/kubeletcertrotate_test.go
@@ -147,12 +147,8 @@ spec:
 	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(context.TODO(), client, apconst.AutopilotName, 10*time.Minute, func(obj interface{}) bool {
-		if plan, ok := obj.(*apv1beta2.Plan); ok {
-			return plan.Status.State == appc.PlanCompleted
-		}
-
-		return false
+	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
+		return plan.Status.State == appc.PlanCompleted
 	})
 
 	// Ensure all state/status are completed

--- a/inttest/kuberouter/kuberouter_hairpin_test.go
+++ b/inttest/kuberouter/kuberouter_hairpin_test.go
@@ -52,7 +52,7 @@ func (s *KubeRouterHairpinSuite) TestK0sGetsUp() {
 	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "kube-router did not start")
 
 	s.T().Log("waiting to see hairpin pod ready")
-	err = common.WaitForPodWithContext(s.Context(), kc, "hairpin-pod", "default")
+	err = common.WaitForPod(s.Context(), kc, "hairpin-pod", "default")
 	s.NoError(err)
 
 	s.T().Run("check hairpin mode", func(t *testing.T) {

--- a/inttest/metrics/metrics_test.go
+++ b/inttest/metrics/metrics_test.go
@@ -41,7 +41,7 @@ func (s *MetricsSuite) TestK0sGetsUp() {
 	cfg, err := s.GetKubeConfig(s.ControllerNode(0))
 	s.NoError(err)
 	s.T().Log("waiting to see metrics ready")
-	s.Require().NoError(common.WaitForMetricsReady(cfg))
+	s.Require().NoError(common.WaitForMetricsReady(s.Context(), cfg))
 }
 
 func TestMetricsSuite(t *testing.T) {

--- a/pkg/kubernetes/watch/apps.go
+++ b/pkg/kubernetes/watch/apps.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func DaemonSets(client Provider[*appsv1.DaemonSetList]) *Watcher[appsv1.DaemonSet] {
+	return FromClient[*appsv1.DaemonSetList, appsv1.DaemonSet](client)
+}
+
+func Deployments(client Provider[*appsv1.DeploymentList]) *Watcher[appsv1.Deployment] {
+	return FromClient[*appsv1.DeploymentList, appsv1.Deployment](client)
+}

--- a/pkg/kubernetes/watch/core.go
+++ b/pkg/kubernetes/watch/core.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Nodes(client Provider[*corev1.NodeList]) *Watcher[corev1.Node] {
+	return FromClient[*corev1.NodeList, corev1.Node](client)
+}
+
+func Pods(client Provider[*corev1.PodList]) *Watcher[corev1.Pod] {
+	return FromClient[*corev1.PodList, corev1.Pod](client)
+}

--- a/pkg/kubernetes/watch/k0s.go
+++ b/pkg/kubernetes/watch/k0s.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	autopilotv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+)
+
+func ClusterConfigs(client Provider[*k0sv1beta1.ClusterConfigList]) *Watcher[k0sv1beta1.ClusterConfig] {
+	return FromClient[*k0sv1beta1.ClusterConfigList, k0sv1beta1.ClusterConfig](client)
+}
+
+func Plans(client Provider[*autopilotv1beta2.PlanList]) *Watcher[autopilotv1beta2.Plan] {
+	return FromClient[*autopilotv1beta2.PlanList, autopilotv1beta2.Plan](client)
+}

--- a/pkg/kubernetes/watch/watcher.go
+++ b/pkg/kubernetes/watch/watcher.go
@@ -1,0 +1,318 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+	"k8s.io/utils/pointer"
+)
+
+// Watcher offers a convenient way of watching Kubernetes resources. An
+// ephemeral alternative to Reflectors and Indexers, useful for one-shot tasks
+// when no caching is required. It performs an initial list of all the resources
+// and then starts watching them. In case the watch needs to be restarted
+// (a.k.a. resource too old), the watcher will re-list all the resources.
+type Watcher[T any] struct {
+	List  func(ctx context.Context, opts metav1.ListOptions) (resourceVersion string, items []T, err error)
+	Watch func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+
+	includeDeletions bool
+	fieldSelector    string
+	errorCallback    func(error) error
+}
+
+// Provider represents the backend for [Watcher].
+// It is compatible with client-go's typed interfaces.
+type Provider[L any] interface {
+	List(ctx context.Context, opts metav1.ListOptions) (L, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+}
+
+// FromClient creates a [Watcher] from the given client-go client. Note that the
+// types L and I need to be connected in a way that L is a pointer type to a
+// struct that has an `Items` field of type []I. This function will panic if
+// this is not the case. Refer to [FromProvider] in order to provide a custom
+// way of obtaining items from the list type.
+func FromClient[L metav1.ListInterface, I any](client Provider[L]) *Watcher[I] {
+	itemsFromList, err := itemsFromList[L, I]()
+	if err != nil {
+		panic(err)
+	}
+	return FromProvider(client, itemsFromList)
+}
+
+// FromProvider creates a [Watcher] from the given [Provider] and the
+// corresponding itemsFromList function.
+func FromProvider[L interface{ GetResourceVersion() string }, I any](provider Provider[L], itemsFromList func(L) []I) *Watcher[I] {
+	return &Watcher[I]{
+		List: func(ctx context.Context, opts metav1.ListOptions) (string, []I, error) {
+			list, err := provider.List(ctx, opts)
+			if err != nil {
+				return "", nil, err
+			}
+			return list.GetResourceVersion(), itemsFromList(list), nil
+		},
+		Watch: provider.Watch,
+	}
+}
+
+// IncludingDeletions will include deleted items in watches.
+func (w *Watcher[T]) IncludingDeletions() *Watcher[T] {
+	w.includeDeletions = true
+	return w
+}
+
+// ExcludingDeletions will suppress deleted items from watches.
+// This is the default.
+func (w *Watcher[T]) ExcludingDeletions() *Watcher[T] {
+	w.includeDeletions = false
+	return w
+}
+
+// WithObjectName sets this Watcher's field selector in a way to only match
+// objects with the given name.
+func (w *Watcher[T]) WithObjectName(name string) *Watcher[T] {
+	return w.WithFieldSelector(fields.OneTermEqualSelector(metav1.ObjectNameField, name))
+}
+
+// WithFieldSelector sets the given field selector for this Watcher. Refer to
+// the [concept] for a general introduction to field selectors. To gain an
+// overview of the supported values, have a look at the usages of
+// [k8s.io/apimachinery/pkg/runtime.Scheme.AddFieldLabelConversionFunc] in the
+// [Kubernetes codebase].
+//
+// [concept]: https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
+// [Kubernetes codebase]: https://sourcegraph.com/search?q=lang:go+AddFieldLabelConversionFunc(...)+repo:^github\.com/kubernetes/kubernetes%24+-file:_test\.go%24+select:content&patternType=structural
+func (w *Watcher[T]) WithFieldSelector(selector fields.Selector) *Watcher[T] {
+	w.fieldSelector = selector.String()
+	return w
+}
+
+// WithoutFieldSelector clears any field selector from this Watcher.
+// This is the default.
+func (w *Watcher[T]) WithoutFieldSelector() *Watcher[T] {
+	w.fieldSelector = ""
+	return w
+}
+
+// WithErrorCallback sets this Watcher's error callback. It's invoked every time
+// an error occurs and determines if the watch should continue or terminate:
+//   - The returned error is nil: continue watching
+//   - The returned error is not nil: terminate watch with that error
+//
+// If the error callback is not set or nil, the default behavior is to terminate.
+func (w *Watcher[T]) WithErrorCallback(callback func(error) error) *Watcher[T] {
+	w.errorCallback = callback
+	return w
+}
+
+// Until runs a watch until condition returns true. It will error out in case
+// the context gets canceled or the condition returns an error.
+func (w *Watcher[T]) Until(ctx context.Context, condition func(*T) (bool, error)) error {
+	listCondition := func(items []T) (bool, error) {
+		for i := range items {
+			ok, err := condition(&items[i])
+			if err != nil {
+				return false, err
+			}
+			if ok {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	}
+
+	return retry(ctx, w.errorCallback, func(ctx context.Context) error {
+		return w.run(ctx, listCondition, condition)
+	})
+}
+
+func itemsFromList[L metav1.ListInterface, I any]() (func(L) []I, error) {
+	// List types from client-go don't provide any methods to get their items.
+	// Hence provide a way to get the items via reflection.
+
+	index, err := func() ([]int, error) {
+		var list L
+		var items []I
+		listType := reflect.TypeOf(list)
+		if listType.Kind() != reflect.Pointer {
+			return nil, fmt.Errorf("not a pointer type: %s", listType)
+		}
+		itemsType := reflect.TypeOf(items)
+		itemsField, ok := listType.Elem().FieldByName("Items")
+		if !ok || itemsField.Type != itemsType {
+			return nil, fmt.Errorf(`expected an "Items" field of type %s in %s`, itemsType, listType)
+		}
+		return itemsField.Index, nil
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	return func(l L) []I {
+		// The compatibility of the types has been checked above.
+		// This will not panic at runtime.
+		return reflect.ValueOf(l).Elem().FieldByIndex(index).Interface().([]I)
+	}, nil
+}
+
+type noRetry struct{ error }
+
+var errResourceTooOld = errors.New("resource too old")
+
+func (w *Watcher[T]) run(ctx context.Context, listCallback func([]T) (bool, error), watchCallback func(*T) (bool, error)) error {
+	var initialResourceVersion string
+	{
+		resourceVersion, items, err := w.List(ctx, metav1.ListOptions{
+			FieldSelector:  w.fieldSelector,
+			TimeoutSeconds: pointer.Int64(30),
+		})
+		if err != nil {
+			return err
+		}
+		if ok, err := listCallback(items); err != nil {
+			return noRetry{err}
+		} else if ok {
+			return nil
+		}
+
+		initialResourceVersion = resourceVersion
+	}
+
+	watcher, err := watchtools.NewRetryWatcher(initialResourceVersion, &cache.ListWatch{
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = w.fieldSelector
+			opts.TimeoutSeconds = pointer.Int64(30)
+			return w.Watch(ctx, opts)
+		},
+	})
+	if err != nil {
+		return err
+	}
+	defer watcher.Stop()
+
+	for {
+		var suppressDeletions bool
+		select {
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				return errors.New("result channel closed unexpectedly")
+			}
+
+			switch event.Type {
+			case watch.Bookmark:
+				continue // nothing to do, handled by RetryWatcher
+
+			case watch.Deleted:
+				suppressDeletions = !w.includeDeletions
+				fallthrough
+
+			case watch.Added, watch.Modified:
+				item, ok := any(event.Object).(*T)
+				if !ok {
+					var example T
+					err = error(&apierrors.UnexpectedObjectError{Object: event.Object})
+					return fmt.Errorf("got an event of type %q, expecting an object of type %T: (%T) %w", event.Type, &example, event.Object, err)
+				}
+
+				if suppressDeletions && isDeleted(item) {
+					continue
+				}
+
+				if ok, err := watchCallback(item); err != nil {
+					return noRetry{err}
+				} else if ok {
+					return nil
+				}
+
+			case watch.Error:
+				fallthrough // go to default case for error handling
+
+			default:
+				err := apierrors.FromObject(event.Object)
+				var statusErr *apierrors.StatusError
+				if errors.As(err, &statusErr) && statusErr.ErrStatus.Code == http.StatusGone {
+					return errResourceTooOld
+				}
+
+				return err
+			}
+
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func isDeleted(resource any) bool {
+	deletable, ok := resource.(interface{ GetDeletionTimestamp() *metav1.Time })
+	return ok && deletable.GetDeletionTimestamp() != nil
+}
+
+func retry(ctx context.Context, errorCallback func(error) error, runWatch func(context.Context) error) error {
+	for {
+		err := runWatch(ctx)
+		if err == nil {
+			// No error means the callbacks returned success. The watch is done.
+			return nil
+		}
+
+		if err == errResourceTooOld {
+			// Start over without delay.
+			continue
+		}
+
+		if err == ctx.Err() {
+			// The context has been canceled. Good bye.
+			return err
+		}
+
+		if err, ok := err.(noRetry); ok {
+			return err.error
+		}
+
+		// Ask the callback about any other errors.
+		if errorCallback != nil {
+			err = errorCallback(err)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		// Retry in 10 secs.
+		select {
+		case <-time.After(10 * time.Second):
+			continue
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}


### PR DESCRIPTION
## Description

Watcher offers a convenient way of watching Kubernetes resources. An ephemeral alternative to Reflectors and Indexers, useful for one-shot tasks when no caching is required. It performs an initial list of all the resources and then starts watching them.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings