### PR TITLE
Fix dualstack config propagation in dynamic config mode

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -81,6 +81,9 @@ check-ap-ha3x3: TIMEOUT=6m
 
 check-kubeletcertrotate: TIMEOUT=15m
 
+check-dualstack-dynamicconfig: K0S_ENABLE_DYNAMIC_CONFIG=true
+check-dualstack-dynamicconfig: check-dualstack
+
 check-ap-updater: .update-server.stamp
 
 .PHONY: $(smoketests)

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -81,8 +81,8 @@ check-ap-ha3x3: TIMEOUT=6m
 
 check-kubeletcertrotate: TIMEOUT=15m
 
-check-dualstack-dynamicconfig: K0S_ENABLE_DYNAMIC_CONFIG=true
-check-dualstack-dynamicconfig: check-dualstack
+check-dualstack-dynamicconfig: export K0S_ENABLE_DYNAMIC_CONFIG=true
+check-dualstack-dynamicconfig: TEST_PACKAGE=dualstack
 
 check-ap-updater: .update-server.stamp
 
@@ -92,7 +92,13 @@ include Makefile.variables
 $(smoketests): K0S_PATH ?= $(realpath ../k0s)
 $(smoketests): K0S_IMAGES_BUNDLE ?= $(realpath ../airgap-image-bundle-linux-amd64.tar)
 $(smoketests): .footloose-alpine.stamp
-	K0S_PATH='$(K0S_PATH)' K0S_UPDATE_FROM_PATH='$(K0S_UPDATE_FROM_PATH)' K0S_IMAGES_BUNDLE='$(K0S_IMAGES_BUNDLE)' K0S_UPDATE_TO_VERSION='$(K0S_UPDATE_TO_VERSION)' go test -count=1 -v -timeout $(TIMEOUT) github.com/k0sproject/k0s/inttest/$(subst check-,,$@)
+$(smoketests): TEST_PACKAGE ?= $(subst check-,,$@)
+$(smoketests):
+	K0S_PATH='$(K0S_PATH)' \
+	K0S_UPDATE_FROM_PATH='$(K0S_UPDATE_FROM_PATH)' \
+	K0S_IMAGES_BUNDLE='$(K0S_IMAGES_BUNDLE)' \
+	K0S_UPDATE_TO_VERSION='$(K0S_UPDATE_TO_VERSION)' \
+	go test -count=1 -v -timeout $(TIMEOUT) github.com/k0sproject/k0s/inttest/$(TEST_PACKAGE)
 .PHONY: clean
 
 clean:

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -46,3 +46,4 @@ smoketests := \
 	check-customdomain \
 	check-capitalhostnames \
 	check-customca \
+	check-dualstack-dynamicconfig \

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -25,6 +25,7 @@ package dualstack
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/stretchr/testify/suite"
@@ -78,7 +79,11 @@ func (s *DualstackSuite) cmdlineForExecutable(node, binary string) []string {
 func (s *DualstackSuite) SetupSuite() {
 	s.FootlooseSuite.SetupSuite()
 	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfigWithDualStack)
-	s.Require().NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
+	controllerArgs := []string{"--config=/tmp/k0s.yaml"}
+	if os.Getenv("K0S_ENABLE_DYNAMIC_CONFIG") == "true" {
+		controllerArgs = append(controllerArgs, "--enable-dynamic-config")
+	}
+	s.Require().NoError(s.InitController(0, controllerArgs...))
 	s.Require().NoError(s.RunWorkers())
 	client, err := s.KubeClient(s.ControllerNode(0))
 	s.Require().NoError(err)

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -81,6 +81,7 @@ func (s *DualstackSuite) SetupSuite() {
 	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfigWithDualStack)
 	controllerArgs := []string{"--config=/tmp/k0s.yaml"}
 	if os.Getenv("K0S_ENABLE_DYNAMIC_CONFIG") == "true" {
+		s.T().Log("Enabling dynamic config for controller")
 		controllerArgs = append(controllerArgs, "--enable-dynamic-config")
 	}
 	s.Require().NoError(s.InitController(0, controllerArgs...))

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
@@ -365,6 +365,7 @@ func (c *ClusterConfig) GetClusterWideConfig() *ClusterConfig {
 				KubeRouter: c.Spec.Network.KubeRouter,
 				PodCIDR:    c.Spec.Network.PodCIDR,
 				Provider:   c.Spec.Network.Provider,
+				DualStack:  c.Spec.Network.DualStack,
 			},
 			WorkerProfiles: c.Spec.WorkerProfiles,
 			Telemetry:      c.Spec.Telemetry,


### PR DESCRIPTION
We did not copy over the dual stack config options to the API config object and thus dualstack was completely broken when dynamic config is enabled.

Fixes #2220

Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings