### PR TITLE
Added airgap bundle support for `tool`

### DIFF
--- a/hack/tool/README.md
+++ b/hack/tool/README.md
@@ -23,7 +23,7 @@ export TOOL_DATADIR=/mycluster/hadev1x3
 ./tool.sh aws ha create \
     --cluster-name hadev1x3 \
     --region ca-central-1 \
-    --k0s-version v1.24.4+k0s.0 \
+    --k0s-version v1.25.2+k0s.0 \
     --controllers 1 \
     --workers 3
 ```
@@ -48,6 +48,35 @@ cp /path/to/my/k0s ${TOOL_DATADIR}
     --k0s-binary k0s \
     --controllers 1 \
     --workers 3
+```
+
+### Creating an HA development `k0s` cluster on AWS (1x3) using an Airgap image bundle
+
+Similar to the non-airgap bundle instructions, this adds arguments for specifying an airgap bundle
+along with a YAML image manifest.
+
+Prerequisites:
+
+* Ensure that the files used for the `k0s` binary and airgap bundle exist in your `TOOL_DATADIR`.
+* A YAML manifest of the images is required.
+  * This can be created using a `spec.images` object
+    * https://docs.k0sproject.io/head/configuration/#specimages
+  * A minimal YAML can consist of simply `default_pull_policy: Never`
+* NOTE: The values for `--k0s-airgap-bundle` and `--k0s-airgap-bundle-config` reference the names of files in `TOOL_DATADIR`,
+and not full paths.
+
+```bash
+# This directory is where the terraform state and private key are saved.
+export TOOL_DATADIR=/mycluster/hadev1x3
+
+./tool.sh aws ha create \
+    --cluster-name hadev1x3 \
+    --region ca-central-1 \
+    --k0s-version v1.25.2+k0s.0 \
+    --controllers 1 \
+    --workers 3 \
+    --k0s-airgap-bundle k0s-airgap-bundle-v1.25.2+k0s.0-amd64 \
+    --k0s-airgap-bundle-config images.yaml
 ```
 
 ### Creating an array of HA `k0s` clusters in an isolated VPC
@@ -87,7 +116,7 @@ export TOOL_DATADIR=/inttests/inttest0
     --region ca-central-1 \
     --vpc-id <vpc_id from step above> \
     --subnet-idx 0 \
-    --k0s-version v1.24.4+k0s.0 \
+    --k0s-version v1.25.2+k0s.0 \
     --controllers 3 \
     --workers 3
 ```
@@ -106,7 +135,7 @@ export TOOL_DATADIR=/inttests/inttestN
     --region ca-central-1 \
     --vpc-id <vpc_id from step above> \
     --subnet-idx N \
-    --k0s-version v1.24.4+k0s.0 \
+    --k0s-version v1.25.2+k0s.0 \
     --controllers 3 \
     --workers 3
 ```

--- a/hack/tool/cmd/aws/ha/ha.go
+++ b/hack/tool/cmd/aws/ha/ha.go
@@ -39,6 +39,8 @@ type options struct {
 	Workers               int
 	K0sBinary             string
 	K0sVersion            string
+	K0sAirgapBundle       string
+	K0sAirgapBundleConfig string
 	K0sUpdateBinary       string
 	K0sUpdateAirgapBundle string
 }
@@ -66,6 +68,8 @@ func newOptionsFlagSet(f *options) *pflag.FlagSet {
 
 	fs.StringVar(&f.K0sBinary, "k0s-binary", "", fmt.Sprintf("The k0s binary in '%s' that the cluster should be created with", constant.DataDir))
 	fs.StringVar(&f.K0sVersion, "k0s-version", "", "The version of k0s to install")
+	fs.StringVar(&f.K0sAirgapBundle, "k0s-airgap-bundle", "", "The k0s airgap bundle to install with k0s")
+	fs.StringVar(&f.K0sAirgapBundleConfig, "k0s-airgap-bundle-config", "", fmt.Sprintf("A YAML definition in '%s' of all the airgap images + versions", constant.DataDir))
 	fs.StringVar(&f.K0sUpdateBinary, "k0s-update-binary", "", fmt.Sprintf("The k0s binary in '%s' that will be available for software update", constant.DataDir))
 	fs.StringVar(&f.K0sUpdateAirgapBundle, "k0s-update-airgap-bundle", "", fmt.Sprintf("The k0s airgap bundle in '%s' that will be available for software update", constant.DataDir))
 
@@ -120,7 +124,7 @@ func newCommandCreate() *cobra.Command {
 					return nil
 				},
 				Create: func(ctx context.Context) error {
-					return provider.ClusterHACreate(ctx, opts.ClusterName, opts.K0sBinary, opts.K0sUpdateBinary, foundK0sVersion, opts.K0sUpdateAirgapBundle, opts.Controllers, opts.Workers, opts.Region)
+					return provider.ClusterHACreate(ctx, opts.ClusterName, opts.K0sBinary, opts.K0sUpdateBinary, foundK0sVersion, opts.K0sAirgapBundle, opts.K0sAirgapBundleConfig, opts.K0sUpdateAirgapBundle, opts.Controllers, opts.Workers, opts.Region)
 				},
 				KubeConfig: func(ctx context.Context) (string, error) {
 					return provider.ClusterHAKubeConfig(ctx)
@@ -151,11 +155,11 @@ func newCommandDestroy() *cobra.Command {
 					return nil
 				},
 				Destroy: func(ctx context.Context) error {
-					return provider.ClusterHADestroy(ctx, opts.ClusterName, opts.K0sBinary, opts.K0sUpdateBinary, opts.K0sVersion, opts.K0sUpdateAirgapBundle, opts.Controllers, opts.Workers, opts.Region)
+					return provider.ClusterHADestroy(ctx, opts.ClusterName, opts.K0sBinary, opts.K0sUpdateBinary, opts.K0sVersion, opts.K0sAirgapBundle, opts.K0sAirgapBundleConfig, opts.K0sUpdateAirgapBundle, opts.Controllers, opts.Workers, opts.Region)
 				},
 			}
 
-			return provision.Deprovision(context.Background(), config)
+			return provision.Deprovision(cmd.Context(), config)
 		},
 	)
 }

--- a/hack/tool/pkg/backend/aws/provider.go
+++ b/hack/tool/pkg/backend/aws/provider.go
@@ -108,7 +108,7 @@ func (p *Provider) VpcInfraDestroy(ctx context.Context, name string, region stri
 
 var haPath = path.Join("aws", "commands", "ha")
 
-func (p *Provider) ClusterHACreate(ctx context.Context, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
+func (p *Provider) ClusterHACreate(ctx context.Context, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sAirgapBundle string, k0sAirgapBundleConfig string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
 	log.Printf("Creating k0s HA cluster")
 
 	return terraform.Apply(ctx, haPath,
@@ -118,12 +118,14 @@ func (p *Provider) ClusterHACreate(ctx context.Context, clusterName string, k0sB
 		tfexec.Var(kv("region", region)),
 		tfexec.Var(kv("k0s_binary", k0sBinary)),
 		tfexec.Var(kv("k0s_version", k0sVersion)),
+		tfexec.Var(kv("k0s_airgap_bundle", k0sAirgapBundle)),
+		tfexec.Var(kv("k0s_airgap_bundle_config", k0sAirgapBundleConfig)),
 		tfexec.Var(kv("k0s_update_binary", k0sBinaryUpdate)),
 		tfexec.Var(kv("k0s_update_airgap_bundle", k0sAirgapBundleUpdate)),
 	)
 }
 
-func (p *Provider) ClusterHADestroy(ctx context.Context, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
+func (p *Provider) ClusterHADestroy(ctx context.Context, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sAirgapBundle string, k0sAirgapBundleConfig string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
 	log.Printf("Destroying k0s HA cluster")
 
 	return terraform.Destroy(ctx, haPath,
@@ -133,6 +135,8 @@ func (p *Provider) ClusterHADestroy(ctx context.Context, clusterName string, k0s
 		tfexec.Var(kv("region", region)),
 		tfexec.Var(kv("k0s_binary", k0sBinary)),
 		tfexec.Var(kv("k0s_version", k0sVersion)),
+		tfexec.Var(kv("k0s_airgap_bundle", k0sAirgapBundle)),
+		tfexec.Var(kv("k0s_airgap_bundle_config", k0sAirgapBundleConfig)),
 		tfexec.Var(kv("k0s_update_binary", k0sBinaryUpdate)),
 		tfexec.Var(kv("k0s_update_airgap_bundle", k0sAirgapBundleUpdate)),
 	)
@@ -146,7 +150,7 @@ func (p *Provider) ClusterHAKubeConfig(ctx context.Context) (string, error) {
 
 var haVpcPath = path.Join("aws", "commands", "havpc")
 
-func (p *Provider) ClusterHAVpcCreate(ctx context.Context, vpcId string, subnetIdx int, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
+func (p *Provider) ClusterHAVpcCreate(ctx context.Context, vpcId string, subnetIdx int, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sAirgapBundle string, k0sAirgapBundleConfig string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
 	log.Printf("Creating k0s HA cluster")
 
 	return terraform.Apply(ctx, haVpcPath,
@@ -158,12 +162,14 @@ func (p *Provider) ClusterHAVpcCreate(ctx context.Context, vpcId string, subnetI
 		tfexec.Var(kv("region", region)),
 		tfexec.Var(kv("k0s_binary", k0sBinary)),
 		tfexec.Var(kv("k0s_version", k0sVersion)),
+		tfexec.Var(kv("k0s_airgap_bundle", k0sAirgapBundle)),
+		tfexec.Var(kv("k0s_airgap_bundle_config", k0sAirgapBundleConfig)),
 		tfexec.Var(kv("k0s_update_binary", k0sBinaryUpdate)),
 		tfexec.Var(kv("k0s_update_airgap_bundle", k0sAirgapBundleUpdate)),
 	)
 }
 
-func (p *Provider) ClusterHAVpcDestroy(ctx context.Context, vpcId string, subnetIdx int, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
+func (p *Provider) ClusterHAVpcDestroy(ctx context.Context, vpcId string, subnetIdx int, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sAirgapBundle string, k0sAirgapBundleConfig string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
 	log.Printf("Destroying k0s HA cluster")
 
 	return terraform.Destroy(ctx, haVpcPath,
@@ -175,6 +181,8 @@ func (p *Provider) ClusterHAVpcDestroy(ctx context.Context, vpcId string, subnet
 		tfexec.Var(kv("region", region)),
 		tfexec.Var(kv("k0s_binary", k0sBinary)),
 		tfexec.Var(kv("k0s_version", k0sVersion)),
+		tfexec.Var(kv("k0s_airgap_bundle", k0sAirgapBundle)),
+		tfexec.Var(kv("k0s_airgap_bundle_config", k0sAirgapBundleConfig)),
 		tfexec.Var(kv("k0s_update_binary", k0sBinaryUpdate)),
 		tfexec.Var(kv("k0s_update_airgap_bundle", k0sAirgapBundleUpdate)),
 	)

--- a/hack/tool/terraform/aws/commands/ha/variables.tf
+++ b/hack/tool/terraform/aws/commands/ha/variables.tf
@@ -35,6 +35,18 @@ variable "k0s_version" {
   default     = ""
 }
 
+variable "k0s_airgap_bundle" {
+  description = "The k0s airgap bundle containing all required images"
+  type        = string
+  default     = ""
+}
+
+variable "k0s_airgap_bundle_config" {
+  description = "The k0s airgap YAML manifest defining the required images"
+  type        = string
+  default     = ""
+}
+
 variable "k0s_update_binary" {
   description = "The name of the binary in '/tool/data' that will be available for update via S3"
   type        = string

--- a/hack/tool/terraform/aws/commands/havpc/variables.tf
+++ b/hack/tool/terraform/aws/commands/havpc/variables.tf
@@ -45,6 +45,18 @@ variable "k0s_version" {
   default     = ""
 }
 
+variable "k0s_airgap_bundle" {
+  description = "The k0s airgap bundle containing all required images"
+  type        = string
+  default     = ""
+}
+
+variable "k0s_airgap_bundle_config" {
+  description = "The k0s airgap YAML manifest defining the required images"
+  type        = string
+  default     = ""
+}
+
 variable "k0s_update_binary" {
   description = "The name of the binary in '/tool/data' that will be available for update via S3"
   type        = string


### PR DESCRIPTION
## Description

For both the AWS `ha` and `havpc` commands, a collection of airgap-specific arguments have been added which allow for seeding a k0s cluster via an airgap bundle.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings