### PR TITLE
Ignore deprecation lints in CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,3 +36,10 @@ issues:
     - source: "^//go:build"
       linters:
         - goheader
+    # Ignore deprecations: They shouldn't break the CI. If this were the case,
+    # it would be pointless to have them. There's no way in reporting them as
+    # warnings without having a non-zero exit code.
+    # https://github.com/golangci/golangci-lint/pull/3184#issuecomment-1235438429
+    - linters:
+        - staticcheck
+      text: "^SA1019:"


### PR DESCRIPTION
## Description

Deprecations shouldn't break the CI. If this were the case, it would somehow be pointless in having them, as adding a deprecation would have the same effect as introducing a breaking API change directly.

Albeit it would be nice to have some indication of deprecations being introduced in CI builds, it's currently impossible to do so without having a second linter run with a different config, whose non-zero error code won't break the build.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings