### PR TITLE
Replace set-output with env file in GH Actions

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -96,23 +96,22 @@ jobs:
         id: k0s_build
         run: |
           make build
-          echo ::set-output name=KUBERNETES_VERSION::$(make print-kubernetes_version)
+          KUBERNETES_VERSION=$(make print-kubernetes_version)
+          echo KUBERNETES_VERSION="$KUBERNETES_VERSION" >> $GITHUB_OUTPUT
         working-directory: ./
 
       - name: Set k0s' Version
         id: bin_info
         run: |
           # run k0s version
-          export ROOTDIR=${{ github.workspace }}
+          K0S_VER=$("$GITHUB_WORKSPACE/k0s" version)
 
-          K0S_VER=$($ROOTDIR/k0s version)
-
-          if [ ${K0S_VER} == "" ]; then
+          if [ -z "$K0S_VER" ]; then
             echo "empty k0s version. failing..."
             exit 1
           fi
 
-          echo ::set-output name=K0S_VERSION::${K0S_VER}
+          echo K0S_VERSION="$K0S_VER" >> $GITHUB_OUTPUT
 
       - name: Terraform Apply
         env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -101,7 +101,7 @@ jobs:
         id: list-smoke-tests
         run: |
           ./vars.sh FROM=inttest smoketests | jq --raw-input --raw-output \
-              'split(" ") | [ .[] | select(. != "") ] | "::set-output name=${{ matrix.target }}-matrix::" + tojson'
+              'split(" ") | [ .[] | select(. != "") ] | "${{ matrix.target }}-matrix=" + tojson' >> $GITHUB_OUTPUT
 
       - name: Create airgap image list
         id: create-airgap-image-list
@@ -117,7 +117,7 @@ jobs:
         # * https://github.com/actions/upload-artifact/issues/199#issuecomment-1190171851
         run: |
           make airgap-images.txt
-          echo ::set-output name=${{ matrix.target }}-hash::${{ hashFiles('Makefile', 'airgap-images.txt', 'hack/image-bundler/*') }}
+          echo '${{ matrix.target }}-hash=${{ hashFiles('Makefile', 'airgap-images.txt', 'hack/image-bundler/*') }}' >> $GITHUB_OUTPUT
 
       - name: Cache airgap image bundle
         id: cache-airgap-image-bundle
@@ -257,7 +257,7 @@ jobs:
       - id: set-matrix
         run: |
           matrix=$(./hack/tools/gen-matrix.sh 1.24.3 1.24.4)
-          echo "::set-output name=matrix::$matrix"
+          echo matrix="$matrix" >> $GITHUB_OUTPUT
 
   autopilot-smoketest:
     name: Autopilot smoke test

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -75,8 +75,8 @@ jobs:
           mike alias -u head main
           mike alias -u "${STABLE}" stable
           mike set-default --push stable
-          echo ::set-output name=LATEST::${LATEST}
-          echo ::set-output name=STABLE::${STABLE}
+          echo LATEST="$LATEST" >> $GITHUB_OUTPUT
+          echo STABLE="$STABLE" >> $GITHUB_OUTPUT
 
       # Ensures the current branch is gh-pages,
       # Creates / updates the "stable" and "latest" plain text files with the corresponding versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Branch name
         id: branch_name
         run: |
-          echo ::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}
+          echo TAG_NAME="${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -38,11 +38,11 @@ jobs:
           prerelease: ${{ contains(github.ref, '-') }} # v0.1.2-beta1, 1.2.3-rc1
       - name: Prepare image tags
         id: image_tag
+        env:
+          TAGS: ${{ steps.branch_name.outputs.TAG_NAME }}
         # Basically just replace the '+' with '-' as '+' is not allowed in tags
         run: |
-          TAGS=${{ steps.branch_name.outputs.TAG_NAME }}
-          TAGS=${TAGS//+/-}
-          echo ::set-output name=IMAGE_TAGS::${TAGS}
+          echo IMAGE_TAGS="${TAGS//+/-}" >> $GITHUB_OUTPUT
   x64:
     needs: release
     runs-on: [self-hosted, linux, x64]


### PR DESCRIPTION
## Description

The use of the `set-output` construct has been deprecated due to security considerations. The new recommended approach is to use the `$GITHUB_OUTPUT` environment file. Change all the usages of set-output to that new scheme.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

**Note:** According to the changelog, there's a minimum version requirement for self-hosted runners of >= `2.297.0`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings