### PR TITLE
Add depguard linter and forbid usage of gopkg.in/yaml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,11 +13,15 @@ run:
 
 linters:
   enable:
-    - revive
-    - gofmt
-    - goheader
+    - depguard # Checks if package imports are in a list of acceptable packages
+    - gofmt    # Checks whether code was gofmt-ed
+    - goheader # Checks is file headers matche a given pattern
+    - revive   # Stricter drop-in replacement for golint
 
 linters-settings:
+  depguard:
+    packages:
+      - gopkg.in/yaml*
   golint:
     min-confidence: 0
   goheader:

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,6 @@ require (
 	golang.org/x/sys v0.0.0-20220908164124-27713097b956
 	golang.org/x/tools v0.1.12
 	google.golang.org/grpc v1.50.0
-	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.10.1
 )
 
@@ -272,6 +271,7 @@ require (
 	gopkg.in/cheggaaa/pb.v1 v1.0.28 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.25.2 // indirect
 	k8s.io/component-helpers v0.25.2 // indirect

--- a/pkg/autopilot/updater/client.go
+++ b/pkg/autopilot/updater/client.go
@@ -16,10 +16,11 @@ package updater
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 const defaultChannel = "stable"
@@ -80,8 +81,12 @@ func (c *client) GetUpdate(channel, clusterID, lastUpdateStatus, currentVersion 
 	}
 	var update Update
 
-	decoder := yaml.NewDecoder(resp.Body)
-	err = decoder.Decode(&update)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal(body, &update)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Since #1672, k0s is consistently using `sigs.k8s.io/yaml`. Add a lint to ensure that the former YAML lib won't be used anymore.

Change the last occurrence of it in a way that no longer reads directly from the `Reader`, but buffers the HTTP response in memory. This is required since `sigs.k8s.io/yaml` doesn't offer any `Reader` API, as it has to do two passes over the input anyways.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [X] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings