### PR TITLE
Add footloose-base as prerequisite to update-server

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -37,8 +37,8 @@ bin/sonobuoy: | bin
 	  footloose-alpine
 	touch $@
 
-.update-server.stamp: update-server/Dockerfile update-server/html/stable/index.yaml
-	docker build -t update-server --build-arg BASE=footloose-alpine -f $< $(dir $<)
+.update-server.stamp: .footloose-alpine.stamp update-server/Dockerfile update-server/html/stable/index.yaml
+	docker build -t update-server --build-arg BASE=footloose-alpine -f update-server/Dockerfile update-server
 	touch $@
 
 check-network: bin/sonobuoy


### PR DESCRIPTION
## Description

It's the base image and has to be present when building the update-server image.

Presumably this caused [the CI error](https://github.com/k0sproject/k0s/actions/runs/3235281832/jobs/5316024647#step:8:20) in #2251.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings