### PR TITLE
Fix iptables mode detection and fallback

### DIFF
--- a/internal/pkg/iptablesutils/iptables.go
+++ b/internal/pkg/iptablesutils/iptables.go
@@ -61,8 +61,20 @@ func DetectIPTablesMode(k0sBinPath string) (string, error) {
 		logrus.Info("kube-related iptables entries not found, go with iptables-legacy")
 		return ModeLegacy, nil
 	}
-	logrus.Info("kube-related iptables entries not found, go with iptables-nft")
-	return ModeNFT, nil
+
+	iptablesPath, err := exec.LookPath("iptables")
+	if err != nil {
+		return "", err
+	}
+	out, err := exec.Command(iptablesPath, "--version").CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	outStr := string(out)
+	if strings.Contains(outStr, "nf_tables") {
+		return ModeNFT, nil
+	}
+	return ModeLegacy, nil
 }
 
 func iptablesEntriesCount(k0sBinPath string, xtablesCmdName string, entries []string) (entriesFound int, total int, err error) {

--- a/internal/pkg/iptablesutils/iptables.go
+++ b/internal/pkg/iptablesutils/iptables.go
@@ -32,10 +32,10 @@ const (
 	ModeLegacy = "legacy"
 )
 
-// DetectIPTablesMode figure out whether iptables-legacy or iptables-nft is in use on the host.
+// DetectHostIPTablesMode figure out whether iptables-legacy or iptables-nft is in use on the host.
 // Follows the same logic as kube-proxy/kube-route.
 // See: https://github.com/kubernetes-sigs/iptables-wrappers/blob/master/iptables-wrapper-installer.sh
-func DetectIPTablesMode(k0sBinPath string) (string, error) {
+func DetectHostIPTablesMode(k0sBinPath string) (string, error) {
 	logrus.Info("Trying to detect iptables mode")
 	logrus.Info("Checking iptables-nft for kube-related entries")
 	nftEntriesCount, nftTotalCount, err := iptablesEntriesCount(k0sBinPath, "xtables-nft-multi", []string{"KUBE-IPTABLES-HINT", "KUBE-KUBELET-CANARY"})

--- a/pkg/component/worker/kernelsetup.go
+++ b/pkg/component/worker/kernelsetup.go
@@ -20,4 +20,5 @@ limitations under the License.
 package worker
 
 // KernelSetup comment
-func KernelSetup() {}
+func KernelSetup()             {}
+func KernelMajorVersion() byte { return 0 }

--- a/pkg/component/worker/kernelsetup_linux.go
+++ b/pkg/component/worker/kernelsetup_linux.go
@@ -83,3 +83,12 @@ func KernelSetup() {
 	enableSysCtl("net/bridge/bridge-nf-call-iptables")
 	enableSysCtl("net/bridge/bridge-nf-call-ip6tables")
 }
+
+// KernelMajorVersion returns the major version number of the running kernel
+func KernelMajorVersion() byte {
+	data, err := os.ReadFile("/proc/sys/kernel/osrelease")
+	if err != nil {
+		return 0
+	}
+	return data[0] - '0'
+}

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -94,7 +94,7 @@ func (k *Kubelet) Init(_ context.Context) error {
 		iptablesMode := k.IPTablesMode
 		if iptablesMode == "" || iptablesMode == "auto" {
 			var err error
-			iptablesMode, err = iptablesutils.DetectIPTablesMode(k.K0sVars.BinDir)
+			iptablesMode, err = iptablesutils.DetectHostIPTablesMode(k.K0sVars.BinDir)
 			if err != nil {
 				if KernelMajorVersion() < 5 {
 					iptablesMode = "legacy"

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -96,8 +96,12 @@ func (k *Kubelet) Init(_ context.Context) error {
 			var err error
 			iptablesMode, err = iptablesutils.DetectIPTablesMode(k.K0sVars.BinDir)
 			if err != nil {
-				logrus.Errorf("error detecting iptables mode: %v, using iptables-nft by default", err)
-				iptablesMode = "nft"
+				if KernelMajorVersion() < 5 {
+					iptablesMode = "legacy"
+				} else {
+					iptablesMode = "nft"
+				}
+				logrus.Infof("error detecting iptables mode: %v, using iptables-%s by default", err, iptablesMode)
 			}
 		}
 		logrus.Infof("using iptables-%s", iptablesMode)


### PR DESCRIPTION
## Description

nf_tables does not seem to work well with older kernels (4.15).

Improve the selection of iptables mode to be more conservative.
- consult `iptables --version` on the host if it exists. Even if k0s will not use this it gives us a hint on the OS default mode.
- when no iptables is found on the host, use legacy for kernels older than 5.0

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings