### PR TITLE
Added 'toolsuite' with a plan-apply operation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/google/go-cmp v0.5.9
 	github.com/gorilla/mux v1.8.0
+	github.com/hashicorp/terraform-exec v0.17.3
 	github.com/imdario/mergo v0.3.13
 	github.com/k0sproject/dig v0.2.0
 	github.com/kardianos/service v1.2.1-0.20210728001519-a323c3813bc7
@@ -168,6 +169,8 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
+	github.com/hashicorp/terraform-json v0.14.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/ishidawataru/sctp v0.0.0-20210707070123-9a39160e9062 // indirect
@@ -235,6 +238,7 @@ require (
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
+	github.com/zclconf/go-cty v1.11.0 // indirect
 	github.com/zmap/zcrypto v0.0.0-20210511125630-18f1e0152cfc // indirect
 	github.com/zmap/zlint/v3 v3.1.0 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,7 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
@@ -149,6 +150,7 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/O
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/kingpin v2.2.6+incompatible/go.mod h1:59OFYbFVLKQKq+mqrL6Rw5bR0c3ACQaawgXx0QYndlE=
@@ -169,6 +171,8 @@ github.com/apex/log v1.1.4/go.mod h1:AlpoD9aScyQfJDVHmLMEcx4oU6LqzkWp4Mg9GdAcEvQ
 github.com/apex/logs v0.0.4/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
+github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
+github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -473,6 +477,7 @@ github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkg
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful/v3 v3.8.0 h1:eCZ8ulSerjdAiaNpF7GxXIE7ZCMo1moN1qX+S609eVw=
 github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -541,6 +546,9 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
+github.com/go-git/go-billy/v5 v5.3.1 h1:CPiOUAzKtMRvolEKw+bG1PLRpT7D3LIs3/3ey4Aiu34=
+github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -642,6 +650,7 @@ github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
+github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -791,6 +800,7 @@ github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
@@ -803,14 +813,22 @@ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdv
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.5.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/hc-install v0.4.0 h1:cZkRFr1WVa0Ty6x5fTvL1TuO1flul231rWkGH92oYYk=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/hashicorp/terraform-exec v0.17.3 h1:MX14Kvnka/oWGmIkyuyvL6POx25ZmKrjlaclkx3eErU=
+github.com/hashicorp/terraform-exec v0.17.3/go.mod h1:+NELG0EqQekJzhvikkeQsOAZpsw0cv/03rbeQJqscAI=
+github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e17dKDpqV7s=
+github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZbIYnAIkEyqP2pNSckM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
@@ -838,6 +856,7 @@ github.com/ishidawataru/sctp v0.0.0-20210707070123-9a39160e9062 h1:G1+wBT0dwjIrB
 github.com/ishidawataru/sctp v0.0.0-20210707070123-9a39160e9062/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jarcoal/httpmock v1.0.5/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
+github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
@@ -885,6 +904,7 @@ github.com/kardianos/service v1.2.1-0.20210728001519-a323c3813bc7/go.mod h1:CIMR
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
+github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -913,6 +933,7 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/go-gypsy v1.0.0/go.mod h1:chkXM0zjdpXOiqkCW1XcCHDfjfk14PH2KKkQWxfJUcU=
+github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
@@ -1258,6 +1279,7 @@ github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b/go.mod h1:
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/segmentio/analytics-go v3.1.0+incompatible h1:IyiOfUgQFVHvsykKKbdI7ZsH374uv3/DfZUo9+G0Z80=
@@ -1387,6 +1409,9 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f h1:p4VB7kIXpOQvVn1ZaTIVp+3vuYAXFe3OJEvjbUYJLaA=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
+github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
+github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/weppos/publicsuffix-go v0.13.1-0.20210123135404-5fd73613514e/go.mod h1:HYux0V0Zi04bHNwOHy4cXJVz/TQjYonnF6aoYhj+3QE=
 github.com/weppos/publicsuffix-go v0.15.1-0.20210511084619-b1f36a2d6c0b h1:FsyNrX12e5BkplJq7wKOLk0+C6LZ+KGXvuEcKUYm5ss=
 github.com/weppos/publicsuffix-go v0.15.1-0.20210511084619-b1f36a2d6c0b/go.mod h1:HYux0V0Zi04bHNwOHy4cXJVz/TQjYonnF6aoYhj+3QE=
@@ -1394,6 +1419,7 @@ github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xanzy/go-gitlab v0.31.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
+github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
@@ -1422,6 +1448,11 @@ github.com/yvasiyarov/gorelic v0.0.7 h1:4DTF1WOM2ZZS/xMOkTFBOcb6XiHu/PKn3rVo6dbe
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 h1:AsFN8kXcCVkUFHyuzp1FtYbzp1nCO/H6+1uPSGEyPzM=
 github.com/zcalusic/sysinfo v0.0.0-20210905121133-6fa2f969a900 h1:4klaqgLMtyCrRio4MV/xE8gcrMOYnvXtmbWPOLjxVBA=
 github.com/zcalusic/sysinfo v0.0.0-20210905121133-6fa2f969a900/go.mod h1:Z/gPVufBrFc8X5sef3m6kkw3r3nlNFp+I6bvASfvBZQ=
+github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
+github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
+github.com/zclconf/go-cty v1.11.0 h1:726SxLdi2SDnjY+BStqB9J1hNp4+2WlzyXLuimibIe0=
+github.com/zclconf/go-cty v1.11.0/go.mod h1:s9IfD1LK5ccNMSWCVFCE2rJfHiZgi7JijgeWIMfhLvA=
+github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521/go.mod h1:3YZ9o3WnatTIZhuOtot4IcUfzoKVjUHqu6WALIyI0nE=
@@ -1623,6 +1654,7 @@ golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180811021610-c39426892332/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -2177,6 +2209,7 @@ gopkg.in/src-d/go-git-fixtures.v3 v3.5.0/go.mod h1:dLBcvytrw/TYZsNTWCnkNF2DSIlzW
 gopkg.in/src-d/go-git.v4 v4.13.1/go.mod h1:nx5NYcxdKxq5fpltdHnPa2Exj4Sx0EclMWZQbYDu2z8=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/hack/tool/cmd/aws/ha/ha.go
+++ b/hack/tool/cmd/aws/ha/ha.go
@@ -42,6 +42,7 @@ type options struct {
 	K0sAirgapBundle       string
 	K0sAirgapBundleConfig string
 	K0sUpdateBinary       string
+	K0sUpdateVersion      string
 	K0sUpdateAirgapBundle string
 }
 
@@ -70,6 +71,7 @@ func newOptionsFlagSet(f *options) *pflag.FlagSet {
 	fs.StringVar(&f.K0sVersion, "k0s-version", "", "The version of k0s to install")
 	fs.StringVar(&f.K0sAirgapBundle, "k0s-airgap-bundle", "", "The k0s airgap bundle to install with k0s")
 	fs.StringVar(&f.K0sAirgapBundleConfig, "k0s-airgap-bundle-config", "", fmt.Sprintf("A YAML definition in '%s' of all the airgap images + versions", constant.DataDir))
+	fs.StringVar(&f.K0sUpdateVersion, "k0s-update-version", "", "The version of k0s that should be used for a cluster update")
 	fs.StringVar(&f.K0sUpdateBinary, "k0s-update-binary", "", fmt.Sprintf("The k0s binary in '%s' that will be available for software update", constant.DataDir))
 	fs.StringVar(&f.K0sUpdateAirgapBundle, "k0s-update-airgap-bundle", "", fmt.Sprintf("The k0s airgap bundle in '%s' that will be available for software update", constant.DataDir))
 
@@ -124,7 +126,8 @@ func newCommandCreate() *cobra.Command {
 					return nil
 				},
 				Create: func(ctx context.Context) error {
-					return provider.ClusterHACreate(ctx, opts.ClusterName, opts.K0sBinary, opts.K0sUpdateBinary, foundK0sVersion, opts.K0sAirgapBundle, opts.K0sAirgapBundleConfig, opts.K0sUpdateAirgapBundle, opts.Controllers, opts.Workers, opts.Region)
+					// TODO: struct this, getting out of control
+					return provider.ClusterHACreate(ctx, opts.ClusterName, opts.K0sBinary, opts.K0sUpdateBinary, foundK0sVersion, opts.K0sUpdateVersion, opts.K0sAirgapBundle, opts.K0sAirgapBundleConfig, opts.K0sUpdateAirgapBundle, opts.Controllers, opts.Workers, opts.Region)
 				},
 				KubeConfig: func(ctx context.Context) (string, error) {
 					return provider.ClusterHAKubeConfig(ctx)
@@ -155,7 +158,8 @@ func newCommandDestroy() *cobra.Command {
 					return nil
 				},
 				Destroy: func(ctx context.Context) error {
-					return provider.ClusterHADestroy(ctx, opts.ClusterName, opts.K0sBinary, opts.K0sUpdateBinary, opts.K0sVersion, opts.K0sAirgapBundle, opts.K0sAirgapBundleConfig, opts.K0sUpdateAirgapBundle, opts.Controllers, opts.Workers, opts.Region)
+					// TODO: struct this, getting out of control
+					return provider.ClusterHADestroy(ctx, opts.ClusterName, opts.K0sBinary, opts.K0sUpdateBinary, opts.K0sVersion, opts.K0sUpdateVersion, opts.K0sAirgapBundle, opts.K0sAirgapBundleConfig, opts.K0sUpdateAirgapBundle, opts.Controllers, opts.Workers, opts.Region)
 				},
 			}
 

--- a/hack/tool/cmd/aws/havpc/havpc.go
+++ b/hack/tool/cmd/aws/havpc/havpc.go
@@ -44,6 +44,7 @@ type options struct {
 	K0sAirgapBundle       string
 	K0sAirgapBundleConfig string
 	K0sUpdateBinary       string
+	K0sUpdateVersion      string
 	K0sUpdateAirgapBundle string
 }
 
@@ -74,6 +75,7 @@ func newOptionsFlagSet(f *options) *pflag.FlagSet {
 	fs.StringVar(&f.K0sVersion, "k0s-version", "", "The version of k0s to install")
 	fs.StringVar(&f.K0sAirgapBundle, "k0s-airgap-bundle", "", "The k0s airgap bundle to install with k0s")
 	fs.StringVar(&f.K0sAirgapBundleConfig, "k0s-airgap-bundle-config", "", fmt.Sprintf("A YAML definition in '%s' of all the airgap images + versions", constant.DataDir))
+	fs.StringVar(&f.K0sUpdateVersion, "k0s-update-version", "", "The version of k0s that should be used for a cluster update")
 	fs.StringVar(&f.K0sUpdateBinary, "k0s-update-binary", "", fmt.Sprintf("The k0s binary in '%s' that will be available for software update", constant.DataDir))
 	fs.StringVar(&f.K0sUpdateAirgapBundle, "k0s-update-airgap-bundle", "", fmt.Sprintf("The k0s airgap bundle in '%s' that will be available for software update", constant.DataDir))
 
@@ -109,7 +111,7 @@ func newCommandCreate() *cobra.Command {
 			foundK0sVersion := opts.K0sVersion
 			var err error
 
-			config := provision.ProvisionConfig{
+			provisionConfig := provision.ProvisionConfig{
 				Init: func(ctx context.Context) error {
 					if err := provider.Init(ctx); err != nil {
 						return err
@@ -130,14 +132,15 @@ func newCommandCreate() *cobra.Command {
 					return nil
 				},
 				Create: func(ctx context.Context) error {
-					return provider.ClusterHAVpcCreate(ctx, opts.VpcId, opts.SubnetIdx, opts.ClusterName, opts.K0sBinary, opts.K0sUpdateBinary, foundK0sVersion, opts.K0sAirgapBundle, opts.K0sAirgapBundleConfig, opts.K0sUpdateAirgapBundle, opts.Controllers, opts.Workers, opts.Region)
+					// TODO: struct this, getting out of control
+					return provider.ClusterHAVpcCreate(ctx, opts.VpcId, opts.SubnetIdx, opts.ClusterName, opts.K0sBinary, opts.K0sUpdateBinary, foundK0sVersion, opts.K0sUpdateVersion, opts.K0sAirgapBundle, opts.K0sAirgapBundleConfig, opts.K0sUpdateAirgapBundle, opts.Controllers, opts.Workers, opts.Region)
 				},
 				KubeConfig: func(ctx context.Context) (string, error) {
 					return provider.ClusterHAVpcKubeConfig(ctx)
 				},
 			}
 
-			return provision.Provision(context.Background(), config)
+			return provision.Provision(context.Background(), provisionConfig)
 		},
 	)
 }
@@ -161,7 +164,8 @@ func newCommandDestroy() *cobra.Command {
 					return nil
 				},
 				Destroy: func(ctx context.Context) error {
-					return provider.ClusterHAVpcDestroy(ctx, opts.VpcId, opts.SubnetIdx, opts.ClusterName, opts.K0sBinary, opts.K0sUpdateBinary, opts.K0sVersion, opts.K0sAirgapBundle, opts.K0sAirgapBundleConfig, opts.K0sUpdateAirgapBundle, opts.Controllers, opts.Workers, opts.Region)
+					// TODO: struct this, getting out of control
+					return provider.ClusterHAVpcDestroy(ctx, opts.VpcId, opts.SubnetIdx, opts.ClusterName, opts.K0sBinary, opts.K0sUpdateBinary, opts.K0sVersion, opts.K0sUpdateVersion, opts.K0sAirgapBundle, opts.K0sAirgapBundleConfig, opts.K0sUpdateAirgapBundle, opts.Controllers, opts.Workers, opts.Region)
 				},
 			}
 

--- a/hack/tool/pkg/backend/aws/provider.go
+++ b/hack/tool/pkg/backend/aws/provider.go
@@ -108,7 +108,7 @@ func (p *Provider) VpcInfraDestroy(ctx context.Context, name string, region stri
 
 var haPath = path.Join("aws", "commands", "ha")
 
-func (p *Provider) ClusterHACreate(ctx context.Context, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sAirgapBundle string, k0sAirgapBundleConfig string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
+func (p *Provider) ClusterHACreate(ctx context.Context, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sUpdateVersion string, k0sAirgapBundle string, k0sAirgapBundleConfig string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
 	log.Printf("Creating k0s HA cluster")
 
 	return terraform.Apply(ctx, haPath,
@@ -122,10 +122,11 @@ func (p *Provider) ClusterHACreate(ctx context.Context, clusterName string, k0sB
 		tfexec.Var(kv("k0s_airgap_bundle_config", k0sAirgapBundleConfig)),
 		tfexec.Var(kv("k0s_update_binary", k0sBinaryUpdate)),
 		tfexec.Var(kv("k0s_update_airgap_bundle", k0sAirgapBundleUpdate)),
+		tfexec.Var(kv("k0s_update_version", k0sUpdateVersion)),
 	)
 }
 
-func (p *Provider) ClusterHADestroy(ctx context.Context, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sAirgapBundle string, k0sAirgapBundleConfig string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
+func (p *Provider) ClusterHADestroy(ctx context.Context, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sUpdateVersion string, k0sAirgapBundle string, k0sAirgapBundleConfig string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
 	log.Printf("Destroying k0s HA cluster")
 
 	return terraform.Destroy(ctx, haPath,
@@ -139,6 +140,7 @@ func (p *Provider) ClusterHADestroy(ctx context.Context, clusterName string, k0s
 		tfexec.Var(kv("k0s_airgap_bundle_config", k0sAirgapBundleConfig)),
 		tfexec.Var(kv("k0s_update_binary", k0sBinaryUpdate)),
 		tfexec.Var(kv("k0s_update_airgap_bundle", k0sAirgapBundleUpdate)),
+		tfexec.Var(kv("k0s_update_version", k0sUpdateVersion)),
 	)
 }
 
@@ -150,7 +152,7 @@ func (p *Provider) ClusterHAKubeConfig(ctx context.Context) (string, error) {
 
 var haVpcPath = path.Join("aws", "commands", "havpc")
 
-func (p *Provider) ClusterHAVpcCreate(ctx context.Context, vpcId string, subnetIdx int, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sAirgapBundle string, k0sAirgapBundleConfig string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
+func (p *Provider) ClusterHAVpcCreate(ctx context.Context, vpcId string, subnetIdx int, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sUpdateVersion string, k0sAirgapBundle string, k0sAirgapBundleConfig string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
 	log.Printf("Creating k0s HA cluster")
 
 	return terraform.Apply(ctx, haVpcPath,
@@ -166,10 +168,11 @@ func (p *Provider) ClusterHAVpcCreate(ctx context.Context, vpcId string, subnetI
 		tfexec.Var(kv("k0s_airgap_bundle_config", k0sAirgapBundleConfig)),
 		tfexec.Var(kv("k0s_update_binary", k0sBinaryUpdate)),
 		tfexec.Var(kv("k0s_update_airgap_bundle", k0sAirgapBundleUpdate)),
+		tfexec.Var(kv("k0s_update_version", k0sUpdateVersion)),
 	)
 }
 
-func (p *Provider) ClusterHAVpcDestroy(ctx context.Context, vpcId string, subnetIdx int, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sAirgapBundle string, k0sAirgapBundleConfig string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
+func (p *Provider) ClusterHAVpcDestroy(ctx context.Context, vpcId string, subnetIdx int, clusterName string, k0sBinary string, k0sBinaryUpdate string, k0sVersion string, k0sUpdateVersion string, k0sAirgapBundle string, k0sAirgapBundleConfig string, k0sAirgapBundleUpdate string, controllers int, workers int, region string) error {
 	log.Printf("Destroying k0s HA cluster")
 
 	return terraform.Destroy(ctx, haVpcPath,
@@ -185,6 +188,7 @@ func (p *Provider) ClusterHAVpcDestroy(ctx context.Context, vpcId string, subnet
 		tfexec.Var(kv("k0s_airgap_bundle_config", k0sAirgapBundleConfig)),
 		tfexec.Var(kv("k0s_update_binary", k0sBinaryUpdate)),
 		tfexec.Var(kv("k0s_update_airgap_bundle", k0sAirgapBundleUpdate)),
+		tfexec.Var(kv("k0s_update_version", k0sUpdateVersion)),
 	)
 }
 

--- a/hack/tool/terraform/aws/commands/ha/outputs.tf
+++ b/hack/tool/terraform/aws/commands/ha/outputs.tf
@@ -16,11 +16,11 @@ locals {
           uploadBinary  = var.k0s_binary != "" ? true : false
           k0sBinaryPath = format("/tool/data/%s", var.k0s_binary)
           files = [
-            for val in (var.k0s_airgap_bundle != "" ? ["airgap"] : []) : {
-              name = "image-bundle"
-              src = format("/tool/data/%s", var.k0s_airgap_bundle)
+            for val in(var.k0s_airgap_bundle != "" ? ["airgap"] : []) : {
+              name   = "image-bundle"
+              src    = format("/tool/data/%s", var.k0s_airgap_bundle)
               dstDir = "/var/lib/k0s/images/"
-              perm = "0755"
+              perm   = "0755"
             }
           ]
         }
@@ -49,10 +49,26 @@ output "k0s_cluster" {
   value = yamlencode(local.k0s_tmpl)
 }
 
+output "k0s_controllers" {
+  value = [
+    for host in module.k0sinfra.controllers : split(".", host.private_dns)[0]
+  ]
+}
+
+output "k0s_workers" {
+  value = [
+    for host in module.k0sinfra.workers : split(".", host.private_dns)[0]
+  ]
+}
+
+output "k0s_update_version" {
+  value = var.k0s_update_version
+}
+
 output "k0s_update_binary_url" {
-  value = length(module.s3updateserver) > 0 ? module.s3updateserver[0].k0s_update_binary_url : ""
+  value = length(module.s3updateserver) > 0 ? module.s3updateserver[0].k0s_update_binary_url : format("https://github.com/k0sproject/k0s/releases/download/%s/k0s-%s-amd64", urlencode(var.k0s_update_version), var.k0s_update_version)
 }
 
 output "k0s_update_airgap_bundle_url" {
-  value = length(module.s3updateserver) > 0 ? module.s3updateserver[0].k0s_update_airgap_bundle_url : ""
+  value = length(module.s3updateserver) > 0 ? module.s3updateserver[0].k0s_update_airgap_bundle_url : format("https://github.com/k0sproject/k0s/releases/download/%s/k0s-airgap-bundle-%s-amd64", urlencode(var.k0s_update_version), var.k0s_update_version)
 }

--- a/hack/tool/terraform/aws/commands/ha/variables.tf
+++ b/hack/tool/terraform/aws/commands/ha/variables.tf
@@ -58,3 +58,9 @@ variable "k0s_update_airgap_bundle" {
   type        = string
   default     = ""
 }
+
+variable "k0s_update_version" {
+  description = "The version of k0s that should be used for a cluster update"
+  type        = string
+  default     = ""
+}

--- a/hack/tool/terraform/aws/commands/havpc/outputs.tf
+++ b/hack/tool/terraform/aws/commands/havpc/outputs.tf
@@ -16,11 +16,11 @@ locals {
           uploadBinary  = var.k0s_binary != "" ? true : false
           k0sBinaryPath = format("/tool/data/%s", var.k0s_binary)
           files = [
-            for val in (var.k0s_airgap_bundle != "" ? ["airgap"] : []) : {
-              name = "image-bundle"
-              src = format("/tool/data/%s", var.k0s_airgap_bundle)
+            for val in(var.k0s_airgap_bundle != "" ? ["airgap"] : []) : {
+              name   = "image-bundle"
+              src    = format("/tool/data/%s", var.k0s_airgap_bundle)
               dstDir = "/var/lib/k0s/images/"
-              perm = "0755"
+              perm   = "0755"
             }
           ]
         }
@@ -49,10 +49,26 @@ output "k0s_cluster" {
   value = yamlencode(local.k0s_tmpl)
 }
 
+output "k0s_controllers" {
+  value = [
+    for host in module.k0sinfra.controllers : split(".", host.private_dns)[0]
+  ]
+}
+
+output "k0s_workers" {
+  value = [
+    for host in module.k0sinfra.workers : split(".", host.private_dns)[0]
+  ]
+}
+
+output "k0s_update_version" {
+  value = var.k0s_update_version
+}
+
 output "k0s_update_binary_url" {
-  value = length(module.s3updateserver) > 0 ? module.s3updateserver[0].k0s_update_binary_url : ""
+  value = length(module.s3updateserver) > 0 ? module.s3updateserver[0].k0s_update_binary_url : format("https://github.com/k0sproject/k0s/releases/download/%s/k0s-%s-amd64", urlencode(var.k0s_update_version), var.k0s_update_version)
 }
 
 output "k0s_update_airgap_bundle_url" {
-  value = length(module.s3updateserver) > 0 ? module.s3updateserver[0].k0s_update_airgap_bundle_url : ""
+  value = length(module.s3updateserver) > 0 ? module.s3updateserver[0].k0s_update_airgap_bundle_url : format("https://github.com/k0sproject/k0s/releases/download/%s/k0s-airgap-bundle-%s-amd64", urlencode(var.k0s_update_version), var.k0s_update_version)
 }

--- a/hack/tool/terraform/aws/commands/havpc/variables.tf
+++ b/hack/tool/terraform/aws/commands/havpc/variables.tf
@@ -68,3 +68,9 @@ variable "k0s_update_airgap_bundle" {
   type        = string
   default     = ""
 }
+
+variable "k0s_update_version" {
+  description = "The version of k0s that should be used for a cluster update"
+  type        = string
+  default     = ""
+}

--- a/hack/tool/terraform/aws/modules/privatekey/main.tf
+++ b/hack/tool/terraform/aws/modules/privatekey/main.tf
@@ -11,5 +11,5 @@ resource "aws_key_pair" "this" {
 resource "local_file" "this" {
   file_permission = 600
   filename        = var.outfile
-  content         = tls_private_key.this.private_key_pem
+  content         = tls_private_key.this.private_key_openssh
 }

--- a/inttest/toolsuite/operations/planapply.go
+++ b/inttest/toolsuite/operations/planapply.go
@@ -1,0 +1,103 @@
+// Copyright 2022 k0s authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+
+	ts "github.com/k0sproject/k0s/inttest/toolsuite"
+	tsutil "github.com/k0sproject/k0s/inttest/toolsuite/util"
+	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+type PlanBuilder func(output tsutil.TerraformOutputMap) (*apv1beta2.Plan, error)
+
+// PlanApplyOperation is an Operation that will read output values from terraform,
+// build a user-provided Plan, and apply it via kubectl.
+func PlanApplyOperation(ctx context.Context, builder PlanBuilder) ts.ClusterOperation {
+	return func(data ts.ClusterData) error {
+		// The the terraform binary, error if missing
+		tfpath, err := exec.LookPath("terraform")
+		if err != nil {
+			return fmt.Errorf("unable to find terraform binary: %w", err)
+		}
+
+		// Initialize terraform to read the state output values.
+		tf, err := tfexec.NewTerraform(data.DataDir, tfpath)
+		if err != nil {
+			return fmt.Errorf("failed to initialize terraform: %w", err)
+		}
+
+		tf.SetStdout(os.Stdout)
+
+		// Collect the terraform output which the specific builders will use for collecting
+		// whatever information they need.
+		tfout, err := tf.Output(ctx)
+		if err != nil {
+			return fmt.Errorf("unable to collect terraform output: %w", err)
+		}
+
+		// Build the plan
+		plan, err := builder(tfout)
+		if err != nil {
+			return fmt.Errorf("failed to build plan: %w", err)
+		}
+
+		// Save + apply the plan
+		planFile := path.Join(data.DataDir, "plan.yaml")
+
+		if err := savePlan(planFile, plan); err != nil {
+			return fmt.Errorf("failed to save plan to '%s': %w", planFile, err)
+		}
+
+		if err := applyPlan(data, planFile); err != nil {
+			return fmt.Errorf("failed to apply plan: %w", err)
+		}
+
+		return nil
+	}
+}
+
+// savePlan saves a marshalled Plan to the data directory.
+func savePlan(planFile string, plan *apv1beta2.Plan) error {
+	data, err := yaml.Marshal(plan)
+	if err != nil {
+		return fmt.Errorf("failed to marshal plan for save: %w", err)
+	}
+
+	return os.WriteFile(planFile, data, 0644)
+}
+
+// applyPlan uses 'kubectl' to apply a plan using the kubeconfig available
+// in the data directory.
+func applyPlan(clusterData ts.ClusterData, planFile string) error {
+	cmd := exec.Command("kubectl", "--kubeconfig", clusterData.KubeConfigFile, "apply", "-f", planFile)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to execute kubectl: %w", err)
+	}
+
+	return nil
+}

--- a/inttest/toolsuite/tests/versionupdate_test.go
+++ b/inttest/toolsuite/tests/versionupdate_test.go
@@ -1,0 +1,146 @@
+// Copyright 2022 k0s authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	ts "github.com/k0sproject/k0s/inttest/toolsuite"
+	tsops "github.com/k0sproject/k0s/inttest/toolsuite/operations"
+	tsutil "github.com/k0sproject/k0s/inttest/toolsuite/util"
+
+	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
+	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
+	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
+	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type VersionUpdateSuite struct {
+	ts.ToolSuite
+}
+
+// TestUpdate uses the cluster kubeconfig to wait for the Plan to complete successfully.
+func (s *VersionUpdateSuite) TestUpdate() {
+	client, err := s.AutopilotClient()
+	assert.NoError(s.T(), err)
+
+	s.T().Logf("Waiting for Plan completion (timeout = %v)", s.Config.OperationTimeout)
+
+	// The plan has enough information to perform a successful update of k0s, so wait for it.
+	plan, err := apcomm.WaitForPlanByName(context.TODO(), client, apconst.AutopilotName, s.Config.OperationTimeout, func(obj interface{}) bool {
+		if plan, ok := obj.(*apv1beta2.Plan); ok {
+			completed := plan.Status.State == appc.PlanCompleted
+
+			if completed {
+				s.T().Log("Plan completed successfully!")
+			}
+
+			return completed
+		}
+
+		return false
+	})
+
+	s.T().Log("Plan completed execution")
+
+	assert.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), plan)
+}
+
+// VersionUpdatePlan creates an autopilot Plan that consists of all controllers and workers as
+// reported by the terraform output. All updates are done sequentially, using the `linux-amd64` k0s
+// distribution hosted on the GitHub project release page.
+func VersionUpdatePlan(output tsutil.TerraformOutputMap) (*apv1beta2.Plan, error) {
+	var updateK0sVersion string
+	if err := tsutil.TerraformOutput(&updateK0sVersion, output, "k0s_update_version"); err != nil {
+		return nil, err
+	}
+
+	var updateK0sUrl string
+	if err := tsutil.TerraformOutput(&updateK0sUrl, output, "k0s_update_binary_url"); err != nil {
+		return nil, err
+	}
+
+	// The k0s filename is URL encoded in the path, but the filename is not.
+
+	var controllers []string
+	if err := tsutil.TerraformOutput(&controllers, output, "k0s_controllers"); err != nil {
+		return nil, fmt.Errorf("unable to parse terraform output for 'k0s_controllers': %w", err)
+	}
+
+	var workers []string
+	if err := tsutil.TerraformOutput(&workers, output, "k0s_workers"); err != nil {
+		return nil, fmt.Errorf("unable to parse terraform output for 'k0s_workers': %w", err)
+	}
+
+	return &apv1beta2.Plan{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Plan",
+			APIVersion: "autopilot.k0sproject.io/v1beta2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "autopilot",
+		},
+		Spec: apv1beta2.PlanSpec{
+			ID:        "abc123",
+			Timestamp: "now",
+			Commands: []apv1beta2.PlanCommand{
+				{
+					K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{
+						Version:     updateK0sVersion,
+						ForceUpdate: true,
+						Platforms: apv1beta2.PlanPlatformResourceURLMap{
+							"linux-amd64": apv1beta2.PlanResourceURL{
+								URL: updateK0sUrl,
+							},
+						},
+						Targets: apv1beta2.PlanCommandTargets{
+							Controllers: apv1beta2.PlanCommandTarget{
+								Discovery: apv1beta2.PlanCommandTargetDiscovery{
+									Static: &apv1beta2.PlanCommandTargetDiscoveryStatic{
+										Nodes: controllers,
+									},
+								},
+							},
+							Workers: apv1beta2.PlanCommandTarget{
+								Discovery: apv1beta2.PlanCommandTargetDiscovery{
+									Static: &apv1beta2.PlanCommandTargetDiscoveryStatic{
+										Nodes: workers,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+// TestVersionUpdateSuite runs the VersionUpdateSuite suite.
+func TestVersionUpdateSuite(t *testing.T) {
+	suite.Run(t, &VersionUpdateSuite{
+		ts.ToolSuite{
+			Operation: tsops.PlanApplyOperation(context.Background(), VersionUpdatePlan),
+		},
+	})
+}

--- a/inttest/toolsuite/toolsuite.go
+++ b/inttest/toolsuite/toolsuite.go
@@ -1,0 +1,206 @@
+// Copyright 2022 k0s authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolsuite
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"time"
+
+	apclient "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	defaultToolImage = "tool:latest"
+)
+
+type ClusterOperation func(data ClusterData) error
+
+type ClusterData struct {
+	DataDir        string
+	KubeConfigFile string
+	PrivateKeyFile string
+}
+
+type Config struct {
+	Image            string
+	TestName         string
+	DataDir          string
+	Provider         string
+	Command          string
+	OperationTimeout time.Duration
+}
+
+var config Config
+
+// init is used to populate all of the arguments that have been passed to the test.
+func init() {
+	flag.StringVar(&config.Image, "image", defaultToolImage, "The name of the image to use")
+	flag.StringVar(&config.TestName, "testname", "", "The name of the test")
+	flag.StringVar(&config.DataDir, "data-dir", "", "The tool data directory")
+	flag.StringVar(&config.Provider, "provider", "", "The name of the tool provider")
+	flag.StringVar(&config.Command, "command", "", "The provider command to invoke")
+	flag.DurationVar(&config.OperationTimeout, "operation-timeout", 10*time.Minute, "The timeout for operations")
+}
+
+type ToolSuite struct {
+	suite.Suite
+	Config    Config
+	Operation ClusterOperation
+}
+
+func (s *ToolSuite) KubeConfigFile() string {
+	return path.Join(s.Config.DataDir, "k0s.kubeconfig")
+}
+
+// generateDockerRunArgs builds up the arguments for a 'docker run', taking into consideration
+// the provider, and all of the extra passthrough arguments provided.
+func generateDockerRunArgs(c Config, command string, action string) ([]string, []string, error) {
+	var runArgs, containerArgs []string
+	var err error
+
+	switch c.Provider {
+	case "aws":
+		runArgs, containerArgs, err = generateDockerRunArgsAWS(c, command, action)
+	}
+
+	if err != nil {
+		return []string{}, []string{}, fmt.Errorf("provider argument is invalid/missing")
+	}
+
+	// Ensure that the volume mount to the data directory is provided to the run arguments.
+
+	return append(runArgs, "-v", fmt.Sprintf("%s:/tool/data", c.DataDir)), containerArgs, nil
+}
+
+// generateDockerRunArgsAWS is the AWS-specific implementation of `generateDockerRunArgs()`, but
+// also seeding the `docker` environment with the AWS credentials.
+func generateDockerRunArgsAWS(c Config, command string, action string) ([]string, []string, error) {
+	runArgs := []string{
+		"-e", "AWS_ACCESS_KEY_ID",
+		"-e", "AWS_SECRET_ACCESS_KEY",
+		"-e", "AWS_SESSION_TOKEN",
+	}
+
+	return runArgs, append([]string{c.Provider, command, action}, flag.Args()...), nil
+}
+
+// SetupSuite will generate the appropriate arguments to 'create' the infrastructure as defined on
+// the command line, and invoke it.
+func (s *ToolSuite) SetupSuite() {
+	if config.Image == "" {
+		s.T().FailNow()
+	}
+
+	s.Config = config
+
+	runArgs, containerArgs, err := generateDockerRunArgs(config, s.Config.Command, "create")
+	if err != nil {
+		s.T().FailNow()
+	}
+
+	if err := dockerRun(s.Config.Image, runArgs, containerArgs); err != nil {
+		s.Failf("unable to run container", "%v\n", err)
+		return
+	}
+}
+
+// KubeClient returns a kubernetes API client
+func (s *ToolSuite) KubeClient() (*kubernetes.Clientset, error) {
+	return clientLoader(s.KubeConfigFile(), func(config *rest.Config) (*kubernetes.Clientset, error) {
+		return kubernetes.NewForConfig(config)
+	})
+}
+
+// AutopilotClient returns an autopilot API client
+func (s *ToolSuite) AutopilotClient() (*apclient.Clientset, error) {
+	return clientLoader(s.KubeConfigFile(), func(config *rest.Config) (*apclient.Clientset, error) {
+		return apclient.NewForConfig(config)
+	})
+}
+
+// clientLoader loads a kubernetes REST configuration, and returns an appropriate API instance via types.
+func clientLoader[CT any](kubeConfigFile string, loader func(config *rest.Config) (*CT, error)) (*CT, error) {
+	kubeConfigBytes, err := ioutil.ReadFile(kubeConfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read kubeconfig '%s': %w", kubeConfigFile, err)
+	}
+
+	kubeConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfigBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+
+	client, err := loader(kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create kubernetes client: %w", err)
+	}
+
+	return client, nil
+}
+
+// TestEntrypoint is the main testing entrypoint for a single toolsuite test. This parses and loads
+// kubernetes cluster configuration from `k0s.kubeconfig`, and passes it to a user-specified delegate
+// operation handler.
+func (s *ToolSuite) TestEntrypoint() {
+	kubeConfigFile := path.Join(s.Config.DataDir, "k0s.kubeconfig")
+
+	clusterData := ClusterData{
+		DataDir:        s.Config.DataDir,
+		KubeConfigFile: kubeConfigFile,
+		PrivateKeyFile: path.Join(s.Config.DataDir, "private.pem"),
+	}
+
+	err := s.Operation(clusterData)
+	assert.NoError(s.T(), err, "Failed in toolsuite handler: %v", err)
+}
+
+// TearDownSuite will generate the appropriate arguments to 'destroy' the infrastructure as defined on
+// the command line, and invoke it.
+func (s *ToolSuite) TearDownSuite() {
+	runArgs, containerArgs, err := generateDockerRunArgs(config, s.Config.Command, "destroy")
+	if err != nil {
+		s.T().FailNow()
+	}
+
+	if err := dockerRun(s.Config.Image, runArgs, containerArgs); err != nil {
+		s.Failf("unable to run container", "%v\n", err)
+		return
+	}
+}
+
+// dockerRun runs docker using the provided run and container arguments.
+func dockerRun(image string, runArgs []string, containerArgs []string) error {
+	args := []string{"run"}
+	args = append(args, runArgs...)
+	args = append(args, image)
+	args = append(args, containerArgs...)
+
+	cmd := exec.Command("docker", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}

--- a/inttest/toolsuite/util/terraform.go
+++ b/inttest/toolsuite/util/terraform.go
@@ -1,0 +1,39 @@
+// Copyright 2022 k0s authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+type TerraformOutputMap map[string]tfexec.OutputMeta
+
+// TerraformOutput is a generic helper for unmarshalling JSON values from
+// a terraform output map.
+func TerraformOutput[VT any](outputValue *VT, output TerraformOutputMap, key string) error {
+	value, found := output[key]
+	if !found {
+		return fmt.Errorf("unable to find key '%s' in terraform output", key)
+	}
+
+	if err := json.Unmarshal(value.Value, outputValue); err != nil {
+		return fmt.Errorf("unable to unmarshal value for key '%s' in terraform output", key)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description

This introduces a new test suite implementation that will use 'tool' to create a `k0s` cluster on setup, and destroy it on tear-down. In between, custom operations are applied that perform tests on the cluster.

The initial operation will build an autopilot 'Plan' and apply it. The determination of success is the test observing that the Plan transitions to 'Completed'

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings