### PR TITLE
Change the log component name, basically fixing copypaste mistake

### DIFF
--- a/pkg/component/controller/leaderelector.go
+++ b/pkg/component/controller/leaderelector.go
@@ -56,7 +56,7 @@ func NewLeasePoolLeaderElector(kubeClientFactory kubeutil.ClientFactoryInterface
 	return &LeasePoolLeaderElector{
 		stopCh:            make(chan struct{}),
 		kubeClientFactory: kubeClientFactory,
-		log:               logrus.WithFields(logrus.Fields{"component": "endpointreconciler"}),
+		log:               logrus.WithFields(logrus.Fields{"component": "poolleaderelector"}),
 		leaderStatus:      d,
 	}
 }


### PR DESCRIPTION
Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>

## Description

Just minor fix of wrong naming 

