### PR TITLE
Ability to disable k0s endpoint-reconciler

### DIFF
--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -41,14 +41,15 @@ import (
 
 // APIServer implement the component interface to run kube api
 type APIServer struct {
-	ClusterConfig      *v1beta1.ClusterConfig
-	K0sVars            constant.CfgVars
-	LogLevel           string
-	Storage            component.Component
-	EnableKonnectivity bool
-	gid                int
-	supervisor         supervisor.Supervisor
-	uid                int
+	ClusterConfig             *v1beta1.ClusterConfig
+	K0sVars                   constant.CfgVars
+	LogLevel                  string
+	Storage                   component.Component
+	EnableKonnectivity        bool
+	DisableEndpointReconciler bool
+	gid                       int
+	supervisor                supervisor.Supervisor
+	uid                       int
 }
 
 var _ component.Component = (*APIServer)(nil)
@@ -145,7 +146,7 @@ func (a *APIServer) Start(_ context.Context) error {
 			args[name] = value
 		}
 	}
-	if a.ClusterConfig.Spec.API.ExternalAddress != "" || a.ClusterConfig.Spec.API.TunneledNetworkingMode {
+	if a.DisableEndpointReconciler {
 		args["endpoint-reconciler-type"] = "none"
 	}
 

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -174,6 +174,7 @@ func AvailableComponents() []string {
 		constant.MetricsServerComponentName,
 		constant.KubeletConfigComponentName,
 		constant.SystemRbacComponentName,
+		constant.APIEndpointReconcilerComponentName,
 	}
 }
 

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -97,6 +97,7 @@ const (
 
 	// Controller component names
 	APIConfigComponentName             = "api-config"
+	APIEndpointReconcilerComponentName = "endpoint-reconciler"
 	ControlAPIComponentName            = "control-api"
 	CoreDNSComponentname               = "coredns"
 	CsrApproverComponentName           = "csr-approver"


### PR DESCRIPTION
Signed-off-by: Alexey Makhov <amakhov@mirantis.com>

## Description

APIEndpoint reconciler is added to the list of the disablable components.
The PR introduces an ability to use `--disabled-components=endpoint-reconciler`

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings