### PR TITLE
Fail inttests when the deadline is exceeded

### DIFF
--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -191,6 +191,12 @@ func (s *FootlooseSuite) SetupSuite() {
 	go func() {
 		defer cleanupTasks.Done()
 		<-ctx.Done()
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			// Record a test failure when the deadline has been exceeded. This
+			// is to ensure that the test is actually marked as failed and the
+			// cluster state will be recorded.
+			assert.Fail(t, "Test deadline exceeded")
+		}
 
 		t.Logf("Cleaning up")
 


### PR DESCRIPTION
## Description

Some tests may not mark themselves as failed when the test context's deadline is exceeded. This can result in green builds, even if the test has been aborted. Moreover, the cluster state wasn't collected in those cases, since the check if the test actually failed was likely to happen before the integration tests recorded the failure.

Record a separate test failure whenever the context timed out, so that the test is stamped as failed in any case and the cluster state will be recorded.

This reveals #2289, so in order to merge this one, we need to either address #2289 or disable the `cnichange` inttest until that is fixed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings