### PR TITLE
Introduce inttest helper AssertSomeKubeSystemPods

### DIFF
--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -53,14 +53,8 @@ func (as *AddonsSuite) TestHelmBasedAddons() {
 	as.NoError(err)
 	as.waitForTestRelease(addonName, "0.4.0", 1)
 	as.waitForTestRelease(ociAddonName, "0.6.0", 1)
-	pods, err := kc.CoreV1().Pods("kube-system").List(as.Context(), v1.ListOptions{
-		Limit: 100,
-	})
-	as.NoError(err)
 
-	podCount := len(pods.Items)
-	as.T().Logf("found %d pods in kube-system", podCount)
-	as.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	as.AssertSomeKubeSystemPods(kc)
 
 	values := map[string]interface{}{
 		"replicaCount": 2,

--- a/inttest/airgap/airgap_test.go
+++ b/inttest/airgap/airgap_test.go
@@ -62,15 +62,7 @@ func (s *AirgapSuite) TestK0sGetsUp() {
 	s.NoError(err)
 	s.Equal("bar", labels["k0sproject.io/foo"])
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see kube-router pods ready")
 	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "kube-router did not start")

--- a/inttest/backup/backup_test.go
+++ b/inttest/backup/backup_test.go
@@ -82,15 +82,7 @@ func (s *BackupSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady(s.WorkerNode(1), kc)
 	s.Require().NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.Require().NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see kube-router pods ready")
 	s.Require().NoError(common.WaitForKubeRouterReady(kc), "kube-router did not start")

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -68,15 +68,7 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady(s.WorkerNode(1), kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(s.Context(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see kube-router pods ready")
 	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "kube-router did not start")

--- a/inttest/byocri/byocri_test.go
+++ b/inttest/byocri/byocri_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package byocri
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -26,7 +25,6 @@ import (
 	"github.com/weaveworks/footloose/pkg/config"
 
 	"github.com/k0sproject/k0s/inttest/common"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type BYOCRISuite struct {
@@ -44,15 +42,7 @@ func (s *BYOCRISuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see CNI pods ready")
 	s.NoError(common.WaitForKubeRouterReady(kc), "CNI did not start")

--- a/inttest/calico/calico_test.go
+++ b/inttest/calico/calico_test.go
@@ -17,13 +17,11 @@ limitations under the License.
 package calico
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/k0sproject/k0s/inttest/common"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type CalicoSuite struct {
@@ -44,15 +42,7 @@ func (s *CalicoSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady("worker1", kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see calico pods ready")
 	s.NoError(common.WaitForDaemonSet(s.Context(), kc, "calico-node"), "calico did not start")

--- a/inttest/capitalhostnames/capitalhostnames_test.go
+++ b/inttest/capitalhostnames/capitalhostnames_test.go
@@ -47,15 +47,7 @@ func (s *CapitalHostnamesSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady("k0s-worker", kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(s.Context(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see kube-router pods ready")
 	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "kube-router did not start")

--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type CliSuite struct {
@@ -106,15 +105,7 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 		err = s.WaitForNodeReady(s.ControllerNode(0), kc)
 		assert.NoError(err)
 
-		pods, err := kc.CoreV1().Pods("kube-system").List(s.Context(), v1.ListOptions{
-			Limit: 100,
-		})
-		assert.NoError(err)
-
-		podCount := len(pods.Items)
-
-		s.T().Logf("found %d pods in kube-system", podCount)
-		s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+		s.AssertSomeKubeSystemPods(kc)
 
 		// Wait till we see all pods running, otherwise we get into weird timing issues and high probability of leaked containerd shim processes
 		require.NoError(common.WaitForDaemonSet(s.Context(), kc, "kube-proxy"))

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -49,6 +49,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -1383,4 +1384,15 @@ func (s *FootlooseSuite) GetUpdateServerIPAddress() string {
 	ipAddress, err := ssh.ExecWithOutput(s.Context(), "hostname -i")
 	s.Require().NoError(err)
 	return ipAddress
+}
+
+func (s *FootlooseSuite) AssertSomeKubeSystemPods(client *kubernetes.Clientset) bool {
+	if pods, err := client.CoreV1().Pods("kube-system").List(s.Context(), v1.ListOptions{
+		Limit: 100,
+	}); s.NoError(err) {
+		s.T().Logf("Found %d pods in kube-system", len(pods.Items))
+		return s.NotEmpty(pods.Items, "Expected to see some pods in kube-system namespace")
+	}
+
+	return false
 }

--- a/inttest/customca/customca_test.go
+++ b/inttest/customca/customca_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/k0sproject/k0s/inttest/common"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type CustomCASuite struct {
@@ -64,15 +63,7 @@ func (s *CustomCASuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(s.Context(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	newCert, err := ssh.ExecWithOutput(s.Context(), fmt.Sprintf("cat /var/lib/k0s/pki/ca.crt"))
 	s.NoError(err)

--- a/inttest/customdomain/customdomain_test.go
+++ b/inttest/customdomain/customdomain_test.go
@@ -17,13 +17,11 @@ limitations under the License.
 package customdomain
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/k0sproject/k0s/inttest/common"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type CustomDomainSuite struct {
@@ -45,15 +43,7 @@ func (s *CustomDomainSuite) TestK0sGetsUpWithCustomDomain() {
 	err = s.WaitForNodeReady(s.WorkerNode(1), kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see CNI pods ready")
 	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "CNI did not start")

--- a/inttest/customports/customports_test.go
+++ b/inttest/customports/customports_test.go
@@ -18,14 +18,12 @@ package customports
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"html/template"
 	"testing"
 
 	"github.com/k0sproject/k0s/inttest/common"
 	"github.com/stretchr/testify/suite"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "k8s.io/client-go/kubernetes"
 )
 
@@ -120,14 +118,7 @@ func (ds *Suite) TestControllerJoinsWithCustomPort() {
 
 	ds.Require().NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
-		Limit: 100,
-	})
-	ds.Require().NoError(err)
-
-	podCount := len(pods.Items)
-	ds.T().Logf("found %d pods in kube-system", podCount)
-	ds.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	ds.AssertSomeKubeSystemPods(kc)
 
 	ds.T().Log("waiting to see CNI pods ready")
 	ds.Require().NoError(common.WaitForKubeRouterReady(kc), "calico did not start")

--- a/inttest/defaultstorage/defaultstorage_test.go
+++ b/inttest/defaultstorage/defaultstorage_test.go
@@ -47,15 +47,7 @@ func (s *DefaultStorageSuite) TestK0sGetsUp() {
 	err = common.WaitForDeployment(s.Context(), kc, "nginx")
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	pv, err := kc.CoreV1().PersistentVolumes().List(context.TODO(), v1.ListOptions{})
 	s.NoError(err)

--- a/inttest/disabledcomponents/disabled_components_test.go
+++ b/inttest/disabledcomponents/disabled_components_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package disabledcomponents
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -38,15 +37,11 @@ func (s *DisabledComponentsSuite) TestK0sGetsUp() {
 	kc, err := s.KubeClient(s.ControllerNode(0))
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
+	if pods, err := kc.CoreV1().Pods("kube-system").List(s.Context(), v1.ListOptions{
 		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Equal(podCount, 0, "expecting to see few pods in kube-system namespace")
+	}); s.NoError(err) {
+		s.Empty(pods.Items, "Expected to see no pods in kube-system namespace")
+	}
 
 	ssh, err := s.SSH(s.ControllerNode(0))
 	s.NoError(err)

--- a/inttest/externaletcd/external_etcd_test.go
+++ b/inttest/externaletcd/external_etcd_test.go
@@ -17,14 +17,12 @@ limitations under the License.
 package externaletcd
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
 	"github.com/avast/retry-go"
 	"github.com/k0sproject/k0s/inttest/common"
 	"github.com/stretchr/testify/suite"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const k0sConfig = `
@@ -78,14 +76,7 @@ func (s *ExternalEtcdSuite) TestK0sWithExternalEtcdCluster() {
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("checking if etcd contains keys")
 	etcdSSH, err := s.SSH(s.ExternalEtcdNode())

--- a/inttest/extraargs/extraargs_test.go
+++ b/inttest/extraargs/extraargs_test.go
@@ -17,13 +17,11 @@ limitations under the License.
 package extraargs
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/k0sproject/k0s/inttest/common"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ExtraArgsSuite struct {
@@ -42,15 +40,7 @@ func (s *ExtraArgsSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see kube-router pods ready")
 	s.NoError(common.WaitForKubeRouterReady(kc), "kube-router did not start")

--- a/inttest/kine/kine_test.go
+++ b/inttest/kine/kine_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kine
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -26,7 +25,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/k0sproject/k0s/inttest/common"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type KineSuite struct {
@@ -47,15 +45,7 @@ func (s *KineSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady(s.WorkerNode(1), kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see CNI pods ready")
 	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "CNI did not start")

--- a/inttest/multicontroller/multicontroller_test.go
+++ b/inttest/multicontroller/multicontroller_test.go
@@ -17,14 +17,12 @@ limitations under the License.
 package multicontroller
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/k0sproject/k0s/inttest/common"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type MultiControllerSuite struct {
@@ -53,15 +51,7 @@ func (s *MultiControllerSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see CNI pods ready")
 	s.NoError(common.WaitForKubeRouterReady(kc), "CNI did not start")

--- a/inttest/psp/psp_test.go
+++ b/inttest/psp/psp_test.go
@@ -43,15 +43,7 @@ func (s *PSPSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady(s.ControllerNode(0), kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	ukc, err := s.UserKubeClient(s.ControllerNode(0))
 	s.NoError(err)

--- a/inttest/singlenode/singlenode_test.go
+++ b/inttest/singlenode/singlenode_test.go
@@ -52,15 +52,7 @@ func (s *SingleNodeSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady(s.ControllerNode(0), kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(s.Context(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see CNI pods ready")
 	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "CNI did not start")

--- a/inttest/upgrade/upgrade_test.go
+++ b/inttest/upgrade/upgrade_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package basic
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -25,8 +24,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/k0sproject/k0s/inttest/common"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type UpgradeSuite struct {
@@ -116,15 +113,7 @@ func (s *UpgradeSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady(s.WorkerNode(1), kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see kube-router pods ready")
 	s.NoError(common.WaitForKubeRouterReady(kc), "kube-router did not start")

--- a/inttest/workerrestart/workerrestart_test.go
+++ b/inttest/workerrestart/workerrestart_test.go
@@ -17,11 +17,9 @@ limitations under the License.
 package workerrestart
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/k0sproject/k0s/inttest/common"
 )
@@ -54,15 +52,7 @@ func (s *WorkerRestartSuite) TestK0sWorkerRestart() {
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
-		Limit: 100,
-	})
-	s.NoError(err)
-
-	podCount := len(pods.Items)
-
-	s.T().Logf("found %d pods in kube-system", podCount)
-	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
+	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see CNI pods ready")
 	s.NoError(common.WaitForKubeRouterReady(kc), "CNI did not start")


### PR DESCRIPTION
## Description

Checking whether some pods exist in the kube-system namespace is so common in the inttests that it warrants its own helper.

This eliminates some more usages of `context.Background()` / `context.TODO()` in the inttests and makes them better respond to test timeouts.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings