### PR TITLE
Inttests: Rename `WaitForKubeRouterReadyWithContext` to `WaitForKubeRouterReady`

### DIFF
--- a/inttest/airgap/airgap_test.go
+++ b/inttest/airgap/airgap_test.go
@@ -73,7 +73,7 @@ func (s *AirgapSuite) TestK0sGetsUp() {
 	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 	s.T().Log("waiting to see kube-router pods ready")
-	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "kube-router did not start")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "kube-router did not start")
 
 	// at that moment we can assume that all pods has at least started
 	events, err := kc.CoreV1().Events("kube-system").List(context.TODO(), v1.ListOptions{

--- a/inttest/backup/backup_test.go
+++ b/inttest/backup/backup_test.go
@@ -93,7 +93,7 @@ func (s *BackupSuite) TestK0sGetsUp() {
 	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 	s.T().Log("waiting to see kube-router pods ready")
-	s.Require().NoError(common.WaitForKubeRouterReady(kc), "kube-router did not start")
+	s.Require().NoError(common.WaitForKubeRouterReady(s.Context(), kc), "kube-router did not start")
 
 	s.Require().NoError(s.backupFunc())
 

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -79,7 +79,7 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 	s.T().Log("waiting to see kube-router pods ready")
-	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "kube-router did not start")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "kube-router did not start")
 
 	s.Require().NoError(s.checkCertPerms(s.ControllerNode(0)))
 	s.Require().NoError(s.checkCSRs(s.WorkerNode(0), kc))

--- a/inttest/byocri/byocri_test.go
+++ b/inttest/byocri/byocri_test.go
@@ -55,7 +55,7 @@ func (s *BYOCRISuite) TestK0sGetsUp() {
 	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 	s.T().Log("waiting to see CNI pods ready")
-	s.NoError(common.WaitForKubeRouterReady(kc), "CNI did not start")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "CNI did not start")
 }
 
 func (s *BYOCRISuite) runDockerWorker() error {

--- a/inttest/capitalhostnames/capitalhostnames_test.go
+++ b/inttest/capitalhostnames/capitalhostnames_test.go
@@ -58,7 +58,7 @@ func (s *CapitalHostnamesSuite) TestK0sGetsUp() {
 	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 	s.T().Log("waiting to see kube-router pods ready")
-	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "kube-router did not start")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "kube-router did not start")
 
 	// Test that we get logs, it's a signal that konnectivity tunnels work
 	s.T().Log("waiting to get logs from pods")

--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -118,7 +118,7 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 
 		// Wait till we see all pods running, otherwise we get into weird timing issues and high probability of leaked containerd shim processes
 		require.NoError(common.WaitForDaemonSet(s.Context(), kc, "kube-proxy"))
-		require.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc))
+		require.NoError(common.WaitForKubeRouterReady(s.Context(), kc))
 		require.NoError(common.WaitForDeploymentWithContext(s.Context(), kc, "coredns"))
 
 		// Check that the kubelet extra flags are properly set

--- a/inttest/common/util.go
+++ b/inttest/common/util.go
@@ -45,20 +45,9 @@ func Poll(ctx context.Context, condition wait.ConditionWithContextFunc) error {
 	return wait.PollImmediateUntilWithContext(ctx, 100*time.Millisecond, condition)
 }
 
-func fallbackContext() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.TODO(), 5*time.Minute)
-}
-
-// WaitForKubeRouterReady waits to see all kube-router pods healthy.
-func WaitForKubeRouterReady(kc *kubernetes.Clientset) error {
-	ctx, cancel := fallbackContext()
-	defer cancel()
-	return WaitForKubeRouterReadyWithContext(ctx, kc)
-}
-
 // WaitForKubeRouterReady waits to see all kube-router pods healthy as long as
 // the context isn't canceled.
-func WaitForKubeRouterReadyWithContext(ctx context.Context, kc *kubernetes.Clientset) error {
+func WaitForKubeRouterReady(ctx context.Context, kc *kubernetes.Clientset) error {
 	return WaitForDaemonSet(ctx, kc, "kube-router")
 }
 

--- a/inttest/configchange/config_test.go
+++ b/inttest/configchange/config_test.go
@@ -63,7 +63,7 @@ func (s *ConfigSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady(s.WorkerNode(1), kc)
 	s.NoError(err)
 	s.T().Log("waiting to see kube-router pods ready")
-	s.NoError(common.WaitForKubeRouterReady(kc), "kube-router did not start")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "kube-router did not start")
 
 	// Cluster is up-and-running, we can now start testing the config changes
 

--- a/inttest/customdomain/customdomain_test.go
+++ b/inttest/customdomain/customdomain_test.go
@@ -56,7 +56,7 @@ func (s *CustomDomainSuite) TestK0sGetsUpWithCustomDomain() {
 	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 	s.T().Log("waiting to see CNI pods ready")
-	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "CNI did not start")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "CNI did not start")
 
 	s.T().Run("check custom domain existence in pod", func(t *testing.T) {
 		// All done via SSH as it's much simpler :)

--- a/inttest/customports/customports_test.go
+++ b/inttest/customports/customports_test.go
@@ -130,7 +130,7 @@ func (ds *Suite) TestControllerJoinsWithCustomPort() {
 	ds.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 	ds.T().Log("waiting to see CNI pods ready")
-	ds.Require().NoError(common.WaitForKubeRouterReady(kc), "calico did not start")
+	ds.Require().NoError(common.WaitForKubeRouterReady(ds.Context(), kc), "calico did not start")
 	ds.T().Log("waiting to see konnectivity-agent pods ready")
 	ds.Require().NoError(common.WaitForDaemonSet(ds.Context(), kc, "konnectivity-agent"), "konnectivity-agent did not start")
 

--- a/inttest/extraargs/extraargs_test.go
+++ b/inttest/extraargs/extraargs_test.go
@@ -53,7 +53,7 @@ func (s *ExtraArgsSuite) TestK0sGetsUp() {
 	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 	s.T().Log("waiting to see kube-router pods ready")
-	s.NoError(common.WaitForKubeRouterReady(kc), "kube-router did not start")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "kube-router did not start")
 
 }
 

--- a/inttest/kine/kine_test.go
+++ b/inttest/kine/kine_test.go
@@ -58,7 +58,7 @@ func (s *KineSuite) TestK0sGetsUp() {
 	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 	s.T().Log("waiting to see CNI pods ready")
-	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "CNI did not start")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "CNI did not start")
 
 	s.T().Run("verify", func(t *testing.T) {
 		ssh, err := s.SSH(s.ControllerNode(0))

--- a/inttest/kuberouter/kuberouter_hairpin_test.go
+++ b/inttest/kuberouter/kuberouter_hairpin_test.go
@@ -49,7 +49,7 @@ func (s *KubeRouterHairpinSuite) TestK0sGetsUp() {
 	s.NoError(err)
 
 	s.T().Log("waiting to see kube-router pods ready")
-	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "kube-router did not start")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "kube-router did not start")
 
 	s.T().Log("waiting to see hairpin pod ready")
 	err = common.WaitForPod(s.Context(), kc, "hairpin-pod", "default")

--- a/inttest/multicontroller/multicontroller_test.go
+++ b/inttest/multicontroller/multicontroller_test.go
@@ -64,7 +64,7 @@ func (s *MultiControllerSuite) TestK0sGetsUp() {
 	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 	s.T().Log("waiting to see CNI pods ready")
-	s.NoError(common.WaitForKubeRouterReady(kc), "CNI did not start")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "CNI did not start")
 }
 
 func TestMultiControllerSuite(t *testing.T) {

--- a/inttest/singlenode/singlenode_test.go
+++ b/inttest/singlenode/singlenode_test.go
@@ -63,7 +63,7 @@ func (s *SingleNodeSuite) TestK0sGetsUp() {
 	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 	s.T().Log("waiting to see CNI pods ready")
-	s.NoError(common.WaitForKubeRouterReadyWithContext(s.Context(), kc), "CNI did not start")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "CNI did not start")
 
 	s.T().Run("verify", func(t *testing.T) {
 		ssh, err := s.SSH(s.ControllerNode(0))

--- a/inttest/upgrade/upgrade_test.go
+++ b/inttest/upgrade/upgrade_test.go
@@ -127,7 +127,7 @@ func (s *UpgradeSuite) TestK0sGetsUp() {
 	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 	s.T().Log("waiting to see kube-router pods ready")
-	s.NoError(common.WaitForKubeRouterReady(kc), "kube-router did not start")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "kube-router did not start")
 
 	// Prev version gets up, let's upgrade everything
 	// Upgrade is just swapping the bin and restarting

--- a/inttest/workerrestart/workerrestart_test.go
+++ b/inttest/workerrestart/workerrestart_test.go
@@ -65,7 +65,7 @@ func (s *WorkerRestartSuite) TestK0sWorkerRestart() {
 	s.Greater(podCount, 0, "expecting to see few pods in kube-system namespace")
 
 	s.T().Log("waiting to see CNI pods ready")
-	s.NoError(common.WaitForKubeRouterReady(kc), "CNI did not start")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "CNI did not start")
 }
 
 func TestWorkerRestartSuite(t *testing.T) {


### PR DESCRIPTION
## Description

Add the context to all call sites that were using the old `WaitForKubeRouterReady` so far.

This eliminates some more usages of `context.Background()` / `context.TODO()` in the inttests and makes them better respond to test timeouts.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings