### PR TITLE
Use test context everywhere in inttests

### DIFF
--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -18,7 +18,6 @@ package addons
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -83,7 +82,7 @@ func (as *AddonsSuite) doPrometheusDelete(chart *v1beta1.Chart) {
 	as.Require().NoError(err)
 	as.Require().NoError(wait.PollImmediate(time.Second, 5*time.Minute, func() (done bool, err error) {
 		as.T().Logf("Expecting have no secrets left for release %s/%s", chart.Namespace, chart.Name)
-		items, err := k8sclient.CoreV1().Secrets("default").List(context.Background(), v1.ListOptions{})
+		items, err := k8sclient.CoreV1().Secrets("default").List(as.Context(), v1.ListOptions{})
 		if err != nil {
 			as.T().Logf("listing secrets error %s", err.Error())
 			return false, nil
@@ -109,7 +108,7 @@ func (as *AddonsSuite) waitForTestRelease(addonName, appVersion string, rev int6
 	as.Require().NoError(err)
 	var chart v1beta1.Chart
 	as.Require().NoError(wait.PollImmediate(time.Second, 5*time.Minute, func() (done bool, err error) {
-		err = chartClient.Get(context.Background(), client.ObjectKey{
+		err = chartClient.Get(as.Context(), client.ObjectKey{
 			Namespace: "kube-system",
 			Name:      fmt.Sprintf("k0s-addon-chart-%s", addonName),
 		}, &chart)
@@ -148,7 +147,7 @@ func (as *AddonsSuite) checkCustomValues(releaseName string) error {
 	}
 	return wait.PollImmediate(time.Second, 2*time.Minute, func() (done bool, err error) {
 		serverDeployment := fmt.Sprintf("%s-echo-server", releaseName)
-		d, err := kc.AppsV1().Deployments("default").Get(context.TODO(), serverDeployment, v1.GetOptions{})
+		d, err := kc.AppsV1().Deployments("default").Get(as.Context(), serverDeployment, v1.GetOptions{})
 		if err != nil {
 			return false, nil
 		}

--- a/inttest/airgap/airgap_test.go
+++ b/inttest/airgap/airgap_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package airgap
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -68,7 +67,7 @@ func (s *AirgapSuite) TestK0sGetsUp() {
 	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "kube-router did not start")
 
 	// at that moment we can assume that all pods has at least started
-	events, err := kc.CoreV1().Events("kube-system").List(context.TODO(), v1.ListOptions{
+	events, err := kc.CoreV1().Events("kube-system").List(s.Context(), v1.ListOptions{
 		Limit: 100,
 	})
 	s.NoError(err)

--- a/inttest/ap-airgap/airgap_test.go
+++ b/inttest/ap-airgap/airgap_test.go
@@ -15,7 +15,6 @@
 package airgap
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -58,9 +57,9 @@ func (s *airgapSuite) SetupTest() {
 	cClient, err := s.ExtensionsClient(s.ControllerNode(0))
 	s.Require().NoError(err)
 
-	_, perr := apcomm.WaitForCRDByName(context.TODO(), cClient, "plans.autopilot.k0sproject.io", 2*time.Minute)
+	_, perr := apcomm.WaitForCRDByName(s.Context(), cClient, "plans.autopilot.k0sproject.io", 2*time.Minute)
 	s.Require().NoError(perr)
-	_, cerr := apcomm.WaitForCRDByName(context.TODO(), cClient, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
+	_, cerr := apcomm.WaitForCRDByName(s.Context(), cClient, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
 	s.Require().NoError(cerr)
 
 	// Create a worker join token

--- a/inttest/ap-ha3x3/ha3x3_test.go
+++ b/inttest/ap-ha3x3/ha3x3_test.go
@@ -15,7 +15,6 @@
 package ha3x3
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -72,9 +71,9 @@ func (s *ha3x3Suite) SetupTest() {
 		client, err := s.ExtensionsClient(s.ControllerNode(0))
 		s.Require().NoError(err)
 
-		_, perr := apcomm.WaitForCRDByName(context.TODO(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
+		_, perr := apcomm.WaitForCRDByName(s.Context(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
 		s.Require().NoError(perr)
-		_, cerr := apcomm.WaitForCRDByName(context.TODO(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
+		_, cerr := apcomm.WaitForCRDByName(s.Context(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
 		s.Require().NoError(cerr)
 
 		// With the primary controller running, create the join token for subsequent controllers.

--- a/inttest/ap-platformselect/platformselect_test.go
+++ b/inttest/ap-platformselect/platformselect_test.go
@@ -15,7 +15,6 @@
 package platformselect
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -45,9 +44,9 @@ func (s *platformSelectSuite) SetupTest() {
 	client, err := s.ExtensionsClient(s.ControllerNode(0))
 	s.Require().NoError(err)
 
-	_, perr := apcomm.WaitForCRDByName(context.TODO(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
+	_, perr := apcomm.WaitForCRDByName(s.Context(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
 	s.Require().NoError(perr)
-	_, cerr := apcomm.WaitForCRDByName(context.TODO(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
+	_, cerr := apcomm.WaitForCRDByName(s.Context(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
 	s.Require().NoError(cerr)
 }
 

--- a/inttest/ap-quorum/quorum_test.go
+++ b/inttest/ap-quorum/quorum_test.go
@@ -15,7 +15,6 @@
 package quorum
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -72,9 +71,9 @@ func (s *quorumSuite) SetupTest() {
 		client, err := s.ExtensionsClient(s.ControllerNode(0))
 		s.Require().NoError(err)
 
-		_, perr := apcomm.WaitForCRDByName(context.TODO(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
+		_, perr := apcomm.WaitForCRDByName(s.Context(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
 		s.Require().NoError(perr)
-		_, cerr := apcomm.WaitForCRDByName(context.TODO(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
+		_, cerr := apcomm.WaitForCRDByName(s.Context(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
 		s.Require().NoError(cerr)
 
 		// With the primary controller running, create the join token for subsequent controllers.

--- a/inttest/ap-quorumsafety/quorumsafety_test.go
+++ b/inttest/ap-quorumsafety/quorumsafety_test.go
@@ -15,7 +15,6 @@
 package quorumsafety
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -72,9 +71,9 @@ func (s *quorumSafetySuite) SetupTest() {
 		client, err := s.ExtensionsClient(s.ControllerNode(0))
 		s.Require().NoError(err)
 
-		_, perr := apcomm.WaitForCRDByName(context.TODO(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
+		_, perr := apcomm.WaitForCRDByName(s.Context(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
 		s.Require().NoError(perr)
-		_, cerr := apcomm.WaitForCRDByName(context.TODO(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
+		_, cerr := apcomm.WaitForCRDByName(s.Context(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
 		s.Require().NoError(cerr)
 
 		// With the primary controller running, create the join token for subsequent controllers.

--- a/inttest/ap-removedapis/removedapis_test.go
+++ b/inttest/ap-removedapis/removedapis_test.go
@@ -15,7 +15,6 @@
 package removedapis
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -48,14 +47,14 @@ func (s *plansRemovedAPIsSuite) SetupTest() {
 	client, err := s.ExtensionsClient(s.ControllerNode(0))
 	s.Require().NoError(err)
 
-	_, err = apcomm.WaitForCRDByName(context.TODO(), client, "k0s-tests.k0s.k0sproject.io", 2*time.Minute)
+	_, err = apcomm.WaitForCRDByName(s.Context(), client, "k0s-tests.k0s.k0sproject.io", 2*time.Minute)
 	s.Require().NoError(err)
 
 	s.PutFile(s.ControllerNode(0), "/var/lib/k0s/manifests/test/test.yaml", testManifest)
 
-	_, perr := apcomm.WaitForCRDByName(context.TODO(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
+	_, perr := apcomm.WaitForCRDByName(s.Context(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
 	s.Require().NoError(perr)
-	_, cerr := apcomm.WaitForCRDByName(context.TODO(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
+	_, cerr := apcomm.WaitForCRDByName(s.Context(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
 	s.Require().NoError(cerr)
 }
 

--- a/inttest/ap-selector/selector_test.go
+++ b/inttest/ap-selector/selector_test.go
@@ -15,7 +15,6 @@
 package selector
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -72,9 +71,9 @@ func (s *selectorSuite) SetupTest() {
 		client, err := s.ExtensionsClient(s.ControllerNode(0))
 		s.Require().NoError(err)
 
-		_, perr := apcomm.WaitForCRDByName(context.TODO(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
+		_, perr := apcomm.WaitForCRDByName(s.Context(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
 		s.Require().NoError(perr)
-		_, cerr := apcomm.WaitForCRDByName(context.TODO(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
+		_, cerr := apcomm.WaitForCRDByName(s.Context(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
 		s.Require().NoError(cerr)
 
 		// With the primary controller running, create the join token for subsequent controllers.

--- a/inttest/ap-single/single_test.go
+++ b/inttest/ap-single/single_test.go
@@ -15,7 +15,6 @@
 package single
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -49,9 +48,9 @@ func (s *plansSingleControllerSuite) SetupTest() {
 	client, err := s.ExtensionsClient(s.ControllerNode(0))
 	s.Require().NoError(err)
 
-	_, perr := apcomm.WaitForCRDByName(context.TODO(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
+	_, perr := apcomm.WaitForCRDByName(s.Context(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
 	s.Require().NoError(perr)
-	_, cerr := apcomm.WaitForCRDByName(context.TODO(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
+	_, cerr := apcomm.WaitForCRDByName(s.Context(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
 	s.Require().NoError(cerr)
 }
 

--- a/inttest/ap-updater/updater_test.go
+++ b/inttest/ap-updater/updater_test.go
@@ -15,7 +15,6 @@
 package updater
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -49,11 +48,11 @@ func (s *plansSingleControllerSuite) SetupTest() {
 	client, err := s.ExtensionsClient(s.ControllerNode(0))
 	s.Require().NoError(err)
 
-	_, perr := apcomm.WaitForCRDByName(context.TODO(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
+	_, perr := apcomm.WaitForCRDByName(s.Context(), client, "plans.autopilot.k0sproject.io", 2*time.Minute)
 	s.Require().NoError(perr)
-	_, cerr := apcomm.WaitForCRDByName(context.TODO(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
+	_, cerr := apcomm.WaitForCRDByName(s.Context(), client, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
 	s.Require().NoError(cerr)
-	_, uerr := apcomm.WaitForCRDByName(context.TODO(), client, "updateconfigs.autopilot.k0sproject.io", 2*time.Minute)
+	_, uerr := apcomm.WaitForCRDByName(s.Context(), client, "updateconfigs.autopilot.k0sproject.io", 2*time.Minute)
 	s.Require().NoError(uerr)
 }
 

--- a/inttest/backup/backup_test.go
+++ b/inttest/backup/backup_test.go
@@ -18,7 +18,6 @@ package basic
 
 import (
 	"bytes"
-	"context"
 	"html/template"
 	"testing"
 
@@ -129,7 +128,7 @@ type snapshot struct {
 func (s *BackupSuite) makeSnapshot(kc *kubernetes.Clientset) snapshot {
 	// Take some UIDs to be able to verify state has restored properly
 	namespaces := make(map[types.UID]string)
-	nsList, err := kc.CoreV1().Namespaces().List(context.TODO(), v1.ListOptions{})
+	nsList, err := kc.CoreV1().Namespaces().List(s.Context(), v1.ListOptions{})
 	s.Require().NoError(err)
 	for _, n := range nsList.Items {
 		namespaces[n.ObjectMeta.UID] = n.Name
@@ -137,13 +136,13 @@ func (s *BackupSuite) makeSnapshot(kc *kubernetes.Clientset) snapshot {
 
 	services := make(map[types.UID]string)
 	{
-		svc, err := kc.CoreV1().Services("default").Get(context.TODO(), "kubernetes", v1.GetOptions{})
+		svc, err := kc.CoreV1().Services("default").Get(s.Context(), "kubernetes", v1.GetOptions{})
 		s.Require().NoError(err)
 		services[svc.ObjectMeta.UID] = svc.Name
 	}
 
 	nodes := make(map[types.UID]string)
-	nodeList, err := kc.CoreV1().Nodes().List(context.TODO(), v1.ListOptions{})
+	nodeList, err := kc.CoreV1().Nodes().List(s.Context(), v1.ListOptions{})
 	s.Require().NoError(err)
 	for _, n := range nodeList.Items {
 		nodes[n.ObjectMeta.UID] = n.Name

--- a/inttest/configchange/config_test.go
+++ b/inttest/configchange/config_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package configchange
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -72,18 +71,18 @@ func (s *ConfigSuite) TestK0sGetsUp() {
 	cfgClient, err := s.getConfigClient()
 	s.Require().NoError(err)
 
-	eventWatch, err := kc.CoreV1().Events("kube-system").Watch(context.Background(), metav1.ListOptions{FieldSelector: "involvedObject.name=k0s"})
+	eventWatch, err := kc.CoreV1().Events("kube-system").Watch(s.Context(), metav1.ListOptions{FieldSelector: "involvedObject.name=k0s"})
 	s.NoError(err)
 	defer eventWatch.Stop()
 
 	s.T().Run("changing cni should fail", func(t *testing.T) {
-		originalConfig, err := cfgClient.Get(context.Background(), "k0s", metav1.GetOptions{})
+		originalConfig, err := cfgClient.Get(s.Context(), "k0s", metav1.GetOptions{})
 		s.NoError(err)
 		newConfig := originalConfig.DeepCopy()
 		newConfig.Spec.Network.Provider = constant.CNIProviderCalico
 		newConfig.Spec.Network.Calico = v1beta1.DefaultCalico()
 		newConfig.Spec.Network.KubeRouter = nil
-		_, err = cfgClient.Update(context.Background(), newConfig, metav1.UpdateOptions{})
+		_, err = cfgClient.Update(s.Context(), newConfig, metav1.UpdateOptions{})
 		s.NoError(err)
 
 		// Check that we see proper event for failed reconcile
@@ -96,12 +95,12 @@ func (s *ConfigSuite) TestK0sGetsUp() {
 	})
 
 	s.T().Run("setting bad ip address should fail", func(t *testing.T) {
-		originalConfig, err := cfgClient.Get(context.Background(), "k0s", metav1.GetOptions{})
+		originalConfig, err := cfgClient.Get(s.Context(), "k0s", metav1.GetOptions{})
 		s.NoError(err)
 		newConfig := originalConfig.DeepCopy()
 		newConfig.Spec.Network = v1beta1.DefaultNetwork()
 		newConfig.Spec.Network.PodCIDR = "invalid ip address"
-		_, err = cfgClient.Update(context.Background(), newConfig, metav1.UpdateOptions{})
+		_, err = cfgClient.Update(s.Context(), newConfig, metav1.UpdateOptions{})
 		s.NoError(err)
 
 		// Check that we see proper event for failed reconcile
@@ -114,7 +113,7 @@ func (s *ConfigSuite) TestK0sGetsUp() {
 	})
 
 	s.T().Run("changing kuberouter MTU should work", func(t *testing.T) {
-		originalConfig, err := cfgClient.Get(context.Background(), "k0s", metav1.GetOptions{})
+		originalConfig, err := cfgClient.Get(s.Context(), "k0s", metav1.GetOptions{})
 		s.NoError(err)
 		newConfig := originalConfig.DeepCopy()
 		newConfig.Spec.Network = v1beta1.DefaultNetwork()
@@ -122,12 +121,12 @@ func (s *ConfigSuite) TestK0sGetsUp() {
 		newConfig.Spec.Network.KubeRouter.MTU = 1300
 
 		// Get the resource version for current kuberouter configmap
-		cml, err := kc.CoreV1().ConfigMaps("kube-system").List(context.Background(), metav1.ListOptions{
+		cml, err := kc.CoreV1().ConfigMaps("kube-system").List(s.Context(), metav1.ListOptions{
 			FieldSelector: fields.OneTermEqualSelector("metadata.name", "kube-router-cfg").String(),
 		})
 		s.NoError(err)
 
-		_, err = cfgClient.Update(context.Background(), newConfig, metav1.UpdateOptions{})
+		_, err = cfgClient.Update(s.Context(), newConfig, metav1.UpdateOptions{})
 		s.NoError(err)
 		event, err := s.waitForReconcileEvent(eventWatch)
 		s.NoError(err)
@@ -137,7 +136,7 @@ func (s *ConfigSuite) TestK0sGetsUp() {
 		// Verify MTU setting have been propagated properly
 		// It takes a while to actually apply the changes through stack applier
 		// Start the watch only from last version so we only get changed cm(s) and not the original one
-		w, err := kc.CoreV1().ConfigMaps("kube-system").Watch(context.Background(), metav1.ListOptions{
+		w, err := kc.CoreV1().ConfigMaps("kube-system").Watch(s.Context(), metav1.ListOptions{
 			FieldSelector:   fields.OneTermEqualSelector("metadata.name", "kube-router-cfg").String(),
 			ResourceVersion: cml.ResourceVersion,
 		})
@@ -168,7 +167,7 @@ func (s *ConfigSuite) waitForReconcileEvent(eventWatch watch.Interface) (*corev1
 }
 
 func (s *ConfigSuite) clearConfigEvents(kc *kubernetes.Clientset) error {
-	return kc.CoreV1().Events("kube-system").DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{FieldSelector: "involvedObject.name=k0s"})
+	return kc.CoreV1().Events("kube-system").DeleteCollection(s.Context(), metav1.DeleteOptions{}, metav1.ListOptions{FieldSelector: "involvedObject.name=k0s"})
 }
 
 // Get the ClusterConfig client from the controller node's kubeconfig.

--- a/inttest/defaultstorage/defaultstorage_test.go
+++ b/inttest/defaultstorage/defaultstorage_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package defaultstorage
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -49,7 +48,7 @@ func (s *DefaultStorageSuite) TestK0sGetsUp() {
 
 	s.AssertSomeKubeSystemPods(kc)
 
-	pv, err := kc.CoreV1().PersistentVolumes().List(context.TODO(), v1.ListOptions{})
+	pv, err := kc.CoreV1().PersistentVolumes().List(s.Context(), v1.ListOptions{})
 	s.NoError(err)
 	s.Greater(len(pv.Items), 0, "At least one persistent volume must be created for the deployment with claims")
 }

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -24,7 +24,6 @@ package dualstack
 // have proper values for spec.PodCIDRs
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -44,7 +43,7 @@ type DualstackSuite struct {
 }
 
 func (s *DualstackSuite) TestDualStackNodesHavePodCIDRs() {
-	nl, err := s.client.CoreV1().Nodes().List(context.Background(), v1meta.ListOptions{})
+	nl, err := s.client.CoreV1().Nodes().List(s.Context(), v1meta.ListOptions{})
 	s.Require().NoError(err)
 	for _, n := range nl.Items {
 		s.Require().Len(n.Spec.PodCIDRs, 2, "Each node must have ipv4 and ipv6 pod cidr")

--- a/inttest/k0scloudprovider/k0scloudprovider_test.go
+++ b/inttest/k0scloudprovider/k0scloudprovider_test.go
@@ -60,9 +60,9 @@ type nodeAddValueFunc func(node string, kc *kubernetes.Clientset, key string, va
 // nodeAddValueHelper provides all of the callback functions needed to test
 // the addition of addresses into the provider (pre, add, post)
 type nodeAddValueHelper struct {
-	addressFoundPre  func(kc *kubernetes.Clientset, node string, addr string, addrType v1.NodeAddressType) (bool, error)
+	addressFoundPre  func(ctx context.Context, kc *kubernetes.Clientset, node string, addr string, addrType v1.NodeAddressType) (bool, error)
 	addressAdd       nodeAddValueFunc
-	addressFoundPost func(kc *kubernetes.Clientset, node string, addr string, addrType v1.NodeAddressType) (bool, error)
+	addressFoundPost func(ctx context.Context, kc *kubernetes.Clientset, node string, addr string, addrType v1.NodeAddressType) (bool, error)
 }
 
 // defaultNodeAddValueHelper creates a nodeAddValueHelper using the provided
@@ -80,7 +80,7 @@ func defaultNodeAddValueHelper(adder nodeAddValueFunc) nodeAddValueHelper {
 func (s *K0sCloudProviderSuite) testAddAddress(kc *kubernetes.Clientset, node string, addr string, helper nodeAddValueHelper) {
 	s.T().Logf("Testing add address - node=%s, addr=%s", node, addr)
 
-	addrFound, err := helper.addressFoundPre(kc, node, addr, v1.NodeExternalIP)
+	addrFound, err := helper.addressFoundPre(s.Context(), kc, node, addr, v1.NodeExternalIP)
 	s.Require().NoError(err)
 	s.Require().False(addrFound, "ExternalIP=%s already exists on node=%s", addr, node)
 
@@ -97,15 +97,15 @@ func (s *K0sCloudProviderSuite) testAddAddress(kc *kubernetes.Clientset, node st
 
 	// Need to ensure that a matching 'ExternalIP' address has been added, indicating that
 	// k0s-cloud-provider properly processed the annotation.
-	foundPostUpdate, err := helper.addressFoundPost(kc, node, addr, v1.NodeExternalIP)
+	foundPostUpdate, err := helper.addressFoundPost(s.Context(), kc, node, addr, v1.NodeExternalIP)
 	s.Require().NoError(err)
 	s.Require().True(foundPostUpdate, "unable to find ExternalIP=%s on node=%s", addr, node)
 }
 
 // nodeHasAddressWithType is a helper for fetching all of the addresses associated to
 // the provided node, and asserting that an IP matches by address + type.
-func nodeHasAddressWithType(kc *kubernetes.Clientset, node string, addr string, addrType v1.NodeAddressType) (bool, error) {
-	n, err := kc.CoreV1().Nodes().Get(context.TODO(), node, metav1.GetOptions{})
+func nodeHasAddressWithType(ctx context.Context, kc *kubernetes.Clientset, node string, addr string, addrType v1.NodeAddressType) (bool, error) {
+	n, err := kc.CoreV1().Nodes().Get(ctx, node, metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}

--- a/inttest/kubeletcertrotate/kubeletcertrotate_test.go
+++ b/inttest/kubeletcertrotate/kubeletcertrotate_test.go
@@ -15,7 +15,6 @@
 package kubeletcertrotate
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -64,9 +63,9 @@ func (s *kubeletCertRotateSuite) SetupTest() {
 	extClient, err := s.ExtensionsClient(s.ControllerNode(0))
 	s.Require().NoError(err)
 
-	_, perr := apcomm.WaitForCRDByName(context.TODO(), extClient, "plans.autopilot.k0sproject.io", 2*time.Minute)
+	_, perr := apcomm.WaitForCRDByName(s.Context(), extClient, "plans.autopilot.k0sproject.io", 2*time.Minute)
 	s.Require().NoError(perr)
-	_, cerr := apcomm.WaitForCRDByName(context.TODO(), extClient, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
+	_, cerr := apcomm.WaitForCRDByName(s.Context(), extClient, "controlnodes.autopilot.k0sproject.io", 2*time.Minute)
 	s.Require().NoError(cerr)
 
 	// Create a worker join token

--- a/inttest/metricscraper/metricscraper_test.go
+++ b/inttest/metricscraper/metricscraper_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package metricscraper
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -56,7 +55,7 @@ func (s *MetricScraperSuite) waitForPushgateway() error {
 	}
 
 	return wait.PollImmediate(time.Second, 2*time.Minute, func() (done bool, err error) {
-		pods, err := kc.CoreV1().Pods("k0s-system").List(context.TODO(), v1.ListOptions{})
+		pods, err := kc.CoreV1().Pods("k0s-system").List(s.Context(), v1.ListOptions{})
 		if err != nil {
 			return false, nil
 		}
@@ -81,7 +80,7 @@ func (s *MetricScraperSuite) waitForMetrics() error {
 
 	return wait.PollImmediate(time.Second*5, 2*time.Minute, func() (done bool, err error) {
 
-		b, err := kc.RESTClient().Get().AbsPath("/api/v1/namespaces/k0s-system/services/http:k0s-pushgateway:http/proxy/metrics").DoRaw(context.Background())
+		b, err := kc.RESTClient().Get().AbsPath("/api/v1/namespaces/k0s-system/services/http:k0s-pushgateway:http/proxy/metrics").DoRaw(s.Context())
 		if err != nil {
 			return false, nil
 		}

--- a/inttest/noderole-no-taints/noderole_no_taints_test.go
+++ b/inttest/noderole-no-taints/noderole_no_taints_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package noderole
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -52,18 +51,18 @@ func (s *NodeRoleNoTaintsSuite) TestK0sNoTaints() {
 	err = s.WaitForNodeLabel(kc, s.ControllerNode(0), "node-role.kubernetes.io/control-plane", "true")
 	s.NoError(err)
 
-	n, err := kc.CoreV1().Nodes().Get(context.TODO(), s.ControllerNode(0), v1.GetOptions{})
+	n, err := kc.CoreV1().Nodes().Get(s.Context(), s.ControllerNode(0), v1.GetOptions{})
 	s.NoError(err)
 	s.NotContains(n.Spec.Taints, corev1.Taint{Key: "node-role.kubernetes.io/master", Effect: "NoSchedule"})
 
 	err = s.WaitForNodeLabel(kc, s.ControllerNode(1), "node-role.kubernetes.io/control-plane", "true")
 	s.NoError(err)
 
-	n, err = kc.CoreV1().Nodes().Get(context.TODO(), s.ControllerNode(1), v1.GetOptions{})
+	n, err = kc.CoreV1().Nodes().Get(s.Context(), s.ControllerNode(1), v1.GetOptions{})
 	s.NoError(err)
 	s.NotContains(n.Spec.Taints, corev1.Taint{Key: "node-role.kubernetes.io/master", Effect: "NoSchedule"})
 
-	n, err = kc.CoreV1().Nodes().Get(context.TODO(), s.WorkerNode(0), v1.GetOptions{})
+	n, err = kc.CoreV1().Nodes().Get(s.Context(), s.WorkerNode(0), v1.GetOptions{})
 	s.NoError(err)
 	s.NotContains(n.Labels, map[string]string{"node-role.kubernetes.io/master": "NoSchedule"})
 }

--- a/inttest/noderole-single/noderole_single_test.go
+++ b/inttest/noderole-single/noderole_single_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package noderole
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -41,7 +40,7 @@ func (s *NodeRoleSingleSuite) TestK0sSingleNode() {
 	err = s.WaitForNodeLabel(kc, s.ControllerNode(0), "node-role.kubernetes.io/control-plane", "true")
 	s.NoError(err)
 
-	n, err := kc.CoreV1().Nodes().Get(context.TODO(), s.ControllerNode(0), v1.GetOptions{})
+	n, err := kc.CoreV1().Nodes().Get(s.Context(), s.ControllerNode(0), v1.GetOptions{})
 	s.NoError(err)
 	s.NotContains(n.Spec.Taints, corev1.Taint{Key: "node-role.kubernetes.io/master", Effect: "NoSchedule"})
 }

--- a/inttest/noderole/noderole_test.go
+++ b/inttest/noderole/noderole_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package noderole
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -52,18 +51,18 @@ func (s *NodeRoleSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeLabel(kc, s.ControllerNode(0), "node-role.kubernetes.io/control-plane", "true")
 	s.NoError(err)
 
-	n, err := kc.CoreV1().Nodes().Get(context.TODO(), s.ControllerNode(0), v1.GetOptions{})
+	n, err := kc.CoreV1().Nodes().Get(s.Context(), s.ControllerNode(0), v1.GetOptions{})
 	s.NoError(err)
 	s.Contains(n.Spec.Taints, corev1.Taint{Key: "node-role.kubernetes.io/master", Effect: "NoSchedule"})
 
 	err = s.WaitForNodeLabel(kc, s.ControllerNode(1), "node-role.kubernetes.io/control-plane", "true")
 	s.NoError(err)
 
-	n, err = kc.CoreV1().Nodes().Get(context.TODO(), s.ControllerNode(1), v1.GetOptions{})
+	n, err = kc.CoreV1().Nodes().Get(s.Context(), s.ControllerNode(1), v1.GetOptions{})
 	s.NoError(err)
 	s.Contains(n.Spec.Taints, corev1.Taint{Key: "node-role.kubernetes.io/master", Effect: "NoSchedule"})
 
-	n, err = kc.CoreV1().Nodes().Get(context.TODO(), s.WorkerNode(0), v1.GetOptions{})
+	n, err = kc.CoreV1().Nodes().Get(s.Context(), s.WorkerNode(0), v1.GetOptions{})
 	s.NoError(err)
 	s.NotContains(n.Labels, map[string]string{"node-role.kubernetes.io/master": "NoSchedule"})
 }

--- a/inttest/psp/psp_test.go
+++ b/inttest/psp/psp_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package psp
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -65,7 +64,7 @@ func (s *PSPSuite) TestK0sGetsUp() {
 		},
 	}
 
-	_, err = ukc.CoreV1().Pods("default").Create(context.TODO(), nonPrivelegedPodReq, v1.CreateOptions{})
+	_, err = ukc.CoreV1().Pods("default").Create(s.Context(), nonPrivelegedPodReq, v1.CreateOptions{})
 	s.NoError(err)
 
 	privelegedPodReq := &corev1.Pod{
@@ -84,7 +83,7 @@ func (s *PSPSuite) TestK0sGetsUp() {
 		},
 	}
 
-	_, err = ukc.CoreV1().Pods("default").Create(context.TODO(), privelegedPodReq, v1.CreateOptions{})
+	_, err = ukc.CoreV1().Pods("default").Create(s.Context(), privelegedPodReq, v1.CreateOptions{})
 	s.NoError(err)
 }
 

--- a/inttest/tunneledkas/suite_test.go
+++ b/inttest/tunneledkas/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tunneledkas
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -54,16 +53,16 @@ func (s *Suite) TestK0sTunneledKasMode() {
 	s.NoError(err)
 	err = s.WaitForNodeReady(s.WorkerNode(1), kc)
 	s.NoError(err)
-	eps, err := kc.CoreV1().Endpoints("default").Get(context.Background(), "kubernetes", v1.GetOptions{})
+	eps, err := kc.CoreV1().Endpoints("default").Get(s.Context(), "kubernetes", v1.GetOptions{})
 	s.NoError(err)
 
-	nodes, err := kc.CoreV1().Nodes().List(context.Background(), v1.ListOptions{})
+	nodes, err := kc.CoreV1().Nodes().List(s.Context(), v1.ListOptions{})
 	s.NoError(err)
 
 	s.Assert().Equal(1, len(eps.Subsets))
 	s.Assert().Equal(len(nodes.Items), len(eps.Subsets[0].Addresses))
 
-	svc, err := kc.CoreV1().Services("default").Get(context.Background(), "kubernetes", v1.GetOptions{})
+	svc, err := kc.CoreV1().Services("default").Get(s.Context(), "kubernetes", v1.GetOptions{})
 	s.NoError(err)
 	s.Equal("Local", string(*svc.Spec.InternalTrafficPolicy))
 
@@ -79,7 +78,7 @@ func (s *Suite) TestK0sTunneledKasMode() {
 		kubeConfig.Host = fmt.Sprintf("https://%s:6443", addr.IP)
 		nodeLocalClient, err := kubernetes.NewForConfig(kubeConfig)
 		s.Require().NoError(err)
-		_, err = nodeLocalClient.CoreV1().Nodes().List(context.Background(), v1.ListOptions{})
+		_, err = nodeLocalClient.CoreV1().Nodes().List(s.Context(), v1.ListOptions{})
 		s.Require().NoError(err)
 	}
 }


### PR DESCRIPTION
## Description

This eliminates some more usages of `context.Background()` / `context.TODO()` in the inttests and makes them better respond to test timeouts.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings