### PR TITLE
Add context to ToolSuite in inttests

### DIFF
--- a/inttest/toolsuite/operations/planapply.go
+++ b/inttest/toolsuite/operations/planapply.go
@@ -34,8 +34,8 @@ type PlanBuilder func(output tsutil.TerraformOutputMap) (*apv1beta2.Plan, error)
 
 // PlanApplyOperation is an Operation that will read output values from terraform,
 // build a user-provided Plan, and apply it via kubectl.
-func PlanApplyOperation(ctx context.Context, builder PlanBuilder) ts.ClusterOperation {
-	return func(data ts.ClusterData) error {
+func PlanApplyOperation(builder PlanBuilder) ts.ClusterOperation {
+	return func(ctx context.Context, data ts.ClusterData) error {
 		// The the terraform binary, error if missing
 		tfpath, err := exec.LookPath("terraform")
 		if err != nil {

--- a/inttest/toolsuite/tests/versionupdate_test.go
+++ b/inttest/toolsuite/tests/versionupdate_test.go
@@ -15,7 +15,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -46,18 +45,12 @@ func (s *VersionUpdateSuite) TestUpdate() {
 	s.T().Logf("Waiting for Plan completion (timeout = %v)", s.Config.OperationTimeout)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(context.TODO(), client, apconst.AutopilotName, s.Config.OperationTimeout, func(obj interface{}) bool {
-		if plan, ok := obj.(*apv1beta2.Plan); ok {
-			completed := plan.Status.State == appc.PlanCompleted
-
-			if completed {
-				s.T().Log("Plan completed successfully!")
-			}
-
-			return completed
+	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, s.Config.OperationTimeout, func(plan *apv1beta2.Plan) bool {
+		completed := plan.Status.State == appc.PlanCompleted
+		if completed {
+			s.T().Log("Plan completed successfully!")
 		}
-
-		return false
+		return completed
 	})
 
 	s.T().Log("Plan completed execution")
@@ -140,7 +133,7 @@ func VersionUpdatePlan(output tsutil.TerraformOutputMap) (*apv1beta2.Plan, error
 func TestVersionUpdateSuite(t *testing.T) {
 	suite.Run(t, &VersionUpdateSuite{
 		ts.ToolSuite{
-			Operation: tsops.PlanApplyOperation(context.Background(), VersionUpdatePlan),
+			Operation: tsops.PlanApplyOperation(VersionUpdatePlan),
 		},
 	})
 }

--- a/inttest/toolsuite/toolsuite.go
+++ b/inttest/toolsuite/toolsuite.go
@@ -15,6 +15,7 @@
 package toolsuite
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -36,7 +37,7 @@ const (
 	defaultToolImage = "tool:latest"
 )
 
-type ClusterOperation func(data ClusterData) error
+type ClusterOperation func(ctx context.Context, data ClusterData) error
 
 type ClusterData struct {
 	DataDir        string
@@ -69,6 +70,10 @@ type ToolSuite struct {
 	suite.Suite
 	Config    Config
 	Operation ClusterOperation
+}
+
+func (s *ToolSuite) Context() context.Context {
+	return context.TODO()
 }
 
 func (s *ToolSuite) KubeConfigFile() string {
@@ -173,7 +178,7 @@ func (s *ToolSuite) TestEntrypoint() {
 		PrivateKeyFile: path.Join(s.Config.DataDir, "private.pem"),
 	}
 
-	err := s.Operation(clusterData)
+	err := s.Operation(s.Context(), clusterData)
 	assert.NoError(s.T(), err, "Failed in toolsuite handler: %v", err)
 }
 


### PR DESCRIPTION
## Description

Prepare ToolSuite-based tests for test cancellation. Add a `Context` method to the suite struct that may be used to obtain some context whenever this is necessary during testing. This mimics the functionality of FootlooseSuite-based tests.

The context returned by the new method is currently just `context.TODO()`, but this can be changed with minimal impact on the rest of the tests whenever actual test cancellation is required.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings