### PR TITLE
Make autopilot new plan tests more resilient

### DIFF
--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/newplan_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/newplan_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,8 +45,6 @@ func TestNewPlan(t *testing.T) {
 		objects                   []crcli.Object
 		command                   apv1beta2.PlanCommand
 		expectedNextState         apv1beta2.PlanStateType
-		expectedRetry             bool
-		expectedError             bool
 		expectedPlanStatusWorkers []apv1beta2.PlanCommandTargetStatus
 		excludedFromPlans         []string
 	}{
@@ -84,8 +83,6 @@ func TestNewPlan(t *testing.T) {
 				},
 			},
 			appc.PlanSchedulableWait,
-			false,
-			false,
 			[]apv1beta2.PlanCommandTargetStatus{
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalPending),
 			},
@@ -127,8 +124,6 @@ func TestNewPlan(t *testing.T) {
 				},
 			},
 			appc.PlanIncompleteTargets,
-			false,
-			false,
 			[]apv1beta2.PlanCommandTargetStatus{
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalMissingNode),
 			},
@@ -183,8 +178,6 @@ func TestNewPlan(t *testing.T) {
 				},
 			},
 			appc.PlanIncompleteTargets,
-			false,
-			false,
 			[]apv1beta2.PlanCommandTargetStatus{
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalMissingPlatform),
 			},
@@ -226,8 +219,6 @@ func TestNewPlan(t *testing.T) {
 				},
 			},
 			appc.PlanRestricted,
-			false,
-			false,
 			[]apv1beta2.PlanCommandTargetStatus{
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalPending),
 			},
@@ -261,10 +252,12 @@ func TestNewPlan(t *testing.T) {
 			ctx := context.TODO()
 			nextState, retry, err := provider.NewPlan(ctx, test.command, &status)
 
+			require.NoError(t, err)
 			assert.Equal(t, test.expectedNextState, nextState)
-			assert.Equal(t, test.expectedRetry, retry)
-			assert.Equal(t, test.expectedError, err != nil, "Unexpected error: %v", err)
-			assert.True(t, cmp.Equal(test.expectedPlanStatusWorkers, status.AirgapUpdate.Workers, cmpopts.IgnoreFields(apv1beta2.PlanCommandTargetStatus{}, "LastUpdatedTimestamp")))
+			assert.False(t, retry)
+			if assert.NotNil(t, status.AirgapUpdate) {
+				assert.True(t, cmp.Equal(test.expectedPlanStatusWorkers, status.AirgapUpdate.Workers, cmpopts.IgnoreFields(apv1beta2.PlanCommandTargetStatus{}, "LastUpdatedTimestamp")))
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Description

When the implementation doesn't provide the expected results, the tests panic and it's hard to spot the cause for the failures. Fix this by only executing assertions when it is safe to do so.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings