### PR TITLE
Unify make prerequisites and gen-bindata args for static assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 aws_private.pem
 out.json
 .vscode
-static/gen_manifests.go
+static/zz_generated_assets.go
 .k0sbuild.docker-image.*
 docs/cli
 site

--- a/static/doc.go
+++ b/static/doc.go
@@ -15,4 +15,4 @@ limitations under the License.
 */
 
 // Package static contains auto-generated source code for static assets.
-package static // This file is intentionally left empty to delcare the "static" package.
+package static // This file is intentionally left empty to declare the "static" package.


### PR DESCRIPTION
## Description

Introduce `static_asset_dirs` make variable and use that to drive both the make prerequisites and the `gen-bindata` inputs. This ensures that those are always in sync (the `misc` folder was missing before this). It addresses the issue fixed in #2184, too. So it's not required anymore to delete the output file before calling `gen-bindata`, but it also won't harm.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings