### PR TITLE
Pin some GH workflows to the k0s repository

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -19,6 +19,7 @@ jobs:
       KUBECONFIG: ${{ github.workspace }}/kubeconfig
 
     name: "K8s Network Conformance Testing"
+    if: github.repository == 'k0sproject/k0s'
     runs-on: ubuntu-latest
     outputs:
       k0s_version: ${{ steps.bin_info.outputs.K0S_VERSION }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -322,6 +322,7 @@ jobs:
 
   smoketest-arm:
     name: Smoke test on armv7/arm64
+    if: github.repository == 'k0sproject/k0s'
     strategy:
       matrix:
         arch:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -67,11 +67,12 @@ jobs:
           mike deploy --push "$VERSION"
 
       - name: Update mike version aliases
+        if: github.repository == 'k0sproject/k0s'
         id: set_versions
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAGS=$(gh release list -L 1000 -R k0sproject/k0s | grep "+k0s." | grep -v Draft | cut -f 1 | k0s_sort)
+          TAGS=$(gh release list -L 1000 -R "$GITHUB_REPOSITORY" | grep "+k0s." | grep -v Draft | cut -f 1 | k0s_sort)
           LATEST=$(echo "${TAGS}" | tail -1)
           STABLE=$(echo "${TAGS}" | grep -v -- "-" | tail -1)
           mike alias -u head main
@@ -85,6 +86,7 @@ jobs:
       # Commits if the files were changed
       # Finally pushes if there are unpushed commits
       - name: Create version files
+        if: github.repository == 'k0sproject/k0s'
         run: |
           LATEST=${{ steps.set_versions.outputs.LATEST }}
           STABLE=${{ steps.set_versions.outputs.STABLE }}


### PR DESCRIPTION
## Description

Some of the GitHub workflows are not usable within forks and will fail there. Add an "if" clause to those, so that they are only run on the main k0s repo.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings