### PR TITLE
[Backport release-1.25] Bump Go to v1.19.3

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,4 +1,4 @@
-go_version = 1.19.1
+go_version = 1.19.3
 
 runc_version = 1.1.4
 runc_buildimage = golang:$(go_version)-alpine3.16


### PR DESCRIPTION
Backporting #2342 to `release-1.25`