### PR TITLE
Watcher with error callback

### DIFF
--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -837,6 +837,7 @@ func (s *FootlooseSuite) WaitForNodeReady(name string, kc *kubernetes.Clientset)
 	s.T().Logf("waiting to see %s ready in kube API", name)
 	return watch.Nodes(kc.CoreV1().Nodes()).
 		WithObjectName(name).
+		WithErrorCallback(RetryWatchErrors(s.T().Logf)).
 		Until(s.Context(), func(n *corev1.Node) (bool, error) {
 			for _, nc := range n.Status.Conditions {
 				if nc.Type == corev1.NodeReady {
@@ -867,6 +868,7 @@ func (s *FootlooseSuite) GetNodeLabels(node string, kc *kubernetes.Clientset) (m
 func (s *FootlooseSuite) WaitForNodeLabel(kc *kubernetes.Clientset, node, labelKey, labelValue string) error {
 	return watch.Nodes(kc.CoreV1().Nodes()).
 		WithObjectName(node).
+		WithErrorCallback(RetryWatchErrors(s.T().Logf)).
 		Until(s.Context(), func(node *corev1.Node) (bool, error) {
 			for k, v := range node.Labels {
 				if labelKey == k {

--- a/pkg/autopilot/common/waitfor.go
+++ b/pkg/autopilot/common/waitfor.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/k0sproject/k0s/inttest/common"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apclient "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset"
 	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
@@ -25,6 +26,8 @@ import (
 	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sirupsen/logrus"
 )
 
 // WaitForPlanByName waits for the existence of a Plan having a specific name.
@@ -54,6 +57,7 @@ func WaitForByName[L metav1.ListInterface, I any](ctx context.Context, client wa
 	var match *I
 	err := watch.FromClient[L, I](client).
 		WithObjectName(name).
+		WithErrorCallback(common.RetryWatchErrors(logrus.Infof)).
 		Until(ctx, func(item *I) (bool, error) {
 			// If any of the conditions fail, indicate that the poll should continue
 			for _, cond := range conds {

--- a/pkg/kubernetes/watch/watcher_test.go
+++ b/pkg/kubernetes/watch/watcher_test.go
@@ -1,0 +1,714 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/utils/pointer"
+)
+
+func TestWatcher(t *testing.T) {
+	ctx := func() context.Context {
+		ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+		t.Cleanup(cancel)
+		return ctx
+	}()
+
+	someConfigMap := corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "someConfigMap"}}
+
+	t.Run("Cancelation", func(t *testing.T) {
+		t.Run("ContextInitiallyCanceled", func(t *testing.T) {
+			t.Parallel()
+			provider, underTest := newTestWatcher()
+			provider.nextList.ListMeta.ResourceVersion = t.Name()
+			provider.watch = func(metav1.ListOptions) error {
+				provider.ch = openEventChanWith()
+				provider.watch = forbiddenWatch(t)
+				return nil
+			}
+
+			ctx, cancel := context.WithCancel(context.TODO())
+			cancel()
+
+			err := underTest.
+				WithErrorCallback(forbiddenErrorCallback(t)).
+				Until(ctx, forbiddenCondition(t))
+
+			assert.Same(t, err, context.Canceled)
+			assert.Equal(t, 1, provider.callsToList)
+			assert.Equal(t, 1, provider.callsToWatch)
+			assert.Equal(t, 1, provider.callsToStop)
+		})
+
+		t.Run("InRetryDelay", func(t *testing.T) {
+			t.Parallel()
+
+			provider, underTest := newTestWatcher()
+			provider.nextList.ResourceVersion = t.Name()
+			provider.watch = func(metav1.ListOptions) error { return assert.AnError }
+			var callsToErrorCallback int
+
+			ctx, cancel := context.WithCancel(context.TODO())
+
+			err := underTest.
+				WithErrorCallback(func(err error) (time.Duration, error) {
+					callsToErrorCallback++
+					require.Same(t, assert.AnError, err)
+					cancel()
+					return 24 * time.Hour, nil
+				}).
+				Until(ctx, forbiddenCondition(t))
+
+			assert.Same(t, err, context.Canceled)
+			assert.Equal(t, 1, provider.callsToList)
+			assert.Equal(t, 1, provider.callsToWatch)
+			assert.Equal(t, 1, callsToErrorCallback)
+			assert.Zero(t, provider.callsToStop)
+		})
+	})
+
+	t.Run("InitialListError", func(t *testing.T) {
+		t.Parallel()
+		provider, underTest := newTestWatcher()
+		provider.nextListErr = assert.AnError
+		var callsToErrorCallback int
+
+		err := underTest.
+			WithErrorCallback(func(err error) (time.Duration, error) {
+				callsToErrorCallback++
+				assert.Same(t, assert.AnError, err)
+				return 0, err
+			}).
+			Until(ctx, forbiddenCondition(t))
+
+		assert.Same(t, assert.AnError, err)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 1, callsToErrorCallback)
+		assert.Zero(t, provider.callsToWatch)
+	})
+
+	t.Run("ListConditionError", func(t *testing.T) {
+		t.Parallel()
+		provider, underTest := newTestWatcher()
+		provider.nextList.Items = []corev1.ConfigMap{someConfigMap}
+		var callsToCondition int
+
+		err := underTest.
+			WithErrorCallback(forbiddenErrorCallback(t)).
+			Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+				assert.Zero(t, callsToCondition, "Condition called more than once")
+				callsToCondition++
+
+				return false, assert.AnError
+			})
+
+		assert.Same(t, assert.AnError, err)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Zero(t, provider.callsToWatch)
+	})
+
+	t.Run("SuccessAfterInitialList", func(t *testing.T) {
+		t.Parallel()
+		provider, underTest := newTestWatcher()
+		provider.nextList.Items = []corev1.ConfigMap{someConfigMap}
+		var callsToCondition int
+
+		err := underTest.
+			WithErrorCallback(forbiddenErrorCallback(t)).
+			Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+				assert.Zero(t, callsToCondition, "Condition called more than once")
+				callsToCondition++
+
+				assert.Equal(t, &someConfigMap, watched)
+				return true, nil
+			})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, callsToCondition)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Zero(t, provider.callsToWatch)
+	})
+
+	t.Run("WatchChannelClosed", func(t *testing.T) {
+		t.Skip("doesn't apply in its current form")
+
+		t.Parallel()
+		provider, underTest := newTestWatcher()
+		provider.nextList.ListMeta.ResourceVersion = t.Name()
+		provider.watch = func(metav1.ListOptions) error {
+			provider.ch = closedEventChanWith()
+			provider.watch = forbiddenWatch(t)
+			return nil
+		}
+
+		err := underTest.
+			WithErrorCallback(forbiddenErrorCallback(t)).
+			Until(ctx, forbiddenCondition(t))
+
+		assert.ErrorContains(t, err, "result channel closed unexpectedly")
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 1, provider.callsToWatch)
+		assert.Equal(t, 1, provider.callsToStop)
+	})
+
+	t.Run("BadWatchEventTypes", func(t *testing.T) {
+		t.Parallel()
+
+		injectedErr := apierrors.NewBadRequest("injected")
+
+		for _, test := range []struct {
+			eventType    apiwatch.EventType
+			errorMessage string
+		}{
+			{apiwatch.Error, "watch error"},
+			{apiwatch.EventType("Bogus"), "unexpected watch event (Bogus)"},
+		} {
+			test := test
+			t.Run(string(test.eventType), func(t *testing.T) {
+				t.Parallel()
+				provider, underTest := newTestWatcher()
+				provider.nextList.ListMeta.ResourceVersion = t.Name()
+				provider.watch = func(opts metav1.ListOptions) error {
+					provider.ch = openEventChanWith(apiwatch.Event{
+						Type:   test.eventType,
+						Object: &injectedErr.ErrStatus,
+					})
+					provider.watch = forbiddenWatch(t)
+					return nil
+				}
+				var callsToErrorCallback int
+
+				assertErr := func(err error) {
+					t.Helper()
+					assert.ErrorContains(t, err, test.errorMessage)
+					var statusErr *apierrors.StatusError
+					if assert.ErrorAs(t, err, &statusErr) {
+						assert.Equal(t, injectedErr, statusErr)
+					}
+				}
+
+				err := underTest.
+					WithErrorCallback(func(err error) (time.Duration, error) {
+						callsToErrorCallback++
+						assertErr(err)
+						return 0, err
+					}).
+					Until(ctx, forbiddenCondition(t))
+
+				assertErr(err)
+				assert.Equal(t, 1, provider.callsToList)
+				assert.Equal(t, 1, provider.callsToWatch)
+				assert.Equal(t, 1, provider.callsToStop)
+			})
+		}
+	})
+
+	t.Run("SuccessAfterWatch", func(t *testing.T) {
+		t.Parallel()
+		provider, underTest := newTestWatcher()
+		provider.nextList.ListMeta.ResourceVersion = t.Name()
+		provider.watch = func(opts metav1.ListOptions) error {
+			assert.Equal(t, t.Name(), opts.ResourceVersion)
+			assert.True(t, opts.AllowWatchBookmarks)
+			assert.Equal(t, opts.TimeoutSeconds, pointer.Int64(120))
+
+			provider.ch = openEventChanWith(
+				apiwatch.Event{
+					Type:   apiwatch.Added,
+					Object: &someConfigMap,
+				})
+			provider.watch = forbiddenWatch(t)
+
+			return nil
+		}
+		var callsToCondition int
+
+		err := underTest.Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+			assert.Equal(t, 1, provider.callsToWatch, "Expected a single call to watch prior to the condition call")
+			assert.Zero(t, callsToCondition, "Condition called more than once")
+			callsToCondition++
+
+			assert.Same(t, &someConfigMap, watched)
+			return true, nil
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, callsToCondition)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 1, provider.callsToWatch)
+		assert.Equal(t, 1, provider.callsToStop)
+	})
+
+	t.Run("ResourceVersionTooOld", func(t *testing.T) {
+		t.Parallel()
+		provider, underTest := newTestWatcher()
+		provider.nextList.ListMeta.ResourceVersion = t.Name()
+		provider.watch = func(metav1.ListOptions) error {
+			provider.ch = openEventChanWith(apiwatch.Event{
+				Type:   apiwatch.Error,
+				Object: &apierrors.NewResourceExpired("injected resource version too old").ErrStatus,
+			})
+
+			provider.watch = func(opts metav1.ListOptions) error {
+				provider.ch = openEventChanWith(apiwatch.Event{
+					Type:   apiwatch.Added,
+					Object: &someConfigMap,
+				})
+				provider.watch = forbiddenWatch(t)
+
+				return nil
+			}
+
+			return nil
+		}
+		var callsToCondition int
+
+		err := underTest.
+			WithErrorCallback(forbiddenErrorCallback(t)).
+			Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+				assert.Equal(t, 2, provider.callsToWatch, "Expected two calls to watch prior to the condition call")
+				assert.Zero(t, callsToCondition, "Condition called more than once")
+				callsToCondition++
+
+				assert.Same(t, &someConfigMap, watched)
+				return true, nil
+			})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, callsToCondition)
+		assert.Equal(t, 2, provider.callsToList)
+		assert.Equal(t, 2, provider.callsToWatch)
+		assert.Equal(t, 2, provider.callsToStop)
+	})
+
+	t.Run("WatchConditionError", func(t *testing.T) {
+		t.Parallel()
+		provider, underTest := newTestWatcher()
+		provider.nextList.ListMeta.ResourceVersion = t.Name()
+		provider.watch = func(opts metav1.ListOptions) error {
+			provider.ch = openEventChanWith(apiwatch.Event{
+				Type:   apiwatch.Added,
+				Object: &someConfigMap,
+			})
+			provider.watch = forbiddenWatch(t)
+
+			return nil
+		}
+		var conditionCalled int
+
+		err := underTest.
+			WithErrorCallback(forbiddenErrorCallback(t)).
+			Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+				assert.Equal(t, 1, provider.callsToWatch, "Expected a single call to watch prior to the condition call")
+				assert.Zero(t, conditionCalled, "Condition called more than once")
+				conditionCalled++
+
+				assert.Same(t, &someConfigMap, watched)
+				return false, assert.AnError
+			})
+
+		assert.Same(t, err, assert.AnError)
+		assert.Equal(t, 1, conditionCalled)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 1, provider.callsToWatch)
+		assert.Equal(t, 1, provider.callsToStop)
+	})
+
+	t.Run("BogusObjectInWatchEvent", func(t *testing.T) {
+		t.Parallel()
+
+		bogusSecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: "bogusSecret",
+			},
+		}
+
+		provider, underTest := newTestWatcher()
+		provider.nextList.ListMeta.ResourceVersion = t.Name()
+		provider.watch = func(opts metav1.ListOptions) error {
+			provider.ch = openEventChanWith(apiwatch.Event{
+				Type:   apiwatch.Added,
+				Object: &bogusSecret,
+			})
+			provider.watch = forbiddenWatch(t)
+
+			return nil
+		}
+		var callsToErrorCallback int
+
+		assertErr := func(err error) {
+			t.Helper()
+			assert.ErrorContains(t, err, `got an event of type "ADDED", expecting an object of type *v1.ConfigMap: `)
+			var wrappedErr *apierrors.UnexpectedObjectError
+			if assert.ErrorAs(t, err, &wrappedErr) {
+				assert.Equal(t, &bogusSecret, wrappedErr.Object)
+			}
+		}
+
+		err := underTest.
+			WithErrorCallback(func(err error) (time.Duration, error) {
+				callsToErrorCallback++
+				assertErr(err)
+				return 0, err
+			}).
+			Until(ctx, forbiddenCondition(t))
+
+		assertErr(err)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 1, provider.callsToWatch)
+		assert.Equal(t, 1, callsToErrorCallback)
+		assert.Equal(t, 1, provider.callsToStop)
+	})
+
+	t.Run("InvalidResourceVersion", func(t *testing.T) {
+		t.Parallel()
+
+		invalidConfigMap := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: "0",
+			},
+		}
+
+		t.Run("InList", func(t *testing.T) {
+			t.Parallel()
+			provider, underTest := newTestWatcher()
+			provider.nextList.ListMeta.ResourceVersion = "0"
+			provider.nextList.Items = []corev1.ConfigMap{invalidConfigMap}
+			var callsToErrorCallback int
+			var callsToCondition int
+
+			err := underTest.
+				WithErrorCallback(func(err error) (time.Duration, error) {
+					callsToErrorCallback++
+					assert.ErrorContains(t, err, `list returned invalid resource version: "0"`)
+					return 0, err
+				}).
+				Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+					assert.Zero(t, callsToCondition, "Condition called more than once")
+					callsToCondition++
+
+					assert.Equal(t, &invalidConfigMap, watched)
+					return false, nil
+				})
+
+			assert.ErrorContains(t, err, `list returned invalid resource version: "0"`)
+			assert.Equal(t, 1, callsToCondition)
+			assert.Equal(t, 1, provider.callsToList)
+			assert.Equal(t, 1, callsToErrorCallback)
+			assert.Zero(t, provider.callsToWatch)
+		})
+
+		t.Run("InWatch", func(t *testing.T) {
+			t.Parallel()
+
+			provider, underTest := newTestWatcher()
+			provider.nextList.ListMeta.ResourceVersion = t.Name()
+			provider.watch = func(opts metav1.ListOptions) error {
+				provider.ch = openEventChanWith(apiwatch.Event{
+					Type:   apiwatch.Added,
+					Object: &invalidConfigMap,
+				})
+				provider.watch = forbiddenWatch(t)
+
+				return nil
+			}
+			var callsToErrorCallback int
+			var callsToCondition int
+
+			assertErr := func(err error) {
+				t.Helper()
+				assert.ErrorContains(t, err, `invalid resource version: `)
+				var wrappedErr *apierrors.UnexpectedObjectError
+				if assert.ErrorAs(t, err, &wrappedErr) {
+					assert.Equal(t, &invalidConfigMap, wrappedErr.Object)
+				}
+			}
+
+			err := underTest.
+				WithErrorCallback(func(err error) (time.Duration, error) {
+					callsToErrorCallback++
+					assertErr(err)
+					return 0, err
+				}).
+				Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+					assert.Zero(t, callsToCondition, "Condition called more than once")
+					callsToCondition++
+
+					assert.Same(t, &invalidConfigMap, watched)
+					return false, nil
+				})
+
+			assertErr(err)
+			assert.Equal(t, 1, callsToCondition)
+			assert.Equal(t, 1, provider.callsToList)
+			assert.Equal(t, 1, provider.callsToWatch)
+			assert.Equal(t, 1, callsToErrorCallback)
+			assert.Equal(t, 1, provider.callsToStop)
+		})
+	})
+
+	t.Run("Bookmarking", func(t *testing.T) {
+		t.Parallel()
+
+		provider, underTest := newTestWatcher()
+		provider.nextList.ListMeta.ResourceVersion = t.Name()
+		var second, third func(opts metav1.ListOptions) error
+		provider.watch = func(opts metav1.ListOptions) error {
+			bookmark := unstructured.Unstructured{
+				Object: map[string]any{
+					"metadata": map[string]any{
+						"resourceVersion": "the bookmark",
+					},
+				},
+			}
+
+			provider.ch = closedEventChanWith(apiwatch.Event{
+				Type:   apiwatch.Bookmark,
+				Object: &bookmark,
+			})
+			provider.watch = second
+
+			return nil
+		}
+		second = func(opts metav1.ListOptions) error {
+			assert.Equal(t, "the bookmark", opts.ResourceVersion)
+			assert.True(t, opts.AllowWatchBookmarks)
+
+			provider.ch = closedEventChanWith(apiwatch.Event{
+				Type:   apiwatch.Added,
+				Object: &someConfigMap,
+			})
+			provider.watch = third
+
+			return nil
+		}
+		third = func(opts metav1.ListOptions) error {
+			assert.Equal(t, "someConfigMap", opts.ResourceVersion)
+			assert.True(t, opts.AllowWatchBookmarks)
+
+			provider.ch = openEventChanWith(apiwatch.Event{
+				Type:   apiwatch.Modified,
+				Object: &someConfigMap,
+			})
+			provider.watch = forbiddenWatch(t)
+
+			return nil
+		}
+		var callsToCondition int
+
+		err := underTest.
+			WithErrorCallback(forbiddenErrorCallback(t)).
+			Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+				defer func() { callsToCondition++ }()
+				assert.Same(t, &someConfigMap, watched)
+				switch callsToCondition {
+				case 0:
+					return false, nil
+				default:
+					require.Fail(t, "Unexpected call to condition")
+					fallthrough
+				case 1:
+					return true, nil
+				}
+			})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 3, provider.callsToWatch)
+		assert.Equal(t, 3, provider.callsToStop)
+	})
+
+	t.Run("WatchError", func(t *testing.T) {
+		t.Parallel()
+
+		provider, underTest := newTestWatcher()
+		provider.nextList.ListMeta.ResourceVersion = t.Name()
+		provider.watch = func(metav1.ListOptions) error {
+			provider.watch = forbiddenWatch(t)
+			return assert.AnError
+		}
+		var callsToErrorCallback int
+
+		err := underTest.
+			WithErrorCallback(func(err error) (time.Duration, error) {
+				callsToErrorCallback++
+				assert.Same(t, assert.AnError, err)
+				return 0, err
+			}).
+			Until(ctx, forbiddenCondition(t))
+
+		assert.Same(t, assert.AnError, err)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 1, provider.callsToWatch)
+		assert.Equal(t, 1, callsToErrorCallback)
+		assert.Zero(t, provider.callsToStop)
+	})
+
+	t.Run("ErrorCallbackAllowsRetry", func(t *testing.T) {
+		t.Parallel()
+
+		retryError := errors.New("retry me")
+		provider, underTest := newTestWatcher()
+		provider.nextListErr = retryError
+		var callsToErrorCallback int
+		var callsToCondition int
+
+		err := underTest.
+			WithErrorCallback(func(err error) (retryAfter time.Duration, _ error) {
+				underTest.WithErrorCallback(forbiddenErrorCallback(t))
+				callsToErrorCallback++
+
+				provider.nextList.Items = []corev1.ConfigMap{someConfigMap}
+				provider.nextListErr = nil
+
+				if assert.Equal(t, err, retryError) {
+					return time.Duration(0), nil
+				}
+				return retryAfter, err
+			}).
+			Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+				assert.Equal(t, 1, callsToErrorCallback, "Expected a single call to error callback prior to the condition call")
+				assert.Zero(t, callsToCondition, "Condition called more than once")
+				callsToCondition++
+
+				assert.Equal(t, &someConfigMap, watched)
+				return true, nil
+			})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, provider.callsToList)
+		assert.Equal(t, 1, callsToErrorCallback)
+		assert.Equal(t, 1, callsToCondition)
+		assert.Zero(t, provider.callsToWatch)
+	})
+
+	t.Run("ErrorCallbackTransformsErr", func(t *testing.T) {
+		t.Parallel()
+
+		listError := errors.New("list error")
+		transformedError := errors.New("transformed error")
+		provider, underTest := newTestWatcher()
+		provider.nextListErr = listError
+		var callsToErrorCallback int
+
+		err := underTest.
+			WithErrorCallback(func(err error) (retryAfter time.Duration, _ error) {
+				underTest.WithErrorCallback(forbiddenErrorCallback(t))
+				assert.Zero(t, callsToErrorCallback, "error callback called more than once")
+				callsToErrorCallback++
+
+				assert.Same(t, listError, err)
+				return time.Duration(0), transformedError
+			}).
+			Until(ctx, forbiddenCondition(t))
+
+		assert.Same(t, transformedError, err)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 1, callsToErrorCallback)
+		assert.Zero(t, provider.callsToWatch)
+	})
+}
+
+func forbiddenCondition(t *testing.T) watch.Condition[corev1.ConfigMap] {
+	return func(*corev1.ConfigMap) (bool, error) {
+		require.Fail(t, "Condition shouldn't be called.")
+		return false, nil
+	}
+}
+
+func forbiddenWatch(t *testing.T) func(metav1.ListOptions) error {
+	return func(metav1.ListOptions) error {
+		require.Fail(t, "Watch shouldn't be called.")
+		return nil
+	}
+}
+
+func forbiddenErrorCallback(t *testing.T) watch.ErrorCallback {
+	return func(err error) (time.Duration, error) {
+		require.Fail(t, "ErrorCallback shouldn't be called.", "Error was: %v", err)
+		return 0, nil
+	}
+}
+
+func openEventChanWith(events ...apiwatch.Event) chan apiwatch.Event {
+	ch := make(chan apiwatch.Event, len(events))
+	for _, event := range events {
+		ch <- event
+	}
+	return ch
+}
+
+func closedEventChanWith(events ...apiwatch.Event) chan apiwatch.Event {
+	ch := openEventChanWith(events...)
+	close(ch)
+	return ch
+}
+
+func newTestWatcher() (*mockProvider, *watch.Watcher[corev1.ConfigMap]) {
+	provider := new(mockProvider)
+	return provider, watch.FromClient[*corev1.ConfigMapList, corev1.ConfigMap](provider)
+}
+
+type mockProvider struct {
+	callsToList int
+	nextList    corev1.ConfigMapList
+	nextListErr error
+
+	callsToWatch int
+	watch        func(metav1.ListOptions) error
+	ch           chan apiwatch.Event
+
+	callsToStop int
+}
+
+func (m *mockProvider) List(ctx context.Context, opts metav1.ListOptions) (*corev1.ConfigMapList, error) {
+	defer func() { m.callsToList++ }()
+	if m.nextListErr != nil {
+		return nil, m.nextListErr
+	}
+	return &m.nextList, nil
+}
+
+func (m *mockProvider) Watch(ctx context.Context, opts metav1.ListOptions) (apiwatch.Interface, error) {
+	defer func() { m.callsToWatch++ }()
+	if err := m.watch(opts); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+func (m *mockProvider) ResultChan() <-chan apiwatch.Event {
+	return m.ch
+}
+
+func (m *mockProvider) Stop() {
+	m.callsToStop++
+}


### PR DESCRIPTION
## Description

**Watcher overhaul**
Don't use client-go's `RetryWatcher` anymore. It merely provides resource version bookkeeping and swallows all other errors by simply logging them via klog. This doesn't provide much control for clients. Implement the bookkeeping directly in the `Watcher` and let the client-provided error callback decide if any errors are good to be retried. Provide a convenience function `IsRetryable` that checks for any well-known error conditions that may be retried. Clients may pass this function directly as an error callback, or use it in their own callback and do some additional things, like logging, retrying even more errors, implement some more sophisticated backoff strategies, ...
 
**Use Watcher error callback in inttests**
So that some errors get retried. Also retry connection reset errors in addition to the well-known watcher errors, since this seems to be a transient error condition that pops up from time to time when running the integration tests on GitHub runners.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings