### PR TITLE
Move LeaderElector into its own package

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -38,6 +38,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/component/controller"
 	"github.com/k0sproject/k0s/pkg/component/controller/clusterconfig"
+	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/status"
 	"github.com/k0sproject/k0s/pkg/component/worker"
 	"github.com/k0sproject/k0s/pkg/config"
@@ -215,15 +216,15 @@ func (c *command) start(ctx context.Context) error {
 	}
 
 	var leaderElector interface {
-		controller.LeaderElector
+		leaderelector.Interface
 		component.Component
 	}
 
 	// One leader elector per controller
 	if !c.SingleNode {
-		leaderElector = controller.NewLeasePoolLeaderElector(adminClientFactory)
+		leaderElector = leaderelector.NewLeasePool(adminClientFactory)
 	} else {
-		leaderElector = &controller.DummyLeaderElector{Leader: true}
+		leaderElector = &leaderelector.Dummy{Leader: true}
 	}
 	c.NodeComponents.Add(ctx, leaderElector)
 

--- a/pkg/applier/manager.go
+++ b/pkg/applier/manager.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/pkg/component"
-	"github.com/k0sproject/k0s/pkg/component/controller"
+	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/constant"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 
@@ -44,7 +44,7 @@ type Manager struct {
 	log           *logrus.Entry
 	stacks        map[string]stack
 
-	LeaderElector controller.LeaderElector
+	LeaderElector leaderelector.Interface
 }
 
 var _ component.Component = (*Manager)(nil)

--- a/pkg/component/controller/apiendpointreconciler.go
+++ b/pkg/component/controller/apiendpointreconciler.go
@@ -23,14 +23,16 @@ import (
 	"sort"
 	"time"
 
-	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component"
-	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
+	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Dummy checks so we catch easily if we miss some interface implementation
@@ -43,13 +45,13 @@ type APIEndpointReconciler struct {
 
 	logger *logrus.Entry
 
-	leaderElector     LeaderElector
+	leaderElector     leaderelector.Interface
 	stopCh            chan struct{}
-	kubeClientFactory k8sutil.ClientFactoryInterface
+	kubeClientFactory kubeutil.ClientFactoryInterface
 }
 
 // NewEndpointReconciler creates new endpoint reconciler
-func NewEndpointReconciler(leaderElector LeaderElector, kubeClientFactory k8sutil.ClientFactoryInterface) *APIEndpointReconciler {
+func NewEndpointReconciler(leaderElector leaderelector.Interface, kubeClientFactory kubeutil.ClientFactoryInterface) *APIEndpointReconciler {
 	return &APIEndpointReconciler{
 		leaderElector:     leaderElector,
 		stopCh:            make(chan struct{}),
@@ -127,7 +129,7 @@ func (a *APIEndpointReconciler) reconcileEndpoints(ctx context.Context) error {
 
 	epClient := c.CoreV1().Endpoints("default")
 
-	ep, err := epClient.Get(ctx, "kubernetes", v1.GetOptions{})
+	ep, err := epClient.Get(ctx, "kubernetes", metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			err := a.createEndpoint(ctx, ipStrings)
@@ -149,7 +151,7 @@ func (a *APIEndpointReconciler) reconcileEndpoints(ctx context.Context) error {
 			},
 		}}
 
-		_, err := epClient.Update(ctx, ep, v1.UpdateOptions{})
+		_, err := epClient.Update(ctx, ep, metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}
@@ -160,11 +162,11 @@ func (a *APIEndpointReconciler) reconcileEndpoints(ctx context.Context) error {
 
 func (a *APIEndpointReconciler) createEndpoint(ctx context.Context, addresses []string) error {
 	ep := &corev1.Endpoints{
-		TypeMeta: v1.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			Kind:       "Endpoints",
 			APIVersion: "v1",
 		},
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "kubernetes",
 		},
 		Subsets: []corev1.EndpointSubset{{
@@ -184,7 +186,7 @@ func (a *APIEndpointReconciler) createEndpoint(ctx context.Context, addresses []
 		return err
 	}
 
-	_, err = c.CoreV1().Endpoints("default").Create(ctx, ep, v1.CreateOptions{})
+	_, err = c.CoreV1().Endpoints("default").Create(ctx, ep, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/component/controller/apiendpointreconciler_test.go
+++ b/pkg/component/controller/apiendpointreconciler_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/k0sproject/k0s/internal/testutil"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 )
 
 var expectedAddresses = []string{
@@ -48,7 +49,7 @@ func TestBasicReconcilerWithNoLeader(t *testing.T) {
 		},
 	}
 
-	r := NewEndpointReconciler(&DummyLeaderElector{Leader: false}, fakeFactory)
+	r := NewEndpointReconciler(&leaderelector.Dummy{Leader: false}, fakeFactory)
 	r.clusterConfig = config
 
 	ctx := context.TODO()
@@ -75,7 +76,7 @@ func TestBasicReconcilerWithNoExistingEndpoint(t *testing.T) {
 		},
 	}
 
-	r := NewEndpointReconciler(&DummyLeaderElector{Leader: true}, fakeFactory)
+	r := NewEndpointReconciler(&leaderelector.Dummy{Leader: true}, fakeFactory)
 	r.clusterConfig = config
 
 	ctx := context.TODO()
@@ -112,7 +113,7 @@ func TestBasicReconcilerWithEmptyEndpointSubset(t *testing.T) {
 		},
 	}
 
-	r := NewEndpointReconciler(&DummyLeaderElector{Leader: true}, fakeFactory)
+	r := NewEndpointReconciler(&leaderelector.Dummy{Leader: true}, fakeFactory)
 	r.clusterConfig = config
 
 	assert.NoError(t, r.Init(ctx))
@@ -155,7 +156,7 @@ func TestReconcilerWithNoNeedForUpdate(t *testing.T) {
 			},
 		},
 	}
-	r := NewEndpointReconciler(&DummyLeaderElector{Leader: true}, fakeFactory)
+	r := NewEndpointReconciler(&leaderelector.Dummy{Leader: true}, fakeFactory)
 	r.clusterConfig = config
 
 	assert.NoError(t, r.Init(ctx))
@@ -199,7 +200,7 @@ func TestReconcilerWithNeedForUpdate(t *testing.T) {
 			},
 		},
 	}
-	r := NewEndpointReconciler(&DummyLeaderElector{Leader: true}, fakeFactory)
+	r := NewEndpointReconciler(&leaderelector.Dummy{Leader: true}, fakeFactory)
 	r.clusterConfig = config
 
 	assert.NoError(t, r.Init(ctx))

--- a/pkg/component/controller/clusterConfig.go
+++ b/pkg/component/controller/clusterConfig.go
@@ -22,23 +22,22 @@ import (
 	"os"
 	"time"
 
+	cfgClient "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/clientset/typed/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component"
+	"github.com/k0sproject/k0s/pkg/component/controller/clusterconfig"
+	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/config"
+	"github.com/k0sproject/k0s/pkg/constant"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/static"
 
-	"github.com/k0sproject/k0s/pkg/component"
-
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	cfgClient "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/clientset/typed/k0s.k0sproject.io/v1beta1"
-	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
-	"github.com/k0sproject/k0s/pkg/constant"
-
-	"github.com/k0sproject/k0s/pkg/component/controller/clusterconfig"
+	"github.com/sirupsen/logrus"
 )
 
 // ClusterConfigReconciler reconciles a ClusterConfig object
@@ -49,14 +48,14 @@ type ClusterConfigReconciler struct {
 
 	configClient  cfgClient.ClusterConfigInterface
 	kubeConfig    string
-	leaderElector LeaderElector
+	leaderElector leaderelector.Interface
 	log           *logrus.Entry
 	saver         manifestsSaver
 	configSource  clusterconfig.ConfigSource
 }
 
 // NewClusterConfigReconciler creates a new clusterConfig reconciler
-func NewClusterConfigReconciler(leaderElector LeaderElector, k0sVars constant.CfgVars, mgr *component.Manager, s manifestsSaver, kubeClientFactory kubeutil.ClientFactoryInterface, configSource clusterconfig.ConfigSource) (*ClusterConfigReconciler, error) {
+func NewClusterConfigReconciler(leaderElector leaderelector.Interface, k0sVars constant.CfgVars, mgr *component.Manager, s manifestsSaver, kubeClientFactory kubeutil.ClientFactoryInterface, configSource clusterconfig.ConfigSource) (*ClusterConfigReconciler, error) {
 	loadingRules := config.ClientConfigLoadingRules{K0sVars: k0sVars}
 	cfg, err := loadingRules.ParseRuntimeConfig()
 	if err != nil {

--- a/pkg/component/controller/csrapprover.go
+++ b/pkg/component/controller/csrapprover.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component"
-	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 )
 
@@ -57,14 +57,14 @@ type CSRApprover struct {
 
 	ClusterConfig     *v1beta1.ClusterConfig
 	KubeClientFactory kubeutil.ClientFactoryInterface
-	leaderElector     LeaderElector
+	leaderElector     leaderelector.Interface
 	clientset         clientset.Interface
 }
 
 var _ component.Component = (*CSRApprover)(nil)
 
 // NewCSRApprover creates the CSRApprover component
-func NewCSRApprover(c *v1beta1.ClusterConfig, leaderElector LeaderElector, kubeClientFactory k8sutil.ClientFactoryInterface) *CSRApprover {
+func NewCSRApprover(c *v1beta1.ClusterConfig, leaderElector leaderelector.Interface, kubeClientFactory kubeutil.ClientFactoryInterface) *CSRApprover {
 	d := atomic.Value{}
 	d.Store(true)
 	return &CSRApprover{

--- a/pkg/component/controller/csrapprover_test.go
+++ b/pkg/component/controller/csrapprover_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/k0sproject/k0s/internal/testutil"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/stretchr/testify/assert"
 	certv1 "k8s.io/api/certificates/v1"
 	core "k8s.io/api/core/v1"
@@ -70,7 +71,7 @@ func TestBasicCRSApprover(t *testing.T) {
 			},
 		},
 	}
-	c := NewCSRApprover(config, &DummyLeaderElector{Leader: true}, fakeFactory)
+	c := NewCSRApprover(config, &leaderelector.Dummy{Leader: true}, fakeFactory)
 
 	assert.NoError(t, c.Init(ctx))
 	assert.NoError(t, c.approveCSR(ctx))

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/apis/helm.k0sproject.io/v1beta1"
 	k0sAPI "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component"
+	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/helm"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
@@ -50,14 +51,14 @@ type ExtensionsController struct {
 	L             *logrus.Entry
 	helm          *helm.Commands
 	kubeConfig    string
-	leaderElector LeaderElector
+	leaderElector leaderelector.Interface
 }
 
 var _ component.Component = (*ExtensionsController)(nil)
 var _ component.Reconciler = (*ExtensionsController)(nil)
 
 // NewExtensionsController builds new HelmAddons
-func NewExtensionsController(s manifestsSaver, k0sVars constant.CfgVars, kubeClientFactory kubeutil.ClientFactoryInterface, leaderElector LeaderElector) *ExtensionsController {
+func NewExtensionsController(s manifestsSaver, k0sVars constant.CfgVars, kubeClientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface) *ExtensionsController {
 	return &ExtensionsController{
 		saver:         s,
 		L:             logrus.WithFields(logrus.Fields{"component": "extensions_controller"}),
@@ -152,7 +153,7 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sAPI.HelmExt
 type ChartReconciler struct {
 	client.Client
 	helm          *helm.Commands
-	leaderElector LeaderElector
+	leaderElector leaderelector.Interface
 	L             *logrus.Entry
 }
 

--- a/pkg/component/controller/leaderelector/dummy.go
+++ b/pkg/component/controller/leaderelector/dummy.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package leaderelector
 
 import (
 	"context"
@@ -22,25 +22,25 @@ import (
 	"github.com/k0sproject/k0s/pkg/component"
 )
 
-type DummyLeaderElector struct {
+type Dummy struct {
 	Leader    bool
 	callbacks []func()
 }
 
-var _ LeaderElector = (*DummyLeaderElector)(nil)
-var _ component.Component = (*DummyLeaderElector)(nil)
+var _ Interface = (*Dummy)(nil)
+var _ component.Component = (*Dummy)(nil)
 
-func (l *DummyLeaderElector) Init(_ context.Context) error { return nil }
-func (l *DummyLeaderElector) Stop() error                  { return nil }
-func (l *DummyLeaderElector) IsLeader() bool               { return l.Leader }
+func (l *Dummy) Init(_ context.Context) error { return nil }
+func (l *Dummy) Stop() error                  { return nil }
+func (l *Dummy) IsLeader() bool               { return l.Leader }
 
-func (l *DummyLeaderElector) AddAcquiredLeaseCallback(fn func()) {
+func (l *Dummy) AddAcquiredLeaseCallback(fn func()) {
 	l.callbacks = append(l.callbacks, fn)
 }
 
-func (l *DummyLeaderElector) AddLostLeaseCallback(func()) {}
+func (l *Dummy) AddLostLeaseCallback(func()) {}
 
-func (l *DummyLeaderElector) Start(_ context.Context) error {
+func (l *Dummy) Start(_ context.Context) error {
 	if !l.Leader {
 		return nil
 	}

--- a/pkg/component/controller/leaderelector/types.go
+++ b/pkg/component/controller/leaderelector/types.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelector
+
+// Interface is the common leader elector component to manage each controller leader status.
+type Interface interface {
+	IsLeader() bool
+	AddAcquiredLeaseCallback(fn func())
+	AddLostLeaseCallback(fn func())
+}

--- a/pkg/component/controller/tunneledapiendpointreconciller.go
+++ b/pkg/component/controller/tunneledapiendpointreconciller.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/sirupsen/logrus"
 	v1core "k8s.io/api/core/v1"
@@ -35,7 +36,7 @@ type TunneledEndpointReconciler struct {
 
 	logger *logrus.Entry
 
-	leaderElector     LeaderElector
+	leaderElector     leaderelector.Interface
 	kubeClientFactory k8sutil.ClientFactoryInterface
 }
 
@@ -225,7 +226,7 @@ func (ter TunneledEndpointReconciler) makeDefaultServiceInternalOnly(ctx context
 	return nil
 }
 
-func NewTunneledEndpointReconciler(leaderElector LeaderElector, kubeClientFactory k8sutil.ClientFactoryInterface) *TunneledEndpointReconciler {
+func NewTunneledEndpointReconciler(leaderElector leaderelector.Interface, kubeClientFactory k8sutil.ClientFactoryInterface) *TunneledEndpointReconciler {
 	return &TunneledEndpointReconciler{
 		leaderElector:     leaderElector,
 		kubeClientFactory: kubeClientFactory,


### PR DESCRIPTION
## Description

Preparation for #2425.

So that it is separate from the component/controller package and can be imported by other packages without creating circular dependencies.

Renames:

* controller.LeaderElector -> leaderelector.Interface
* controller.LeasePoolLeaderElector -> leaderelector.LeasePool
* controller.DummyLeaderElector -> leaderelector.Dummy

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings