### PR TITLE
Add the latest v1.24 version into the testing matrix.

### DIFF
--- a/.github/workflows/autopilot-branch-to-latest.yaml
+++ b/.github/workflows/autopilot-branch-to-latest.yaml
@@ -155,6 +155,16 @@ jobs:
             subnet: 2,
           },
 
+          # In the default case this will be an update to the same version,
+          # however this allows for testing latest branch version releases
+          # to RC builds (or whatever defined in GHA input)
+          {
+            name: "v1246-0",
+            fromver: "v1.24.6+k0s.0",
+            tover: "${{ github.event.inputs.v124latest }}",
+            subnet: 3,
+          },
+
           # latest branch versions to latest
           {
             name: "v124to125",


### PR DESCRIPTION
## Description

This allows for testing the latest v1.24 version against whatever version is provided in GHA input. The default case for this would be an autopilot update to the same version, which was missing in the matrix.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings