### PR TITLE
Add `ECONNREFUSED` into the known syscalls for `RetryWatchErrors`

### DIFF
--- a/inttest/common/util.go
+++ b/inttest/common/util.go
@@ -196,9 +196,15 @@ func RetryWatchErrors(logf func(format string, args ...any)) watch.ErrorCallback
 			return retryDelay, nil
 		}
 
-		if errors.Is(err, syscall.ECONNRESET) {
-			retryDelay := 1 * time.Second
+		retryDelay := 1 * time.Second
+
+		switch {
+		case errors.Is(err, syscall.ECONNRESET):
 			logf("Encountered connection reset while watching, retrying in %s: %v", retryDelay, err)
+			return retryDelay, nil
+
+		case errors.Is(err, syscall.ECONNREFUSED):
+			logf("Encountered connection refused while watching, retrying in %s: %v", retryDelay, err)
 			return retryDelay, nil
 		}
 

--- a/inttest/common/util_test.go
+++ b/inttest/common/util_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package common
+
+import (
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRetryWatchErrors ensures that the ErrorCallback returned by RetryWatchErrors can
+// properly identify known syscall errors.
+func TestRetryWatchErrors_syscalls(t *testing.T) {
+	defaultRetryDelay := 1 * time.Second
+
+	tests := []struct {
+		name          string
+		err           error
+		expectedDelay time.Duration
+		expectedError error
+	}{
+		{name: "ECONNRESET", err: syscall.ECONNRESET, expectedDelay: defaultRetryDelay, expectedError: nil},
+		{name: "ECONNREFUSED", err: syscall.ECONNREFUSED, expectedDelay: defaultRetryDelay, expectedError: nil},
+
+		// The fallthrough case, don't expect retries with this.
+		{name: "EBADFD", err: syscall.EBADFD, expectedDelay: 0, expectedError: syscall.EBADFD},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ecb := RetryWatchErrors(func(format string, args ...any) {})
+			retryDelay, err := ecb(test.err)
+
+			assert.Equal(t, test.expectedDelay, retryDelay)
+			assert.Equal(t, test.expectedError, err)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This also adds the beginnings of unit tests around this code.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings