### PR TITLE
[Backport release-1.25] Bump Calico to v3.24.4

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,13 +98,13 @@ spec:
     calico:
       cni:
         image: docker.io/calico/cni
-        version: v3.18.1
+        version: v3.24.4
       node:
         image: docker.io/calico/node
-        version: v3.18.1
+        version: v3.24.4
       kubecontrollers:
         image: docker.io/calico/kube-controllers
-        version: v3.18.1
+        version: v3.24.4
     kuberouter:
       cni:
         image: docker.io/cloudnativelabs/kube-router

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -85,7 +85,7 @@ const (
 	CoreDNSImage                       = "docker.io/coredns/coredns"
 	CoreDNSImageVersion                = "1.9.4"
 	CalicoImage                        = "docker.io/calico/cni"
-	CalicoComponentImagesVersion       = "v3.24.3"
+	CalicoComponentImagesVersion       = "v3.24.4"
 	CalicoNodeImage                    = "docker.io/calico/node"
 	KubeControllerImage                = "docker.io/calico/kube-controllers"
 	KubeRouterCNIImage                 = "docker.io/cloudnativelabs/kube-router"


### PR DESCRIPTION
Backport of #2355.