### PR TITLE
Added a Sonobuoy `toolsuite` operation for k8s conformance tests.

### DIFF
--- a/hack/tool/terraform/aws/modules/k0sinfra/main.tf
+++ b/hack/tool/terraform/aws/modules/k0sinfra/main.tf
@@ -55,8 +55,8 @@ resource "aws_security_group_rule" "egress_allow_all_external" {
   security_group_id = aws_security_group.this.id
   type              = "egress"
   from_port         = 0
-  to_port           = 63335
-  protocol          = "tcp"
+  to_port           = 65335
+  protocol          = "all"
   cidr_blocks       = ["0.0.0.0/0"]
 }
 

--- a/inttest/toolsuite/operations/sonobuoy.go
+++ b/inttest/toolsuite/operations/sonobuoy.go
@@ -1,0 +1,110 @@
+// Copyright 2022 k0s authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+
+	"github.com/cavaliergopher/grab/v3"
+	ts "github.com/k0sproject/k0s/inttest/toolsuite"
+)
+
+const (
+	sonobuoyVersion = "0.56.11"
+	sonobuoyOs      = "linux"
+	sonobuoyArch    = "amd64"
+)
+
+type SonobuoyConfig struct {
+	Parameters []string
+}
+
+// SonobuoyOperation builds a ClusterOperation that runs a Sonobuoy k8s conformance test
+// using the clusters k0s.kubeconfig. Results are stored in the data directory as `results.tar.gz`
+func SonobuoyOperation(config SonobuoyConfig) ts.ClusterOperation {
+	return func(ctx context.Context, data ts.ClusterData) error {
+		sonobuoyBinary, cleanup, err := downloadSonobuoy(ctx, sonobuoyVersion, sonobuoyOs, sonobuoyArch)
+		defer cleanup()
+
+		if err != nil {
+			return fmt.Errorf("failed to download sonobuoy distribution")
+		}
+
+		// Run sonobuoy, and wait
+
+		runArgs := []string{"run", "--kubeconfig", data.KubeConfigFile, "--wait"}
+		runArgs = append(runArgs, config.Parameters...)
+
+		sonobuoyCommand := exec.Command(sonobuoyBinary, runArgs...)
+		sonobuoyCommand.Stdout = os.Stdout
+		sonobuoyCommand.Stderr = os.Stderr
+		err = sonobuoyCommand.Run()
+
+		if err != nil {
+			fmt.Printf("Received an error running sonobuoy, will attempt to collect results: %v\n", err)
+		}
+
+		// Collect the results
+
+		resultsCommand := exec.Command(sonobuoyBinary, "retrieve", data.DataDir, "--kubeconfig", data.KubeConfigFile, "--filename", "results.tar.gz")
+		resultsCommand.Stdout = os.Stdout
+		resultsCommand.Stderr = os.Stderr
+		return resultsCommand.Run()
+	}
+}
+
+// downloadSonobuoy downloads the sonobuoy distribution for the provided OS and architecture.
+// The result is a path to the sonobuoy binary in a temporary directory, a cleanup function to remove
+// the transient binary/downloads, and any error that occurs.
+func downloadSonobuoy(ctx context.Context, version string, osname string, arch string) (string, func(), error) {
+	// As we create files, add them for removal
+	var filesToRemove []string
+	cleanup := func() {
+		for _, f := range filesToRemove {
+			_ = os.RemoveAll(f)
+		}
+	}
+
+	sonobuoyUrl := fmt.Sprintf("https://github.com/vmware-tanzu/sonobuoy/releases/download/v%s/sonobuoy_%s_%s_%s.tar.gz", version, version, osname, arch)
+	resp, err := grab.Get("/tmp", sonobuoyUrl)
+	if err != nil {
+		return "", cleanup, fmt.Errorf("failed to download the sonobuoy distribution: %w", err)
+	}
+
+	filesToRemove = append(filesToRemove, resp.Filename)
+
+	// Extract the distribution to its own unique directory
+
+	sonobuoyDir, err := os.MkdirTemp("/tmp", "sonobuoyop")
+	if err != nil {
+		return "", cleanup, err
+	}
+
+	filesToRemove = append(filesToRemove, sonobuoyDir)
+
+	extractCommand := exec.Command("tar", "-C", sonobuoyDir, "-xzf", resp.Filename)
+	extractCommand.Stdout = os.Stdout
+	extractCommand.Stderr = os.Stderr
+
+	if err := extractCommand.Run(); err != nil {
+		return "", cleanup, fmt.Errorf("failed to extract sonobuoy distribution: %w", err)
+	}
+
+	return path.Join(sonobuoyDir, "sonobuoy"), cleanup, nil
+}

--- a/inttest/toolsuite/tests/conformance_test.go
+++ b/inttest/toolsuite/tests/conformance_test.go
@@ -1,0 +1,60 @@
+// Copyright 2022 k0s authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	ts "github.com/k0sproject/k0s/inttest/toolsuite"
+	tsops "github.com/k0sproject/k0s/inttest/toolsuite/operations"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ConformanceConfig struct {
+	KubernetesVersion string
+}
+
+type ConformanceSuite struct {
+	ts.ToolSuite
+}
+
+var config ConformanceConfig
+
+func init() {
+	flag.StringVar(&config.KubernetesVersion, "conformance-kubernetes-version", "", "The kubernetes version of the conformance tests to run")
+}
+
+// TestConformanceSuite runs the Sonobuoy conformance tests for a specific k8s version.
+func TestConformanceSuite(t *testing.T) {
+	if config.KubernetesVersion == "" {
+		t.Fatal("--conformance-kubernetes-version is a required parameter")
+	}
+
+	suite.Run(t, &ConformanceSuite{
+		ts.ToolSuite{
+			Operation: tsops.SonobuoyOperation(
+				tsops.SonobuoyConfig{
+					Parameters: []string{
+						"--mode=certified-conformance",
+						fmt.Sprintf("--kubernetes-version=%s", config.KubernetesVersion),
+					},
+				},
+			),
+		},
+	})
+}


### PR DESCRIPTION
## Description
Taking advantage of how `toolsuite` works, this Sonobuoy operation will run a k8s conformance test for a given version against the cluster setup with `toolsuite`.

The new `conformance_test.go` is the testing entrypoint which handles the wiring of the Sonobuoy operation to `toolsuite` (w/version arguments)

This also addresses two bugs in the AWS security group configuration which were preventing UDP conformance tests from completing successfully.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings