### PR TITLE
Fix builds and ap-airgap inttests on mac m1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,8 +215,8 @@ lint: .k0sbuild.docker-image.k0s go.sum codegen
 	CGO_ENABLED=0 $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v$(golangci-lint_version)
 	$(GO_ENV) golangci-lint run --verbose $(GOLANGCI_LINT_FLAGS) $(GO_DIRS)
 
-airgap-images.txt: k0s
-	./k0s airgap list-images > '$@' || { \
+airgap-images.txt: k0s .k0sbuild.docker-image.k0s 
+	$(GO_ENV) ./k0s airgap list-images > '$@' || { \
 	  code=$$? && \
 	  rm -f -- '$@' && \
 	  exit $$code ; \

--- a/inttest/ap-airgap/airgap_test.go
+++ b/inttest/ap-airgap/airgap_test.go
@@ -90,6 +90,8 @@ spec:
         platforms:
           linux-amd64:
             url: http://localhost/dist/bundle.tar
+          linux-arm64:
+            url: http://localhost/dist/bundle.tar
         workers:
           discovery:
             static:
@@ -100,6 +102,8 @@ spec:
         forceupdate: true
         platforms:
           linux-amd64:
+            url: http://localhost/dist/k0s
+          linux-arm64:
             url: http://localhost/dist/k0s
         targets:
           controllers:


### PR DESCRIPTION
## Description

k0s is unable to build and test on apple silicon. This changes fixes partially some of the issues https://github.com/k0sproject/k0s/issues/2372

WIth this PR the airgap image bundle can be generated correctly and airgap and ap-airgap tests pass.
The scope of tests that remain broken is unknown at this point but at least ap-ha3x3 is still broken.

Also I have snuck a commit to add .DS_Store in the .gitignore, but since that's mac related and very small I think it makes sense

Fixes # (issue)
Partially https://github.com/k0sproject/k0s/issues/2372
## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings