### PR TITLE
Let k0s exchange the kubelet bootstrap kubeconfig

### DIFF
--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -25,6 +25,7 @@ smoketests := \
 	check-externaletcd \
 	check-extraargs \
 	check-hacontrolplane \
+	check-hostnameoverride \
 	check-k0scloudprovider \
 	check-kine \
 	check-kuberouter \

--- a/inttest/hostnameoverride/hostnameoverride_test.go
+++ b/inttest/hostnameoverride/hostnameoverride_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hostnameoverride
+
+import (
+	"testing"
+
+	"github.com/k0sproject/k0s/inttest/common"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type hostnameOverrideSuite struct {
+	common.FootlooseSuite
+}
+
+func (s *hostnameOverrideSuite) TestK0sGetsUp() {
+	s.Require().NoError(s.InitController(0, "--disable-components=konnectivity-server,metrics-server"))
+	s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(0)))
+
+	// Create a worker join token
+	joinToken, err := s.GetJoinToken("worker")
+	s.Require().NoError(err)
+
+	// Start the workers using the join token
+	s.Require().NoError(s.RunWorkersWithToken(joinToken, "--kubelet-extra-args=--hostname-override=foobar"))
+
+	client, err := s.KubeClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.Require().NoError(s.WaitForNodeReady("foobar", client))
+}
+
+func TestHostnameOverrideSuite(t *testing.T) {
+	suite.Run(t, &hostnameOverrideSuite{
+		common.FootlooseSuite{
+			ControllerCount: 1,
+			WorkerCount:     1,
+		},
+	})
+}

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -150,13 +150,12 @@ func (k *Kubelet) Start(ctx context.Context) error {
 	resolvConfPath := resolvconf.Path()
 
 	args := stringmap.StringMap{
-		"--root-dir":             k.dataDir,
-		"--config":               kubeletConfigPath,
-		"--bootstrap-kubeconfig": k.K0sVars.KubeletBootstrapConfigPath,
-		"--kubeconfig":           k.K0sVars.KubeletAuthConfigPath,
-		"--v":                    k.LogLevel,
-		"--runtime-cgroups":      "/system.slice/containerd.service",
-		"--cert-dir":             filepath.Join(k.dataDir, "pki"),
+		"--root-dir":        k.dataDir,
+		"--config":          kubeletConfigPath,
+		"--kubeconfig":      k.K0sVars.KubeletAuthConfigPath,
+		"--v":               k.LogLevel,
+		"--runtime-cgroups": "/system.slice/containerd.service",
+		"--cert-dir":        filepath.Join(k.dataDir, "pki"),
 	}
 
 	if len(k.Labels) > 0 {

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -133,7 +133,6 @@ type CfgVars struct {
 	KineSocketPath             string // The unix socket path for kine
 	KonnectivitySocketDir      string // location of konnectivity's socket path
 	KubeletAuthConfigPath      string // KubeletAuthConfigPath defines the default kubelet auth config path
-	KubeletBootstrapConfigPath string // KubeletBootstrapConfigPath defines the default path for kubelet bootstrap auth config
 	KubeletVolumePluginDir     string // location for kubelet plugins volume executables
 	ManifestsDir               string // location for all stack manifests
 	RunDir                     string // location of supervised pid files and sockets
@@ -186,7 +185,6 @@ func GetConfig(dataDir string) CfgVars {
 		KineSocketPath:             formatPath(runDir, KineSocket),
 		KonnectivitySocketDir:      formatPath(runDir, "konnectivity-server"),
 		KubeletAuthConfigPath:      formatPath(dataDir, "kubelet.conf"),
-		KubeletBootstrapConfigPath: formatPath(dataDir, "kubelet-bootstrap.conf"),
 		KubeletVolumePluginDir:     KubeletVolumePluginDir,
 		ManifestsDir:               formatPath(dataDir, "manifests"),
 		RunDir:                     runDir,


### PR DESCRIPTION
## Description

Instead of passing the bootstrap kubeconfig to the kubelet in order to exchange that for a regular certificate-based kubeconfig, let k0s do this. This way, k0s has full control over the bootstrapping process and can safely delete the bootstrap kubeconfig after a successful exchange.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings