### PR TITLE
Don't create the test network if it already exists

### DIFF
--- a/inttest/ap-airgap/airgap_test.go
+++ b/inttest/ap-airgap/airgap_test.go
@@ -44,7 +44,7 @@ func (s *airgapSuite) SetupSuite() {
 // TearDownSuite tears down the network created after footloose has finished.
 func (s *airgapSuite) TearDownSuite() {
 	s.FootlooseSuite.TearDownSuite()
-	s.Require().NoError(s.DestroyNetwork(network))
+	s.Require().NoError(s.MaybeDestroyNetwork(network))
 }
 
 // SetupTest prepares the controller and filesystem, getting it into a consistent

--- a/inttest/ap-ha3x3/ha3x3_test.go
+++ b/inttest/ap-ha3x3/ha3x3_test.go
@@ -51,7 +51,7 @@ func (s *ha3x3Suite) SetupSuite() {
 // TearDownSuite tears down the network created after footloose has finished.
 func (s *ha3x3Suite) TearDownSuite() {
 	s.FootlooseSuite.TearDownSuite()
-	s.Require().NoError(s.DestroyNetwork(network))
+	s.Require().NoError(s.MaybeDestroyNetwork(network))
 }
 
 // SetupTest prepares the controller and filesystem, getting it into a consistent

--- a/inttest/ap-quorum/quorum_test.go
+++ b/inttest/ap-quorum/quorum_test.go
@@ -50,7 +50,7 @@ func (s *quorumSuite) SetupSuite() {
 // TearDownSuite tears down the network created after footloose has finished.
 func (s *quorumSuite) TearDownSuite() {
 	s.FootlooseSuite.TearDownSuite()
-	s.Require().NoError(s.DestroyNetwork(network))
+	s.Require().NoError(s.MaybeDestroyNetwork(network))
 }
 
 // SetupTest prepares the controller and filesystem, getting it into a consistent

--- a/inttest/ap-quorumsafety/quorumsafety_test.go
+++ b/inttest/ap-quorumsafety/quorumsafety_test.go
@@ -50,7 +50,7 @@ func (s *quorumSafetySuite) SetupSuite() {
 // TearDownSuite tears down the network created after footloose has finished.
 func (s *quorumSafetySuite) TearDownSuite() {
 	s.FootlooseSuite.TearDownSuite()
-	s.Require().NoError(s.DestroyNetwork(network))
+	s.Require().NoError(s.MaybeDestroyNetwork(network))
 }
 
 // SetupTest prepares the controller and filesystem, getting it into a consistent

--- a/inttest/ap-selector/selector_test.go
+++ b/inttest/ap-selector/selector_test.go
@@ -50,7 +50,7 @@ func (s *selectorSuite) SetupSuite() {
 // TearDownSuite tears down the network created after footloose has finished.
 func (s *selectorSuite) TearDownSuite() {
 	s.FootlooseSuite.TearDownSuite()
-	s.Require().NoError(s.DestroyNetwork(network))
+	s.Require().NoError(s.MaybeDestroyNetwork(network))
 }
 
 // SetupTest prepares the controller and filesystem, getting it into a consistent

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -1289,16 +1289,34 @@ func (s *FootlooseSuite) getIPAddress(nodeName string) string {
 // CreateNetwork creates a docker network with the provided name, destroying
 // any network that has the same name first.
 func (s *FootlooseSuite) CreateNetwork(name string) error {
-	_ = s.DestroyNetwork(name)
+	// Don't create the network if it already exists as it might be in use from previous tests
+	// ran with K0S_KEEP_AFTER_TEST variable set.
+	if s.NetworkExists(name) {
+		return nil
+	}
 
 	cmd := exec.Command("docker", "network", "create", name)
 	return cmd.Run()
 }
 
-// DestroyNetwork removes a docker network with the provided name.
-func (s *FootlooseSuite) DestroyNetwork(name string) error {
+// MaybeDestroyNetwork removes a docker network with the provided name.
+// The network might not get removed if there's still containers attached to it.
+// This is the case for example when running the tests with K0S_KEEP_AFTER_TEST=always.
+func (s *FootlooseSuite) MaybeDestroyNetwork(name string) error {
+	// If we're supposed to leave the footloose containers running, don't try to destroy the network
+	if keepEnvironment(s.T()) {
+		return nil
+	}
 	cmd := exec.Command("docker", "network", "rm", name)
 	return cmd.Run()
+}
+
+// NetworkExists returns true if a docker network with the provided name exists.
+func (s *FootlooseSuite) NetworkExists(name string) bool {
+	cmd := exec.Command("docker", "network", "inspect", name)
+	err := cmd.Run()
+
+	return err == nil
 }
 
 // RunCommandController runs a command via SSH on a specified controller node

--- a/inttest/kubeletcertrotate/kubeletcertrotate_test.go
+++ b/inttest/kubeletcertrotate/kubeletcertrotate_test.go
@@ -46,7 +46,7 @@ func (s *kubeletCertRotateSuite) SetupSuite() {
 // TearDownSuite tears down the network created after footloose has finished.
 func (s *kubeletCertRotateSuite) TearDownSuite() {
 	s.FootlooseSuite.TearDownSuite()
-	s.Require().NoError(s.DestroyNetwork(network))
+	s.Require().NoError(s.MaybeDestroyNetwork(network))
 }
 
 type statusJSON struct {


### PR DESCRIPTION
Also don't try to remove it if we're leaving the footloose containers running after the tests as the `docker network rm` call would fail.

Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings