### PR TITLE
Add lint for package import order

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ run:
 linters:
   enable:
     - depguard # Checks if package imports are in a list of acceptable packages
+    - gci      # Checks import order
     - gofmt    # Checks whether code was gofmt-ed
     - goheader # Checks is file headers matche a given pattern
     - revive   # Stricter drop-in replacement for golint
@@ -22,6 +23,14 @@ linters-settings:
   depguard:
     packages:
       - gopkg.in/yaml*
+  gci:
+    custom-order: true
+    sections:
+      - standard
+      - prefix(tool)
+      - prefix(github.com/k0sproject/k0s)
+      - prefix(k8s.io)
+      - default
   golint:
     min-confidence: 0
   goheader:

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ bindata: static/zz_generated_assets.go pkg/assets/zz_generated_offsets_$(TARGET_
 lint: GOLANGCI_LINT_FLAGS ?=
 lint: .k0sbuild.docker-image.k0s go.sum codegen
 	CGO_ENABLED=0 $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v$(golangci-lint_version)
-	$(GO_ENV) golangci-lint run --verbose $(GOLANGCI_LINT_FLAGS) $(GO_DIRS)
+	$(GO_ENV) golangci-lint run --verbose $(GOLANGCI_LINT_FLAGS) $(GO_DIRS) ./inttest/...
 
 airgap-images.txt: k0s .k0sbuild.docker-image.k0s 
 	$(GO_ENV) ./k0s airgap list-images > '$@' || { \

--- a/cmd/airgap/airgap.go
+++ b/cmd/airgap/airgap.go
@@ -17,9 +17,9 @@ limitations under the License.
 package airgap
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/k0sproject/k0s/pkg/config"
+
+	"github.com/spf13/cobra"
 )
 
 func NewAirgapCmd() *cobra.Command {

--- a/cmd/airgap/listimages_test.go
+++ b/cmd/airgap/listimages_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+
 	"github.com/stretchr/testify/suite"
 )
 

--- a/cmd/config/create.go
+++ b/cmd/config/create.go
@@ -19,11 +19,11 @@ package config
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
-	"sigs.k8s.io/yaml"
-
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/config"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 )
 
 func NewCreateCmd() *cobra.Command {

--- a/cmd/install/util.go
+++ b/cmd/install/util.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-
 	"github.com/spf13/pflag"
 )
 

--- a/cmd/install/worker.go
+++ b/cmd/install/worker.go
@@ -17,9 +17,9 @@ limitations under the License.
 package install
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/k0sproject/k0s/pkg/config"
+
+	"github.com/spf13/cobra"
 )
 
 func installWorkerCmd(installFlags *installFlags) *cobra.Command {

--- a/cmd/sysinfo/sysinfo.go
+++ b/cmd/sysinfo/sysinfo.go
@@ -25,9 +25,10 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
 	"github.com/k0sproject/k0s/pkg/constant"
 
+	"k8s.io/kubectl/pkg/util/term"
+
 	"github.com/logrusorgru/aurora/v3"
 	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/util/term"
 )
 
 func NewSysinfoCmd() *cobra.Command {

--- a/cmd/sysinfo/sysinfo_test.go
+++ b/cmd/sysinfo/sysinfo_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+
 	"github.com/logrusorgru/aurora/v3"
 	"github.com/stretchr/testify/assert"
 )

--- a/cmd/token/preshared.go
+++ b/cmd/token/preshared.go
@@ -24,15 +24,16 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/spf13/cobra"
-	v1 "k8s.io/api/core/v1"
-	fakeclientset "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/testing"
-	"sigs.k8s.io/yaml"
-
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/token"
+
+	v1 "k8s.io/api/core/v1"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/testing"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 )
 
 func preSharedCmd() *cobra.Command {

--- a/hack/tool/cmd/aws/ha/ha.go
+++ b/hack/tool/cmd/aws/ha/ha.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+
 	"tool/cmd/aws/provision"
 	"tool/pkg/backend/aws"
 	"tool/pkg/constant"

--- a/hack/tool/cmd/aws/havpc/havpc.go
+++ b/hack/tool/cmd/aws/havpc/havpc.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+
 	"tool/cmd/aws/provision"
 	"tool/pkg/backend/aws"
 	"tool/pkg/constant"

--- a/hack/tool/cmd/aws/provision/provision.go
+++ b/hack/tool/cmd/aws/provision/provision.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+
 	"tool/pkg/constant"
 
 	k0sctlcmd "github.com/k0sproject/k0sctl/cmd"

--- a/hack/tool/pkg/terraform/terraform.go
+++ b/hack/tool/pkg/terraform/terraform.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"os"
 	"path"
+
 	"tool/pkg/constant"
 
 	"github.com/hashicorp/terraform-exec/tfexec"

--- a/hack/validate-images/main.go
+++ b/hack/validate-images/main.go
@@ -26,15 +26,14 @@ import (
 	"os"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/k0sproject/k0s/pkg/airgap"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/estesp/manifest-tool/v2/pkg/registry"
 	"github.com/estesp/manifest-tool/v2/pkg/store"
 	"github.com/estesp/manifest-tool/v2/pkg/types"
 	"github.com/estesp/manifest-tool/v2/pkg/util"
-
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 

--- a/internal/autopilot/testutil/client.go
+++ b/internal/autopilot/testutil/client.go
@@ -17,10 +17,10 @@ package testutil
 import (
 	apclient "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset"
 	apclientfake "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset/fake"
+	"github.com/k0sproject/k0s/pkg/autopilot/client"
+
 	extclientfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	extclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
-
-	"github.com/k0sproject/k0s/pkg/autopilot/client"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"

--- a/internal/pkg/sysinfo/probes/linux/cgroups.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroups.go
@@ -25,9 +25,9 @@ import (
 	"sync"
 	"syscall"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+
+	"golang.org/x/sys/unix"
 )
 
 type CgroupsProbes struct {

--- a/internal/pkg/sysinfo/probes/linux/cgroups_test.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroups_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
 	test_sysinfo "github.com/k0sproject/k0s/internal/testutil/sysinfo"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/internal/pkg/sysinfo/probes/linux/linux_test.go
+++ b/internal/pkg/sysinfo/probes/linux/linux_test.go
@@ -26,8 +26,8 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
-
 	test_sysinfo "github.com/k0sproject/k0s/internal/testutil/sysinfo"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/internal/pkg/sysinfo/probes/linux/procfs.go
+++ b/internal/pkg/sysinfo/probes/linux/procfs.go
@@ -24,9 +24,9 @@ import (
 	"os"
 	"syscall"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+
+	"golang.org/x/sys/unix"
 )
 
 func (l *LinuxProbes) RequireProcFS() {

--- a/internal/pkg/templatewriter/templatewriter.go
+++ b/internal/pkg/templatewriter/templatewriter.go
@@ -21,10 +21,10 @@ import (
 	"io"
 	"text/template"
 
-	"github.com/Masterminds/sprig"
-
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/pkg/constant"
+
+	"github.com/Masterminds/sprig"
 )
 
 // TemplateWriter is a helper to write templated kube manifests

--- a/internal/testutil/kube_client.go
+++ b/internal/testutil/kube_client.go
@@ -18,7 +18,8 @@ package testutil
 
 import (
 	"fmt"
-	"k8s.io/client-go/rest"
+
+	cfgClient "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/clientset/typed/k0s.k0sproject.io/v1beta1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -29,10 +30,9 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 	restfake "k8s.io/client-go/rest/fake"
 	kubetesting "k8s.io/client-go/testing"
-
-	cfgClient "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/clientset/typed/k0s.k0sproject.io/v1beta1"
 )
 
 // NewFakeClientFactory creates new client factory which uses internally only the kube fake client interface

--- a/internal/testutil/sysinfo/reporter.go
+++ b/internal/testutil/sysinfo/reporter.go
@@ -18,6 +18,7 @@ package sysinfo
 
 import (
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+
 	"github.com/stretchr/testify/mock"
 )
 

--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -22,15 +22,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/inttest/common"
 	"github.com/k0sproject/k0s/pkg/apis/helm.k0sproject.io/v1beta1"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/stretchr/testify/suite"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )

--- a/inttest/airgap/airgap_test.go
+++ b/inttest/airgap/airgap_test.go
@@ -20,10 +20,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
+	"github.com/k0sproject/k0s/inttest/common"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/stretchr/testify/suite"
 )
 
 const k0sConfig = `

--- a/inttest/ap-airgap/airgap_test.go
+++ b/inttest/ap-airgap/airgap_test.go
@@ -19,12 +19,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k0sproject/k0s/inttest/common"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
-
-	"github.com/k0sproject/k0s/inttest/common"
 
 	"github.com/stretchr/testify/suite"
 )

--- a/inttest/ap-ha3x3/ha3x3_test.go
+++ b/inttest/ap-ha3x3/ha3x3_test.go
@@ -20,12 +20,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k0sproject/k0s/inttest/common"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
-
-	"github.com/k0sproject/k0s/inttest/common"
 
 	"github.com/stretchr/testify/suite"
 )

--- a/inttest/ap-platformselect/platformselect_test.go
+++ b/inttest/ap-platformselect/platformselect_test.go
@@ -19,12 +19,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k0sproject/k0s/inttest/common"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
-
-	"github.com/k0sproject/k0s/inttest/common"
 
 	"github.com/stretchr/testify/suite"
 )

--- a/inttest/ap-quorum/quorum_test.go
+++ b/inttest/ap-quorum/quorum_test.go
@@ -19,12 +19,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k0sproject/k0s/inttest/common"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
-
-	"github.com/k0sproject/k0s/inttest/common"
 
 	"github.com/stretchr/testify/suite"
 )

--- a/inttest/ap-quorumsafety/quorumsafety_test.go
+++ b/inttest/ap-quorumsafety/quorumsafety_test.go
@@ -19,12 +19,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k0sproject/k0s/inttest/common"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
-
-	"github.com/k0sproject/k0s/inttest/common"
 
 	"github.com/stretchr/testify/suite"
 )

--- a/inttest/ap-removedapis/removedapis_test.go
+++ b/inttest/ap-removedapis/removedapis_test.go
@@ -19,12 +19,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k0sproject/k0s/inttest/common"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
-
-	"github.com/k0sproject/k0s/inttest/common"
 
 	"github.com/stretchr/testify/suite"
 )

--- a/inttest/ap-selector/selector_test.go
+++ b/inttest/ap-selector/selector_test.go
@@ -19,12 +19,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k0sproject/k0s/inttest/common"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
-
-	"github.com/k0sproject/k0s/inttest/common"
 
 	"github.com/stretchr/testify/suite"
 )

--- a/inttest/ap-single/single_test.go
+++ b/inttest/ap-single/single_test.go
@@ -19,12 +19,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k0sproject/k0s/inttest/common"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
-
-	"github.com/k0sproject/k0s/inttest/common"
 
 	"github.com/stretchr/testify/suite"
 )

--- a/inttest/ap-updater/updater_test.go
+++ b/inttest/ap-updater/updater_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/k0sproject/k0s/inttest/common"
-
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"

--- a/inttest/backup/backup_test.go
+++ b/inttest/backup/backup_test.go
@@ -21,13 +21,13 @@ import (
 	"html/template"
 	"testing"
 
+	"github.com/k0sproject/k0s/inttest/common"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/stretchr/testify/suite"
-
-	"github.com/k0sproject/k0s/inttest/common"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const configWithExternaladdress = `

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/k0sproject/k0s/inttest/common"
+
 	capi "k8s.io/api/certificates/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type BasicSuite struct {

--- a/inttest/byocri/byocri_test.go
+++ b/inttest/byocri/byocri_test.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/k0sproject/k0s/inttest/common"
+
 	"github.com/avast/retry-go"
 	"github.com/stretchr/testify/suite"
 	"github.com/weaveworks/footloose/pkg/config"
-
-	"github.com/k0sproject/k0s/inttest/common"
 )
 
 type BYOCRISuite struct {

--- a/inttest/calico/calico_test.go
+++ b/inttest/calico/calico_test.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
+	"github.com/k0sproject/k0s/inttest/common"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/stretchr/testify/suite"
 )
 
 type CalicoSuite struct {

--- a/inttest/capitalhostnames/capitalhostnames_test.go
+++ b/inttest/capitalhostnames/capitalhostnames_test.go
@@ -19,10 +19,11 @@ package basic
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/k0sproject/k0s/inttest/common"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type CapitalHostnamesSuite struct {

--- a/inttest/capitalhostnames/capitalhostnames_test.go
+++ b/inttest/capitalhostnames/capitalhostnames_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package basic
 
 import (

--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/k0sproject/k0s/inttest/common"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/inttest/cnichange/cnichange_test.go
+++ b/inttest/cnichange/cnichange_test.go
@@ -19,9 +19,9 @@ package cnichange
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/k0sproject/k0s/inttest/common"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type CNIChangeSuite struct {

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -319,7 +319,7 @@ func (s *FootlooseSuite) cleanupSuite(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			s.dumpClusterState(t, ctx, filepath.Join(tmpDir, "cluster-state.tar"))
+			s.dumpClusterState(ctx, t, filepath.Join(tmpDir, "cluster-state.tar"))
 		}()
 	}
 
@@ -338,7 +338,7 @@ func (s *FootlooseSuite) cleanupSuite(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			s.dumpNodeLogs(t, ctx, node, tmpDir)
+			s.dumpNodeLogs(ctx, t, node, tmpDir)
 		}()
 	}
 
@@ -356,7 +356,7 @@ func (s *FootlooseSuite) cleanupSuite(t *testing.T) {
 	cleanupClusterDir(t, s.clusterDir)
 }
 
-func (s *FootlooseSuite) dumpClusterState(t *testing.T, ctx context.Context, filePath string) {
+func (s *FootlooseSuite) dumpClusterState(ctx context.Context, t *testing.T, filePath string) {
 	node := s.ControllerNode(0)
 
 	ssh, err := s.SSH(node)
@@ -396,7 +396,7 @@ func (s *FootlooseSuite) dumpClusterState(t *testing.T, ctx context.Context, fil
 	t.Logf("Dumped cluster state into %s", filePath)
 }
 
-func (s *FootlooseSuite) dumpNodeLogs(t *testing.T, ctx context.Context, node, dir string) {
+func (s *FootlooseSuite) dumpNodeLogs(ctx context.Context, t *testing.T, node, dir string) {
 	ssh, err := s.SSH(node)
 	if err != nil {
 		t.Logf("Failed to ssh into node %s to get logs: %s", node, err.Error())

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -45,9 +45,9 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	apclient "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset"
 	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
-	extclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	extclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -55,7 +55,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/yaml"
 
 	"github.com/go-openapi/jsonpointer"
 	"github.com/stretchr/testify/assert"
@@ -64,6 +63,7 @@ import (
 	"github.com/weaveworks/footloose/pkg/config"
 	"go.uber.org/multierr"
 	"golang.org/x/sync/errgroup"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/inttest/common/util_test.go
+++ b/inttest/common/util_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package common
 
 import (

--- a/inttest/configchange/config_test.go
+++ b/inttest/configchange/config_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k0sproject/k0s/inttest/common"
 	cfgClient "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/clientset/typed/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
@@ -32,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/k0sproject/k0s/inttest/common"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/inttest/ctr/ctr_test.go
+++ b/inttest/ctr/ctr_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/inttest/common"
+
 	"github.com/stretchr/testify/suite"
 )
 

--- a/inttest/customca/customca_test.go
+++ b/inttest/customca/customca_test.go
@@ -36,7 +36,7 @@ func (s *CustomCASuite) TestK0sGetsUp() {
 	s.Require().NoError(err)
 	defer ssh.Disconnect()
 
-	ssh.Exec(s.Context(), "sh -e", common.SSHStreams{
+	s.Require().NoError(ssh.Exec(s.Context(), "sh -e", common.SSHStreams{
 		In: strings.NewReader(fmt.Sprintf(`
 			K0S_PATH=%q
 			IP_ADDRESS=%q
@@ -46,7 +46,7 @@ func (s *CustomCASuite) TestK0sGetsUp() {
 			openssl req -x509 -new -nodes -key /var/lib/k0s/pki/ca.key -sha256 -days 365 -out /var/lib/k0s/pki/ca.crt -subj "/CN=Test CA"
 			"$K0S_PATH" token pre-shared --cert /var/lib/k0s/pki/ca.crt --url https://"$IP_ADDRESS":6443/ --out /var/lib/k0s/manifests/test
 		`, s.K0sFullPath, s.GetControllerIPAddress(0))),
-	})
+	}))
 
 	cert, err := ssh.ExecWithOutput(s.Context(), "cat /var/lib/k0s/pki/ca.crt")
 	s.Require().NoError(err)

--- a/inttest/customca/customca_test.go
+++ b/inttest/customca/customca_test.go
@@ -21,9 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/k0sproject/k0s/inttest/common"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type CustomCASuite struct {

--- a/inttest/customdomain/customdomain_test.go
+++ b/inttest/customdomain/customdomain_test.go
@@ -19,9 +19,9 @@ package customdomain
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/k0sproject/k0s/inttest/common"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type CustomDomainSuite struct {

--- a/inttest/customports/customports_test.go
+++ b/inttest/customports/customports_test.go
@@ -23,8 +23,10 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/inttest/common"
-	"github.com/stretchr/testify/suite"
+
 	k8s "k8s.io/client-go/kubernetes"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type Suite struct {

--- a/inttest/defaultstorage/defaultstorage_test.go
+++ b/inttest/defaultstorage/defaultstorage_test.go
@@ -19,10 +19,11 @@ package defaultstorage
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
+	"github.com/k0sproject/k0s/inttest/common"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/stretchr/testify/suite"
 )
 
 type DefaultStorageSuite struct {

--- a/inttest/disabledcomponents/disabled_components_test.go
+++ b/inttest/disabledcomponents/disabled_components_test.go
@@ -20,10 +20,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/k0sproject/k0s/inttest/common"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type DisabledComponentsSuite struct {

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -27,14 +27,14 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
-	"github.com/stretchr/testify/suite"
-	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"testing"
 
 	"github.com/k0sproject/k0s/inttest/common"
+
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "k8s.io/client-go/kubernetes"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type DualstackSuite struct {

--- a/inttest/externaletcd/external_etcd_test.go
+++ b/inttest/externaletcd/external_etcd_test.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/avast/retry-go"
 	"github.com/k0sproject/k0s/inttest/common"
+
+	"github.com/avast/retry-go"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/inttest/extraargs/extraargs_test.go
+++ b/inttest/extraargs/extraargs_test.go
@@ -19,9 +19,9 @@ package extraargs
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/k0sproject/k0s/inttest/common"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type ExtraArgsSuite struct {

--- a/inttest/hacontrolplane/hacontrolplane_test.go
+++ b/inttest/hacontrolplane/hacontrolplane_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/k0sproject/k0s/inttest/common"
+
 	"github.com/stretchr/testify/suite"
 )
 

--- a/inttest/k0scloudprovider/k0scloudprovider_test.go
+++ b/inttest/k0scloudprovider/k0scloudprovider_test.go
@@ -23,10 +23,12 @@ import (
 
 	"github.com/k0sproject/k0s/inttest/common"
 	"github.com/k0sproject/k0s/pkg/k0scloudprovider"
-	"github.com/stretchr/testify/suite"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type K0sCloudProviderSuite struct {

--- a/inttest/k0sctl/k0sctl_test.go
+++ b/inttest/k0sctl/k0sctl_test.go
@@ -29,10 +29,10 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/k0sproject/k0s/inttest/common"
+
 	"github.com/stretchr/testify/suite"
 	"sigs.k8s.io/yaml"
-
-	"github.com/k0sproject/k0s/inttest/common"
 )
 
 const k0sctlVersion = "v0.13.0"

--- a/inttest/kine/kine_test.go
+++ b/inttest/kine/kine_test.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/k0sproject/k0s/inttest/common"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-
-	"github.com/k0sproject/k0s/inttest/common"
 )
 
 type KineSuite struct {

--- a/inttest/kubectl/kubectl_test.go
+++ b/inttest/kubectl/kubectl_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/k0sproject/k0s/inttest/common"
 	"github.com/k0sproject/k0s/pkg/constant"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/inttest/kubeletcertrotate/kubeletcertrotate_test.go
+++ b/inttest/kubeletcertrotate/kubeletcertrotate_test.go
@@ -88,7 +88,7 @@ func (s *kubeletCertRotateSuite) SetupTest() {
 	workerSSH, err := s.SSH(s.WorkerNode(0))
 	s.Require().NoError(err)
 	s.T().Log("waiting to see kubelet rotating the client cert before triggering Plan creation")
-	workerSSH.ExecWithOutput(s.Context(), "inotifywait --no-dereference /var/lib/k0s/kubelet/pki/kubelet-client-current.pem")
+	s.Require().NoError(workerSSH.Exec(s.Context(), "inotifywait --no-dereference /var/lib/k0s/kubelet/pki/kubelet-client-current.pem", common.SSHStreams{}))
 	output, err := workerSSH.ExecWithOutput(s.Context(), "k0s status -ojson")
 	s.Require().NoError(err)
 	status := statusJSON{}

--- a/inttest/kubeletcertrotate/kubeletcertrotate_test.go
+++ b/inttest/kubeletcertrotate/kubeletcertrotate_test.go
@@ -20,13 +20,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k0sproject/k0s/inttest/common"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 	"github.com/k0sproject/k0s/pkg/install"
-
-	"github.com/k0sproject/k0s/inttest/common"
 
 	"github.com/stretchr/testify/suite"
 )

--- a/inttest/metrics/metrics_test.go
+++ b/inttest/metrics/metrics_test.go
@@ -19,9 +19,9 @@ package metrics
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/k0sproject/k0s/inttest/common"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type MetricsSuite struct {

--- a/inttest/metricscraper/metricscraper_test.go
+++ b/inttest/metricscraper/metricscraper_test.go
@@ -21,12 +21,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/suite"
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/k0sproject/k0s/inttest/common"
+
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type MetricScraperSuite struct {

--- a/inttest/multicontroller/multicontroller_test.go
+++ b/inttest/multicontroller/multicontroller_test.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/k0sproject/k0s/inttest/common"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type MultiControllerSuite struct {

--- a/inttest/noderole-no-taints/noderole_no_taints_test.go
+++ b/inttest/noderole-no-taints/noderole_no_taints_test.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
+	"github.com/k0sproject/k0s/inttest/common"
+
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/stretchr/testify/suite"
 )
 
 type NodeRoleNoTaintsSuite struct {

--- a/inttest/noderole-single/noderole_single_test.go
+++ b/inttest/noderole-single/noderole_single_test.go
@@ -19,11 +19,12 @@ package noderole
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
+	"github.com/k0sproject/k0s/inttest/common"
+
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/stretchr/testify/suite"
 )
 
 type NodeRoleSingleSuite struct {

--- a/inttest/noderole/noderole_test.go
+++ b/inttest/noderole/noderole_test.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
+	"github.com/k0sproject/k0s/inttest/common"
+
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/stretchr/testify/suite"
 )
 
 type NodeRoleSuite struct {

--- a/inttest/singlenode/singlenode_test.go
+++ b/inttest/singlenode/singlenode_test.go
@@ -18,17 +18,16 @@ package singlenode
 
 import (
 	"fmt"
-
 	"testing"
 
+	"github.com/k0sproject/k0s/inttest/common"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-
-	"github.com/k0sproject/k0s/inttest/common"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const k0sPartialConfig = `

--- a/inttest/statussocket/statussocket_test.go
+++ b/inttest/statussocket/statussocket_test.go
@@ -19,9 +19,9 @@ package statussocket
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/k0sproject/k0s/inttest/common"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type StatusSocketSuite struct {

--- a/inttest/toolsuite/operations/planapply.go
+++ b/inttest/toolsuite/operations/planapply.go
@@ -27,10 +27,10 @@ import (
 	tsutil "github.com/k0sproject/k0s/inttest/toolsuite/util"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 
-	"sigs.k8s.io/yaml"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 type PlanBuilder func(output tsutil.TerraformOutputMap) (*apv1beta2.Plan, error)

--- a/inttest/toolsuite/operations/planapply.go
+++ b/inttest/toolsuite/operations/planapply.go
@@ -1,16 +1,18 @@
-// Copyright 2022 k0s authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package operations
 

--- a/inttest/toolsuite/operations/sonobuoy.go
+++ b/inttest/toolsuite/operations/sonobuoy.go
@@ -1,16 +1,18 @@
-// Copyright 2022 k0s authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package operations
 
@@ -81,8 +83,8 @@ func downloadSonobuoy(ctx context.Context, version string, osname string, arch s
 		}
 	}
 
-	sonobuoyUrl := fmt.Sprintf("https://github.com/vmware-tanzu/sonobuoy/releases/download/v%s/sonobuoy_%s_%s_%s.tar.gz", version, version, osname, arch)
-	resp, err := grab.Get("/tmp", sonobuoyUrl)
+	sonobuoyURL := fmt.Sprintf("https://github.com/vmware-tanzu/sonobuoy/releases/download/v%s/sonobuoy_%s_%s_%s.tar.gz", version, version, osname, arch)
+	resp, err := grab.Get("/tmp", sonobuoyURL)
 	if err != nil {
 		return "", cleanup, fmt.Errorf("failed to download the sonobuoy distribution: %w", err)
 	}

--- a/inttest/toolsuite/operations/sonobuoy.go
+++ b/inttest/toolsuite/operations/sonobuoy.go
@@ -23,8 +23,9 @@ import (
 	"os/exec"
 	"path"
 
-	"github.com/cavaliergopher/grab/v3"
 	ts "github.com/k0sproject/k0s/inttest/toolsuite"
+
+	"github.com/cavaliergopher/grab/v3"
 )
 
 const (

--- a/inttest/toolsuite/tests/conformance_test.go
+++ b/inttest/toolsuite/tests/conformance_test.go
@@ -1,16 +1,18 @@
-// Copyright 2022 k0s authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package tests
 

--- a/inttest/toolsuite/tests/versionupdate_test.go
+++ b/inttest/toolsuite/tests/versionupdate_test.go
@@ -1,16 +1,18 @@
-// Copyright 2022 k0s authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package tests
 
@@ -68,8 +70,8 @@ func VersionUpdatePlan(output tsutil.TerraformOutputMap) (*apv1beta2.Plan, error
 		return nil, err
 	}
 
-	var updateK0sUrl string
-	if err := tsutil.TerraformOutput(&updateK0sUrl, output, "k0s_update_binary_url"); err != nil {
+	var updateK0sURL string
+	if err := tsutil.TerraformOutput(&updateK0sURL, output, "k0s_update_binary_url"); err != nil {
 		return nil, err
 	}
 
@@ -103,7 +105,7 @@ func VersionUpdatePlan(output tsutil.TerraformOutputMap) (*apv1beta2.Plan, error
 						ForceUpdate: true,
 						Platforms: apv1beta2.PlanPlatformResourceURLMap{
 							"linux-amd64": apv1beta2.PlanResourceURL{
-								URL: updateK0sUrl,
+								URL: updateK0sURL,
 							},
 						},
 						Targets: apv1beta2.PlanCommandTargets{

--- a/inttest/toolsuite/tests/versionupdate_test.go
+++ b/inttest/toolsuite/tests/versionupdate_test.go
@@ -23,7 +23,6 @@ import (
 	ts "github.com/k0sproject/k0s/inttest/toolsuite"
 	tsops "github.com/k0sproject/k0s/inttest/toolsuite/operations"
 	tsutil "github.com/k0sproject/k0s/inttest/toolsuite/util"
-
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"

--- a/inttest/toolsuite/toolsuite.go
+++ b/inttest/toolsuite/toolsuite.go
@@ -1,16 +1,18 @@
-// Copyright 2022 k0s authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package toolsuite
 

--- a/inttest/toolsuite/toolsuite.go
+++ b/inttest/toolsuite/toolsuite.go
@@ -28,11 +28,12 @@ import (
 
 	apclient "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
 const (

--- a/inttest/toolsuite/util/terraform.go
+++ b/inttest/toolsuite/util/terraform.go
@@ -1,16 +1,18 @@
-// Copyright 2022 k0s authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package util
 

--- a/inttest/tunneledkas/suite_test.go
+++ b/inttest/tunneledkas/suite_test.go
@@ -22,11 +22,12 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
+	"github.com/k0sproject/k0s/inttest/common"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/stretchr/testify/suite"
 )
 
 type Suite struct {

--- a/inttest/upgrade/upgrade_test.go
+++ b/inttest/upgrade/upgrade_test.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/k0sproject/k0s/inttest/common"
+
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/k0sproject/k0s/inttest/common"
 )
 
 type UpgradeSuite struct {

--- a/inttest/workerrestart/workerrestart_test.go
+++ b/inttest/workerrestart/workerrestart_test.go
@@ -19,9 +19,9 @@ package workerrestart
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/k0sproject/k0s/inttest/common"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type WorkerRestartSuite struct {

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/k0sproject/k0s/cmd"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/apis/autopilot.k0sproject.io/v1beta2/info.go
+++ b/pkg/apis/autopilot.k0sproject.io/v1beta2/info.go
@@ -19,6 +19,7 @@ package v1beta2
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 

--- a/pkg/apis/helm.k0sproject.io/v1beta1/chart_types.go
+++ b/pkg/apis/helm.k0sproject.io/v1beta1/chart_types.go
@@ -19,8 +19,10 @@ package v1beta1
 import (
 	"crypto/sha256"
 	"fmt"
-	"github.com/sirupsen/logrus"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/apis/helm.k0sproject.io/v1beta1/groupversion_info.go
+++ b/pkg/apis/helm.k0sproject.io/v1beta1/groupversion_info.go
@@ -21,6 +21,7 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/api.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/api.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/asaskevich/govalidator"
 	"github.com/k0sproject/k0s/internal/pkg/iface"
 	"github.com/k0sproject/k0s/internal/pkg/stringslice"
+
+	"github.com/asaskevich/govalidator"
 )
 
 var _ Validateable = (*APISpec)(nil)

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
@@ -22,9 +22,9 @@ import (
 	"io"
 	"reflect"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/k0sproject/k0s/internal/pkg/strictyaml"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/internal/pkg/iface"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/feature_gates_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/feature_gates_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/internal/pkg/stringmap"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/groupversion_info.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/groupversion_info.go
@@ -21,6 +21,7 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/images_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/images_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/pkg/constant"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/network.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/network.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/asaskevich/govalidator"
 	utilnet "k8s.io/utils/net"
+
+	"github.com/asaskevich/govalidator"
 )
 
 var _ Validateable = (*Network)(nil)

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/storage.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/storage.go
@@ -22,12 +22,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/k0sproject/k0s/internal/pkg/iface"
+	"github.com/k0sproject/k0s/pkg/constant"
+
 	"k8s.io/utils/strings/slices"
 
 	"github.com/sirupsen/logrus"
-
-	"github.com/k0sproject/k0s/internal/pkg/iface"
-	"github.com/k0sproject/k0s/pkg/constant"
 )
 
 // supported storage types

--- a/pkg/applier/applier_test.go
+++ b/pkg/applier/applier_test.go
@@ -22,14 +22,15 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	kubeutil "github.com/k0sproject/k0s/internal/testutil"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	kubeutil "github.com/k0sproject/k0s/internal/testutil"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestApplierAppliesAllManifestsInADirectory(t *testing.T) {

--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -24,9 +24,6 @@ import (
 	"sync"
 	"time"
 
-	jsonpatch "github.com/evanphx/json-patch"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +33,10 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/restmapper"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 )
 
 const (

--- a/pkg/applier/stackapplier.go
+++ b/pkg/applier/stackapplier.go
@@ -23,10 +23,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/avast/retry-go"
 	"github.com/k0sproject/k0s/pkg/debounce"
 	"github.com/k0sproject/k0s/pkg/kubernetes"
 
+	"github.com/avast/retry-go"
 	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/assets/stage.go
+++ b/pkg/assets/stage.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/autopilot/checks/checks.go
+++ b/pkg/autopilot/checks/checks.go
@@ -17,14 +17,15 @@ package checks
 import (
 	"fmt"
 
-	"github.com/sirupsen/logrus"
-	"golang.org/x/mod/semver"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/resource"
-	"sigs.k8s.io/yaml"
-
 	"github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/static"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/resource"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/mod/semver"
+	"sigs.k8s.io/yaml"
 )
 
 func CanUpdate(clientFactory kubernetes.ClientFactoryInterface, newVersion string) error {

--- a/pkg/autopilot/client/client.go
+++ b/pkg/autopilot/client/client.go
@@ -18,8 +18,8 @@ import (
 	"sync"
 
 	apclient "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset"
-	extclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 
+	extclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )

--- a/pkg/autopilot/common/telemetry.go
+++ b/pkg/autopilot/common/telemetry.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"github.com/k0sproject/k0s/pkg/telemetry"
+
 	"github.com/segmentio/analytics-go"
 )
 

--- a/pkg/autopilot/controller/delegate/delegate.go
+++ b/pkg/autopilot/controller/delegate/delegate.go
@@ -18,6 +18,7 @@ import (
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 
 	"k8s.io/apimachinery/pkg/types"
+
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/autopilot/controller/delegate/specialized.go
+++ b/pkg/autopilot/controller/delegate/specialized.go
@@ -20,6 +20,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/autopilot/controller/delegate/specialized_test.go
+++ b/pkg/autopilot/controller/delegate/specialized_test.go
@@ -15,12 +15,13 @@
 package delegate
 
 import (
-	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
-
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
+
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestNodeReady ensures that the delegate can identify when a worker node is

--- a/pkg/autopilot/controller/index.go
+++ b/pkg/autopilot/controller/index.go
@@ -21,6 +21,7 @@ import (
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 
 	v1 "k8s.io/api/core/v1"
+
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crman "sigs.k8s.io/controller-runtime/pkg/manager"
 )

--- a/pkg/autopilot/controller/leases.go
+++ b/pkg/autopilot/controller/leases.go
@@ -21,8 +21,10 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/autopilot/client"
 	"github.com/k0sproject/k0s/pkg/leaderelection"
-	"github.com/sirupsen/logrus"
+
 	clientset "k8s.io/client-go/kubernetes"
+
+	"github.com/sirupsen/logrus"
 )
 
 type LeaseEventStatus string

--- a/pkg/autopilot/controller/leases_test.go
+++ b/pkg/autopilot/controller/leases_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/k0sproject/k0s/internal/autopilot/testutil"
 	"github.com/k0sproject/k0s/pkg/autopilot/constant"
 	"github.com/k0sproject/k0s/pkg/leaderelection"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/newplan.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/newplan.go
@@ -16,6 +16,7 @@ package airgapupdate
 
 import (
 	"context"
+
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	"github.com/k0sproject/k0s/pkg/autopilot/checks"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"

--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/newplan_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/newplan_test.go
@@ -25,14 +25,15 @@ import (
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/provider.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/provider.go
@@ -24,8 +24,9 @@ import (
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 	"github.com/k0sproject/k0s/pkg/kubernetes"
 
-	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/sirupsen/logrus"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable_test.go
@@ -25,13 +25,14 @@ import (
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimruntime "k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apimruntime "k8s.io/apimachinery/pkg/runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulablewait_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulablewait_test.go
@@ -26,13 +26,14 @@ import (
 	apsigcomm "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common"
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/discovery/discover.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/discovery/discover.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/discovery/discover_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/discovery/discover_test.go
@@ -23,12 +23,13 @@ import (
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/newplan.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/newplan.go
@@ -16,6 +16,7 @@ package k0supdate
 
 import (
 	"context"
+
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	"github.com/k0sproject/k0s/pkg/autopilot/checks"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
@@ -24,6 +25,7 @@ import (
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 
 	v1 "k8s.io/api/core/v1"
+
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/newplan_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/newplan_test.go
@@ -25,14 +25,15 @@ import (
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable_test.go
@@ -25,12 +25,13 @@ import (
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimruntime "k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apimruntime "k8s.io/apimachinery/pkg/runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulablewait_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulablewait_test.go
@@ -26,13 +26,14 @@ import (
 	apsigcomm "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common"
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/exists.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/exists.go
@@ -21,6 +21,7 @@ import (
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 
 	"k8s.io/apimachinery/pkg/types"
+
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/exists_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/exists_test.go
@@ -23,10 +23,11 @@ import (
 	apscheme "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset/scheme"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/stretchr/testify/assert"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/ident.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/ident.go
@@ -20,6 +20,7 @@ import (
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 
 	v1 "k8s.io/api/core/v1"
+
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/update.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/update.go
@@ -22,6 +22,7 @@ import (
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/autopilot/controller/plans/core/initprovidershandler_test.go
+++ b/pkg/autopilot/controller/plans/core/initprovidershandler_test.go
@@ -22,11 +22,12 @@ import (
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apscheme2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset/scheme"
 
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestInitProvidersHandle runs through a table of scenarios for testing `initprovidershandler`

--- a/pkg/autopilot/controller/plans/core/planstatecontroller_test.go
+++ b/pkg/autopilot/controller/plans/core/planstatecontroller_test.go
@@ -22,12 +22,13 @@ import (
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apscheme2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset/scheme"
 
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	cr "sigs.k8s.io/controller-runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"

--- a/pkg/autopilot/controller/plans/core/planstatehandler_test.go
+++ b/pkg/autopilot/controller/plans/core/planstatehandler_test.go
@@ -22,11 +22,12 @@ import (
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apscheme2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset/scheme"
 
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestHandle runs through a table of scenarios focusing on the edge cases of the `Handle()` function

--- a/pkg/autopilot/controller/plans/init_test.go
+++ b/pkg/autopilot/controller/plans/init_test.go
@@ -22,8 +22,9 @@ import (
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 
-	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
 	crev "sigs.k8s.io/controller-runtime/pkg/event"
 )
 

--- a/pkg/autopilot/controller/plans/predicate_test.go
+++ b/pkg/autopilot/controller/plans/predicate_test.go
@@ -20,8 +20,9 @@ import (
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
 	crev "sigs.k8s.io/controller-runtime/pkg/event"
 )
 

--- a/pkg/autopilot/controller/readyprober.go
+++ b/pkg/autopilot/controller/readyprober.go
@@ -25,12 +25,12 @@ import (
 	apcli "github.com/k0sproject/k0s/pkg/autopilot/client"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 	"k8s.io/client-go/rest"
 	k8sprobe "k8s.io/kubernetes/pkg/probe"
 	k8shttpprobe "k8s.io/kubernetes/pkg/probe/http"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
 const readyzURLFormat = "https://%s:6443/readyz?verbose"

--- a/pkg/autopilot/controller/root_controller.go
+++ b/pkg/autopilot/controller/root_controller.go
@@ -30,9 +30,10 @@ import (
 	apupdate "github.com/k0sproject/k0s/pkg/autopilot/controller/updates"
 	"github.com/k0sproject/k0s/pkg/kubernetes"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cr "sigs.k8s.io/controller-runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crman "sigs.k8s.io/controller-runtime/pkg/manager"

--- a/pkg/autopilot/controller/root_worker.go
+++ b/pkg/autopilot/controller/root_worker.go
@@ -17,8 +17,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
 	"time"
 
 	apscheme "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset/scheme"
@@ -28,10 +26,12 @@ import (
 	apsig "github.com/k0sproject/k0s/pkg/autopilot/controller/signal"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	cr "sigs.k8s.io/controller-runtime"
-	crman "sigs.k8s.io/controller-runtime/pkg/manager"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/sirupsen/logrus"
+	cr "sigs.k8s.io/controller-runtime"
+	crman "sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 type rootWorker struct {

--- a/pkg/autopilot/controller/setup.go
+++ b/pkg/autopilot/controller/setup.go
@@ -24,14 +24,14 @@ import (
 	apcli "github.com/k0sproject/k0s/pkg/autopilot/client"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
+	k0sinstall "github.com/k0sproject/k0s/pkg/install"
 
-	"github.com/avast/retry-go"
-	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	k0sinstall "github.com/k0sproject/k0s/pkg/install"
+	"github.com/avast/retry-go"
+	"github.com/sirupsen/logrus"
 )
 
 // SetupController defines operations that should be run once to completion,

--- a/pkg/autopilot/controller/signal/airgap/signal_test.go
+++ b/pkg/autopilot/controller/signal/airgap/signal_test.go
@@ -25,12 +25,13 @@ import (
 	apsigcomm "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common"
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
 
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	crev "sigs.k8s.io/controller-runtime/pkg/event"

--- a/pkg/autopilot/controller/signal/k0s/apply_test.go
+++ b/pkg/autopilot/controller/signal/k0s/apply_test.go
@@ -20,8 +20,9 @@ import (
 
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 
-	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
 	crev "sigs.k8s.io/controller-runtime/pkg/event"
 )
 

--- a/pkg/autopilot/controller/signal/k0s/cordon.go
+++ b/pkg/autopilot/controller/signal/k0s/cordon.go
@@ -24,16 +24,16 @@ import (
 	apsigpred "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common/predicate"
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubectl/pkg/drain"
+
+	"github.com/sirupsen/logrus"
 	cr "sigs.k8s.io/controller-runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crev "sigs.k8s.io/controller-runtime/pkg/event"
 	crman "sigs.k8s.io/controller-runtime/pkg/manager"
 	crpred "sigs.k8s.io/controller-runtime/pkg/predicate"
-
-	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/kubectl/pkg/drain"
 )
 
 // cordoningEventFilter creates a controller-runtime predicate that governs which objects

--- a/pkg/autopilot/controller/signal/k0s/download_test.go
+++ b/pkg/autopilot/controller/signal/k0s/download_test.go
@@ -20,8 +20,9 @@ import (
 
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 
-	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
 	crev "sigs.k8s.io/controller-runtime/pkg/event"
 )
 

--- a/pkg/autopilot/controller/signal/k0s/init.go
+++ b/pkg/autopilot/controller/signal/k0s/init.go
@@ -17,12 +17,12 @@ package k0s
 import (
 	"context"
 	"fmt"
+
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	apsigpred "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common/predicate"
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
-
 	k0sinstall "github.com/k0sproject/k0s/pkg/install"
 
 	"github.com/sirupsen/logrus"

--- a/pkg/autopilot/controller/signal/k0s/restart_windows.go
+++ b/pkg/autopilot/controller/signal/k0s/restart_windows.go
@@ -17,6 +17,7 @@ package k0s
 import (
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	apsigpred "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common/predicate"
+
 	"github.com/sirupsen/logrus"
 	crman "sigs.k8s.io/controller-runtime/pkg/manager"
 	crpred "sigs.k8s.io/controller-runtime/pkg/predicate"

--- a/pkg/autopilot/controller/signal/k0s/signal_test.go
+++ b/pkg/autopilot/controller/signal/k0s/signal_test.go
@@ -26,12 +26,13 @@ import (
 	apsigcomm "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common"
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
 
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	crev "sigs.k8s.io/controller-runtime/pkg/event"

--- a/pkg/autopilot/controller/signal/k0s/uncordon.go
+++ b/pkg/autopilot/controller/signal/k0s/uncordon.go
@@ -25,10 +25,11 @@ import (
 	apsigpred "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common/predicate"
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
 
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubectl/pkg/drain"
+
+	"github.com/sirupsen/logrus"
 	cr "sigs.k8s.io/controller-runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crev "sigs.k8s.io/controller-runtime/pkg/event"

--- a/pkg/autopilot/controller/updates/update_controller.go
+++ b/pkg/autopilot/controller/updates/update_controller.go
@@ -20,8 +20,10 @@ import (
 
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcli "github.com/k0sproject/k0s/pkg/autopilot/client"
-	"github.com/sirupsen/logrus"
+
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/sirupsen/logrus"
 	cr "sigs.k8s.io/controller-runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crman "sigs.k8s.io/controller-runtime/pkg/manager"

--- a/pkg/autopilot/controller/updates/updater.go
+++ b/pkg/autopilot/controller/updates/updater.go
@@ -19,18 +19,19 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/robfig/cron"
-	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	crcli "sigs.k8s.io/controller-runtime/pkg/client"
-
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 	"github.com/k0sproject/k0s/pkg/autopilot/controller/signal/k0s"
 	uc "github.com/k0sproject/k0s/pkg/autopilot/updater"
 	k0sinstall "github.com/k0sproject/k0s/pkg/install"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/robfig/cron"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const defaultCronSchedule = "@hourly"

--- a/pkg/autopilot/signaling/v2/signaling_v2.go
+++ b/pkg/autopilot/signaling/v2/signaling_v2.go
@@ -20,8 +20,9 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/go-playground/validator/v10"
 	"github.com/k0sproject/k0s/pkg/autopilot/signaling"
+
+	"github.com/go-playground/validator/v10"
 )
 
 const (

--- a/pkg/backup/config.go
+++ b/pkg/backup/config.go
@@ -26,6 +26,7 @@ import (
 	"path"
 
 	"github.com/k0sproject/k0s/internal/pkg/file"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/backup/etcd.go
+++ b/pkg/backup/etcd.go
@@ -25,13 +25,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"go.etcd.io/etcd/client/v3/snapshot"
-	"go.uber.org/zap"
-
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/pkg/etcd"
 
+	"go.etcd.io/etcd/client/v3/snapshot"
 	utilsnapshot "go.etcd.io/etcd/etcdutl/v3/snapshot"
+	"go.uber.org/zap"
 )
 
 const etcdBackup = "etcd-snapshot.db"

--- a/pkg/backup/filesystem.go
+++ b/pkg/backup/filesystem.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/file"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/backup/manager.go
+++ b/pkg/backup/manager.go
@@ -27,13 +27,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/k0sproject/k0s/internal/pkg/archive"
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Manager hold configuration for particular backup-restore process

--- a/pkg/backup/sqlitedb.go
+++ b/pkg/backup/sqlitedb.go
@@ -25,12 +25,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/rqlite/rqlite/db"
-	"github.com/sirupsen/logrus"
-
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/pkg/constant"
+
+	"github.com/rqlite/rqlite/db"
+	"github.com/sirupsen/logrus"
 )
 
 const kineBackup = "kine-state-backup.db"

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -27,6 +27,11 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/k0sproject/k0s/internal/pkg/file"
+	"github.com/k0sproject/k0s/internal/pkg/stringslice"
+	"github.com/k0sproject/k0s/internal/pkg/users"
+	"github.com/k0sproject/k0s/pkg/constant"
+
 	"github.com/cloudflare/cfssl/certinfo"
 	"github.com/cloudflare/cfssl/cli"
 	"github.com/cloudflare/cfssl/cli/genkey"
@@ -35,11 +40,6 @@ import (
 	"github.com/cloudflare/cfssl/initca"
 	"github.com/cloudflare/cfssl/signer"
 	"github.com/sirupsen/logrus"
-
-	"github.com/k0sproject/k0s/internal/pkg/file"
-	"github.com/k0sproject/k0s/internal/pkg/stringslice"
-	"github.com/k0sproject/k0s/internal/pkg/users"
-	"github.com/k0sproject/k0s/pkg/constant"
 )
 
 // Request defines the certificate request fields

--- a/pkg/cleanup/cleanup_unix.go
+++ b/pkg/cleanup/cleanup_unix.go
@@ -21,9 +21,9 @@ import (
 	"os/exec"
 
 	"github.com/k0sproject/k0s/pkg/component/worker"
-
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/container/runtime"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/cleanup/containers.go
+++ b/pkg/cleanup/containers.go
@@ -28,9 +28,10 @@ import (
 
 	"github.com/k0sproject/k0s/internal/pkg/file"
 
+	"k8s.io/mount-utils"
+
 	"github.com/avast/retry-go"
 	"github.com/sirupsen/logrus"
-	"k8s.io/mount-utils"
 )
 
 type containers struct {

--- a/pkg/cleanup/directories.go
+++ b/pkg/cleanup/directories.go
@@ -21,8 +21,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/mount-utils"
+
+	"github.com/sirupsen/logrus"
 )
 
 type directories struct {

--- a/pkg/cleanup/users.go
+++ b/pkg/cleanup/users.go
@@ -19,6 +19,7 @@ package cleanup
 import (
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/install"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/component/controller/apiendpointreconciler.go
+++ b/pkg/component/controller/apiendpointreconciler.go
@@ -23,14 +23,15 @@ import (
 	"sort"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component"
+	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
-	"github.com/k0sproject/k0s/pkg/component"
-	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/sirupsen/logrus"
 )
 
 // Dummy checks so we catch easily if we miss some interface implementation

--- a/pkg/component/controller/apiendpointreconciler_test.go
+++ b/pkg/component/controller/apiendpointreconciler_test.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/k0sproject/k0s/internal/testutil"
+	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/k0sproject/k0s/internal/testutil"
-	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/stretchr/testify/assert"
 )
 
 var expectedAddresses = []string{

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -27,8 +27,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/k0sproject/k0s/internal/pkg/stringmap"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/internal/pkg/users"
@@ -37,6 +35,8 @@ import (
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/supervisor"
+
+	"github.com/sirupsen/logrus"
 )
 
 // APIServer implement the component interface to run kube api

--- a/pkg/component/controller/apiserver_test.go
+++ b/pkg/component/controller/apiserver_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
+
 	"github.com/stretchr/testify/suite"
 )
 

--- a/pkg/component/controller/autopilot.go
+++ b/pkg/component/controller/autopilot.go
@@ -23,10 +23,10 @@ import (
 	apcli "github.com/k0sproject/k0s/pkg/autopilot/client"
 	apcont "github.com/k0sproject/k0s/pkg/autopilot/controller"
 	aproot "github.com/k0sproject/k0s/pkg/autopilot/controller/root"
-
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/kubernetes"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/component/controller/calico.go
+++ b/pkg/component/controller/calico.go
@@ -25,15 +25,13 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
-
 	"github.com/k0sproject/k0s/static"
 
 	"github.com/sirupsen/logrus"
-
-	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 )
 
 // Dummy checks so we catch easily if we miss some interface implementation

--- a/pkg/component/controller/calico_test.go
+++ b/pkg/component/controller/calico_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 )

--- a/pkg/component/controller/clusterConfig.go
+++ b/pkg/component/controller/clusterConfig.go
@@ -22,23 +22,21 @@ import (
 	"os"
 	"time"
 
+	cfgClient "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/clientset/typed/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component"
+	"github.com/k0sproject/k0s/pkg/component/controller/clusterconfig"
 	"github.com/k0sproject/k0s/pkg/config"
+	"github.com/k0sproject/k0s/pkg/constant"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/static"
 
-	"github.com/k0sproject/k0s/pkg/component"
-
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	cfgClient "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/clientset/typed/k0s.k0sproject.io/v1beta1"
-	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
-	"github.com/k0sproject/k0s/pkg/constant"
-
-	"github.com/k0sproject/k0s/pkg/component/controller/clusterconfig"
+	"github.com/sirupsen/logrus"
 )
 
 // ClusterConfigReconciler reconciles a ClusterConfig object

--- a/pkg/component/controller/clusterconfig/staticsource.go
+++ b/pkg/component/controller/clusterconfig/staticsource.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -24,8 +24,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/k0sproject/k0s/internal/pkg/flags"
 	"github.com/k0sproject/k0s/internal/pkg/stringmap"
 	"github.com/k0sproject/k0s/internal/pkg/users"
@@ -34,6 +32,8 @@ import (
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/supervisor"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Manager implement the component interface to run kube scheduler

--- a/pkg/component/controller/controllersleasecounter.go
+++ b/pkg/component/controller/controllersleasecounter.go
@@ -22,13 +22,12 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component"
-
-	"github.com/sirupsen/logrus"
-
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/pkg/leaderelection"
 
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
+
+	"github.com/sirupsen/logrus"
 )
 
 // K0sControllersLeaseCounter implements a component that manages a lease per controller.

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -24,17 +24,17 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/k0sproject/k0s/pkg/component"
-
-	"github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/sirupsen/logrus"
 )
 
 const coreDNSTemplate = `

--- a/pkg/component/controller/csrapprover.go
+++ b/pkg/component/controller/csrapprover.go
@@ -26,17 +26,18 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component"
+	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
+	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
+
 	authorization "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/certificates/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 
-	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
-	"github.com/k0sproject/k0s/pkg/component"
-	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
-	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/sirupsen/logrus"
 )
 
 var kubeletServerUsages = []v1.KeyUsage{

--- a/pkg/component/controller/csrapprover_test.go
+++ b/pkg/component/controller/csrapprover_test.go
@@ -28,10 +28,12 @@ import (
 
 	"github.com/k0sproject/k0s/internal/testutil"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
-	"github.com/stretchr/testify/assert"
+
 	certv1 "k8s.io/api/certificates/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBasicCRSApprover(t *testing.T) {

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -25,9 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
-
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/internal/pkg/stringmap"
@@ -40,6 +37,9 @@ import (
 	"github.com/k0sproject/k0s/pkg/etcd"
 	"github.com/k0sproject/k0s/pkg/supervisor"
 	"github.com/k0sproject/k0s/pkg/token"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
 // Etcd implement the component interface to run etcd

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/avast/retry-go"
-	"github.com/bombsimon/logrusr/v2"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/apis/helm.k0sproject.io/v1beta1"
 	k0sAPI "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
@@ -31,11 +29,15 @@ import (
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/helm"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
-	"github.com/sirupsen/logrus"
-	"helm.sh/helm/v3/pkg/release"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/avast/retry-go"
+	"github.com/bombsimon/logrusr/v2"
+	"github.com/sirupsen/logrus"
+	"helm.sh/helm/v3/pkg/release"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"

--- a/pkg/component/controller/extensions_controller_test.go
+++ b/pkg/component/controller/extensions_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/pkg/apis/helm.k0sproject.io/v1beta1"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/component/controller/k0scloudprovider_test.go
+++ b/pkg/component/controller/k0scloudprovider_test.go
@@ -24,9 +24,11 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/k0scloudprovider"
+
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	v1 "k8s.io/api/core/v1"
 )
 
 func EmptyAddressCollector(node *v1.Node) []v1.NodeAddress {

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -24,18 +24,17 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
-	"github.com/k0sproject/k0s/pkg/component"
-	"github.com/k0sproject/k0s/pkg/etcd"
-	clientv3 "go.etcd.io/etcd/client/v3"
-
-	"github.com/sirupsen/logrus"
-
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/users"
+	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/assets"
+	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
+	"github.com/k0sproject/k0s/pkg/etcd"
 	"github.com/k0sproject/k0s/pkg/supervisor"
+
+	"github.com/sirupsen/logrus"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // Kine implement the component interface to run kine

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -25,8 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/stringmap"
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo/machineid"
@@ -39,6 +37,8 @@ import (
 	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/pkg/supervisor"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Konnectivity implements the component interface of konnectivity server

--- a/pkg/component/controller/kubeletconfig.go
+++ b/pkg/component/controller/kubeletconfig.go
@@ -26,19 +26,20 @@ import (
 	"path/filepath"
 	"reflect"
 
-	"github.com/imdario/mergo"
-	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
-	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
-
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
+	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/imdario/mergo"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 )
 
 // Dummy checks so we catch easily if we miss some interface implementation

--- a/pkg/component/controller/kubeletconfig_test.go
+++ b/pkg/component/controller/kubeletconfig_test.go
@@ -25,9 +25,9 @@ import (
 	"github.com/k0sproject/k0s/pkg/apis/helm.k0sproject.io/v1beta1"
 	config "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
-	"sigs.k8s.io/yaml"
 
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 var k0sVars = constant.GetConfig("")

--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -22,14 +22,13 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/k0sproject/k0s/pkg/component"
-
-	"github.com/sirupsen/logrus"
-
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
+
+	"github.com/sirupsen/logrus"
 )
 
 // KubeProxy is the component implementation to manage kube-proxy

--- a/pkg/component/controller/kuberouter_test.go
+++ b/pkg/component/controller/kuberouter_test.go
@@ -22,15 +22,17 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/k0sproject/dig"
 	"github.com/k0sproject/k0s/internal/testutil"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/k0sproject/dig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKubeRouterConfig(t *testing.T) {

--- a/pkg/component/controller/leaderelector.go
+++ b/pkg/component/controller/leaderelector.go
@@ -24,6 +24,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/component"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/pkg/leaderelection"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/component/controller/manifests.go
+++ b/pkg/component/controller/manifests.go
@@ -24,6 +24,7 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/pkg/constant"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/component/controller/metrics.go
+++ b/pkg/component/controller/metrics.go
@@ -26,13 +26,14 @@ import (
 	"path"
 	"time"
 
-	"k8s.io/client-go/rest"
-
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/kubernetes"
+
+	"k8s.io/client-go/rest"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/component/controller/metricserver.go
+++ b/pkg/component/controller/metricserver.go
@@ -24,16 +24,16 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/k0sproject/k0s/pkg/component"
-
-	"github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sirupsen/logrus"
 )
 
 const metricServerTemplate = `

--- a/pkg/component/controller/metricserver_test.go
+++ b/pkg/component/controller/metricserver_test.go
@@ -23,9 +23,11 @@ import (
 
 	"github.com/k0sproject/k0s/internal/testutil"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
-	"github.com/stretchr/testify/require"
+
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/require"
 )
 
 var cfg = v1beta1.DefaultClusterConfig()

--- a/pkg/component/controller/noderole.go
+++ b/pkg/component/controller/noderole.go
@@ -22,15 +22,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-openapi/jsonpointer"
-	"github.com/sirupsen/logrus"
+	"github.com/k0sproject/k0s/pkg/constant"
+	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/k0sproject/k0s/pkg/constant"
-	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/go-openapi/jsonpointer"
+	"github.com/sirupsen/logrus"
 )
 
 // NodeRole implements the component interface to manage node role labels for worker nodes

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/k0sproject/k0s/internal/pkg/stringmap"
 	"github.com/k0sproject/k0s/internal/pkg/users"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
@@ -30,6 +28,8 @@ import (
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/supervisor"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Scheduler implement the component interface to run kube scheduler

--- a/pkg/component/controller/tunneledapiendpointreconciller.go
+++ b/pkg/component/controller/tunneledapiendpointreconciller.go
@@ -23,11 +23,13 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
-	"github.com/sirupsen/logrus"
+
 	v1core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/sirupsen/logrus"
 )
 
 type TunneledEndpointReconciler struct {

--- a/pkg/component/manager.go
+++ b/pkg/component/manager.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/performance"
+
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )

--- a/pkg/component/status/status.go
+++ b/pkg/component/status/status.go
@@ -30,11 +30,13 @@ import (
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/component/worker"
 	"github.com/k0sproject/k0s/pkg/install"
-	"github.com/sirupsen/logrus"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/sirupsen/logrus"
 )
 
 type Status struct {

--- a/pkg/component/worker/autopilot.go
+++ b/pkg/component/worker/autopilot.go
@@ -25,12 +25,13 @@ import (
 	apcli "github.com/k0sproject/k0s/pkg/autopilot/client"
 	apcont "github.com/k0sproject/k0s/pkg/autopilot/controller"
 	aproot "github.com/k0sproject/k0s/pkg/autopilot/controller/root"
-	"github.com/sirupsen/logrus"
-
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
+
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
+
+	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/pkg/component/worker/certificate_manager.go
+++ b/pkg/component/worker/certificate_manager.go
@@ -25,11 +25,12 @@ import (
 	"os"
 	"sync"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/certificate"
 	k8skubeletcert "k8s.io/kubernetes/pkg/kubelet/certificate"
+
+	"github.com/sirupsen/logrus"
 )
 
 var _ certificate.Manager = (*CertificateManager)(nil)

--- a/pkg/component/worker/containerd.go
+++ b/pkg/component/worker/containerd.go
@@ -21,15 +21,15 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
-
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/pkg/assets"
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/supervisor"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
 const confTmpl = `

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -28,15 +28,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/avast/retry-go"
-	"github.com/docker/libnetwork/resolvconf"
-	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/validation"
-	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
-	"k8s.io/utils/pointer"
-	"sigs.k8s.io/yaml"
-
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/internal/pkg/flags"
@@ -46,6 +37,16 @@ import (
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/supervisor"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
+	"k8s.io/utils/pointer"
+
+	"github.com/avast/retry-go"
+	"github.com/docker/libnetwork/resolvconf"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 )
 
 // Kubelet is the component implementation to manage kubelet

--- a/pkg/component/worker/kubelet_test.go
+++ b/pkg/component/worker/kubelet_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package worker
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/component/worker/kubeletconfigclient.go
+++ b/pkg/component/worker/kubeletconfigclient.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/constant"
 	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -23,12 +23,13 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/avast/retry-go"
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/platforms"
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/pkg/component"
 	"github.com/k0sproject/k0s/pkg/constant"
+
+	"github.com/avast/retry-go"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/platforms"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/component/worker/static_pods.go
+++ b/pkg/component/worker/static_pods.go
@@ -30,13 +30,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/avast/retry-go"
-	"github.com/gorilla/mux"
 	"github.com/k0sproject/k0s/pkg/component"
-	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
+
+	"github.com/avast/retry-go"
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/component/worker/static_pods_test.go
+++ b/pkg/component/worker/static_pods_test.go
@@ -24,14 +24,14 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/avast/retry-go"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/component/worker/utils.go
+++ b/pkg/component/worker/utils.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"path"
 
-	"k8s.io/client-go/tools/clientcmd"
-
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/token"
+
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 func HandleKubeletBootstrapToken(encodedToken string, k0sVars constant.CfgVars) error {

--- a/pkg/config/api_config.go
+++ b/pkg/config/api_config.go
@@ -21,14 +21,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/avast/retry-go"
-	"github.com/imdario/mergo"
-	"github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/clientset/typed/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/avast/retry-go"
+	"github.com/imdario/mergo"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,7 @@ import (
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/clientset/typed/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
+
 	"k8s.io/client-go/tools/clientcmd"
 )
 

--- a/pkg/config/file_config.go
+++ b/pkg/config/file_config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
+
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 )

--- a/pkg/constant/constant_shared_test.go
+++ b/pkg/constant/constant_shared_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"golang.org/x/tools/go/packages"
 )
 

--- a/pkg/container/runtime/cri.go
+++ b/pkg/container/runtime/cri.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 var _ ContainerRuntime = (*CRIRuntime)(nil)

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	clientv3 "go.etcd.io/etcd/client/v3"

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -23,6 +23,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/k0sproject/k0s/internal/pkg/dir"
+	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/constant"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
 	"github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -31,12 +37,7 @@ import (
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/repo"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/yaml"
-
-	"github.com/k0sproject/k0s/internal/pkg/dir"
-	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
-	"github.com/k0sproject/k0s/pkg/constant"
 )
 
 // Commands run different helm command in the same way as CLI tool

--- a/pkg/install/users.go
+++ b/pkg/install/users.go
@@ -24,12 +24,12 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/k0sproject/k0s/internal/pkg/stringslice"
 	"github.com/k0sproject/k0s/internal/pkg/users"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
+
+	"github.com/sirupsen/logrus"
 )
 
 func GetControllerUsers(clusterConfig *v1beta1.ClusterConfig) []string {

--- a/pkg/k0scloudprovider/command.go
+++ b/pkg/k0scloudprovider/command.go
@@ -20,13 +20,14 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/cloud-provider/app"
 	"k8s.io/cloud-provider/app/config"
 	"k8s.io/cloud-provider/options"
 	cliflag "k8s.io/component-base/cli/flag"
+
+	"github.com/sirupsen/logrus"
 )
 
 type Command func(stopCh <-chan struct{})

--- a/pkg/kubernetes/lease_test.go
+++ b/pkg/kubernetes/lease_test.go
@@ -20,9 +20,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	coordination "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidLease(t *testing.T) {

--- a/pkg/kubernetes/watch/watcher_test.go
+++ b/pkg/kubernetes/watch/watcher_test.go
@@ -23,8 +23,6 @@ import (
 	"time"
 
 	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -32,6 +30,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"k8s.io/utils/pointer"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWatcher(t *testing.T) {

--- a/pkg/leaderelection/lease_pool.go
+++ b/pkg/leaderelection/lease_pool.go
@@ -20,13 +20,15 @@ import (
 	"context"
 	"time"
 
-	"github.com/cloudflare/cfssl/log"
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo/machineid"
-	"github.com/sirupsen/logrus"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
+
+	"github.com/cloudflare/cfssl/log"
+	"github.com/sirupsen/logrus"
 )
 
 // The LeasePool represents a single lease accessed by multiple clients (considered part of the "pool")

--- a/pkg/leaderelection/lease_pool_test.go
+++ b/pkg/leaderelection/lease_pool_test.go
@@ -23,8 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +30,9 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	fakecoordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1/fake"
 	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLeasePoolWatcherTriggersOnLeaseAcquisition(t *testing.T) {

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -29,10 +29,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/pkg/constant"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Supervisor is dead simple and stupid process supervisor, just tries to keep the process running in a while-true loop

--- a/pkg/telemetry/component.go
+++ b/pkg/telemetry/component.go
@@ -22,12 +22,13 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component"
-
 	"github.com/k0sproject/k0s/pkg/constant"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
-	"github.com/sirupsen/logrus"
+
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Component is a telemetry component for k0s component manager

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -21,13 +21,14 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/segmentio/analytics-go"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo/machineid"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/segmentio/analytics-go"
 )
 
 type telemetryData struct {

--- a/pkg/token/joinclient.go
+++ b/pkg/token/joinclient.go
@@ -27,8 +27,10 @@ import (
 	"os"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
-	"github.com/sirupsen/logrus"
+
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/sirupsen/logrus"
 )
 
 // JoinClient is the client we can use to call k0s join APIs

--- a/pkg/token/manager.go
+++ b/pkg/token/manager.go
@@ -21,14 +21,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/k0sproject/k0s/internal/pkg/random"
+	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/k0sproject/k0s/internal/pkg/random"
-	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/sirupsen/logrus"
 )
 
 type Token struct {


### PR DESCRIPTION
## Description

Add lint for package import order via gci. Apply the new format to all the go files.

Also lint inttests and fix all the linter errors. Mostly go header formatting, but also a variable naming, function argument ordering and a missing err check.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings