### PR TITLE
Add metricsBindAddress parameter to kubeProxy conf

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,6 +69,7 @@ spec:
     kubeProxy:
       disabled: false
       mode: iptables
+      metricsBindAddress: 0.0.0.0:10249
   telemetry:
     enabled: true
   controllerManager:

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/kubeproxy.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/kubeproxy.go
@@ -30,15 +30,17 @@ const (
 
 // KubeProxy defines the configuration for kube-proxy
 type KubeProxy struct {
-	Disabled bool   `json:"disabled,omitempty"`
-	Mode     string `json:"mode,omitempty"`
+	Disabled           bool   `json:"disabled,omitempty"`
+	Mode               string `json:"mode,omitempty"`
+	MetricsBindAddress string `json:"metricsBindAddress,omitempty"`
 }
 
 // DefaultKubeProxy creates the default config for kube-proxy
 func DefaultKubeProxy() *KubeProxy {
 	return &KubeProxy{
-		Disabled: false,
-		Mode:     "iptables",
+		Disabled:           false,
+		Mode:               "iptables",
+		MetricsBindAddress: "0.0.0.0:10249",
 	}
 }
 

--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -110,6 +110,7 @@ func (k *KubeProxy) getConfig(clusterConfig *v1beta1.ClusterConfig) (proxyConfig
 		PullPolicy:           clusterConfig.Spec.Images.DefaultPullPolicy,
 		DualStack:            clusterConfig.Spec.Network.DualStack.Enabled,
 		Mode:                 clusterConfig.Spec.Network.KubeProxy.Mode,
+		MetricsBindAddress:   clusterConfig.Spec.Network.KubeProxy.MetricsBindAddress,
 	}
 
 	return cfg, nil
@@ -122,6 +123,7 @@ type proxyConfig struct {
 	Image                string
 	PullPolicy           string
 	Mode                 string
+	MetricsBindAddress   string
 }
 
 const proxyTemplate = `
@@ -243,7 +245,7 @@ data:
       tcpTimeout: 0s
       udpTimeout: 0s
     kind: KubeProxyConfiguration
-    metricsBindAddress: "0.0.0.0:10249"
+    metricsBindAddress: {{ .MetricsBindAddress }}
     nodePortAddresses: null
     oomScoreAdj: null
     portRange: ""

--- a/static/manifests/v1beta1/CustomResourceDefinition/k0s.k0sproject.io_clusterconfigs.yaml
+++ b/static/manifests/v1beta1/CustomResourceDefinition/k0s.k0sproject.io_clusterconfigs.yaml
@@ -339,6 +339,8 @@ spec:
                     properties:
                       disabled:
                         type: boolean
+                      metricsBindAddress:
+                        type: string
                       mode:
                         type: string
                     type: object


### PR DESCRIPTION
## Description
Prior to this the value was hardcorded.
Fixes #1544

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings