### PR TITLE
Fix list rendering in docs/contributors/testing.md

### DIFF
--- a/docs/contributors/testing.md
+++ b/docs/contributors/testing.md
@@ -9,21 +9,21 @@ Please run the following style and formatting commands and fix/check-in any chan
 
 1. Linting
 
-    We use [`golangci-lint`](https://golangci-lint.run/) for style verification.
-    In the repository's root directory, simply run:
+   We use [`golangci-lint`](https://golangci-lint.run/) for style verification.
+   In the repository's root directory, simply run:
 
-    ```shell
-    make lint
-    ```
+   ```shell
+   make lint
+   ```
 
-    There's no need to install `golangci-lint` manually. The build system will
-    take care of that.
+   There's no need to install `golangci-lint` manually. The build system will
+   take care of that.
 
 2. Go fmt
 
-    ```shell
-    go fmt ./...
-    ```
+   ```shell
+   go fmt ./...
+   ```
 
 3. Checking the documentation
 
@@ -32,21 +32,23 @@ Please run the following style and formatting commands and fix/check-in any chan
 
 4. Pre-submit Flight Checks
 
-    In the repository root directory, make sure that:
+   In the repository root directory, make sure that:
 
-    * `make build && git diff --exit-code` runs successfully.  
-      Verifies that the build is working and that the generated source code
-      matches the one that's checked into source control.
-    * `make check-unit` runs successfully.
-      Verifies that all the unit tests pass.
-    * `make check-basic` runs successfully.  
-      Verifies basic cluster functionality using one controller and two workers.
-    * `make check-hacontrolplane` runs successfully.  
-      Verifies that joining of controllers works.
+   * `make build && git diff --exit-code` runs successfully.  
+     Verifies that the build is working and that the generated source code
+     matches the one that's checked into source control.
+   * `make check-unit` runs successfully.  
+     Verifies that all the unit tests pass.
+   * `make check-basic` runs successfully.  
+     Verifies basic cluster functionality using one controller and two workers.
+   * `make check-hacontrolplane` runs successfully.  
+     Verifies that joining of controllers works.
 
-    Please note that this last test is prone to "flakiness", so it might fail on occasion. If it fails constantly, take a deeper look at your code to find the source of the problem.
+   Please note that this last test is prone to "flakiness", so it might fail on
+   occasion. If it fails constantly, take a deeper look at your code to find the
+   source of the problem.
 
-    If you find that all tests passed, you may open a pull request upstream.
+   If you find that all tests passed, you may open a pull request upstream.
 
 ## Opening A Pull Request
 


### PR DESCRIPTION
## Description

The introduction of `mdx_truly_sane_lists` affected the rendering of Markdown lists in the docs. While it improved the layout in the majority of the cases, it regressed for the lists in `testing.md`.

Fix the lists by using a three space indentation for the outer ordered lists.

<details><summary>before</summary>

![before](https://user-images.githubusercontent.com/1215104/201035950-caed8770-bb6f-4b68-8fb3-2a7f2872c377.png)
</details>

<details><summary>after</summary>

![after](https://user-images.githubusercontent.com/1215104/201035947-8966ad76-7fea-40ce-9f23-72e06357b60f.png)
</details>

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings