### PR TITLE
Remove unused make targets manifests and .helmCRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,12 +278,6 @@ clean: clean-gocache clean-docker-image clean-airgap-image-bundles
 	-$(MAKE) -C embedded-bins clean
 	-$(MAKE) -C inttest clean
 
-.PHONY: manifests
-manifests: .helmCRD .cfgCRD
-
-.PHONY: .helmCRD
-
-
 .PHONY: docs
 docs:
 	$(MAKE) -C docs


### PR DESCRIPTION
The target .helmCRD doesn't anything at all and manifests isn't even working because it calls '.cfgCRD' which doesn't exist anymore.

This is a bit of a cleanup without any actual impact.

Signed-off-by: Juan Luis de Sousa-Valadas Castaño <jvaladas@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings