### PR TITLE
Let the ARM based smoke tests not be fail-fast

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -324,6 +324,7 @@ jobs:
     name: Smoke test on armv7/arm64
     if: github.repository == 'k0sproject/k0s'
     strategy:
+      fail-fast: false
       matrix:
         arch:
           - arm # this is armv7


### PR DESCRIPTION
## Description

This is done for the other integration tests, too. The test failures are almost always specific to certain jobs, and it's counterproductive to cancel other jobs that are still running, but are likely to succeed. Those cancelled jobs need to be re-run along with the failed tests, even this wouldn't have been necessary if they hadn't been cancelled in the first place.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings