### PR TITLE
Refactor iptables mode detection to improve logging

### DIFF
--- a/internal/pkg/iptablesutils/iptables.go
+++ b/internal/pkg/iptablesutils/iptables.go
@@ -18,13 +18,13 @@ package iptablesutils
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"go.uber.org/multierr"
 )
 
 const (
@@ -37,69 +37,92 @@ const (
 // See: https://github.com/kubernetes-sigs/iptables-wrappers/blob/master/iptables-wrapper-installer.sh
 func DetectHostIPTablesMode(k0sBinPath string) (string, error) {
 	logrus.Info("Trying to detect iptables mode")
-	logrus.Info("Checking iptables-nft for kube-related entries")
-	nftEntriesCount, nftTotalCount, err := iptablesEntriesCount(k0sBinPath, "xtables-nft-multi", []string{"KUBE-IPTABLES-HINT", "KUBE-KUBELET-CANARY"})
-	if err != nil {
-		return "", fmt.Errorf("error checking iptables-nft entries: %w", err)
-	}
-	if nftEntriesCount > 0 {
-		logrus.Info("kube-related iptables entries found for iptables-nft")
+
+	nftMatches, nftTotal, nftErr := findMatchingEntries(k0sBinPath, ModeNFT, "KUBE-IPTABLES-HINT", "KUBE-KUBELET-CANARY")
+	if nftErr != nil {
+		logrus.WithError(nftErr).Debug("Failed to inspect iptables rules in nft mode")
+		nftErr = fmt.Errorf("nft: %w", nftErr)
+	} else if nftMatches {
+		logrus.Infof("Some kube-related iptables entries found for iptables-nft")
 		return ModeNFT, nil
 	}
 
-	logrus.Info("Checking iptables-legacy for kube-related entries")
-	legacyEntriesCount, legacyTotalCount, err := iptablesEntriesCount(k0sBinPath, "xtables-legacy-multi", []string{"KUBE-IPTABLES-HINT", "KUBE-KUBELET-CANARY"})
-	if err != nil {
-		return "", fmt.Errorf("error checking iptables-legacy entries: %w", err)
-	}
-	if legacyEntriesCount > 0 {
-		logrus.Info("kube-related iptables entries found for iptables-legacy")
+	legacyMatches, legacyTotal, legacyErr := findMatchingEntries(k0sBinPath, ModeLegacy, "KUBE-IPTABLES-HINT", "KUBE-KUBELET-CANARY")
+	if legacyErr != nil {
+		logrus.WithError(legacyErr).Debug("Failed to inspect iptables rules in legacy mode")
+		legacyErr = fmt.Errorf("legacy: %w", legacyErr)
+	} else if legacyMatches {
+		logrus.Infof("Some kube-related iptables entries found for iptables-legacy")
 		return ModeLegacy, nil
 	}
 
-	if legacyTotalCount > nftTotalCount {
-		logrus.Info("kube-related iptables entries not found, go with iptables-legacy")
+	if nftErr == nil && legacyErr == nil && legacyTotal > nftTotal {
+		logrus.Infof(
+			"No kube-related entries found in neither iptables-nft nor iptables-legacy, "+
+				"but there are more legacy entries than nft entries (%d vs. %d), "+
+				"so go with iptables-legacy",
+			legacyTotal, nftTotal,
+		)
 		return ModeLegacy, nil
 	}
 
 	iptablesPath, err := exec.LookPath("iptables")
 	if err != nil {
-		return "", err
+		return "", multierr.Combine(err, nftErr, legacyErr)
 	}
+
 	out, err := exec.Command(iptablesPath, "--version").CombinedOutput()
 	if err != nil {
-		return "", err
+		return "", multierr.Combine(err, nftErr, legacyErr)
 	}
-	outStr := string(out)
+
+	outStr := strings.TrimSpace(string(out))
+	mode := ModeLegacy
+
 	if strings.Contains(outStr, "nf_tables") {
-		return ModeNFT, nil
+		mode = ModeNFT
 	}
-	return ModeLegacy, nil
+
+	logrus.Infof("Selecting iptables-%s: %s --version: %s", mode, iptablesPath, outStr)
+	return mode, nil
 }
 
-func iptablesEntriesCount(k0sBinPath string, xtablesCmdName string, entries []string) (entriesFound int, total int, err error) {
-	xtablesBinPath := filepath.Join(k0sBinPath, xtablesCmdName)
+func findMatchingEntries(k0sBinPath, mode string, entries ...string) (entriesFound bool, total uint, _ error) {
+	binaryPath := filepath.Join(k0sBinPath, fmt.Sprintf("xtables-%s-multi", mode))
 
-	cmdString := fmt.Sprintf("(%s iptables-save || true; %s ip6tables-save || true) 2>/dev/null", xtablesBinPath, xtablesBinPath)
-	cmd := exec.Command("/bin/sh", "-c", cmdString)
+	findMatches := func(subcommand string) error {
+		cmd := exec.Command(binaryPath, subcommand)
+		out, err := cmd.StdoutPipe()
+		if err != nil {
+			return err
+		}
+		if err := cmd.Start(); err != nil {
+			return err
+		}
 
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err = cmd.Run()
-	if err != nil {
-		return 0, 0, err
-	}
-
-	scanner := bufio.NewScanner(&out)
-	scanner.Split(bufio.ScanLines)
-	for scanner.Scan() {
-		total++
-		line := scanner.Text()
-		for _, entry := range entries {
-			if strings.Contains(line, entry) {
-				entriesFound++
+		scanner := bufio.NewScanner(out)
+		scanner.Split(bufio.ScanLines)
+		for scanner.Scan() {
+			total++
+			if !entriesFound {
+				line := scanner.Text()
+				for _, entry := range entries {
+					if strings.Contains(line, entry) {
+						entriesFound = true
+					}
+				}
 			}
 		}
+
+		return cmd.Wait()
+	}
+
+	v4Err, v6Err := findMatches("iptables-save"), findMatches("ip6tables-save")
+	if v4Err != nil && v6Err != nil {
+		return false, 0, multierr.Combine(
+			fmt.Errorf("iptables-save: %w", v4Err),
+			fmt.Errorf("ip6tables-save: %w", v6Err),
+		)
 	}
 
 	return entriesFound, total, nil

--- a/internal/pkg/iptablesutils/iptables_test.go
+++ b/internal/pkg/iptablesutils/iptables_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package iptablesutils_test
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/k0s/internal/pkg/file"
+	"github.com/k0sproject/k0s/internal/pkg/iptablesutils"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectHostIPTablesMode(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	require.NoError(t, err)
+
+	writeScript := func(t *testing.T, parentDir, fileName, content string) {
+		path := filepath.Join(parentDir, fileName)
+		content = "#!" + sh + " -eu\n\n" + content
+		require.NoError(t, file.WriteContentAtomically(path, []byte(content), 0755))
+	}
+
+	writeXtables := func(t *testing.T, parentDir, mode, v4Script, v6Script string) {
+		content := fmt.Sprintf(
+			"case \"$1\" in iptables-save) %s ;; ip6tables-save) %s ;; *) exit 1 ;; esac",
+			v4Script, v6Script,
+		)
+
+		writeScript(t, parentDir, fmt.Sprintf("xtables-%s-multi", mode), content)
+	}
+
+	pathDir := t.TempDir()
+	t.Setenv("PATH", pathDir)
+
+	t.Run("iptables_not_found", func(t *testing.T) {
+		binDir := t.TempDir()
+
+		_, err := iptablesutils.DetectHostIPTablesMode(binDir)
+
+		var execErr *exec.Error
+		require.ErrorAs(t, err, &execErr)
+		assert.Equal(t, "iptables", execErr.Name)
+		assert.ErrorIs(t, execErr.Err, exec.ErrNotFound)
+	})
+
+	t.Run("xtables_nft", func(t *testing.T) {
+		binDir := t.TempDir()
+		writeXtables(t, binDir, "nft",
+			strings.Repeat("echo KUBE-IPTABLES-HINT\n", 1),
+			strings.Repeat("echo KUBE-IPTABLES-HINT\n", 1),
+		)
+
+		mode, err := iptablesutils.DetectHostIPTablesMode(binDir)
+		require.NoError(t, err)
+		assert.Equal(t, iptablesutils.ModeNFT, mode)
+	})
+
+	t.Run("xtables_legacy", func(t *testing.T) {
+		binDir := t.TempDir()
+		writeXtables(t, binDir, "legacy",
+			strings.Repeat("echo KUBE-IPTABLES-HINT\n", 1),
+			strings.Repeat("echo KUBE-IPTABLES-HINT\n", 1),
+		)
+
+		mode, err := iptablesutils.DetectHostIPTablesMode(binDir)
+		require.NoError(t, err)
+		assert.Equal(t, iptablesutils.ModeLegacy, mode)
+	})
+
+	t.Run("xtables_nft_over_legacy", func(t *testing.T) {
+		binDir := t.TempDir()
+
+		writeXtables(t, binDir, "nft",
+			strings.Repeat("echo KUBE-IPTABLES-HINT\n", 1),
+			strings.Repeat("echo KUBE-IPTABLES-HINT\n", 1),
+		)
+		writeXtables(t, binDir, "legacy",
+			strings.Repeat("echo KUBE-IPTABLES-HINT\n", 3),
+			strings.Repeat("echo KUBE-IPTABLES-HINT\n", 3),
+		)
+
+		mode, err := iptablesutils.DetectHostIPTablesMode(binDir)
+		require.NoError(t, err)
+		assert.Equal(t, iptablesutils.ModeNFT, mode)
+	})
+
+	t.Run("xtables_legacy_over_nft_more_entries", func(t *testing.T) {
+		binDir := t.TempDir()
+		writeXtables(t, binDir, "nft",
+			strings.Repeat("echo FOOBAR\n", 1),
+			strings.Repeat("echo FOOBAR\n", 1),
+		)
+		writeXtables(t, binDir, "legacy",
+			strings.Repeat("echo FOOBAR\n", 1),
+			strings.Repeat("echo FOOBAR\n", 2),
+		)
+
+		mode, err := iptablesutils.DetectHostIPTablesMode(binDir)
+		require.NoError(t, err)
+		assert.Equal(t, iptablesutils.ModeLegacy, mode)
+	})
+
+	t.Run("fallback_to_iptables_if_xtables_nft_over_legacy_more_entries", func(t *testing.T) {
+		binDir := t.TempDir()
+		writeXtables(t, binDir, "nft",
+			strings.Repeat("echo FOOBAR\n", 1),
+			strings.Repeat("echo FOOBAR\n", 2),
+		)
+		writeXtables(t, binDir, "legacy",
+			strings.Repeat("echo FOOBAR\n", 1),
+			strings.Repeat("echo FOOBAR\n", 1),
+		)
+
+		_, err := iptablesutils.DetectHostIPTablesMode(binDir)
+		var execErr *exec.Error
+		require.ErrorAs(t, err, &execErr)
+		assert.Equal(t, "iptables", execErr.Name)
+		assert.ErrorIs(t, execErr.Err, exec.ErrNotFound)
+	})
+
+	t.Run("xtables_nft_fails", func(t *testing.T) {
+		binDir := t.TempDir()
+		writeXtables(t, binDir, "nft", "exit 1", "exit 1")
+		writeXtables(t, binDir, "legacy", "exit 1", "echo KUBE-IPTABLES-HINT")
+
+		mode, err := iptablesutils.DetectHostIPTablesMode(binDir)
+		require.NoError(t, err)
+		assert.Equal(t, iptablesutils.ModeLegacy, mode)
+	})
+
+	t.Run("xtables_legacy_fails", func(t *testing.T) {
+		binDir := t.TempDir()
+		writeXtables(t, binDir, "nft", "exit 1", "echo KUBE-IPTABLES-HINT")
+		writeXtables(t, binDir, "legacy", "exit 1", "exit 1")
+
+		mode, err := iptablesutils.DetectHostIPTablesMode(binDir)
+		require.NoError(t, err)
+		assert.Equal(t, iptablesutils.ModeNFT, mode)
+	})
+
+	t.Run("xtables_fails", func(t *testing.T) {
+		binDir := t.TempDir()
+		writeXtables(t, binDir, "nft", "exit 99", "exit 88")
+		writeXtables(t, binDir, "legacy", "exit 77", "exit 66")
+
+		_, err := iptablesutils.DetectHostIPTablesMode(binDir)
+		assert.ErrorIs(t, err, exec.ErrNotFound)
+	})
+
+	binDir := t.TempDir()
+	writeScript(t, pathDir, "iptables", "")
+	writeXtables(t, binDir, "nft", "", "")
+	writeXtables(t, binDir, "legacy", "", "")
+
+	t.Run("iptables_legacy", func(t *testing.T) {
+		mode, err := iptablesutils.DetectHostIPTablesMode(binDir)
+		require.NoError(t, err)
+		assert.Equal(t, iptablesutils.ModeLegacy, mode)
+	})
+
+	writeScript(t, pathDir, "iptables", "echo foo-nf_tables-bar")
+
+	t.Run("iptables_nft", func(t *testing.T) {
+		mode, err := iptablesutils.DetectHostIPTablesMode(binDir)
+		require.NoError(t, err)
+		assert.Equal(t, iptablesutils.ModeNFT, mode)
+	})
+
+	writeScript(t, pathDir, "iptables", "exit 1")
+
+	t.Run("iptables_broken", func(t *testing.T) {
+		_, err := iptablesutils.DetectHostIPTablesMode(binDir)
+		var exitErr *exec.ExitError
+		require.ErrorAs(t, err, &exitErr)
+		assert.Equal(t, 1, exitErr.ExitCode())
+	})
+}
+
+func TestMain(m *testing.M) {
+	logrus.SetLevel(logrus.DebugLevel)
+	m.Run()
+}

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -98,11 +98,11 @@ func (k *Kubelet) Init(_ context.Context) error {
 			iptablesMode, err = iptablesutils.DetectHostIPTablesMode(k.K0sVars.BinDir)
 			if err != nil {
 				if KernelMajorVersion() < 5 {
-					iptablesMode = "legacy"
+					iptablesMode = iptablesutils.ModeLegacy
 				} else {
-					iptablesMode = "nft"
+					iptablesMode = iptablesutils.ModeNFT
 				}
-				logrus.Infof("error detecting iptables mode: %v, using iptables-%s by default", err, iptablesMode)
+				logrus.WithError(err).Infof("Failed to detect iptables mode, using iptables-%s by default", iptablesMode)
 			}
 		}
 		logrus.Infof("using iptables-%s", iptablesMode)


### PR DESCRIPTION
## Description

Previously, all errors emitted by the k0s-shipped xtables binaries were swallowed. Improve debug logging and error reporting to help diagnose k0s's mode selection decisions.

Add unit test for this to ensure that there are no behavioral changes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings