### PR TITLE
Add unstructured and metadata utils to manifest applier

### DIFF
--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -142,7 +142,6 @@ func (a *Applier) Delete(ctx context.Context) error {
 	}
 	stack := Stack{
 		Name:      a.Name,
-		Resources: []*unstructured.Unstructured{},
 		Client:    a.client,
 		Discovery: a.discoveryClient,
 	}

--- a/pkg/applier/meta.go
+++ b/pkg/applier/meta.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applier
+
+import (
+	"strings"
+
+	"github.com/k0sproject/k0s/pkg/build"
+)
+
+const (
+	// MetaPrefix is the prefix to all label and annotation names unique to k0s.
+	MetaPrefix = "k0s.k0sproject.io"
+
+	// NameLabel stack label
+	NameLabel = MetaPrefix + "/stack"
+
+	// ChecksumAnnotation defines the annotation key to used for stack checksums
+	ChecksumAnnotation = MetaPrefix + "/stack-checksum"
+
+	// LastConfigAnnotation defines the annotation to be used for last applied configs
+	LastConfigAnnotation = MetaPrefix + "/last-applied-configuration"
+)
+
+// Meta is a convenience wrapper for metav1.ObjectMeta.Labels and
+// metav1.ObjectMeta.Annotations.
+type Meta map[string]string
+
+var metaVersionValue = strings.ReplaceAll(build.Version, "+", "-")
+
+// CommonLabels returns a set of common labels to be set on all k0s-owned resources.
+//
+// See https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
+func CommonLabels(componentName string) Meta {
+	return map[string]string{
+		"app.kubernetes.io/name":       "k0s",
+		"app.kubernetes.io/component":  componentName,
+		"app.kubernetes.io/version":    metaVersionValue,
+		"app.kubernetes.io/managed-by": "k0s",
+	}
+}
+
+// WithAll returns a copy of this Meta with the given value added to it,
+// possibly overwriting a previous value.
+func (m Meta) With(name, value string) Meta {
+	return m.WithAll(map[string]string{name: value})
+}
+
+// WithAll returns a copy of this Meta with other added to it, overwriting any
+// duplicates.
+func (m Meta) WithAll(other map[string]string) Meta {
+	combined := make(Meta, len(m)+len(other))
+	for n, v := range m {
+		combined[n] = v
+	}
+	for n, v := range other {
+		combined[n] = v
+	}
+
+	return combined
+}

--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -38,17 +38,6 @@ import (
 	"k8s.io/client-go/restmapper"
 )
 
-const (
-	// NameLabel stack label
-	NameLabel = "k0s.k0sproject.io/stack"
-
-	// ChecksumAnnotation defines the annotation key to used for stack checksums
-	ChecksumAnnotation = "k0s.k0sproject.io/stack-checksum"
-
-	// LastConfigAnnotation defines the annotation to be used for last applied configs
-	LastConfigAnnotation = "k0s.k0sproject.io/last-applied-configuration"
-)
-
 // Stack is a k8s resource bundle
 type Stack struct {
 	Name          string

--- a/pkg/applier/stackapplier.go
+++ b/pkg/applier/stackapplier.go
@@ -127,7 +127,7 @@ func (s *StackApplier) apply(ctx context.Context) {
 	err := retry.Do(
 		func() error { return s.doApply(ctx) },
 		retry.OnRetry(func(attempt uint, err error) {
-			s.log.WithError(err).Warnf("Retrying after backoff, attempt #%d", attempt)
+			s.log.WithError(err).Warnf("Failed to apply manifests in attempt #%d, retrying after backoff", attempt+1)
 		}),
 		retry.Context(ctx),
 		retry.LastErrorOnly(true),

--- a/pkg/applier/unstructured.go
+++ b/pkg/applier/unstructured.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applier
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// ToUnstructured converts the given runtime object to an unstructured one using
+// the given scheme. The scheme can be nil, in which case client-go's default
+// scheme is used.
+func ToUnstructured(s *runtime.Scheme, object runtime.Object) (u *unstructured.Unstructured, err error) {
+	u = new(unstructured.Unstructured)
+	u.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(object)
+	if err != nil {
+		return nil, err
+	}
+
+	gvk := u.GroupVersionKind()
+	if gvk.Group == "" || gvk.Kind == "" {
+		if s == nil {
+			s = scheme.Scheme
+		}
+
+		kinds, _, err := s.ObjectKinds(object)
+		if err != nil {
+			return nil, err
+		}
+		apiVersion, kind := kinds[0].ToAPIVersionAndKind()
+		u.SetAPIVersion(apiVersion)
+		u.SetKind(kind)
+	}
+
+	return u, nil
+}
+
+// ToUnstructuredSlice converts the given runtime objects to unstructured ones
+// using the given scheme. The scheme can be nil, in which case client-go's
+// default scheme is used.
+func ToUnstructuredSlice[T runtime.Object](s *runtime.Scheme, objects ...T) ([]*unstructured.Unstructured, error) {
+	converted := make([]*unstructured.Unstructured, len(objects))
+	for i, object := range objects {
+		var err error
+		converted[i], err = ToUnstructured(s, object)
+		if err != nil {
+			return nil, fmt.Errorf("at index %d, for some %s: %w", i, object.GetObjectKind().GroupVersionKind(), err)
+		}
+	}
+	return converted, nil
+}


### PR DESCRIPTION
## Description

Preparation for #2425.

Introduce some utilities to deal with the conversion of client-go types into unstructured objects, as required by the manifest applier. Add some functions to deal with common metadata, as well.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings