### PR TITLE
[experiment] Run tests on in-cluster runners

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -178,7 +178,10 @@ jobs:
   smoketest:
     name: Smoke test
     needs: build
-    runs-on: ubuntu-latest
+    runs-on:
+    - self-hosted
+    - linux
+    - custom-runner
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -178,10 +178,7 @@ jobs:
   smoketest:
     name: Smoke test
     needs: build
-    runs-on:
-    - self-hosted
-    - linux
-    - custom-runner
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -337,12 +334,13 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - arm # this is armv7
+#          - arm # this is armv7
           - arm64
     runs-on:
       - self-hosted
       - linux
       - ${{ matrix.arch }}
+      - custom-runner
 
     steps:
       # https://github.com/actions/checkout/issues/273#issuecomment-642908752 (see below)


### PR DESCRIPTION
Signed-off-by: Alexey Makhov <amakhov@mirantis.com>

## Description
The PR demonstrates the ability to run our tests on in-cluster GHA runners using [actions-runner-controller](https://github.com/actions-runner-controller/actions-runner-controller).

Steps to create runners:
1. Deploy cert-manager
2. Create a github token secret
3. Deploy `actions-runner-controller`
4. Deploy runners using the following configuration:
```
---
apiVersion: actions.summerwind.dev/v1alpha1
kind: RunnerSet
metadata:
  name: test-runnerset
spec:
  repository: k0sproject/k0s
  # By default, the controller reboots runner after each job. When disabled, your runner becomes "persistent".
  # A persistent runner does not stop after workflow job ends, and in this mode actions/runner is known to clean only runner's work dir after each job
  #ephemeral: false
  labels:
    - custom-runner
  selector:
    matchLabels:
      app: test-runnerset
  serviceName: test-runnerset
  template:
    metadata:
      labels:
        app: test-runnerset
    spec:
      # Since we are running k0s tests in the kubernetes pod, we need an external dns to be added into /etc/resolv.conf
      # By default it inherits resolv.conf of the runner container with in-cluster dns address (10.96.0.10) which
      # is unaccessible from the footloose-based k0s cluster.
      dnsConfig:
        nameservers:
          - 1.1.1.1
      topologySpreadConstraints:
        - maxSkew: 1
          topologyKey: kubernetes.io/hostname
          whenUnsatisfiable: ScheduleAnyway
          labelSelector:
            matchLabels:
              runnerset-name: test-runnerset
      containers:
      # The order of the containers matters (the runner must go first):
      # https://github.com/actions-runner-controller/actions-runner-controller/blob/v0.22.0/controllers/runner_pod_controller.go#L69
      # Keep it here to ensure the order
      - name: runner
      - name: docker
        volumeMounts:
          - mountPath: /sys/fs/cgroup
            name: cgroups
          - mountPath: /var/lib/docker/volumes/
            name: volumes
        resources:
          limits:
            cpu: "2"
            memory: "7Gi"
          requests:
            cpu: "1"
            memory: "1Gi"
      volumes:
      - name: cgroups
        hostPath:
          path: "/sys/fs/cgroup/runner"
      - name: volumes
        emptyDir: {}
---
apiVersion: actions.summerwind.dev/v1alpha1
kind: HorizontalRunnerAutoscaler
metadata:
  name: test-runnerdeploy-autoscaler
spec:
  scaleTargetRef:
    name: test-runnerset
    kind: RunnerSet
  minReplicas: 1
  maxReplicas: 2
  metrics:
    - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
      repositoryNames:
        - k0s
    - type: PercentageRunnersBusy
      scaleUpThreshold: '0.75'
      scaleDownThreshold: '0.25'
      scaleUpFactor: '2'
      scaleDownFactor: '0.5'
```