### PR TITLE
Fix status controller shutdown

### DIFF
--- a/pkg/component/status/status.go
+++ b/pkg/component/status/status.go
@@ -100,7 +100,9 @@ func (s *Status) Stop() error {
 	if err := s.httpserver.Shutdown(ctx); err != nil && err != context.Canceled {
 		return err
 	}
-	return os.Remove(s.Socket)
+	// Unix socket doesn't need to be explicitly removed because it's hadled
+	// by httpserver.Shutdown
+	return nil
 }
 
 type statusHandler struct {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2291

Graceful Stops of k0s controller reported the following error:

```
[...] remove /run/k0s/status.sock: no such file or directory
[...] Failed to stop node components error="failed to stop components"
```

This happened because we're removing a socket that was already removed by the previous function.

Technical details to justify that it's only one line change :) : 
```
<snip>
// Init initializes component
func (s *Status) Init(_ context.Context) error {
<snip>
	s.listener, err = net.Listen("unix", s.Socket)
<snip>
}
// Start runs the component
func (s *Status) Start(_ context.Context) error {
	go func() {
		if err := s.httpserver.Serve(s.listener); err != nil && err != http.ErrServerClosed {
			s.L.Errorf("failed to start status server at %s: %s", s.Socket, err)
		}
	}()
	return nil
}
```

And stopped as:

```
func (s *Status) Stop() error {
<snip>
	if err := s.httpserver.Shutdown(ctx); err != nil && err != context.Canceled {
		return err
	}
<snip>
}
```
```
func (srv *Server) Shutdown(ctx context.Context) error {
<snip>
	lnerr := srv.closeListenersLocked()
<snip>
}
<snip>

func (s *Server) closeListenersLocked() error {
<snip>
		if cerr := (*ln).Close(); cerr != nil && err == nil {
<snip>
}
```

Now if we go all the way down in the UnixListener implementation we can see that it closes the socket for us, and even has a nice comment about it:

```
func (ln *UnixListener) close() error {
	// The operating system doesn't clean up
	// the file that announcing created, so
	// we have to clean it up ourselves.
	// There's a race here--we can't know for
	// sure whether someone else has come along
	// and replaced our socket name already--
	// but this sequence (remove then close)
	// is at least compatible with the auto-remove
	// sequence in ListenUnix. It's only non-Go
	// programs that can mess us up.
	// Even if there are racy calls to Close, we want to unlink only for the first one.
	ln.unlinkOnce.Do(func() {
		if ln.path[0] != '@' && ln.unlink {
			syscall.Unlink(ln.path)
		}
	})
	return ln.fd.Close()
}
```

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings