### PR TITLE
Fix k0s restore location

### DIFF
--- a/internal/pkg/dir/dir.go
+++ b/internal/pkg/dir/dir.go
@@ -58,10 +58,6 @@ func Init(path string, perm os.FileMode) error {
 
 // Copy copies the content of a folder
 func Copy(src string, dst string) error {
-	cmd := exec.Command("cp", "-r", src, dst)
-	err := cmd.Run()
-	if err != nil {
-		return err
-	}
-	return nil
+	cmd := exec.Command("cp", "-r", "--", src, dst)
+	return cmd.Run()
 }

--- a/internal/pkg/dir/dir_test.go
+++ b/internal/pkg/dir/dir_test.go
@@ -18,42 +18,71 @@ package dir
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
 
 // CheckPermissions checks the correct permissions
 func checkPermissions(t *testing.T, path string, want os.FileMode) {
 	info, err := os.Stat(path)
-	if err != nil {
-		t.Errorf("%s: %v", path, err)
-		return
-	}
-	got := info.Mode().Perm()
-	if got != want {
-		t.Errorf("%s has permission %o. Expected is %o", path, got, want)
-	}
+	require.NoError(t, err, path)
+	assert.Equalf(t, want, info.Mode().Perm(), "%s has unexpected permissions", path)
 }
 
 func TestInit(t *testing.T) {
 	dir := t.TempDir()
 
 	foo := filepath.Join(dir, "foo")
-	err := Init(foo, 0700)
-	if err != nil {
-		t.Errorf("failed to create temp dir foo: %v", err)
-	}
+	require.NoError(t, Init(foo, 0700), "failed to create temp dir foo")
+
 	checkPermissions(t, foo, 0700)
 
 	oldUmask := unix.Umask(0027)
 	t.Cleanup(func() { unix.Umask(oldUmask) })
 
 	bar := filepath.Join(dir, "bar")
-	err = Init(bar, 0755)
-	if err != nil {
-		t.Errorf("failed to create temp dir bar: %v", err)
-	}
+	require.NoError(t, Init(bar, 0755), "failed to create temp dir bar")
 	checkPermissions(t, bar, 0755)
+}
+
+func TestCopy_empty(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	srcDirname := path.Base(src)
+
+	require.NoError(t, Copy(src, dst), "Unable to copy empty dir")
+
+	//rmdir will fail if the directory has anything at all
+	require.NoError(t, os.Remove(path.Join(dst, srcDirname)), "Unable to remove supposedly empty dir")
+}
+
+func TestCopy_FilesAndDirs(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	srcDirname := path.Base(src)
+
+	expectedDirs := []string{"dir1/", "dir2/", "dir2/dir1/", "dir2/dir2/"}
+	expectedFiles := []string{"dir1/file1", "dir1/file2", "dir2/file1", "dir2/dir2/file1"}
+
+	for _, dir := range expectedDirs {
+		p := path.Join(src, dir)
+		require.NoErrorf(t, os.Mkdir(p, 0700), "Unable to create directory %s", p)
+	}
+
+	for _, file := range expectedFiles {
+		p := path.Join(src, file)
+		require.NoError(t, os.WriteFile(p, []byte{}, 0600), "Unable to create file %s:", p)
+	}
+
+	require.NoError(t, Copy(src, dst), "Unable to copy dir with contents")
+
+	destPath := path.Join(dst, srcDirname)
+	for _, file := range expectedFiles {
+		assert.FileExists(t, path.Join(destPath, file), "File not copied")
+	}
 }

--- a/pkg/backup/filesystem.go
+++ b/pkg/backup/filesystem.go
@@ -77,9 +77,9 @@ func (d FileSystemStep) Restore(restoreFrom, restoreTo string) error {
 		logrus.Debugf("Path `%s` not found in the archive, skipping...", objectPathInArchive)
 		return nil
 	}
-	logrus.Infof("restoring from `%s` to `%s`", objectPathInArchive, objectPathInRestored)
+	logrus.Infof("restoring from `%s` to `%s`", objectPathInArchive, restoreTo)
 	if stat.IsDir() {
-		return dir.Copy(objectPathInArchive, objectPathInRestored)
+		return dir.Copy(objectPathInArchive, restoreTo)
 	}
 	return file.Copy(objectPathInArchive, objectPathInRestored)
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Prior to this patch k0s retore would restore some files to a wrong location. This patch solves this issue.

Fixes #2459
Find more technical details of what was wrong in the issue.

Signed-off-by: Juan Luis de Sousa-Valadas Castaño <jvaladas@mirantis.com>


## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings