### PR TITLE
Introduce Normalize method for controller options

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -85,12 +85,8 @@ func NewControllerCmd() *cobra.Command {
 			if len(c.TokenArg) > 0 && len(c.TokenFile) > 0 {
 				return fmt.Errorf("you can only pass one token argument either as a CLI argument 'k0s controller [join-token]' or as a flag 'k0s controller --token-file [path]'")
 			}
-			if len(c.DisableComponents) > 0 {
-				for _, cmp := range c.DisableComponents {
-					if !slices.Contains(config.AvailableComponents(), cmp) {
-						return fmt.Errorf("unknown component %s", cmp)
-					}
-				}
+			if err := c.ControllerOptions.Normalize(); err != nil {
+				return err
 			}
 			if len(c.TokenFile) > 0 {
 				bytes, err := os.ReadFile(c.TokenFile)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -406,7 +406,8 @@ spec:
 k0s allows completely disabling some of the system components. This allows the user to build a minimal Kubernetes control plane and use what ever components they need to fullfill their need for the controlplane. Disabling the system components happens through a commandline flag for the controller process:
 
 ```sh
---disable-components strings                     disable components (valid items: konnectivity-server,kube-scheduler,kube-controller-manager,control-api,csr-approver,kube-proxy,coredns,network-provider,helm,metrics-server,kubelet-config,system-rbac)
+--disable-components strings                     disable components (valid items: api-config,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,kubelet-config,metrics-server,network-provider,node-role,system-rbac)
+
 ```
 
 If you use k0sctl just add the flag when installing the cluster for the first controller at `spec.hosts.installFlags` in the config file like e.g.:

--- a/pkg/config/cli_test.go
+++ b/pkg/config/cli_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+)
+
+func TestAvailableComponents_SortedAndUnique(t *testing.T) {
+	expected := slices.Clone(availableComponents)
+	slices.Sort(expected)
+
+	assert.Equal(t, expected, availableComponents, "Available components aren't sorted")
+
+	slices.Compact(expected)
+	assert.Equal(t, expected, availableComponents, "Available components contain duplicates")
+}
+
+func TestControllerOptions_Normalize(t *testing.T) {
+	t.Run("failsOnUnknownComponent", func(t *testing.T) {
+		disabled := []string{"i-dont-exist"}
+
+		underTest := ControllerOptions{DisableComponents: disabled}
+		err := underTest.Normalize()
+
+		assert.ErrorContains(t, err, "unknown component i-dont-exist")
+	})
+
+	t.Run("removesDuplicateComponents", func(t *testing.T) {
+		disabled := []string{"helm", "kube-proxy", "coredns", "kube-proxy", "autopilot"}
+		expected := []string{"helm", "kube-proxy", "coredns", "autopilot"}
+
+		underTest := ControllerOptions{DisableComponents: disabled}
+		err := underTest.Normalize()
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, underTest.DisableComponents)
+	})
+}


### PR DESCRIPTION
## Description

Move the existing validation out of controller.go into a method on ControllerOptions, so that the functionality becomes easier to test. Moving the logic also allows for replacing AvailableCommands() with a private global variable availableCommands, since it's no longer required to be visible outside the config package.

Also: Add missing components to the list of available components:

* api-config
* autopilot
* node-role

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings