### PR TITLE
Fix propagation of default storage class setting

### DIFF
--- a/inttest/common/util.go
+++ b/inttest/common/util.go
@@ -111,6 +111,21 @@ func WaitForDeployment(ctx context.Context, kc *kubernetes.Clientset, name strin
 		})
 }
 
+func WaitForDefaultStorageClass(ctx context.Context, kc *kubernetes.Clientset) error {
+	return Poll(ctx, waitForDefaultStorageClass(kc))
+}
+
+func waitForDefaultStorageClass(kc *kubernetes.Clientset) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (done bool, err error) {
+		sc, err := kc.StorageV1().StorageClasses().Get(ctx, "openebs-hostpath", metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		return sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true", nil
+	}
+}
+
 // WaitForDeploymentWithContext waits for a deployment to become ready as long
 // as the given context isn't canceled.
 func WaitForDeploymentWithContext(ctx context.Context, kc *kubernetes.Clientset, name string) error {

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -43,6 +43,7 @@ import (
 	ctrlManager "sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
 )
 
 // Helm watch for Chart crd
@@ -78,9 +79,13 @@ func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0
 	defer ec.L.Info("Extensions reconcilation finished")
 
 	helmSettings := clusterConfig.Spec.Extensions.Helm
+	var err error
 	switch clusterConfig.Spec.Extensions.Storage.Type {
 	case k0sAPI.OpenEBSLocal:
-		helmSettings = addOpenEBSHelmExtension(helmSettings)
+		helmSettings, err = addOpenEBSHelmExtension(helmSettings, clusterConfig.Spec.Extensions.Storage)
+		if err != nil {
+			ec.L.Errorf("can't add openebs helm extension: %v", err)
+		}
 	default:
 	}
 
@@ -91,7 +96,20 @@ func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0
 	return nil
 }
 
-func addOpenEBSHelmExtension(helmSpec *k0sAPI.HelmExtensions) *k0sAPI.HelmExtensions {
+func addOpenEBSHelmExtension(helmSpec *k0sAPI.HelmExtensions, storageExtension *k0sAPI.StorageExtension) (*k0sAPI.HelmExtensions, error) {
+	openEBSValues := map[string]interface{}{
+		"localprovisioner": map[string]interface{}{
+			"hostpathClass": map[string]interface{}{
+				"enabled":        true,
+				"isDefaultClass": storageExtension.CreateDefaultStorageClass,
+			},
+		},
+	}
+	values, err := yamlifyValues(openEBSValues)
+	if err != nil {
+		logrus.Errorf("can't yamlify openebs values: %v", err)
+		return nil, err
+	}
 	if helmSpec == nil {
 		helmSpec = &k0sAPI.HelmExtensions{
 			Repositories: k0sAPI.RepositoriesSettings{},
@@ -107,9 +125,18 @@ func addOpenEBSHelmExtension(helmSpec *k0sAPI.HelmExtensions) *k0sAPI.HelmExtens
 		ChartName: "openebs-internal/openebs",
 		TargetNS:  "openebs",
 		Version:   constant.OpenEBSVersion,
+		Values:    values,
 		Timeout:   time.Duration(time.Minute * 30), // it takes a while to install openebs
 	})
-	return helmSpec
+	return helmSpec, nil
+}
+
+func yamlifyValues(values map[string]interface{}) (string, error) {
+	bytes, err := yaml.Marshal(values)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
 }
 
 // reconcileHelmExtensions creates instance of Chart CR for each chart of the config file


### PR DESCRIPTION


Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

## Description

The `spec.extensions.storage.create_default_storage_class` was not properly propagated to Helm values for OpenEBS.

Also fix the inttest to utilize the default SC setting. Needed to re-arrange the test order a bit so that the PVC is only created after the default SC is actually created.

Fixes #2466 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings