### PR TITLE
Bump golang version, 1.25

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,4 +1,7 @@
-go_version = 1.19.3
+alpine_version = 3.16
+alpine_patch_version = $(alpine_version).3
+golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
+go_version = 1.19.4
 
 runc_version = 1.1.4
 runc_buildimage = golang:$(go_version)-alpine3.16


### PR DESCRIPTION
Signed-off-by: Mikhail Sakhnov <msakhnov@mirantis.com>
(cherry picked from commit 8cbe29a0da297f12446ae5b3a1f17dd8c8d0d1e7)
