### PR TITLE
kube-router: Add support for `ipMasq` config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,6 +110,7 @@ spec:
     kuberouter:
       autoMTU: true
       hairpin: Enabled
+      ipMasq: false
       metricsPort: 8080
       mtu: 0
       peerRouterASNs: ""
@@ -227,6 +228,7 @@ CALICO_IPV6POOL_CIDR: "{{ spec.network.dualStack.IPv6podCIDR }}"
 | `peerRouterASNs` | Comma-separated list of [global peer ASNs](https://github.com/cloudnativelabs/kube-router/blob/master/docs/bgp.md#global-external-bgp-peers).                                                                                                                             |
 | `hairpin`        | Hairpin mode, supported modes `Enabled`: enabled cluster wide, `Allowed`: must be allowed per service [using annotations](https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md#hairpin-mode), `Disabled`: doesn't work at all (default: Enabled) |
 | `hairpinMode`    | **Deprecated** Use `hairpin` instead. If both `hairpin` and `hairpinMode` are defined, this is ignored. If only hairpinMode is configured explicitly activates hairpinMode (https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md#hairpin-mode).  |
+| `ipMasq`         | IP masquerade for traffic originating from the pod network, and destined outside of it (default: false) |
 
 **Note**: Kube-router allows many networking aspects to be configured per node, service, and pod (for more information, refer to the [Kube-router user guide](https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md)).
 

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/kuberouter.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/kuberouter.go
@@ -30,6 +30,8 @@ type KubeRouter struct {
 	Hairpin Hairpin `json:"hairpin"`
 	// DEPRECATED: Use hairpin instead. Activates Hairpin Mode (allow a Pod behind a Service to communicate to its own ClusterIP:Port)
 	HairpinMode bool `json:"hairpinMode,omitempty"`
+	// IP masquerade for traffic originating from the pod network, and destined outside of it (default: false)
+	IPMasq bool `json:"ipMasq"`
 	// Comma-separated list of global peer addresses
 	PeerRouterASNs string `json:"peerRouterASNs"`
 	// Comma-separated list of global peer ASNs

--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -50,6 +50,7 @@ type kubeRouterConfig struct {
 	CNIImage          string
 	GlobalHairpin     bool
 	CNIHairpin        bool
+	IPMasq            bool
 	PeerRouterIPs     string
 	PeerRouterASNs    string
 	PullPolicy        string
@@ -110,6 +111,7 @@ func (k *KubeRouter) Reconcile(_ context.Context, clusterConfig *v1beta1.Cluster
 		MetricsPort:       clusterConfig.Spec.Network.KubeRouter.MetricsPort,
 		PeerRouterIPs:     clusterConfig.Spec.Network.KubeRouter.PeerRouterIPs,
 		PeerRouterASNs:    clusterConfig.Spec.Network.KubeRouter.PeerRouterASNs,
+		IPMasq:            clusterConfig.Spec.Network.KubeRouter.IPMasq,
 		CNIImage:          clusterConfig.Spec.Images.KubeRouter.CNI.URI(),
 		CNIInstallerImage: clusterConfig.Spec.Images.KubeRouter.CNIInstaller.URI(),
 		PullPolicy:        clusterConfig.Spec.Images.DefaultPullPolicy,
@@ -172,6 +174,7 @@ data:
              "bridge":"kube-bridge",
              "isDefaultGateway":true,
              "hairpinMode": {{ .CNIHairpin }},
+             "ipMasq": {{ .IPMasq }},
              "ipam":{
                 "type":"host-local"
              }

--- a/pkg/component/controller/kuberouter_test.go
+++ b/pkg/component/controller/kuberouter_test.go
@@ -45,6 +45,7 @@ func TestKubeRouterConfig(t *testing.T) {
 	cfg.Spec.Network.KubeRouter.PeerRouterASNs = "12345,67890"
 	cfg.Spec.Network.KubeRouter.PeerRouterIPs = "1.2.3.4,4.3.2.1"
 	cfg.Spec.Network.KubeRouter.Hairpin = v1beta1.HairpinAllowed
+	cfg.Spec.Network.KubeRouter.IPMasq = true
 
 	saver := inMemorySaver{}
 	kr := NewKubeRouter(k0sVars, saver)
@@ -72,6 +73,7 @@ func TestKubeRouterConfig(t *testing.T) {
 	require.Equal(t, false, p.Dig("auto-mtu"))
 	require.Equal(t, float64(1450), p.Dig("mtu"))
 	require.Equal(t, true, p.Dig("hairpinMode"))
+	require.Equal(t, true, p.Dig("ipMasq"))
 }
 
 type hairpinTest struct {
@@ -143,6 +145,7 @@ func TestKubeRouterDefaultManifests(t *testing.T) {
 	require.Equal(t, true, p.Dig("auto-mtu"))
 	require.Nil(t, p.Dig("mtu"))
 	require.Equal(t, true, p.Dig("hairpinMode"))
+	require.Equal(t, false, p.Dig("ipMasq"))
 }
 
 func findConfig(resources []*unstructured.Unstructured) (corev1.ConfigMap, error) {

--- a/static/manifests/v1beta1/CustomResourceDefinition/k0s.k0sproject.io_clusterconfigs.yaml
+++ b/static/manifests/v1beta1/CustomResourceDefinition/k0s.k0sproject.io_clusterconfigs.yaml
@@ -372,6 +372,10 @@ spec:
                           Mode (allow a Pod behind a Service to communicate to its
                           own ClusterIP:Port)'
                         type: boolean
+                      ipMasq:
+                        description: 'IP masquerade for traffic originating from the
+                          pod network, and destined outside of it (default: false)'
+                        type: boolean
                       metricsPort:
                         description: 'Kube-router metrics server port. Set to 0 to
                           disable metrics  (default: 8080)'


### PR DESCRIPTION
Resolves #2497. Allows users to specify `ipMasq` under spec.network.kuberouter to enable the [CNI
bridge](https://www.cni.dev/plugins/current/main/bridge/) IP Masquerade feature.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

Deployed a new cluster with ipMasq: true

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings