### PR TITLE
k0s binary path detection for autopilot

### DIFF
--- a/inttest/ap-single/single_test.go
+++ b/inttest/ap-single/single_test.go
@@ -42,6 +42,13 @@ type plansSingleControllerSuite struct {
 func (s *plansSingleControllerSuite) SetupTest() {
 	s.Require().NoError(s.WaitForSSH(s.ControllerNode(0), 2*time.Minute, 1*time.Second))
 
+	// Move the k0s binary to a new location, so we can check the binary location detection
+	ssh, err := s.SSH(s.ControllerNode(0))
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+	_, err = ssh.ExecWithOutput(s.Context(), "cp /dist/k0s /tmp/k0s")
+	s.Require().NoError(err)
+
 	s.Require().NoError(s.InitController(0), "--disable-components=metrics-server")
 	s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(0)))
 
@@ -114,6 +121,7 @@ spec:
 func TestPlansSingleControllerSuite(t *testing.T) {
 	suite.Run(t, &plansSingleControllerSuite{
 		common.FootlooseSuite{
+			K0sFullPath:     "/tmp/k0s",
 			ControllerCount: 1,
 			WorkerCount:     0,
 			LaunchMode:      common.LaunchModeOpenRC,

--- a/pkg/autopilot/controller/signal/k0s/init.go
+++ b/pkg/autopilot/controller/signal/k0s/init.go
@@ -17,6 +17,8 @@ package k0s
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
@@ -49,13 +51,19 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 		return fmt.Errorf("unable to determine hostname for controlnode 'signal' reconciler: %w", err)
 	}
 
+	k0sBinaryPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("unable to determine k0s binary path for controlnode 'signal' reconciler: %w", err)
+	}
+	k0sBinaryDir := filepath.Dir(k0sBinaryPath)
+
 	logger.Infof("Using effective hostname = '%v'", hostname)
 
 	if err := registerSignalController(logger, mgr, signalControllerEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s signal")), delegate, clusterID); err != nil {
 		return fmt.Errorf("unable to register k0s 'signal' controller: %w", err)
 	}
 
-	if err := registerDownloading(logger, mgr, downloadEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s downloading")), delegate); err != nil {
+	if err := registerDownloading(logger, mgr, downloadEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s downloading")), delegate, k0sBinaryDir); err != nil {
 		return fmt.Errorf("unable to register k0s 'downloading' controller: %w", err)
 	}
 
@@ -63,7 +71,7 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 		return fmt.Errorf("unable to register k0s 'cordoning' controller: %w", err)
 	}
 
-	if err := registerApplyingUpdate(logger, mgr, applyingUpdateEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s applying-update")), delegate); err != nil {
+	if err := registerApplyingUpdate(logger, mgr, applyingUpdateEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s applying-update")), delegate, k0sBinaryDir); err != nil {
 		return fmt.Errorf("unable to register k0s 'applying-update' controller: %w", err)
 	}
 


### PR DESCRIPTION
Signed-off-by: Alexey Makhov <amakhov@mirantis.com>

## Description

Autopilot now detects k0s path instead of using the hardcoded one to update the running binary.

Fixes #2499

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings