### PR TITLE
[Backport release-1.25] Calico test improved: added pod-to-pod connectivity check

### DIFF
--- a/inttest/calico/calico_test.go
+++ b/inttest/calico/calico_test.go
@@ -18,12 +18,15 @@ package calico
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/k0sproject/k0s/inttest/common"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type CalicoSuite struct {
@@ -37,6 +40,8 @@ func (s *CalicoSuite) TestK0sGetsUp() {
 
 	kc, err := s.KubeClient("controller0", "")
 	s.NoError(err)
+	restConfig, err := s.GetKubeConfig("controller0", "")
+	s.NoError(err)
 
 	err = s.WaitForNodeReady("worker0", kc)
 	s.NoError(err)
@@ -44,7 +49,7 @@ func (s *CalicoSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady("worker1", kc)
 	s.NoError(err)
 
-	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), v1.ListOptions{
+	pods, err := kc.CoreV1().Pods("kube-system").List(context.TODO(), metav1.ListOptions{
 		Limit: 100,
 	})
 	s.NoError(err)
@@ -56,6 +61,44 @@ func (s *CalicoSuite) TestK0sGetsUp() {
 
 	s.T().Log("waiting to see calico pods ready")
 	s.NoError(common.WaitForCalicoReady(kc), "calico did not start")
+	s.NoError(common.WaitForPodLogs(kc, "kube-system"))
+
+	createdTargetPod, err := kc.CoreV1().Pods("default").Create(s.Context(), &corev1.Pod{
+		TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "nginx", Image: "docker.io/library/nginx:1.23.1-alpine"}},
+			NodeSelector: map[string]string{
+				"kubernetes.io/hostname": "worker0",
+			},
+		},
+	}, metav1.CreateOptions{})
+	s.Require().NoError(err)
+	s.Require().NoError(common.WaitForPod(kc, "nginx", "default"), "nginx pod did not start")
+
+	targetPod, err := kc.CoreV1().Pods(createdTargetPod.Namespace).Get(s.Context(), createdTargetPod.Name, metav1.GetOptions{})
+	s.Require().NoError(err)
+
+	sourcePod, err := kc.CoreV1().Pods("default").Create(s.Context(), &corev1.Pod{
+		TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "alpine"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    "alpine",
+				Image:   "alpine:3.16",
+				Command: []string{"sleep", "infinity"},
+			}},
+			NodeSelector: map[string]string{
+				"kubernetes.io/hostname": "worker1",
+			},
+		},
+	}, metav1.CreateOptions{})
+	s.Require().NoError(err)
+	s.NoError(common.WaitForPod(kc, "alpine", "default"), "alpine pod did not start")
+
+	out, err := common.PodExecCmdOutput(kc, restConfig, sourcePod.Name, sourcePod.Namespace, fmt.Sprintf("/usr/bin/wget -qO- %s", targetPod.Status.PodIP))
+	s.Require().NoError(err, out)
+	s.Require().True(strings.Contains(out, "Welcome to nginx"))
 }
 
 func TestCalicoSuite(t *testing.T) {

--- a/inttest/common/pod.go
+++ b/inttest/common/pod.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"bytes"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// PodExecCmdOutput exec command on specific pod and wait the command's output.
+func PodExecCmdOutput(client kubernetes.Interface, config *restclient.Config, podName, namespace string, command string) (string, error) {
+	cmd := []string{
+		"/bin/sh",
+		"-c",
+		command,
+	}
+	req := client.CoreV1().RESTClient().Post().Resource("pods").Name(podName).Namespace(namespace).SubResource("exec")
+	option := &v1.PodExecOptions{
+		Command: cmd,
+		Stdin:   false,
+		Stdout:  true,
+		Stderr:  true,
+		TTY:     false,
+	}
+	req.VersionedParams(option, scheme.ParameterCodec)
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return "", err
+	}
+
+	var b bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdout: &b,
+		Stderr: &b,
+	})
+	if err != nil {
+		return b.String(), err
+	}
+
+	return b.String(), nil
+}


### PR DESCRIPTION
Backport of #2387. See #2385.