### PR TITLE
Disable konnectivity agent control plane proxy if not used

### DIFF
--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -359,9 +359,9 @@ spec:
       priorityClassName: system-cluster-critical
       tolerations:
         - operator: Exists
-      {{ if .TunneledNetworkingMode }}
+      {{- if .TunneledNetworkingMode }}
       hostNetwork: true
-      {{ end }}
+      {{- end }}
       containers:
         - image: {{ .Image }}
           imagePullPolicy: {{ .PullPolicy }}
@@ -387,11 +387,13 @@ spec:
                   "--service-account-token-path=/var/run/secrets/tokens/konnectivity-agent-token",
                   "--agent-identifiers=host=$(NODE_IP)",
                   "--agent-id=$(NODE_IP)",
-                  {{ if .TunneledNetworkingMode }}
+                  {{- if .TunneledNetworkingMode }}
                   # agent need to listen on the node ip to be on pair with the tunneled network reconciler
                   "--bind-address=$(NODE_IP)",
                   "--apiserver-port-mapping=6443:localhost:{{.KASPort}}"
-                  {{ end }} 
+                  {{- else }}
+                  "--feature-gates=NodeToMasterTraffic=false"
+                  {{- end }}
                   ]
           volumeMounts:
             - mountPath: /var/run/secrets/tokens


### PR DESCRIPTION
## Description

The control plane proxy provided by konnectivity agent is only used if k0s is running in tunneled networking mode. The konnectivity agent starts it by default. Explicitly disable konnectivity's `NodeToMasterTraffic` feature gate if not using tunneled networking mode, so that the unused proxy isn't launched in that case.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings