### PR TITLE
Bump cri-dockerd to v0.3.0

### DIFF
--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -12,6 +12,7 @@ smoketests := \
 	check-ap-removedapis \
 	check-backup \
 	check-basic \
+	check-byocri \
 	check-calico \
 	check-cli \
 	check-clusterreboot \
@@ -50,5 +51,3 @@ smoketests := \
 	check-network-conformance-kuberouter \
 	check-network-conformance-calico \
 	check-embedded-binaries \
-#   byo-cri test disabled untill cri-dockerd has release with v1 CRI API
-#	check-byocri \

--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -36,5 +36,6 @@ RUN curl -L https://github.com/etcd-io/etcd/releases/download/v$ETCD_VERSION/etc
   | tar xz -C /opt --strip-components=1
 
 # Install cri-dockerd shim for custom CRI testing
-RUN curl -sSfL https://github.com/Mirantis/cri-dockerd/releases/download/v0.2.6/cri-dockerd-0.2.6.amd64.tgz | tar -zxv --strip-components=1 cri-dockerd/cri-dockerd -C /usr/local/bin/
+RUN curl -sSfLo /usr/local/bin/cri-dockerd https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.0/cri-dockerd-0.3.0.amd64 \
+  && chmod 755 /usr/local/bin/cri-dockerd
 ADD cri-dockerd.sh /etc/init.d/cri-dockerd


### PR DESCRIPTION
## Description

https://github.com/Mirantis/cri-dockerd/releases/tag/v0.3.0

Also: Revert commit 2fb262ce7122cdfec5060c1954e9fc195e5b3894 and re-enable the byo-cri inttest.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings