### PR TITLE
Fix the test custom-domain flakyness

### DIFF
--- a/inttest/customdomain/customdomain_test.go
+++ b/inttest/customdomain/customdomain_test.go
@@ -57,6 +57,7 @@ func (s *CustomDomainSuite) TestK0sGetsUpWithCustomDomain() {
 		_, err = ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s kc run nginx --image docker.io/nginx:1-alpine")
 		s.Require().NoError(err)
 		s.NoError(common.WaitForPod(s.Context(), kc, "nginx", "default"))
+		s.NoError(common.WaitForPodLogs(s.Context(), kc, "default"))
 		output, err := ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s kc exec nginx -- cat /etc/resolv.conf")
 		s.Require().NoError(err)
 		s.Contains(output, "search default.svc.something.local svc.something.local something.local")


### PR DESCRIPTION

## Description
The test custom-domain has become flaky. I'm not quite sure when did this happen, but it was recently. We can see in many executions such as: 

https://github.com/k0sproject/k0s/actions/runs/3742332086/jobs/6359020341
https://github.com/k0sproject/k0s/actions/runs/3740780796/jobs/6349616080
https://github.com/k0sproject/k0s/actions/runs/3731323166/attempts/2

We can solve this simply by waiting for konnectivity to be ready before actually starting the test.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings