### PR TITLE
Make Supervisor kill pidFile before Start

### DIFF
--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -104,7 +104,7 @@ func TestGetEnv(t *testing.T) {
 
 	env := getEnv("/var/lib/k0s", "foo", false)
 	sort.Strings(env)
-	expected := "[HTTPS_PROXY=a.b.c:1080 PATH=/var/lib/k0s/bin:/usr/local/bin k1=v1 k2=foo_v2 k3=foo_v3 k4=v4]"
+	expected := "[HTTPS_PROXY=a.b.c:1080 PATH=/var/lib/k0s/bin:/usr/local/bin _K0S_MANAGED=yes k1=v1 k2=foo_v2 k3=foo_v3 k4=v4]"
 	actual := fmt.Sprintf("%s", env)
 	if actual != expected {
 		t.Errorf("Failed in env processing with keepEnvPrefix=false, expected: %q, actual: %q", expected, actual)
@@ -112,7 +112,7 @@ func TestGetEnv(t *testing.T) {
 
 	env = getEnv("/var/lib/k0s", "foo", true)
 	sort.Strings(env)
-	expected = "[FOO_PATH=/usr/local/bin FOO_k2=foo_v2 FOO_k3=foo_v3 HTTPS_PROXY=a.b.c:1080 PATH=/var/lib/k0s/bin:/bin k1=v1 k2=v2 k3=v3 k4=v4]"
+	expected = "[FOO_PATH=/usr/local/bin FOO_k2=foo_v2 FOO_k3=foo_v3 HTTPS_PROXY=a.b.c:1080 PATH=/var/lib/k0s/bin:/bin _K0S_MANAGED=yes k1=v1 k2=v2 k3=v3 k4=v4]"
 	actual = fmt.Sprintf("%s", env)
 	if actual != expected {
 		t.Errorf("Failed in env processing with keepEnvPrefix=true, expected: %q, actual: %q", expected, actual)

--- a/pkg/supervisor/supervisor_unix.go
+++ b/pkg/supervisor/supervisor_unix.go
@@ -1,0 +1,148 @@
+//go:build unix
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package supervisor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	exitCheckInterval = 200 * time.Millisecond
+)
+
+// killPid signals SIGTERM to a PID and if it's still running after
+// s.TimeoutStop sends SIGKILL.
+func (s *Supervisor) killPid(pid int, check <-chan time.Time, deadline <-chan time.Time) error {
+	if s.KillFunction == nil {
+		s.KillFunction = syscall.Kill
+	}
+	// Kill the process pid
+	if deadline == nil {
+		deadlineTicker := time.NewTicker(s.TimeoutStop)
+		deadline = deadlineTicker.C
+		defer deadlineTicker.Stop()
+	}
+	if check == nil {
+		checkTicker := time.NewTicker(exitCheckInterval)
+		check = checkTicker.C
+		defer checkTicker.Stop()
+
+	}
+
+	// Using two tickers is not very elegant but makes testing easier...
+Loop:
+	for {
+		select {
+		case <-check:
+			shouldKill, err := s.shouldKillProcess(pid)
+			if err != nil {
+				return err
+			}
+			if !shouldKill {
+				return nil
+			}
+
+			err = s.KillFunction(pid, syscall.SIGTERM)
+			if err == syscall.ESRCH {
+				return nil
+			} else if err != nil {
+				return fmt.Errorf("failed to send SIGTERM to pid %d: %s", s.cmd.Process.Pid, err)
+			}
+		case <-deadline:
+			break Loop
+		}
+	}
+
+	shouldKill, err := s.shouldKillProcess(pid)
+	if err != nil {
+		return err
+	}
+	if !shouldKill {
+		return nil
+	}
+
+	err = s.KillFunction(pid, syscall.SIGKILL)
+	if err == syscall.ESRCH {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to send SIGKILL to pid %d: %s", s.cmd.Process.Pid, err)
+	}
+	return nil
+}
+
+// maybeKillPidFile checks kills the process in the pidFile if it's has
+// the same binary as the supervisor's and also checks that the env
+// `_KOS_MANAGED=yes`. This function does not delete the old pidFile as
+// this is done by the caller.
+// The tickers are used for testing purposes, otherwise set them to nil.
+func (s *Supervisor) maybeKillPidFile(check <-chan time.Time, deadline <-chan time.Time) error {
+	if s.ProcFSPath == "" {
+		s.ProcFSPath = "/proc"
+	}
+
+	pid, err := os.ReadFile(s.PidFile)
+	if os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to read pid file %s: %v", s.PidFile, err)
+	}
+
+	p, err := strconv.Atoi(strings.TrimSuffix(string(pid), "\n"))
+	if err != nil {
+		return fmt.Errorf("failed to parse pid file %s: %v", s.PidFile, err)
+	}
+
+	return s.killPid(p, check, deadline)
+}
+
+func (s *Supervisor) shouldKillProcess(pid int) (bool, error) {
+	cmdline, err := os.ReadFile(filepath.Join(s.ProcFSPath, strconv.Itoa(pid), "cmdline"))
+	if os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("failed to read process %d cmdline: %v", pid, err)
+	}
+
+	// only kill process if it has the expected cmd
+	cmd := strings.Split(string(cmdline), "\x00")
+	if cmd[0] != s.BinPath {
+		return false, nil
+	}
+
+	//only kill process if it has the _KOS_MANAGED env set
+	env, err := os.ReadFile(filepath.Join(s.ProcFSPath, strconv.Itoa(pid), "environ"))
+	if os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("failed to read process %d environ: %v", pid, err)
+	}
+
+	for _, e := range strings.Split(string(env), "\x00") {
+		if e == k0sManaged {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/supervisor/supervisor_unix_test.go
+++ b/pkg/supervisor/supervisor_unix_test.go
@@ -1,0 +1,245 @@
+//go:build unix
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package supervisor
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func createMockProcess(procFSPath string, pid string, cmdline []byte, k0smanaged bool) error {
+	if err := os.Mkdir(filepath.Join(procFSPath, pid), 0700); err != nil {
+		return fmt.Errorf("Failed to create fake proc dir: %v", err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(procFSPath, pid, "cmdline"), cmdline, 0700); err != nil {
+		return fmt.Errorf("Failed to write cmdline: %v", err)
+	}
+
+	var env []byte
+	if k0smanaged {
+		env = []byte(fmt.Sprintf("ENV1=A\x00%s\x00ENV3=B\x00", k0sManaged))
+	} else {
+		env = []byte("ENV1=A\x00ENV3=B\x00")
+	}
+	if err := ioutil.WriteFile(filepath.Join(procFSPath, pid, "environ"), env, 0700); err != nil {
+		return fmt.Errorf("Failed to write environ: %v", err)
+	}
+	return nil
+}
+
+type mockKiller struct {
+	ProcFSPath string
+}
+
+func (m *mockKiller) killNow(pid int, s syscall.Signal) error {
+	// os.RemoveAll() doesn't return an error if the path doesn't exist
+	// so we need to check that first.
+	path := filepath.Join(m.ProcFSPath, strconv.Itoa(pid))
+	if _, err := os.Stat(path); err != nil {
+		return syscall.ESRCH
+	}
+
+	err := os.RemoveAll(path)
+	return err
+}
+
+func (m *mockKiller) killOnSigKill(pid int, s syscall.Signal) error {
+	// os.RemoveAll() doesn't return an error if the path doesn't exist
+	// so we need to check that first.
+	path := filepath.Join(m.ProcFSPath, strconv.Itoa(pid))
+	if _, err := os.Stat(path); err != nil {
+		return syscall.ESRCH
+	}
+
+	if s == syscall.SIGKILL {
+		return os.RemoveAll(path)
+	}
+	return nil
+}
+
+func TestKillPid(t *testing.T) {
+	t.Run("Kill immediately", func(t *testing.T) {
+		m := mockKiller{
+			ProcFSPath: t.TempDir(),
+		}
+		s := Supervisor{
+			Name:         "supervisor-test-is-running",
+			ProcFSPath:   m.ProcFSPath,
+			KillFunction: m.killNow,
+			BinPath:      "/bin/true",
+		}
+		require.NoError(t, createMockProcess(s.ProcFSPath, "123", []byte("/bin/true\x00"), true))
+
+		check := make(chan time.Time)
+		deadline := make(chan time.Time)
+		defer close(check)
+		defer close(deadline)
+
+		go func() {
+			check <- time.Now()
+			check <- time.Now()
+			deadline <- time.Now()
+		}()
+		require.NoError(t, s.killPid(123, check, deadline), "Failed to kill pid")
+
+		// If we can read deadline, then we guarantee that check was read twice because it's
+		// unbuffered. This guarantees the loop has run exactly twice.
+		<-deadline
+	})
+
+	t.Run("Force SigKill", func(t *testing.T) {
+		m := mockKiller{
+			ProcFSPath: t.TempDir(),
+		}
+		s := Supervisor{
+			Name:         "supervisor-test-is-running",
+			TimeoutStop:  exitCheckInterval,
+			ProcFSPath:   m.ProcFSPath,
+			KillFunction: m.killOnSigKill,
+			BinPath:      "/bin/true",
+		}
+		require.NoError(t, createMockProcess(s.ProcFSPath, "123", []byte("/bin/true\x00"), true))
+
+		check := make(chan time.Time)
+		deadline := make(chan time.Time)
+		verify := make(chan time.Time)
+		defer close(check)
+		defer close(deadline)
+		defer close(verify)
+
+		go func() {
+			check <- time.Now()
+			deadline <- time.Now()
+			verify <- time.Now()
+		}()
+		require.NoError(t, s.killPid(123, check, deadline), "Error deleting fake pid")
+
+		<-verify
+	})
+}
+
+func TestMaybeKillPidFile(t *testing.T) {
+	t.Run("Kill non existing pidFile", func(t *testing.T) {
+		s := Supervisor{
+			PidFile: filepath.Join(t.TempDir(), "invalid"),
+		}
+		require.NoError(t, s.maybeKillPidFile(nil, nil), "If the file doesn't exist should exit without error")
+	})
+
+	t.Run("Kill invalid pidFile", func(t *testing.T) {
+		s := Supervisor{
+			PidFile: filepath.Join(t.TempDir(), "invalid"),
+		}
+		require.NoError(t, ioutil.WriteFile(s.PidFile, []byte("invalid"), 0600), "Failed to create invalid pidFile")
+
+		require.Error(t, s.maybeKillPidFile(nil, nil), "Should have failed to kill invalid pidFile")
+	})
+	t.Run("Don't kill validPidFile pointing to different process", func(t *testing.T) {
+		m := mockKiller{
+			ProcFSPath: t.TempDir(),
+		}
+		s := Supervisor{
+			PidFile:      filepath.Join(t.TempDir(), "valid"),
+			ProcFSPath:   m.ProcFSPath,
+			KillFunction: m.killNow,
+			BinPath:      "/bin/true",
+		}
+
+		require.NoError(t, createMockProcess(s.ProcFSPath, "12345", []byte("/bin/false\x00"), true))
+		require.NoError(t, ioutil.WriteFile(s.PidFile, []byte("12345\n"), 0700), "Failed to create valid pidFile")
+
+		check := make(chan time.Time)
+		deadline := make(chan time.Time)
+		defer close(check)
+		defer close(deadline)
+		go func() {
+			check <- time.Now()
+		}()
+
+		require.NoError(t, s.maybeKillPidFile(check, deadline), "Error killing valid pidFile")
+
+		_, err := os.Stat(filepath.Join(m.ProcFSPath, "12345"))
+		require.NoError(t, err, "Should not have killed the process")
+	})
+
+	t.Run("Don't kill process without the env", func(t *testing.T) {
+		m := mockKiller{
+			ProcFSPath: t.TempDir(),
+		}
+		s := Supervisor{
+			PidFile:      filepath.Join(t.TempDir(), "valid"),
+			ProcFSPath:   m.ProcFSPath,
+			KillFunction: m.killNow,
+			BinPath:      "/bin/true",
+		}
+
+		require.NoError(t, createMockProcess(s.ProcFSPath, "12345", []byte("/bin/true\x00arg1\x00arg2\x00"), false))
+		require.NoError(t, ioutil.WriteFile(s.PidFile, []byte("12345\n"), 0700), "Failed to create valid pidFile")
+
+		check := make(chan time.Time)
+		deadline := make(chan time.Time)
+		defer close(check)
+		defer close(deadline)
+		go func() {
+			check <- time.Now()
+		}()
+		require.NoError(t, s.maybeKillPidFile(check, deadline), "Error killing valid pidFile")
+
+		_, err := os.Stat(filepath.Join(m.ProcFSPath, "12345"))
+		require.NoError(t, err, "Should not have killed the process")
+	})
+
+	t.Run("Kill process which must be killed", func(t *testing.T) {
+		m := mockKiller{
+			ProcFSPath: t.TempDir(),
+		}
+		s := Supervisor{
+			PidFile:      filepath.Join(t.TempDir(), "valid"),
+			ProcFSPath:   m.ProcFSPath,
+			KillFunction: m.killNow,
+			BinPath:      "/bin/true",
+		}
+
+		require.NoError(t, createMockProcess(s.ProcFSPath, "12345", []byte("/bin/true\x00arg1\x00arg2\x00"), true))
+		require.NoError(t, ioutil.WriteFile(s.PidFile, []byte("12345\n"), 0700), "Failed to create valid pidFile")
+
+		check := make(chan time.Time)
+		deadline := make(chan time.Time)
+		defer close(check)
+		defer close(deadline)
+
+		go func() {
+			check <- time.Now()
+			check <- time.Now()
+		}()
+
+		require.NoError(t, s.maybeKillPidFile(check, deadline), "Error killing valid pidFile")
+
+		_, err := os.Stat(filepath.Join(m.ProcFSPath, "12345"))
+		require.Error(t, err, "Should have killed the process")
+	})
+}

--- a/pkg/supervisor/supervisor_windows.go
+++ b/pkg/supervisor/supervisor_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package supervisor
+
+import (
+	"time"
+)
+
+// maybeKillPidFile checks kills the process in the pidFile if it's has
+// the same binary as the supervisor's. This function does not delete
+// the old pidFile as this is done by the caller.
+func (s *Supervisor) maybeKillPidFile(check <-chan time.Time, deadline <-chan time.Time) error {
+	s.log.Warnf("maybeKillPidFile is not implemented on Windows")
+	return nil
+}


### PR DESCRIPTION
## Description

Prior to this commit the pidFiles were written but ignored. This avoids starting the same process twice which could be a problem.

The PR is marked as a draft because the tests need to be refactored because there is a lot of duplicate code. But other than that I'm quite happy with the current result

Fixes #2537

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings