### PR TITLE
Fix footloose-alpine Dockerfile

### DIFF
--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -36,6 +36,9 @@ RUN curl -L https://github.com/etcd-io/etcd/releases/download/v$ETCD_VERSION/etc
   | tar xz -C /opt --strip-components=1
 
 # Install cri-dockerd shim for custom CRI testing
-RUN curl -sSfLo /usr/local/bin/cri-dockerd https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.0/cri-dockerd-0.3.0.amd64 \
+RUN curl -sSfLo /tmp/cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.0/cri-dockerd-0.3.0.amd64.tgz \
+  && tar xf /tmp/cri-dockerd.tgz --directory /tmp/ \
+  && mv /tmp/cri-dockerd/cri-dockerd /usr/local/bin/cri-dockerd \
+  && rm -rf /tmp/cri-dockerd \
   && chmod 755 /usr/local/bin/cri-dockerd
 ADD cri-dockerd.sh /etc/init.d/cri-dockerd


### PR DESCRIPTION
## Description

The footloose-alpine image broke because the cri-dockerd release ships a tar.gz. rather than an executable.

Signed-off-by: Juan Luis de Sousa-Valadas Castaño <jvaladas@mirantis.com>


## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings