### PR TITLE
Remove redundant direct router library dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ static/zz_generated_assets.go
 docs/cli
 site
 k0sctl.yaml
-*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ static/zz_generated_assets.go
 docs/cli
 site
 k0sctl.yaml
+*.swp

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/google/go-cmp v0.5.9
-	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/terraform-exec v0.17.3
 	github.com/imdario/mergo v0.3.13
 	github.com/k0sproject/dig v0.2.0
@@ -167,6 +166,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/trillian v1.4.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect

--- a/internal/pkg/middleware/allow_methods.go
+++ b/internal/pkg/middleware/allow_methods.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+// AllowMethods is a middleware that accepts list of given HTTP methods.
+// Responds with HTTP status code 405 "Method not allowed" if no match is found.
+func AllowMethods(methods ...string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			for _, m := range methods {
+				if strings.EqualFold(m, r.Method) {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+		return http.HandlerFunc(fn)
+	}
+}

--- a/internal/pkg/middleware/allow_methods_test.go
+++ b/internal/pkg/middleware/allow_methods_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAllowMethods(t *testing.T) {
+	tests := []struct {
+		name         string
+		method       string
+		allowMethods []string
+		isNextCalled bool
+	}{
+		{name: "allow get", method: http.MethodGet, allowMethods: []string{http.MethodGet}, isNextCalled: true},
+		{name: "allow post", method: http.MethodPost, allowMethods: []string{http.MethodPost}, isNextCalled: true},
+		{name: "allow get and post", method: http.MethodGet, allowMethods: []string{http.MethodGet, http.MethodPost}, isNextCalled: true},
+		{name: "deny all", method: http.MethodGet},
+		{name: "deny post", method: http.MethodPost, allowMethods: []string{http.MethodGet}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isNextCalled := false
+			fn := func(_ http.ResponseWriter, _ *http.Request) {
+				isNextCalled = true
+			}
+			h := AllowMethods(test.allowMethods...)(http.HandlerFunc(fn))
+			rec := httptest.NewRecorder()
+			r, err := http.NewRequest(test.method, "/", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			h.ServeHTTP(rec, r)
+			if isNextCalled != test.isNextCalled {
+				t.Fatalf("test: %s got: %v want: %v", test.name, isNextCalled, test.isNextCalled)
+			}
+			if isNextCalled {
+				if rec.Result().StatusCode != http.StatusOK {
+					t.Fatalf("test: %s got: %v want: %v", test.name, rec.Result().StatusCode, http.StatusOK)
+				}
+			} else {
+				if rec.Result().StatusCode != http.StatusMethodNotAllowed {
+					t.Fatalf("test: %s got: %v want: %v", test.name, rec.Result().StatusCode, http.StatusMethodNotAllowed)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Tuomo Sirén <tuomo.siren@gmail.com>

## Description

Remove direct dependency to gorilla-mux. Standard library provides routing capabilities in itself thus there is no need for additional routing library unless doing e.g. regexp based routing. In this case avoiding a separate library eases debugging and makes the source code walk through more pleasant.

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings