### PR TITLE
Fix CNI change test 

### DIFF
--- a/pkg/kubernetes/watch/core.go
+++ b/pkg/kubernetes/watch/core.go
@@ -35,3 +35,7 @@ func Nodes(client Provider[*corev1.NodeList]) *Watcher[corev1.Node] {
 func Pods(client Provider[*corev1.PodList]) *Watcher[corev1.Pod] {
 	return FromClient[*corev1.PodList, corev1.Pod](client)
 }
+
+func Events(client Provider[*corev1.EventList]) *Watcher[corev1.Event] {
+	return FromClient[*corev1.EventList, corev1.Event](client)
+}


### PR DESCRIPTION
by checking that config reconciler gives out proper warning event

Previously we used to fail the controller bootstrap but since we've moved the reconcilers to be more "async" that behaviour has changed which was not reflected in this test.

Introducing #2290 surfaces the bugs in this test case.

Fixes #2289

Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings