### PR TITLE
Add local IPv6 addresses to certificates

### DIFF
--- a/cmd/controller/certificates.go
+++ b/cmd/controller/certificates.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -173,7 +174,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 		"127.0.0.1",
 	}
 
-	localIPs, err := detectLocalIPs()
+	localIPs, err := detectLocalIPs(ctx)
 	if err != nil {
 		return fmt.Errorf("error detecting local IP: %w", err)
 	}
@@ -217,23 +218,28 @@ func (c *Certificates) Init(ctx context.Context) error {
 	return eg.Wait()
 }
 
-func detectLocalIPs() ([]string, error) {
-	var localIPs []string
-	addrs, err := net.LookupIP("localhost")
+func detectLocalIPs(ctx context.Context) ([]string, error) {
+	resolver := net.DefaultResolver
+
+	addrs, err := resolver.LookupIPAddr(ctx, "localhost")
 	if err != nil {
 		return nil, err
 	}
 
 	if hostname, err := os.Hostname(); err == nil {
-		hostnameAddrs, err := net.LookupIP(hostname)
+		hostnameAddrs, err := resolver.LookupIPAddr(ctx, hostname)
 		if err == nil {
 			addrs = append(addrs, hostnameAddrs...)
+		} else if errors.Is(err, ctx.Err()) {
+			return nil, err
 		}
 	}
 
+	var localIPs []string
 	for _, addr := range addrs {
-		if addr.To4() != nil {
-			localIPs = append(localIPs, addr.String())
+		ip := addr.IP
+		if ip.To4() != nil || ip.To16() != nil {
+			localIPs = append(localIPs, ip.String())
 		}
 	}
 


### PR DESCRIPTION
## Description

The same has already been done for IPv4 addresses in #1683. Moreover, forward the context to detectLocalIPs(), so that the
resolution may be cancelled.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings