### PR TITLE
Improve CoreDNS affinity check in basic inttest

### DIFF
--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -18,6 +18,7 @@ package basic
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -25,9 +26,13 @@ import (
 	"github.com/k0sproject/k0s/inttest/common"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
+	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
 
 	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
@@ -208,13 +213,30 @@ func (s *BasicSuite) verifyContainerdDefaultConfig() {
 }
 
 func (s *BasicSuite) verifyCoreDNSAntiAffinity(kc *kubernetes.Clientset) {
-	opts := metav1.ListOptions{
-		LabelSelector: "k8s-app=kube-dns",
-	}
-	pods, err := kc.CoreV1().Pods("kube-system").List(s.Context(), opts)
-	s.NoError(err)
-	s.Equal(2, len(pods.Items))
-	s.NotEqual(pods.Items[0].Spec.NodeName, pods.Items[1].Spec.NodeName)
+	// Wait until both CoreDNs Pods got assigned to a node
+	pods := map[string]types.UID{}
+
+	s.NoError(watch.Pods(kc.CoreV1().Pods("kube-system")).
+		WithLabels(labels.Set{"k8s-app": "kube-dns"}).
+		WithErrorCallback(common.RetryWatchErrors(s.T().Logf)).
+		Until(s.Context(), func(pod *corev1.Pod) (bool, error) {
+			// Keep waiting if there's no node assigned yet.
+			nodeName := pod.Spec.NodeName
+			if nodeName == "" {
+				s.T().Logf("Pod %s not scheduled yet: %+v", pod.ObjectMeta.Name, pod.Status)
+				return false, nil
+			}
+
+			uid := pod.GetUID()
+			if prevUID, ok := pods[nodeName]; ok && uid != prevUID {
+				return false, errors.New("multiple CoreDNS pods scheduled on the same node")
+			}
+
+			s.T().Logf("Pod %s scheduled on %s", pod.ObjectMeta.Name, pod.Spec.NodeName)
+
+			pods[nodeName] = pod.GetUID()
+			return len(pods) > 1, nil
+		}))
 }
 
 func TestBasicSuite(t *testing.T) {


### PR DESCRIPTION
## Description

The inttest sometimes fails with the following message:

    basic_test.go:217:
        	Error Trace:	/home/gh-runner/actions-runner/_work/k0s/k0s/inttest/basic/basic_test.go:217
        	            				/home/gh-runner/actions-runner/_work/k0s/k0s/inttest/basic/basic_test.go:105
        	Error:      	Should not be: ""
        	Test:       	TestBasicSuite/TestK0sGetsUp

This indicates that the test doesn't wait until the CoreDNS Pods are properly scheduled. Maybe because it simply checks too early, or because the cluster is not healthy.

Replace the one-shot affinity check with a watch on the Pods that waits until two of them get scheduled. Add some logging and a better error message.

Moreover: Add label selector functionality to the Kubernetes Watcher in a similar manner as the field selectors are implemented. Remove WithoutFieldSelector() as it can be replaced by WithFieldSelector(fields.Everything()). Leave a note about this in the docs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings