### PR TITLE
Replace unmaintained GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,9 @@ jobs:
           echo TAG_NAME="${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-create-release@v1.4.0
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          release_name: ${{ steps.branch_name.outputs.TAG_NAME }}
           draft: true # So we can manually edit before publishing
           prerelease: ${{ contains(github.ref, '-') }} # v0.1.2-beta1, 1.2.3-rc1
       - name: Prepare image tags
@@ -89,9 +86,7 @@ jobs:
 
       - name: Upload Release Assets - Binary
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./k0s
@@ -106,9 +101,7 @@ jobs:
 
       - name: Upload Release Assets - Bundle
         id: upload-release-asset-images
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./airgap-image-bundle-linux-amd64.tar
@@ -157,9 +150,7 @@ jobs:
 
       - name: Upload Release Assets
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./k0s.exe
@@ -224,9 +215,7 @@ jobs:
 
       - name: Upload Release Assets - Binary
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./k0s
@@ -241,9 +230,7 @@ jobs:
 
       - name: Upload Release Assets - Bundle
         id: upload-release-asset-images
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./airgap-image-bundle-linux-arm64.tar
@@ -322,9 +309,7 @@ jobs:
 
       - name: Upload Release Assets - Binary
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./k0s
@@ -339,9 +324,7 @@ jobs:
 
       - name: Upload Release Assets - Bundle
         id: upload-release-asset-images
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./airgap-image-bundle-linux-arm.tar
@@ -519,8 +502,6 @@ jobs:
 
       - name: Upload conformance test result to Release Assets
         uses: shogo82148/actions-upload-release-asset@v1.6.3 # Allows us to upload a file with wildcard patterns
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: inttest/*_sonobuoy_*.tar.gz


### PR DESCRIPTION
## Description

* actions/create-release -> shogo82148/actions-create-release
* actions/upload-release-asset -> shogo82148/actions-upload-release-asset

Both actions are unmaintained and are still based on Node 12. The following warning is currently issued:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/create-release@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Pick the shogo actions out of the available alternatives since k0s already uses its upload-release-asset action in another place. Remove the GITHUB_TOKEN as it's no longer required.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings