### PR TITLE
Containerd imports handled by k0s

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -6,6 +6,18 @@ k0s uses [containerd](https://github.com/containerd/containerd) as the default C
 
 ## containerd configuration
 
+By default k0s manages the full containerd configuration. User has the option of fully overriding, and thus also managing, the configuration themselves.
+
+### User managed containerd configuration
+
+In the default k0s generated configuration there's a "magic" comment telling k0s it is k0s managed:
+
+```toml
+# k0s_managed=true
+```
+
+If you wish to take over the configuration management remove this line.
+
 To make changes to containerd configuration you must first generate a default containerd configuration, with the default values set to `/etc/k0s/containerd.toml`:
 
 ```shell
@@ -34,15 +46,17 @@ state = "/run/k0s/containerd"
   address = "/run/k0s/containerd.sock"
 ```
 
-Finally, if you want to change CRI look into:
+## k0s managed dynamic runtime configuration
 
-```toml
-  [plugins."io.containerd.runtime.v1.linux"]
-    shim = "containerd-shim"
-    runtime = "runc"
-```
+From 1.27.0 onwards k0s enables dynamic configuration on containerd CRI runtimes. This works by k0s creating a special directory in `/etc/k0s/containerd.d/` where user can drop-in partial containerd configuration snippets.
 
-## Using gVisor
+When k0s starts up it'll find these files and adds these in containerd configuration `imports` list. If k0s sees the configuration drop-ins are CRI related configurations k0s will automatically collect all these into a single file and adds that as a single import file. This is to overcome some hard limitation on containerd 1.X versions. Read more at [containerd#8056](https://github.com/containerd/containerd/pull/8056)
+
+### Examples
+
+Following chapters provide some examples how to configure different runtimes for containerd using k0s managed drop-in configurations.
+
+#### Using gVisor
 
 [gVisor](https://gvisor.dev/docs/) is an application kernel, written in Go, that implements a substantial portion of the Linux system call interface. It provides an additional layer of isolation between running applications and the host operating system.
 
@@ -51,16 +65,15 @@ Finally, if you want to change CRI look into:
     ```shell
     (
       set -e
-      URL=https://storage.googleapis.com/gvisor/releases/release/latest
+      ARCH=$(uname -m)
+      URL=https://storage.googleapis.com/gvisor/releases/release/latest/${ARCH}
       wget ${URL}/runsc ${URL}/runsc.sha512 \
-        ${URL}/gvisor-containerd-shim ${URL}/gvisor-containerd-shim.sha512 \
         ${URL}/containerd-shim-runsc-v1 ${URL}/containerd-shim-runsc-v1.sha512
       sha512sum -c runsc.sha512 \
-        -c gvisor-containerd-shim.sha512 \
         -c containerd-shim-runsc-v1.sha512
       rm -f *.sha512
-      chmod a+rx runsc gvisor-containerd-shim containerd-shim-runsc-v1
-      sudo mv runsc gvisor-containerd-shim containerd-shim-runsc-v1 /usr/local/bin
+      chmod a+rx runsc containerd-shim-runsc-v1
+      sudo mv runsc containerd-shim-runsc-v1 /usr/local/bin
     )
     ```
 
@@ -69,11 +82,10 @@ Finally, if you want to change CRI look into:
 2. Prepare the config for `k0s` managed containerD, to utilize gVisor as additional runtime:
 
     ```shell
-    cat <<EOF | sudo tee /etc/k0s/containerd.toml
-    disabled_plugins = ["restart"]
-    [plugins.linux]
-      shim_debug = true
-    [plugins.cri.containerd.runtimes.runsc]
+    cat <<EOF | sudo tee /etc/k0s/containerd.d/gvisor.toml
+    version = 2
+
+    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
       runtime_type = "io.containerd.runsc.v1"
     EOF
     ```
@@ -110,20 +122,27 @@ Finally, if you want to change CRI look into:
         image: nginx
     ```
 
-5. (Optional) Verify tht the created nginx pod is running under gVisor runtime:
+5. (Optional) Verify that the created nginx pod is running under gVisor runtime:
 
     ```shell
     # kubectl exec nginx-gvisor -- dmesg | grep -i gvisor
     [    0.000000] Starting gVisor...
     ```
 
-## Using `nvidia-container-runtime`
+#### Using `nvidia-container-runtime`
 
-By default, CRI is set to runC. As such, you must configure Nvidia GPU support by replacing `runc` with `nvidia-container-runtime`:
+First, install the NVIDIA runtime components:
+
+```shell
+distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
+   && curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add - \
+   && curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+sudo apt-get update && sudo apt-get install -y nvidia-container-runtime
+```
+
+Next, drop in the containerd runtime configuration snippet into `/etc/k0s/containerd.d/nvidia.toml`
 
 ```toml
-[plugins."io.containerd.grpc.v1.cri".containerd]
-    default_runtime_name = "nvidia"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
     privileged_without_host_devices = false
     runtime_engine = ""
@@ -131,6 +150,18 @@ By default, CRI is set to runC. As such, you must configure Nvidia GPU support b
     runtime_type = "io.containerd.runc.v1"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
     BinaryName = "/usr/bin/nvidia-container-runtime"
+```
+
+Create the needed `RuntimeClass`:
+
+```shell
+cat <<EOF | kubectl apply -f -
+apiVersion: node.k8s.io/v1beta1
+kind: RuntimeClass
+metadata:
+  name: nvidia
+handler: nvidia
+EOF
 ```
 
 **Note** Detailed instruction on how to run `nvidia-container-runtime` on your node is available [here](https://docs.nvidia.com/datacenter/cloud-native/kubernetes/install-k8s.html#install-nvidia-container-toolkit-nvidia-docker2).

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -50,7 +50,7 @@ state = "/run/k0s/containerd"
 
 From 1.27.0 onwards k0s enables dynamic configuration on containerd CRI runtimes. This works by k0s creating a special directory in `/etc/k0s/containerd.d/` where user can drop-in partial containerd configuration snippets.
 
-When k0s starts up it'll find these files and adds these in containerd configuration `imports` list. If k0s sees the configuration drop-ins are CRI related configurations k0s will automatically collect all these into a single file and adds that as a single import file. This is to overcome some hard limitation on containerd 1.X versions. Read more at [containerd#8056](https://github.com/containerd/containerd/pull/8056)
+k0s will automatically pick up these files and adds these in containerd configuration `imports` list. If k0s sees the configuration drop-ins are CRI related configurations k0s will automatically collect all these into a single file and adds that as a single import file. This is to overcome some hard limitation on containerd 1.X versions. Read more at [containerd#8056](https://github.com/containerd/containerd/pull/8056)
 
 ### Examples
 
@@ -100,7 +100,7 @@ Following chapters provide some examples how to configure different runtimes for
 
     ```shell
     cat <<EOF | kubectl apply -f -
-    apiVersion: node.k8s.io/v1beta1
+    apiVersion: node.k8s.io/v1
     kind: RuntimeClass
     metadata:
       name: gvisor
@@ -156,7 +156,7 @@ Create the needed `RuntimeClass`:
 
 ```shell
 cat <<EOF | kubectl apply -f -
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
   name: nvidia
@@ -165,8 +165,6 @@ EOF
 ```
 
 **Note** Detailed instruction on how to run `nvidia-container-runtime` on your node is available [here](https://docs.nvidia.com/datacenter/cloud-native/kubernetes/install-k8s.html#install-nvidia-container-toolkit-nvidia-docker2).
-
-After editing the configuration, restart `k0s` to get containerd using the newly configured runtime.
 
 ## Using custom CRI runtime
 

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/image-spec v1.1.0-rc2
+	github.com/pelletier/go-toml v1.9.5
 	github.com/robfig/cron v1.2.0
 	github.com/rqlite/rqlite v4.6.0+incompatible
 	github.com/segmentio/analytics-go v3.1.0+incompatible
@@ -130,6 +131,7 @@ require (
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
 	github.com/emicklei/go-restful/v3 v3.10.1 // indirect
 	github.com/envoyproxy/go-control-plane v0.10.3 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.9.1 // indirect
@@ -217,7 +219,6 @@ require (
 	github.com/opencontainers/runc v1.1.4 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
 	github.com/opencontainers/selinux v1.10.1 // indirect
-	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -497,6 +497,7 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20190911111923-ecfe977594f1 h1:yY9rWGoXv1U5pl4gxqlULARMQD7x0QG85lqEXTWysik=
+github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -54,3 +54,4 @@ smoketests := \
 	check-network-conformance-calico \
 	check-embedded-binaries \
 	check-custom-cidrs \
+	check-containerdimports \

--- a/inttest/containerdimports/containerd_imports_test.go
+++ b/inttest/containerdimports/containerd_imports_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containerdimports
+
+import (
+	"testing"
+
+	"github.com/k0sproject/k0s/inttest/common"
+
+	"github.com/stretchr/testify/suite"
+
+	corev1 "k8s.io/api/core/v1"
+	nodesv1 "k8s.io/api/node/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ContainerDImportsSuite struct {
+	common.FootlooseSuite
+}
+
+func (s *ContainerDImportsSuite) TestK0sGetsUp() {
+	ssh, err := s.SSH(s.ControllerNode(0))
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	s.NoError(s.InitController(0))
+
+	s.NoError(s.RunWorkers())
+
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	if err != nil {
+		s.FailNow("failed to obtain Kubernetes client", err)
+	}
+
+	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
+	s.NoError(err)
+
+	s.AssertSomeKubeSystemPods(kc)
+
+	s.T().Log("waiting to see kube-router pods ready")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "kube-router did not start")
+
+	s.addContainerDRuntime()
+	s.T().Log("Creating new RuntimeClass for foo runtime")
+	runtimeClassName := "foo"
+
+	runtimeClass := nodesv1.RuntimeClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: runtimeClassName,
+		},
+		Handler: runtimeClassName,
+	}
+	_, err = kc.NodeV1().RuntimeClasses().Create(s.Context(), &runtimeClass, metav1.CreateOptions{})
+	s.Require().NoError(err)
+	s.T().Log("Creating new Pod for foo runtime")
+	// Create new Pod for foo runtime
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		Spec: corev1.PodSpec{
+			RuntimeClassName: &runtimeClassName,
+			Containers: []corev1.Container{
+				{
+					Name:  "foo",
+					Image: "docker.io/nginx:1-alpine",
+				},
+			},
+		},
+	}
+	_, err = kc.CoreV1().Pods("default").Create(s.Context(), &pod, metav1.CreateOptions{})
+	s.Require().NoError(err)
+	s.Require().NoError(common.WaitForPod(s.Context(), kc, "foo", "default"))
+
+	s.T().Log("Creating new Pod for default runc runtime")
+	normalNginxPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "normal-nginx",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "docker.io/nginx:1-alpine",
+				},
+			},
+		},
+	}
+	_, err = kc.CoreV1().Pods("default").Create(s.Context(), &normalNginxPod, metav1.CreateOptions{})
+	s.Require().NoError(err)
+	s.Require().NoError(common.WaitForPod(s.Context(), kc, "normal-nginx", "default"))
+
+}
+
+func (s *ContainerDImportsSuite) addContainerDRuntime() {
+	s.T().Log("Setting up alternative runtime and config")
+	workerSSH, err := s.SSH(s.WorkerNode(0))
+	s.Require().NoError(err)
+	defer workerSSH.Disconnect()
+
+	// Make an "alias" runtime using runc
+	workerSSH.Exec(s.Context(), "ln -s /var/lib/k0s/bin/runc /var/lib/k0s/bin/runfoo", common.SSHStreams{})
+
+	// Configure containerd to use it
+	s.PutFile(s.WorkerNode(0), "/etc/k0s/containerd.d/foo.toml", fooRuntimeConfig)
+
+	// Restart k0s to pick up the new config for containerd
+	s.T().Log("Restarting k0s on worker")
+	workerSSH.Exec(s.Context(), "rc-service k0sworker restart", common.SSHStreams{})
+}
+
+func TestContainerDImportsSuite(t *testing.T) {
+	s := ContainerDImportsSuite{
+		common.FootlooseSuite{
+			LaunchMode:      common.LaunchModeOpenRC, // so we can easily restart k0s
+			ControllerCount: 1,
+			WorkerCount:     1,
+		},
+	}
+	suite.Run(t, &s)
+}
+
+const fooRuntimeConfig = `
+version = 2
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.foo]
+      runtime_type = "io.containerd.runc.v2"
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.foo.options]
+        BinaryName = "/var/lib/k0s/bin/runfoo"
+`

--- a/inttest/containerdimports/containerd_imports_test.go
+++ b/inttest/containerdimports/containerd_imports_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 k0s authors
+Copyright 2023 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/containerdimports/containerd_imports_test.go
+++ b/inttest/containerdimports/containerd_imports_test.go
@@ -119,10 +119,6 @@ func (s *ContainerDImportsSuite) addContainerDRuntime() {
 
 	// Configure containerd to use it
 	s.PutFile(s.WorkerNode(0), "/etc/k0s/containerd.d/foo.toml", fooRuntimeConfig)
-
-	// Restart k0s to pick up the new config for containerd
-	s.T().Log("Restarting k0s on worker")
-	workerSSH.Exec(ctx, "rc-service k0sworker restart", common.SSHStreams{})
 }
 
 func TestContainerDImportsSuite(t *testing.T) {

--- a/pkg/component/worker/containerd.go
+++ b/pkg/component/worker/containerd.go
@@ -87,7 +87,7 @@ func (c *ContainerD) Start(_ context.Context) error {
 	logrus.Info("Starting containerD")
 
 	if err := c.setupConfig(); err != nil {
-		return err
+		return fmt.Errorf("failed to setup containerd config: %w", err)
 	}
 
 	c.supervisor = supervisor.Supervisor{
@@ -189,7 +189,7 @@ func isK0sManagedConfig(path string) (bool, error) {
 
 func isPre1_27ManagedConfig(path string) (bool, error) {
 	// Check MD5 sum of the config file
-	// If it matches the pre 1.26 config, it's k0s managed
+	// If it matches the pre 1.27 config, it's k0s managed
 	md5sum := md5.New()
 	f, err := os.Open(path)
 	if err != nil {
@@ -203,12 +203,12 @@ func isPre1_27ManagedConfig(path string) (bool, error) {
 
 	sum := md5sum.Sum(nil)
 
-	pre1_26ConfigSumBytes, err := hex.DecodeString(pre1_27ConfigSum)
+	pre1_27ConfigSumBytes, err := hex.DecodeString(pre1_27ConfigSum)
 	if err != nil {
 		return false, err
 	}
 
-	if bytes.Equal(pre1_26ConfigSumBytes, sum) {
+	if bytes.Equal(pre1_27ConfigSumBytes, sum) {
 		return true, nil
 	}
 

--- a/pkg/component/worker/containerd.go
+++ b/pkg/component/worker/containerd.go
@@ -17,10 +17,16 @@ limitations under the License.
 package worker
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -30,21 +36,27 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/assets"
 	"github.com/k0sproject/k0s/pkg/component/manager"
+	"github.com/k0sproject/k0s/pkg/component/worker/containerd"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/supervisor"
 )
 
+const magicMarker = "# k0s_managed=true"
+
 const confTmpl = `
-# This is a placeholder configuration for k0s managed containerD.
-# If you wish to customize the config replace this file with your custom configuration.
+# k0s_managed=true
+# This is a placeholder configuration for k0s managed containerD. 
+# If you wish to override the config, remove the first line and replace this file with your custom configuration.
 # For reference see https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md
 version = 2
 imports = [
-	"{{ .ImportsGlob }}"
+	{{- range $i := .Imports }}
+	"{{ $i }}",
+	{{- end }}
 ]
 `
 const confPath = "/etc/k0s/containerd.toml"
-const importsPath = "/etc/k0s/containerd_imports/*.toml"
+const importsPath = "/etc/k0s/containerd.d/"
 
 // ContainerD implement the component interface to manage containerd as k0s component
 type ContainerD struct {
@@ -96,8 +108,15 @@ func (c *ContainerD) Start(_ context.Context) error {
 }
 
 func (c *ContainerD) setupConfig() error {
-	// If the config file exists, use it as-is
-	if file.Exists(confPath) {
+	// Check if the config file is user managed
+	// If it is, we should not touch it
+	k0sManaged, err := isK0sManagedConfig(confPath)
+	if err != nil {
+		return err
+	}
+
+	if !k0sManaged {
+		logrus.Infof("containerd config file %s is not k0s managed, skipping config generation", confPath)
 		return nil
 	}
 
@@ -107,14 +126,20 @@ func (c *ContainerD) setupConfig() error {
 	if err := dir.Init(filepath.Dir(importsPath), 0755); err != nil {
 		return err
 	}
+	containerDConfigurer := containerd.NewConfigurer()
+
+	imports, err := containerDConfigurer.HandleImports()
+	if err != nil {
+		return err
+	}
 	output := bytes.NewBuffer([]byte{})
 	tw := templatewriter.TemplateWriter{
 		Name:     "containerdconfig",
 		Template: confTmpl,
 		Data: struct {
-			ImportsGlob string
+			Imports []string
 		}{
-			ImportsGlob: importsPath,
+			Imports: imports,
 		},
 	}
 	if err := tw.WriteToBuffer(output); err != nil {
@@ -126,4 +151,66 @@ func (c *ContainerD) setupConfig() error {
 // Stop stops containerD
 func (c *ContainerD) Stop() error {
 	return c.supervisor.Stop()
+}
+
+// This is the md5sum of the default k0s containerd config file before 1.27
+const pre1_27ConfigSum = "59039b43303742a5496b13fd57f9beec"
+
+// isK0sManagedConfig checks if the config file is k0s managed
+// - If the config file does not exist, it's k0s managed
+// - If the config file md5sum matches the pre 1.27 config, it's k0s managed
+// - If the config file has the magic marker, it's k0s managed
+func isK0sManagedConfig(path string) (bool, error) {
+	// If the file does not exist, it's k0s managed (new install)
+	if !file.Exists(path) {
+		return true, nil
+	}
+	pre1_27Managed, err := isPre1_27ManagedConfig(path)
+	if err != nil {
+		return false, err
+	}
+	if pre1_27Managed {
+		return true, nil
+	}
+	// Check if the config file has the magic marker
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), magicMarker) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func isPre1_27ManagedConfig(path string) (bool, error) {
+	// Check MD5 sum of the config file
+	// If it matches the pre 1.26 config, it's k0s managed
+	md5sum := md5.New()
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(md5sum, f); err != nil {
+		return false, err
+	}
+
+	sum := md5sum.Sum(nil)
+
+	pre1_26ConfigSumBytes, err := hex.DecodeString(pre1_27ConfigSum)
+	if err != nil {
+		return false, err
+	}
+
+	if bytes.Equal(pre1_26ConfigSumBytes, sum) {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/pkg/component/worker/containerd/criconfig.go
+++ b/pkg/component/worker/containerd/criconfig.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containerd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/BurntSushi/toml"
+	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0s/pkg/constant"
+	"github.com/sirupsen/logrus"
+)
+
+// FIXME Figure out if we can get this programmatically from containerd so we're always in sync
+const runcCRIConfigTemplate = `
+[plugins."io.containerd.grpc.v1.cri"]
+    device_ownership_from_security_context = false
+    disable_apparmor = false
+    disable_cgroup = false
+    disable_hugetlb_controller = true
+    disable_proc_mount = false
+    disable_tcp_service = true
+    enable_selinux = false
+    enable_tls_streaming = false
+    enable_unprivileged_icmp = false
+    enable_unprivileged_ports = false
+    ignore_image_defined_volumes = false
+    max_concurrent_downloads = 3
+    max_container_log_line_size = 16384
+    netns_mounts_under_state_dir = false
+    restrict_oom_score_adj = false
+    sandbox_image = "{{.PauseImage}}"
+    selinux_category_range = 1024
+    stats_collect_period = 10
+    stream_idle_timeout = "4h0m0s"
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    systemd_cgroup = false
+    tolerate_missing_hugetlb_controller = true
+    unset_seccomp_profile = ""
+
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      conf_template = ""
+      ip_pref = ""
+      max_conf_num = 1
+
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      default_runtime_name = "runc"
+      disable_snapshot_annotations = true
+      discard_unpacked_layers = false
+      ignore_rdt_not_enabled_errors = false
+      no_pivot = false
+      snapshotter = "overlayfs"
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+        base_runtime_spec = ""
+        cni_conf_dir = ""
+        cni_max_conf_num = 0
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        runtime_engine = ""
+        runtime_path = ""
+        runtime_root = ""
+        runtime_type = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          base_runtime_spec = ""
+          cni_conf_dir = ""
+          cni_max_conf_num = 0
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          runtime_engine = ""
+          runtime_path = ""
+          runtime_root = ""
+          runtime_type = "io.containerd.runc.v2"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            BinaryName = ""
+            CriuImagePath = ""
+            CriuPath = ""
+            CriuWorkPath = ""
+            IoGid = 0
+            IoUid = 0
+            NoNewKeyring = false
+            NoPivotRoot = false
+            Root = ""
+            ShimCgroup = ""
+            SystemdCgroup = false
+`
+
+const importsPath = "/etc/k0s/containerd.d/*.toml"
+const containerdCRIConfigPath = "/run/k0s/containerd-cri.toml"
+
+type CRIConfigurer struct {
+	loadPath       string
+	pauseImage     string
+	criRuntimePath string
+
+	log *logrus.Entry
+}
+
+func NewConfigurer() *CRIConfigurer {
+
+	pauseImage := v1beta1.ImageSpec{
+		Image:   constant.KubePauseContainerImage,
+		Version: constant.KubePauseContainerImageVersion,
+	}
+	return &CRIConfigurer{
+		loadPath:       importsPath,
+		criRuntimePath: containerdCRIConfigPath,
+		pauseImage:     pauseImage.URI(),
+		log:            logrus.WithField("component", "containerd"),
+	}
+}
+
+// HandleImports Resolves containerd imports from the import glob path.
+// If the partial config has CRI plugin enabled, it will add to the runc CRI config (single file).
+// if no CRI plugin is found, it will add the file as-is to imports list returned.
+// Once all files are processed the concatenated CRI config file is written and added to the imports list.
+func (c *CRIConfigurer) HandleImports() ([]string, error) {
+	var imports []string
+	var criConfigBuffer bytes.Buffer
+
+	// Add runc CRI config
+	err := c.generateRunCConfig(&criConfigBuffer)
+	if err != nil {
+		return nil, err
+	}
+
+	files, err := filepath.Glob(c.loadPath)
+	c.log.Debugf("found containerd config files: %v", files)
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range files {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+		c.log.Debugf("parsing containerd config file: %s", file)
+		hasCRI, err := c.hasCRIPluginConfig(data)
+		if err != nil {
+			return nil, err
+		}
+		if hasCRI {
+			c.log.Debugf("found CRI plugin config in %s, appending to CRI config", file)
+			// Append all CRI plugin configs into single file
+			// and add it to imports
+			criConfigBuffer.WriteString(fmt.Sprintf("# appended from %s\n", file))
+			_, err := criConfigBuffer.Write(data)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			c.log.Debugf("adding %s as-is to imports", file)
+			// Add file to imports
+			imports = append(imports, file)
+		}
+	}
+
+	// Write the CRI config to a file and add it to imports
+	err = os.WriteFile(c.criRuntimePath, criConfigBuffer.Bytes(), 0644)
+	if err != nil {
+		return nil, err
+	}
+	imports = append(imports, c.criRuntimePath)
+
+	return imports, nil
+}
+
+func (c *CRIConfigurer) generateRunCConfig(w io.Writer) error {
+	t, err := template.New("runcCRIConfig").Parse(runcCRIConfigTemplate)
+	if err != nil {
+		return err
+	}
+
+	data := struct {
+		PauseImage string
+	}{
+		PauseImage: c.pauseImage,
+	}
+
+	err = t.Execute(w, data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *CRIConfigurer) hasCRIPluginConfig(data []byte) (bool, error) {
+	var tomlConfig map[string]interface{}
+	if err := toml.Unmarshal(data, &tomlConfig); err != nil {
+		return false, err
+	}
+	c.log.Debugf("parsed containerd config: %+v", tomlConfig)
+	if _, ok := tomlConfig["plugins"]; ok {
+		if _, ok := tomlConfig["plugins"].(map[string]interface{})["io.containerd.grpc.v1.cri"]; ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/component/worker/containerd/criconfig.go
+++ b/pkg/component/worker/containerd/criconfig.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 k0s authors
+Copyright 2023 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/component/worker/containerd/criconfig_test.go
+++ b/pkg/component/worker/containerd/criconfig_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2022 k0s authors
+Copyright 2023 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package containerd
 
 import (

--- a/pkg/component/worker/containerd/criconfig_test.go
+++ b/pkg/component/worker/containerd/criconfig_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -50,7 +50,7 @@ version = 2
 
 }
 
-func TestCRIConfigurer_ResolveImports(t *testing.T) {
+func TestCRIConfigurer_HandleImports(t *testing.T) {
 	t.Run("should have single import for CRI if there's nothing in imports dir", func(t *testing.T) {
 		testLoadPath := filepath.Join(t.TempDir(), "*.toml")
 		criRuntimePath := filepath.Join(t.TempDir(), "cri.toml")

--- a/pkg/component/worker/containerd/criconfig_test.go
+++ b/pkg/component/worker/containerd/criconfig_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package containerd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCRIConfigurer_hasCRIPluginConfig(t *testing.T) {
+	t.Run("should return true if config has cri plugin configs", func(t *testing.T) {
+		cfg := `
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+    endpoint = ["https://registry-1.docker.io"]
+`
+		c := NewConfigurer()
+		hasCRIPluginConfig, err := c.hasCRIPluginConfig([]byte(cfg))
+		require.NoError(t, err)
+		require.True(t, hasCRIPluginConfig)
+	})
+
+	t.Run("should return false if config has no cri plugin configs", func(t *testing.T) {
+		cfg := `
+timeout = 3
+version = 2
+`
+		c := NewConfigurer()
+		hasCRIPluginConfig, err := c.hasCRIPluginConfig([]byte(cfg))
+		require.NoError(t, err)
+		require.False(t, hasCRIPluginConfig)
+	})
+
+}
+
+func TestCRIConfigurer_ResolveImports(t *testing.T) {
+	t.Run("should have single import for CRI if there's nothing in imports dir", func(t *testing.T) {
+		testLoadPath := filepath.Join(t.TempDir(), "*.toml")
+		criRuntimePath := filepath.Join(t.TempDir(), "cri.toml")
+		c := CRIConfigurer{
+			loadPath:       testLoadPath,
+			criRuntimePath: criRuntimePath,
+			log:            logrus.New().WithField("test", t.Name()),
+		}
+		imports, err := c.HandleImports()
+		require.NoError(t, err)
+		require.Len(t, imports, 1)
+		require.Equal(t, criRuntimePath, imports[0])
+	})
+
+	t.Run("should have single import for all CRI configs", func(t *testing.T) {
+		tmp := t.TempDir()
+		testLoadPath := filepath.Join(tmp, "*.toml")
+		criRuntimePath := filepath.Join(t.TempDir(), "cri.toml")
+		criRuntimeConfig := `
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+`
+		err := os.WriteFile(filepath.Join(tmp, "foo.toml"), []byte(criRuntimeConfig), 0644)
+		require.NoError(t, err)
+		c := CRIConfigurer{
+			loadPath:       testLoadPath,
+			criRuntimePath: criRuntimePath,
+			log:            logrus.New().WithField("test", t.Name()),
+		}
+		imports, err := c.HandleImports()
+		require.NoError(t, err)
+		require.Len(t, imports, 1)
+		require.Contains(t, imports, criRuntimePath)
+		criCfg := loadFile(t, criRuntimePath)
+		require.Contains(t, criCfg, criRuntimeConfig)
+	})
+
+	t.Run("should have two imports when one non CRI snippet", func(t *testing.T) {
+		tmp := t.TempDir()
+		testLoadPath := filepath.Join(tmp, "*.toml")
+		criRuntimePath := filepath.Join(t.TempDir(), "cri.toml")
+		criRuntimeConfig := `
+foo = "bar"
+version = 2
+`
+		nonCriConfigPath := filepath.Join(tmp, "foo.toml")
+		err := os.WriteFile(nonCriConfigPath, []byte(criRuntimeConfig), 0644)
+		require.NoError(t, err)
+		c := CRIConfigurer{
+			loadPath:       testLoadPath,
+			criRuntimePath: criRuntimePath,
+			log:            logrus.New().WithField("test", t.Name()),
+		}
+		imports, err := c.HandleImports()
+		require.NoError(t, err)
+		require.Len(t, imports, 2)
+		require.Contains(t, imports, criRuntimePath)
+		require.Contains(t, imports, nonCriConfigPath)
+	})
+}
+
+func loadFile(t *testing.T, path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/pkg/component/worker/containerd_test.go
+++ b/pkg/component/worker/containerd_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 k0s authors
+Copyright 2023 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/component/worker/containerd_test.go
+++ b/pkg/component/worker/containerd_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_isK0sManagedConfig(t *testing.T) {
+
+	t.Run("should return true if file does not exist", func(t *testing.T) {
+		isManaged, err := isK0sManagedConfig("non-existent.toml")
+		require.NoError(t, err)
+		require.True(t, isManaged)
+	})
+
+	t.Run("should return true if md5 matches with pre 1.27 default config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "containerd.toml")
+		cfg := `
+# This is a placeholder configuration for k0s managed containerD.
+# If you wish to customize the config replace this file with your custom configuration.
+# For reference see https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md
+version = 2
+`
+		err := os.WriteFile(configPath, []byte(cfg), 0644)
+		require.NoError(t, err)
+		isManaged, err := isK0sManagedConfig(configPath)
+		require.NoError(t, err)
+		require.True(t, isManaged)
+	})
+
+	t.Run("should return false if md5 differs with pre 1.27 default config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "containerd.toml")
+		cfg := `
+# This is a placeholder configuration for k0s managed containerD.
+# If you wish to customize the config replace this file with your custom configuration.
+# For reference see https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md
+version = 2
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+    endpoint = ["https://registry-1.docker.io"]
+
+`
+		err := os.WriteFile(configPath, []byte(cfg), 0644)
+		require.NoError(t, err)
+		isManaged, err := isK0sManagedConfig(configPath)
+		require.NoError(t, err)
+		require.False(t, isManaged)
+	})
+}


### PR DESCRIPTION
## Description

As noted in https://github.com/k0sproject/k0s/pull/2604#issuecomment-1400173518 the current way containerd handles imports for CRI configs produces less than expected results.

In this PR I propose an alternative where k0s handles the imports:
- k0s reads all "partials" from `/etc/k0s/containerd.d/*.toml`
- if a partial has CRI configs k0s will append them in memory with the default CRI config (using runc)
- if a partial does NOT have CRI config k0s will add it as normal `import` in containerd config
- once all CRI configs are appended in memory, k0s will drop the cri configs into `/run/k0s/containerd-cri.toml` file and add that as normal import in main containerd config toml

As noted in our proposed fix in upstream [containerd PR](https://github.com/containerd/containerd/pull/8056), it's not going to be included in 1.x releases. 😞  Hence the need to handle this at k0s side.