### PR TITLE
test(supervisor): use `t.Setenv` to set env vars in tests

### DIFF
--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -99,20 +99,26 @@ func TestSupervisorStart(t *testing.T) {
 }
 
 func TestGetEnv(t *testing.T) {
-	// backup environment vars
+	// backup environment vars, and restore them when test finishes
 	oldEnv := os.Environ()
+	t.Cleanup(func() {
+		for _, e := range oldEnv {
+			key, val, _ := strings.Cut(e, "=")
+			assert.NoError(t, os.Setenv(key, val))
+		}
+	})
 
 	os.Clearenv()
-	os.Setenv("k3", "v3")
-	os.Setenv("PATH", "/bin")
-	os.Setenv("k2", "v2")
-	os.Setenv("FOO_k3", "foo_v3")
-	os.Setenv("k4", "v4")
-	os.Setenv("FOO_k2", "foo_v2")
-	os.Setenv("FOO_HTTPS_PROXY", "a.b.c:1080")
-	os.Setenv("HTTPS_PROXY", "1.2.3.4:8888")
-	os.Setenv("k1", "v1")
-	os.Setenv("FOO_PATH", "/usr/local/bin")
+	t.Setenv("k3", "v3")
+	t.Setenv("PATH", "/bin")
+	t.Setenv("k2", "v2")
+	t.Setenv("FOO_k3", "foo_v3")
+	t.Setenv("k4", "v4")
+	t.Setenv("FOO_k2", "foo_v2")
+	t.Setenv("FOO_HTTPS_PROXY", "a.b.c:1080")
+	t.Setenv("HTTPS_PROXY", "1.2.3.4:8888")
+	t.Setenv("k1", "v1")
+	t.Setenv("FOO_PATH", "/usr/local/bin")
 
 	env := getEnv("/var/lib/k0s", "foo", false)
 	sort.Strings(env)
@@ -128,13 +134,6 @@ func TestGetEnv(t *testing.T) {
 	actual = fmt.Sprintf("%s", env)
 	if actual != expected {
 		t.Errorf("Failed in env processing with keepEnvPrefix=true, expected: %q, actual: %q", expected, actual)
-	}
-
-	//restore environment vars
-	os.Clearenv()
-	for _, e := range oldEnv {
-		kv := strings.SplitN(e, "=", 2)
-		os.Setenv(kv[0], kv[1])
 	}
 }
 

--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -124,17 +124,13 @@ func TestGetEnv(t *testing.T) {
 	sort.Strings(env)
 	expected := "[HTTPS_PROXY=a.b.c:1080 PATH=/var/lib/k0s/bin:/usr/local/bin _K0S_MANAGED=yes k1=v1 k2=foo_v2 k3=foo_v3 k4=v4]"
 	actual := fmt.Sprintf("%s", env)
-	if actual != expected {
-		t.Errorf("Failed in env processing with keepEnvPrefix=false, expected: %q, actual: %q", expected, actual)
-	}
+	assert.Equal(t, expected, actual)
 
 	env = getEnv("/var/lib/k0s", "foo", true)
 	sort.Strings(env)
 	expected = "[FOO_PATH=/usr/local/bin FOO_k2=foo_v2 FOO_k3=foo_v3 HTTPS_PROXY=a.b.c:1080 PATH=/var/lib/k0s/bin:/bin _K0S_MANAGED=yes k1=v1 k2=v2 k3=v3 k4=v4]"
 	actual = fmt.Sprintf("%s", env)
-	if actual != expected {
-		t.Errorf("Failed in env processing with keepEnvPrefix=true, expected: %q, actual: %q", expected, actual)
-	}
+	assert.Equal(t, expected, actual)
 }
 
 func TestRespawn(t *testing.T) {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

```go
func TestFoo(t *testing.T) {
	// before
	os.Setenv(key, "new value")
	defer os.Unsetenv(key)
	
	// after
	t.Setenv(key, "new value")
}
```

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings