### PR TITLE
Fix docs Python Docker image

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -6,8 +6,9 @@ on:
       - main
       - release-*
     paths:
-      - docs/**
       - mkdocs.yml
+      - embedded-bins/Makefile.variables
+      - docs/**
 
 jobs:
   build:
@@ -30,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           # https://github.com/actions/setup-python/issues/521
-          # https://github.com/actions/python-versions/blob/3.10.5-2650229445/installers/nix-setup-template.sh#L53
+          # https://github.com/actions/python-versions/blob/3.10.9-3636985951/installers/nix-setup-template.sh#L53
           pip install --disable-pip-version-check -r docs/requirements_pip.txt
           pip --version
           pip install --disable-pip-version-check -r docs/requirements.txt

--- a/docs/Makefile.variables
+++ b/docs/Makefile.variables
@@ -1,3 +1,3 @@
-python_version = 3.10.5
+python_version = 3.10.9
 
 k0s_releases_url = https://api.github.com/repos/k0sproject/k0s/releases


### PR DESCRIPTION
The CI didn't trigger the docs build on changes to `embedded-bins/Makefile.variables`. This lead to the effect that CI didn't catch a non-existing Python Docker image.

Update to the current point release of Python, so that the correct Docker image is available again. Also trigger the docs CI workflows on changes to the aforementioned Makefile.

See #2472. Fixes #2642.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings