### PR TITLE
Introduce WaitForPlanState helper in AP inttests

### DIFF
--- a/inttest/ap-airgap/airgap_test.go
+++ b/inttest/ap-airgap/airgap_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
@@ -130,12 +129,8 @@ spec:
 	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
-		return plan.Status.State == appc.PlanCompleted
-	})
-
+	_, err = apcomm.WaitForPlanState(s.Context(), client, apconst.AutopilotName, 10*time.Minute, appc.PlanCompleted)
 	s.Require().NoError(err)
-	s.Equal(appc.PlanCompleted, plan.Status.State)
 
 	// We are not confirming the image importing functionality of k0s, but we can get a pretty good idea if it worked.
 

--- a/inttest/ap-ha3x3/ha3x3_test.go
+++ b/inttest/ap-ha3x3/ha3x3_test.go
@@ -158,14 +158,10 @@ spec:
 	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
-		return plan.Status.State == appc.PlanCompleted
-	})
+	plan, err := apcomm.WaitForPlanState(s.Context(), client, apconst.AutopilotName, 10*time.Minute, appc.PlanCompleted)
 	s.Require().NoError(err)
 
 	// Ensure all state/status are completed
-	s.Equal(appc.PlanCompleted, plan.Status.State)
-
 	s.Equal(1, len(plan.Status.Commands))
 	cmd := plan.Status.Commands[0]
 

--- a/inttest/ap-platformselect/platformselect_test.go
+++ b/inttest/ap-platformselect/platformselect_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
@@ -95,12 +94,8 @@ spec:
 	// as the binary would fail to run.
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
-		return plan.Status.State == appc.PlanCompleted
-	})
-
+	plan, err := apcomm.WaitForPlanState(s.Context(), client, apconst.AutopilotName, 10*time.Minute, appc.PlanCompleted)
 	s.Require().NoError(err)
-	s.Equal(appc.PlanCompleted, plan.Status.State)
 
 	s.Equal(1, len(plan.Status.Commands))
 	cmd := plan.Status.Commands[0]

--- a/inttest/ap-quorum/quorum_test.go
+++ b/inttest/ap-quorum/quorum_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
@@ -130,12 +129,8 @@ spec:
 	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
-		return plan.Status.State == appc.PlanCompleted
-	})
-
+	plan, err := apcomm.WaitForPlanState(s.Context(), client, apconst.AutopilotName, 10*time.Minute, appc.PlanCompleted)
 	s.Require().NoError(err)
-	s.Equal(appc.PlanCompleted, plan.Status.State)
 
 	s.Equal(1, len(plan.Status.Commands))
 	cmd := plan.Status.Commands[0]

--- a/inttest/ap-quorumsafety/quorumsafety_test.go
+++ b/inttest/ap-quorumsafety/quorumsafety_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
@@ -153,12 +152,8 @@ spec:
 
 	// The plan should fail with "InconsistentTargets" due to autopilot detecting that `controller2`
 	// despite existing as a `ControlNode`, does not resolve.
-	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
-		return plan.Status.State == appc.PlanInconsistentTargets
-	})
-
+	_, err = apcomm.WaitForPlanState(s.Context(), client, apconst.AutopilotName, 10*time.Minute, appc.PlanInconsistentTargets)
 	s.Require().NoError(err)
-	s.Equal(appc.PlanInconsistentTargets, plan.Status.State)
 }
 
 // TestQuorumSafetySuite sets up a suite using 2 controllers, and runs a specific

--- a/inttest/ap-removedapis/removedapis_test.go
+++ b/inttest/ap-removedapis/removedapis_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
@@ -74,12 +73,8 @@ func (s *plansRemovedAPIsSuite) TestApply() {
 	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 5*time.Minute, func(plan *apv1beta2.Plan) bool {
-		return plan.Status.State == appc.PlanWarning
-	})
-
+	plan, err := apcomm.WaitForPlanState(s.Context(), client, apconst.AutopilotName, 5*time.Minute, appc.PlanWarning)
 	s.Require().NoError(err)
-	s.Equal(appc.PlanWarning, plan.Status.State)
 
 	s.Equal(1, len(plan.Status.Commands))
 	cmd := plan.Status.Commands[0]

--- a/inttest/ap-selector/selector_test.go
+++ b/inttest/ap-selector/selector_test.go
@@ -153,12 +153,8 @@ spec:
 	s.NotEmpty(apc)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(s.Context(), apc, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
-		return plan.Status.State == appc.PlanCompleted
-	})
-
+	plan, err := apcomm.WaitForPlanState(s.Context(), apc, apconst.AutopilotName, 10*time.Minute, appc.PlanCompleted)
 	s.Require().NoError(err)
-	s.Equal(appc.PlanCompleted, plan.Status.State)
 
 	s.Equal(1, len(plan.Status.Commands))
 	cmd := plan.Status.Commands[0]

--- a/inttest/ap-single/single_test.go
+++ b/inttest/ap-single/single_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
@@ -99,12 +98,8 @@ spec:
 	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
-		return plan.Status.State == appc.PlanCompleted
-	})
-
+	plan, err := apcomm.WaitForPlanState(s.Context(), client, apconst.AutopilotName, 10*time.Minute, appc.PlanCompleted)
 	s.Require().NoError(err)
-	s.Equal(appc.PlanCompleted, plan.Status.State)
 
 	s.Equal(1, len(plan.Status.Commands))
 	cmd := plan.Status.Commands[0]

--- a/inttest/ap-updater/updater_test.go
+++ b/inttest/ap-updater/updater_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/k0sproject/k0s/inttest/common"
 
-	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
@@ -97,12 +96,8 @@ spec:
 	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
-		return plan.Status.State == appc.PlanCompleted
-	})
-
+	_, err = apcomm.WaitForPlanState(s.Context(), client, apconst.AutopilotName, 10*time.Minute, appc.PlanCompleted)
 	s.Require().NoError(err)
-	s.Equal(appc.PlanCompleted, plan.Status.State)
 }
 
 // TestPlansSingleControllerSuite sets up a suite using a single controller, running various

--- a/inttest/kubeletcertrotate/kubeletcertrotate_test.go
+++ b/inttest/kubeletcertrotate/kubeletcertrotate_test.go
@@ -146,15 +146,10 @@ spec:
 	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, 10*time.Minute, func(plan *apv1beta2.Plan) bool {
-		return plan.Status.State == appc.PlanCompleted
-	})
+	plan, err := apcomm.WaitForPlanState(s.Context(), client, apconst.AutopilotName, 10*time.Minute, appc.PlanCompleted)
+	s.Require().NoError(err)
 
 	// Ensure all state/status are completed
-
-	s.Require().NoError(err)
-	s.Equal(appc.PlanCompleted, plan.Status.State)
-
 	s.Equal(1, len(plan.Status.Commands))
 	cmd := plan.Status.Commands[0]
 

--- a/inttest/toolsuite/tests/versionupdate_test.go
+++ b/inttest/toolsuite/tests/versionupdate_test.go
@@ -45,18 +45,10 @@ func (s *VersionUpdateSuite) TestUpdate() {
 	s.T().Logf("Waiting for Plan completion (timeout = %v)", s.Config.OperationTimeout)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := apcomm.WaitForPlanByName(s.Context(), client, apconst.AutopilotName, s.Config.OperationTimeout, func(plan *apv1beta2.Plan) bool {
-		completed := plan.Status.State == appc.PlanCompleted
-		if completed {
-			s.T().Log("Plan completed successfully!")
-		}
-		return completed
-	})
-
-	s.T().Log("Plan completed execution")
-
-	assert.NoError(s.T(), err)
-	assert.NotEmpty(s.T(), plan)
+	plan, err := apcomm.WaitForPlanState(s.Context(), client, apconst.AutopilotName, s.Config.OperationTimeout, appc.PlanCompleted)
+	if s.NoError(err) {
+		s.NotEmpty(plan)
+	}
 }
 
 // VersionUpdatePlan creates an autopilot Plan that consists of all controllers and workers as


### PR DESCRIPTION
## Description

Many inttests used the `WaitForPlanByName` helper to wait for a certain terminal Plan state. When the Plan reached another terminal state than the expected one, the tests would just hang and fail with a timeout.

Improve fail-fastness and error reporting for those cases by introducing the aforementioned helper that'll stop watching for changes as soon as a terminal state has been reached, returning an error in those cases where there was a state mismatch.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings