### PR TITLE
[Backport release-1.25] Replace unmaintained GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,9 @@ jobs:
           echo TAG_NAME="${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-create-release@v1.4.0
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          release_name: ${{ steps.branch_name.outputs.TAG_NAME }}
           draft: true # So we can manually edit before publishing
           prerelease: ${{ contains(github.ref, '-') }} # v0.1.2-beta1, 1.2.3-rc1
       - name: Prepare image tags
@@ -89,9 +86,7 @@ jobs:
 
       - name: Upload Release Assets - Binary
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./k0s
@@ -106,9 +101,7 @@ jobs:
 
       - name: Upload Release Assets - Bundle
         id: upload-release-asset-images
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./airgap-image-bundle-linux-amd64.tar
@@ -157,9 +150,7 @@ jobs:
 
       - name: Upload Release Assets
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./k0s.exe
@@ -224,9 +215,7 @@ jobs:
 
       - name: Upload Release Assets - Binary
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./k0s
@@ -241,9 +230,7 @@ jobs:
 
       - name: Upload Release Assets - Bundle
         id: upload-release-asset-images
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./airgap-image-bundle-linux-arm64.tar
@@ -322,9 +309,7 @@ jobs:
 
       - name: Upload Release Assets - Binary
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./k0s
@@ -339,9 +324,7 @@ jobs:
 
       - name: Upload Release Assets - Bundle
         id: upload-release-asset-images
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./airgap-image-bundle-linux-arm.tar
@@ -491,8 +474,6 @@ jobs:
 
       - name: Upload conformance test result to Release Assets
         uses: shogo82148/actions-upload-release-asset@v1.6.3 # Allows us to upload a file with wildcard patterns
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: inttest/*_sonobuoy_*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -490,7 +490,7 @@ jobs:
         working-directory: ./inttest
 
       - name: Upload conformance test result to Release Assets
-        uses: shogo82148/actions-upload-release-asset@v1.6.2 # Allows us to upload a file with wildcard patterns
+        uses: shogo82148/actions-upload-release-asset@v1.6.3 # Allows us to upload a file with wildcard patterns
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Backport of #2636 to `release-1.25`.
See #2634, #2254.