### PR TITLE
[Backport release-1.22] Bump etcd binary to v3.5.7

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -9,8 +9,8 @@ on:
     - cron: "0 23 * * *"
 
 env:
-  GO_VERSION: ~1.16
-  GO_VERSION_WIN: ~1.16
+  GO_VERSION: ~1.17
+  GO_VERSION_WIN: ~1.17
 
 jobs:
   terraform:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,8 +28,8 @@ on:
       - '.github/workflows/mkdocs-set-default-version.yml'
       - 'mkdocs.yml'
 env:
-  GO_VERSION: ~1.16
-  GO_VERSION_WIN: ~1.16
+  GO_VERSION: ~1.17
+  GO_VERSION_WIN: ~1.17
 
 jobs:
   build:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,8 +30,8 @@ on:
       - '*.md'
 
 env:
-  GO_VERSION: ~1.16
-  GO_VERSION_WIN: ~1.16
+  GO_VERSION: ~1.17
+  GO_VERSION_WIN: ~1.17
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
   #pull_request:
 env:
-  GO_VERSION: ~1.16
-  GO_VERSION_WIN: ~1.16
+  GO_VERSION: ~1.17
+  GO_VERSION_WIN: ~1.17
 
 jobs:
   release:
@@ -44,7 +44,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Set up Go 1.16
+      - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ k0s: .k0sbuild.docker-vol.gocache
 
 k0s.exe: TARGET_OS = windows
 k0s.exe: BUILD_GO_CGO_ENABLED = 0
-k0s.exe: GOLANG_IMAGE = golang:1.16-alpine
+k0s.exe: GOLANG_IMAGE = golang:1.17-alpine
 k0s.exe: pkg/assets/zz_generated_offsets_windows.go
 k0s.exe: .k0sbuild.docker-vol.gocache
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDIMAGE=golang:1.16-alpine
+ARG BUILDIMAGE=golang:1.17-alpine
 
 FROM $BUILDIMAGE
 RUN apk add --no-cache gcc musl-dev binutils-gold

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,4 +1,4 @@
-go_version = 1.16.15
+go_version = 1.17.13
 
 runc_version = 1.1.3
 runc_buildimage = golang:$(go_version)-alpine

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -37,7 +37,7 @@ kine_build_go_cgo_cflags = "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1"
 kine_build_go_ldflags = "-w -s"
 kine_build_go_ldflags_extra = "-extldflags=-static"
 
-etcd_version = 3.5.6
+etcd_version = 3.5.7
 etcd_buildimage = golang:$(go_version)-alpine
 #etcd_build_go_tags =
 etcd_build_go_cgo_enabled = 0

--- a/embedded-bins/containerd/Dockerfile
+++ b/embedded-bins/containerd/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDIMAGE=golang:1.16-alpine
+ARG BUILDIMAGE=golang:1.17-alpine
 FROM $BUILDIMAGE AS build
 
 ARG VERSION

--- a/embedded-bins/etcd/Dockerfile
+++ b/embedded-bins/etcd/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDIMAGE=golang:1.16-alpine
+ARG BUILDIMAGE=golang:1.17-alpine
 FROM $BUILDIMAGE AS build
 
 ARG VERSION

--- a/embedded-bins/kine/Dockerfile
+++ b/embedded-bins/kine/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDIMAGE=golang:1.16-alpine
+ARG BUILDIMAGE=golang:1.17-alpine
 FROM $BUILDIMAGE AS build
 
 ARG VERSION

--- a/embedded-bins/konnectivity/Dockerfile
+++ b/embedded-bins/konnectivity/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDIMAGE=golang:1.16-alpine
+ARG BUILDIMAGE=golang:1.17-alpine
 FROM $BUILDIMAGE AS build
 
 ARG VERSION

--- a/embedded-bins/kubernetes/Dockerfile
+++ b/embedded-bins/kubernetes/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDIMAGE=golang:1.16-alpine
+ARG BUILDIMAGE=golang:1.17-alpine
 FROM $BUILDIMAGE AS build
 
 ARG VERSION

--- a/embedded-bins/runc/Dockerfile
+++ b/embedded-bins/runc/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDIMAGE=golang:1.16-alpine
+ARG BUILDIMAGE=golang:1.17-alpine
 FROM $BUILDIMAGE AS build
 
 ARG VERSION


### PR DESCRIPTION
Backport of #2633 to `release-1.22`.
See #2629, #2620.

Also: Update Go to 1.17.13, so that the new etcd version compiles.

Supersedes #2649.