### PR TITLE
[Backport release-1.23] Replace set-output with env file in GH Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -110,7 +110,7 @@ jobs:
         # * https://github.com/actions/upload-artifact/issues/199#issuecomment-1190171851
         run: |
           make airgap-images.txt
-          echo ::set-output name=linux-hash::${{ hashFiles('Makefile', 'airgap-images.txt', 'hack/image-bundler/*') }}
+          echo 'linux-hash=${{ hashFiles('Makefile', 'airgap-images.txt', 'hack/image-bundler/*') }}' >> $GITHUB_OUTPUT
 
       - name: Cache airgap image bundle
         id: cache-airgap-image-bundle

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -93,8 +93,8 @@ jobs:
           mike alias -u head main
           mike alias -u "${STABLE}" stable
           mike set-default --push stable
-          echo ::set-output name=LATEST::${LATEST}
-          echo ::set-output name=STABLE::${STABLE}
+          echo LATEST="$LATEST" >> $GITHUB_OUTPUT
+          echo STABLE="$STABLE" >> $GITHUB_OUTPUT
 
       # Ensures the current branch is gh-pages,
       # Creates / updates the "stable" and "latest" plain text files with the corresponding versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Branch name
         id: branch_name
         run: |
-          echo ::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}
+          echo TAG_NAME="${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -101,11 +101,11 @@ jobs:
 
       - name: Prepare tags
         id: prep
+        env:
+          TAGS: ${{ needs.release.outputs.tag_name }}
         # Basically just replace the '+' with '-' as '+' is not allowed in tags
         run: |
-          TAGS=${{ needs.release.outputs.tag_name }}
-          TAGS=${TAGS//+/-}
-          echo ::set-output name=tags::${TAGS}
+          echo IMAGE_TAGS="${TAGS//+/-}" >> $GITHUB_OUTPUT
 
       - name: Build image and push to GitHub image registry
         uses: docker/build-push-action@v1


### PR DESCRIPTION
Backport of #2646 to `release-1.23`.
See #2264.