### PR TITLE
NLLB: Replace hard coded port 80 with configured ports

### DIFF
--- a/pkg/component/worker/nllb/envoy.go
+++ b/pkg/component/worker/nllb/envoy.go
@@ -84,9 +84,6 @@ type envoyPodParams struct {
 
 // envoyFilesParams holds the parameters for the Envoy config files.
 type envoyFilesParams struct {
-	// Port to which Envoy will bind the konnectivity server load balancer.
-	konnectivityServerBindPort uint16
-
 	// Addresses on which the upstream API servers are listening.
 	apiServers []k0snet.HostPort
 
@@ -167,10 +164,6 @@ func (e *envoyProxy) start(ctx context.Context, profile workerconfig.Profile, ap
 		},
 	}
 
-	if nllb.EnvoyProxy.KonnectivityServerBindPort != nil {
-		e.config.envoyFilesParams.konnectivityServerBindPort = uint16(*nllb.EnvoyProxy.KonnectivityServerBindPort)
-	}
-
 	err = writeEnvoyConfigFiles(&e.config.envoyParams, &e.config.envoyFilesParams)
 	if err != nil {
 		return err
@@ -223,6 +216,10 @@ func (e *envoyProxy) stop() {
 }
 
 func writeEnvoyConfigFiles(params *envoyParams, filesParams *envoyFilesParams) error {
+	var konnectivityServerBindPort uint16
+	if params.konnectivityServerBindPort != nil {
+		konnectivityServerBindPort = *params.konnectivityServerBindPort
+	}
 	data := struct {
 		BindIP                     net.IP
 		APIServerBindPort          uint16
@@ -232,7 +229,7 @@ func writeEnvoyConfigFiles(params *envoyParams, filesParams *envoyFilesParams) e
 	}{
 		BindIP:                     params.bindIP,
 		APIServerBindPort:          params.apiServerBindPort,
-		KonnectivityServerBindPort: filesParams.konnectivityServerBindPort,
+		KonnectivityServerBindPort: konnectivityServerBindPort,
 		KonnectivityServerPort:     filesParams.konnectivityServerPort,
 		UpstreamServers:            filesParams.apiServers,
 	}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2659 

## Type of change

Changes the NLLB pods to declare the correct ports based on the configuration instead of hardcoding part 80.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [X] Manual test
- [ ] Auto test added

The test was to replace the binaries in a cluster and inspecting the NLLB pods. Results can be seen in #2659.

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [X] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings