### PR TITLE
[Backport release-1.23] Replace unmaintained GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,9 @@ jobs:
           echo ::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-create-release@v1.4.0
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          release_name: ${{ steps.branch_name.outputs.TAG_NAME }}
           draft: true # So we can manually edit before publishing
           prerelease: ${{ contains(github.ref, '-') }} # v0.1.2-beta1, 1.2.3-rc1
 
@@ -73,9 +70,7 @@ jobs:
 
       - name: Upload Release Assets - Binary
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./k0s
@@ -90,9 +85,7 @@ jobs:
 
       - name: Upload Release Assets - Bundle
         id: upload-release-asset-images
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./airgap-image-bundle-linux-amd64.tar
@@ -165,9 +158,7 @@ jobs:
 
       - name: Upload Release Assets
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./k0s.exe
@@ -213,9 +204,7 @@ jobs:
 
       - name: Upload Release Assets - Binary
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./k0s
@@ -224,9 +213,7 @@ jobs:
 
       - name: Upload Release Assets - Bundle
         id: upload-release-asset-images
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./airgap-image-bundle-linux-arm64.tar
@@ -269,9 +256,7 @@ jobs:
 
       - name: Upload Release Assets - Binary
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./k0s
@@ -280,9 +265,7 @@ jobs:
 
       - name: Upload Release Assets - Bundle
         id: upload-release-asset-images
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        uses: shogo82148/actions-upload-release-asset@v1.6.3
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./airgap-image-bundle-linux-arm.tar
@@ -350,8 +333,6 @@ jobs:
 
       - name: Upload conformance test result to Release Assets
         uses: shogo82148/actions-upload-release-asset@v1.6.3 # Allows us to upload a file with wildcard patterns
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: inttest/sonobuoy/*_sonobuoy_*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,7 +349,7 @@ jobs:
         working-directory: ./inttest
 
       - name: Upload conformance test result to Release Assets
-        uses: shogo82148/actions-upload-release-asset@v1.6.2 # Allows us to upload a file with wildcard patterns
+        uses: shogo82148/actions-upload-release-asset@v1.6.3 # Allows us to upload a file with wildcard patterns
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,7 +349,7 @@ jobs:
         working-directory: ./inttest
 
       - name: Upload conformance test result to Release Assets
-        uses: shogo82148/actions-upload-release-asset@v1.3.2 # Allows us to upload a file with wildcard patterns
+        uses: shogo82148/actions-upload-release-asset@v1.6.2 # Allows us to upload a file with wildcard patterns
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Backport of #1697, #2681 to `release-1.23`.
See #2634.