### PR TITLE
[release-1.23] Upgrade GitHub actions to use Node.js 16

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -42,12 +42,12 @@ jobs:
           fi
         working-directory: ./
       - name: Run git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.github_ref }}
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
@@ -76,7 +76,7 @@ jobs:
           terraform apply -auto-approve
 
       - name: Bindata
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: generated-bindata
         with:
           path: |

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,18 +46,18 @@ jobs:
           echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # for `git describe`
           persist-credentials: false
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Go modules cache
         with:
           path: ~/go/pkg/mod
@@ -66,7 +66,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Bindata cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: generated-bindata
         with:
           path: |
@@ -90,7 +90,7 @@ jobs:
         run: go run hack/validate-images/main.go -architectures amd64,arm64,arm
 
       - name: Cache compiled binary for further testing
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-compiled-binary
         with:
           path: |
@@ -138,15 +138,15 @@ jobs:
           echo "cachePrefix=k0s-win-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION_WIN }}
         id: go
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Go modules cache
         with:
           path: ~/go/pkg/mod
@@ -155,7 +155,7 @@ jobs:
             ${{ runner.os }}-go-win-
 
       - name: Bindata cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: generated-bindata
         with:
           path: |
@@ -215,16 +215,16 @@ jobs:
           PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
           echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
       - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-compiled-binary
         with:
           path: |
@@ -236,7 +236,7 @@ jobs:
 
       - name: Collect test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.cachePrefix }}-logs-${{ matrix.smoke-suite }}-${{ github.run_number }}
           path: |
@@ -253,16 +253,16 @@ jobs:
           PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
           echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
       - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-compiled-binary
         with:
           path: |
@@ -271,7 +271,7 @@ jobs:
 
           # We need the bindata cache too so the makefile targets and deps work properly
       - name: Bindata cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: generated-bindata
         with:
           path: |
@@ -301,7 +301,7 @@ jobs:
           make -C inttest check-airgap
 
       - name: Cache images bundle
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: save-bundle
         with:
           path: |
@@ -310,7 +310,7 @@ jobs:
 
       - name: Collect test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.cachePrefix }}-logs-check-airgap-${{ github.run_number }}
           path: |
@@ -322,18 +322,18 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # for `git describe`
           persist-credentials: false
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Go modules cache
         with:
           path: ~/go/pkg/mod
@@ -341,7 +341,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Bindata cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: generated-bindata
         with:
           path: |
@@ -382,7 +382,7 @@ jobs:
 
       - name: Collect test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.cachePrefix }}-logs-check-basic-arm64-${{ github.run_number }}
           path: |
@@ -394,12 +394,12 @@ jobs:
       # We cannot rely on this as it's not working on arm, see https://github.com/actions/setup-go/issues/106
       # Instead we must have proper golang version setup at system level.
       # - name: Set up Go 1.x
-      #   uses: actions/setup-go@v2
+      #   uses: actions/setup-go@v3
       #   with:
       #     go-version: ${{ env.GO_VERSION }}
       #   id: go
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install GoLang for ARMHF
         run: "echo $HOME/.local/go/bin >> $GITHUB_PATH; rm -rf $HOME/.local/go && mkdir -p $HOME/.local/go && curl --silent -L https://golang.org/dl/go$(make -s -f go_version.mk).linux-armv6l.tar.gz | tar -C $HOME/.local -xz"
@@ -407,7 +407,7 @@ jobs:
         run: go version
 
       - name: Bindata cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: generated-bindata
         with:
           path: |
@@ -447,7 +447,7 @@ jobs:
           make check-airgap
       - name: Collect test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.cachePrefix }}-logs-check-basic-armv7-${{ github.run_number }}
           path: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: codegen
         run: |
           make -j$(nproc) pkg/assets/zz_generated_offsets_linux.go static/gen_manifests.go
@@ -47,7 +47,7 @@ jobs:
           EMBEDDED_BINS_BUILDMODE: none
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go

--- a/.github/workflows/mkdocs-set-default-version.yml
+++ b/.github/workflows/mkdocs-set-default-version.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.x'
 
       - name: Checkout deps
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: lensapp/mkdocs-material-insiders
           token: ${{ env.GITHUB_TOKEN }}
@@ -31,7 +31,7 @@ jobs:
           pip install mike
 
       - name: Checkout Release from k0s
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-docs-manual.yml
+++ b/.github/workflows/publish-docs-manual.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -37,7 +37,7 @@ jobs:
           pip install git+https://${{ secrets.GH_TOKEN }}@github.com/lensapp/mkdocs-material-insiders.git
 
       - name: Checkout k0s ${{ github.event.inputs.version }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: '${{ github.event.inputs.version }}'
           fetch-depth: 0

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -18,17 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Go modules cache
         with:
           path: ~/go/pkg/mod
@@ -46,7 +46,7 @@ jobs:
           go install github.com/k0sproject/version/cmd/k0s_sort@v0.2.2
 
       - name: Checkout k0s
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,10 @@ jobs:
       EULA_NOTICE: ${{ secrets.EULA_NOTICE }}
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.16
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
@@ -66,7 +66,7 @@ jobs:
 
       - name: Collect smoke test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: logs
           path: tests/*.log
@@ -83,7 +83,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Upload Artifact for use in other Jobs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: k0s-amd64
           path: ./k0s
@@ -146,10 +146,10 @@ jobs:
       TARGET_OS: windows
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
@@ -182,10 +182,10 @@ jobs:
       EULA_NOTICE: ${{ secrets.EULA_NOTICE }}
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
@@ -206,7 +206,7 @@ jobs:
 
       - name: Collect smoke test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: logs
           path: tests/*.log
@@ -247,7 +247,7 @@ jobs:
         run: go version
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         run: make EMBEDDED_BINS_BUILDMODE=docker
@@ -262,7 +262,7 @@ jobs:
 
       - name: Collect smoke test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: logs
           path: tests/*.log
@@ -305,10 +305,10 @@ jobs:
         working-directory: ./inttest/conformance/terraform
     steps:
       - name: Run git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
@@ -322,7 +322,7 @@ jobs:
         run: terraform init
 
       - name: Fetch k0s Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: k0s-amd64
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v5
         with:
           stale-issue-message: 'The issue is marked as stale since no activity has been recorded in 30 days'
           stale-pr-message: 'The PR is marked as stale since no activity has been recorded in 30 days'


### PR DESCRIPTION
## Description

Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The following actions have been upgraded:

* actions/checkout@v2 -> actions/checkout@v3
* actions/cache@v2 -> actions/cache@v3
* actions/setup-go@v2 -> actions/setup-go@v3
* actions/setup-python@v2 -> actions/setup-python@v3
* actions/upload-artifact@v2 -> actions/upload-artifact@v3
* actions/download-artifact@v3 -> actions/download-artifact@v3
* actions/stale@v3 -> actions/stale@v5

See:
* #1668

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings