### PR TITLE
[Backport release-1.22] Upgrade GitHub actions to use Node.js 16

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -42,12 +42,12 @@ jobs:
           fi
         working-directory: ./
       - name: Run git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.github_ref }}
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
@@ -76,7 +76,7 @@ jobs:
           terraform apply -auto-approve
 
       - name: Bindata
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: generated-bindata
         with:
           path: |

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
     name: Lint markdown
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: articulate/actions-markdownlint@v1
         with:
           config: .github/workflows/markdownlint-config.json

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,15 +42,15 @@ jobs:
           echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Go modules cache
         with:
           path: ~/go/pkg/mod
@@ -59,7 +59,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Bindata cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: generated-bindata
         with:
           path: |
@@ -83,7 +83,7 @@ jobs:
         run: go run hack/validate-images/main.go -architectures amd64,arm64
       
       - name: Cache compiled binary for further testing
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-compiled-binary
         with:
           path: |
@@ -100,15 +100,15 @@ jobs:
           echo "cachePrefix=k0s-win-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION_WIN }}
         id: go
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Go modules cache
         with:
           path: ~/go/pkg/mod
@@ -117,7 +117,7 @@ jobs:
             ${{ runner.os }}-go-win-
 
       - name: Bindata cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: generated-bindata
         with:
           path: |
@@ -173,16 +173,16 @@ jobs:
           PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
           echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
       - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-compiled-binary
         with:
           path: |
@@ -194,7 +194,7 @@ jobs:
 
       - name: Collect test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.cachePrefix }}-logs-${{ matrix.smoke-suite }}-${{ github.run_number }}
           path: |
@@ -211,16 +211,16 @@ jobs:
           PR_NUMBER=$(echo ${GITHUB_REF} | cut -d / -f 3 )
           echo "cachePrefix=k0s-${PR_NUMBER}-${{ github.sha }}" >> $GITHUB_ENV
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
       - name: Cache compiled binary for smoke testing
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-compiled-binary
         with:
           path: |
@@ -229,7 +229,7 @@ jobs:
 
           # We need the bindata cache too so the makefile targets and deps work properly
       - name: Bindata cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: generated-bindata
         with:
           path: |
@@ -255,7 +255,7 @@ jobs:
         run: make check-airgap
 
       - name: Cache images bundle
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: save-bundle
         with:
           path: |
@@ -264,7 +264,7 @@ jobs:
 
       - name: Collect test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.cachePrefix }}-logs-check-airgap-${{ github.run_number }}
           path: |
@@ -276,15 +276,15 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Go modules cache
         with:
           path: ~/go/pkg/mod
@@ -292,7 +292,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Bindata cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: generated-bindata
         with:
           path: |
@@ -312,7 +312,7 @@ jobs:
 
       - name: Collect test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.cachePrefix }}-logs-check-basic-arm-${{ github.run_number }}
           path: |
@@ -324,12 +324,12 @@ jobs:
       # We cannot rely on this as it's not working on arm, see https://github.com/actions/setup-go/issues/106
       # Instead we must have proper golang version setup at system level.
       # - name: Set up Go 1.x
-      #   uses: actions/setup-go@v2
+      #   uses: actions/setup-go@v3
       #   with:
       #     go-version: ${{ env.GO_VERSION }}
       #   id: go
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install GoLang for ARMHF
         run: "echo $HOME/.local/go/bin >> $GITHUB_PATH; rm -rf $HOME/.local/go && mkdir -p $HOME/.local/go && curl --silent -L https://golang.org/dl/go$(make -s -f go_version.mk).linux-armv6l.tar.gz | tar -C $HOME/.local -xz"
@@ -337,7 +337,7 @@ jobs:
         run: go version
 
       - name: Bindata cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: generated-bindata
         with:
           path: |
@@ -357,7 +357,7 @@ jobs:
 
       - name: Collect test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.cachePrefix }}-logs-check-basic-armv7-${{ github.run_number }}
           path: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: codegen
         run: |
           make -j$(nproc) pkg/assets/zz_generated_offsets_linux.go static/gen_manifests.go
@@ -47,7 +47,7 @@ jobs:
           EMBEDDED_BINS_BUILDMODE: none
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go

--- a/.github/workflows/mkdocs-set-default-version.yml
+++ b/.github/workflows/mkdocs-set-default-version.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.x'
 
       - name: Checkout deps
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: lensapp/mkdocs-material-insiders
           token: ${{ env.GITHUB_TOKEN }}
@@ -31,7 +31,7 @@ jobs:
           pip install mike
 
       - name: Checkout Release from k0s
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -42,7 +42,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
       - name: Using Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: mkdocs deploy main

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -17,11 +17,11 @@ jobs:
         node-version: [12.x]
     steps:
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.x'
       - name: Checkout deps
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: lensapp/mkdocs-material-insiders
           token: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,10 @@ jobs:
       EULA_NOTICE: ${{ secrets.EULA_NOTICE }}
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.17
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
@@ -66,7 +66,7 @@ jobs:
 
       - name: Collect smoke test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: logs
           path: tests/*.log
@@ -83,7 +83,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Upload Artifact for use in other Jobs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: k0s-amd64
           path: ./k0s
@@ -146,10 +146,10 @@ jobs:
       TARGET_OS: windows
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
@@ -182,10 +182,10 @@ jobs:
       EULA_NOTICE: ${{ secrets.EULA_NOTICE }}
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
@@ -207,7 +207,7 @@ jobs:
 
       - name: Collect smoke test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: logs
           path: tests/*.log
@@ -248,7 +248,7 @@ jobs:
         run: go version
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         run: make EMBEDDED_BINS_BUILDMODE=docker
@@ -263,7 +263,7 @@ jobs:
 
       - name: Collect smoke test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: logs
           path: tests/*.log
@@ -306,10 +306,10 @@ jobs:
         working-directory: ./inttest/conformance/terraform
     steps:
       - name: Run git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
@@ -323,7 +323,7 @@ jobs:
         run: terraform init
 
       - name: Fetch k0s Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: k0s-amd64
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v5
         with:
           repo-token: ${{ secrets.GH_TOKEN }}
           # Empty message to prevent issues from being closed or staled


### PR DESCRIPTION
Backport to `release-1.22`:

* #2692
* #2696 

See:
* #1668