### PR TITLE
Properly bridge cfssl logs to logrus

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"path"
@@ -29,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	k0slog "github.com/k0sproject/k0s/internal/pkg/log"
 	mw "github.com/k0sproject/k0s/internal/pkg/middleware"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
@@ -65,7 +65,7 @@ func NewAPICmd() *cobra.Command {
 		Short: "Run the controller API",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			logrus.SetOutput(cmd.OutOrStdout())
-			logrus.SetLevel(logrus.InfoLevel)
+			k0slog.SetInfoLevel()
 			return config.CallParentPersistentPreRun(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -109,12 +109,10 @@ func (c *command) start() (err error) {
 		ReadTimeout:  15 * time.Second,
 	}
 
-	log.Fatal(srv.ListenAndServeTLS(
+	return srv.ListenAndServeTLS(
 		filepath.Join(c.K0sVars.CertRootDir, "k0s-api.crt"),
 		filepath.Join(c.K0sVars.CertRootDir, "k0s-api.key"),
-	))
-
-	return nil
+	)
 }
 
 func (c *command) etcdHandler() http.Handler {

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -29,6 +29,7 @@ import (
 	workercmd "github.com/k0sproject/k0s/cmd/worker"
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/file"
+	k0slog "github.com/k0sproject/k0s/internal/pkg/log"
 	"github.com/k0sproject/k0s/internal/pkg/stringmap"
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
@@ -74,7 +75,7 @@ func NewControllerCmd() *cobra.Command {
 	Note: Token can be passed either as a CLI argument or as a flag`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			logrus.SetOutput(cmd.OutOrStdout())
-			logrus.SetLevel(logrus.InfoLevel)
+			k0slog.SetInfoLevel()
 			return config.CallParentPersistentPreRun(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -27,7 +27,6 @@ import (
 	"github.com/k0sproject/k0s/pkg/certificate"
 	"github.com/k0sproject/k0s/pkg/config"
 
-	"github.com/cloudflare/cfssl/log"
 	"github.com/spf13/cobra"
 )
 
@@ -68,9 +67,6 @@ Note: A certificate once signed cannot be revoked for a particular user`,
 	optionally add groups:
 	$ k0s kubeconfig create username --groups [groups]`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// disable cfssl log
-			log.Level = log.LevelFatal
-
 			if len(args) == 0 {
 				return fmt.Errorf("username is mandatory")
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,7 @@ import (
 	"github.com/k0sproject/k0s/cmd/validate"
 	"github.com/k0sproject/k0s/cmd/version"
 	"github.com/k0sproject/k0s/cmd/worker"
+	k0slog "github.com/k0sproject/k0s/internal/pkg/log"
 	"github.com/k0sproject/k0s/pkg/build"
 	"github.com/k0sproject/k0s/pkg/config"
 
@@ -57,12 +58,13 @@ func NewRootCmd() *cobra.Command {
 		Short: "k0s - Zero Friction Kubernetes",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if config.Verbose {
-				logrus.SetLevel(logrus.InfoLevel)
+				k0slog.SetInfoLevel()
 			}
 
 			if config.Debug {
 				// TODO: check if it actually works and is not overwritten by something else
-				logrus.SetLevel(logrus.DebugLevel)
+				k0slog.SetDebugLevel()
+
 				go func() {
 					log := logrus.WithField("debug_server", config.DebugListenOn)
 					log.Debug("Starting debug server")

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 	"syscall"
 
+	k0slog "github.com/k0sproject/k0s/internal/pkg/log"
 	"github.com/k0sproject/k0s/internal/pkg/stringmap"
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo"
 	"github.com/k0sproject/k0s/pkg/build"
@@ -57,7 +58,7 @@ func NewWorkerCmd() *cobra.Command {
 	Note: Token can be passed either as a CLI argument or as a flag`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			logrus.SetOutput(cmd.OutOrStdout())
-			logrus.SetLevel(logrus.InfoLevel)
+			k0slog.SetInfoLevel()
 			return config.CallParentPersistentPreRun(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/pkg/log/cfssl.go
+++ b/internal/pkg/log/cfssl.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	cfssllog "github.com/cloudflare/cfssl/log"
+	"github.com/sirupsen/logrus"
+)
+
+type cfsslAdapter logrus.Entry
+
+var _ cfssllog.SyslogWriter = (*cfsslAdapter)(nil)
+
+// Debug implements log.SyslogWriter
+func (a *cfsslAdapter) Debug(msg string) {
+	(*logrus.Entry)(a).Debug(msg)
+}
+
+// Info implements log.SyslogWriter
+func (a *cfsslAdapter) Info(msg string) {
+	(*logrus.Entry)(a).Info(msg)
+}
+
+// Warning implements log.SyslogWriter
+func (a *cfsslAdapter) Warning(msg string) {
+	(*logrus.Entry)(a).Warn(msg)
+}
+
+// Err implements log.SyslogWriter
+func (a *cfsslAdapter) Err(msg string) {
+	(*logrus.Entry)(a).Error(msg)
+}
+
+// Crit implements log.SyslogWriter
+func (a *cfsslAdapter) Crit(msg string) {
+	(*logrus.Entry)(a).Error(msg)
+}
+
+// Emerg implements log.SyslogWriter
+func (a *cfsslAdapter) Emerg(msg string) {
+	(*logrus.Entry)(a).Error(msg)
+}

--- a/internal/pkg/log/k0s.go
+++ b/internal/pkg/log/k0s.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	cfssllog "github.com/cloudflare/cfssl/log"
+	"github.com/sirupsen/logrus"
+)
+
+func InitLogging() {
+	customFormatter := new(logrus.TextFormatter)
+	customFormatter.TimestampFormat = "2006-01-02 15:04:05"
+	customFormatter.FullTimestamp = true
+	logrus.SetFormatter(customFormatter)
+
+	cfssllog.SetLogger((*cfsslAdapter)(logrus.WithField("component", "cfssl")))
+
+	SetWarnLevel()
+}
+
+func SetDebugLevel() {
+	logrus.SetLevel(logrus.DebugLevel)
+	cfssllog.Level = cfssllog.LevelDebug
+}
+
+func SetInfoLevel() {
+	logrus.SetLevel(logrus.InfoLevel)
+	cfssllog.Level = cfssllog.LevelInfo
+}
+
+func SetWarnLevel() {
+	logrus.SetLevel(logrus.WarnLevel)
+	cfssllog.Level = cfssllog.LevelWarning
+}

--- a/main.go
+++ b/main.go
@@ -23,17 +23,13 @@ import (
 	"strings"
 
 	"github.com/k0sproject/k0s/cmd"
-	"github.com/sirupsen/logrus"
+	k0slog "github.com/k0sproject/k0s/internal/pkg/log"
 )
 
 //go:generate make codegen
 
 func init() {
-	logrus.SetLevel(logrus.WarnLevel)
-	customFormatter := new(logrus.TextFormatter)
-	customFormatter.TimestampFormat = "2006-01-02 15:04:05"
-	customFormatter.FullTimestamp = true
-	logrus.SetFormatter(customFormatter)
+	k0slog.InitLogging()
 }
 
 func main() {


### PR DESCRIPTION
## Description

Occasionally, k0s used the cfssl log package by accident. Fix this by using logrus in all places. Moreover, bridge the cfssl logs to logrus, so they also respect the log levels and so on.

Reported by @mbana.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings