### PR TITLE
Integrate Troubleshoot support bundle collection into inttests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -274,19 +274,14 @@ jobs:
           }
           make -C inttest ${{ matrix.smoke-suite }}
 
-      - name: Collect test logs
+      - name: Collect k0s logs and support bundle
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: smoketest-${{ matrix.smoke-suite }}-logs
-          path: /tmp/*.log
-
-      - name: Collect cluster state
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: smoketest-${{ matrix.smoke-suite }}-cluster-state
-          path: /tmp/cluster-state.tar
+          name: smoketest-${{ matrix.smoke-suite }}-files
+          path: |
+            /tmp/*.log
+            /tmp/support-bundle.tar.gz
 
       - name: Collect sonobuoy results
         if: failure() && contains(matrix.smoke-suite, 'conformance')
@@ -363,19 +358,14 @@ jobs:
         run: |
           make -C inttest ${{ matrix.smoke-suite }} K0S_UPDATE_FROM_BIN=../k0s-${{ matrix.version }}
 
-      - name: Collect test logs
+      - name: Collect k0s logs and support bundle
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: autopilot-smoketest-${{ matrix.smoke-suite }}-${{ matrix.version }}-logs
-          path: /tmp/*.log
-
-      - name: Collect cluster state
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: autopilot-smoketest-${{ matrix.smoke-suite }}-${{ matrix.version }}-cluster-state
-          path: /tmp/cluster-state.tar
+          name: autopilot-smoketest-${{ matrix.smoke-suite }}-${{ matrix.version }}-files
+          path: |
+            /tmp/*.log
+            /tmp/support-bundle.tar.gz
 
   smoketest-arm:
     name: Smoke test on armv7/arm64
@@ -504,19 +494,14 @@ jobs:
           make --touch airgap-image-bundle-linux-${{ matrix.arch }}.tar
           make check-airgap
 
-      - name: Collect test logs
+      - name: Collect k0s logs and support bundle
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: smoketest-${{ matrix.arch }}-check-basic-logs
-          path: /tmp/*.log
-
-      - name: Collect cluster state
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: smoketest-${{ matrix.arch }}-smoke-cluster-state
-          path: /tmp/cluster-state.tar
+          name: smoketest-${{ matrix.arch }}-check-basic-files
+          path: |
+            /tmp/*.log
+            /tmp/support-bundle.tar.gz
 
       # https://github.com/actions/checkout/issues/273#issuecomment-642908752
       # Golang mod cache tends to set directories to read-only, which breaks any

--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -31,6 +31,11 @@ RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-re
   && chmod +x /usr/local/bin/kubectl
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
+# Install troublbeshoot support bundle
+RUN curl -Lo - https://github.com/replicatedhq/troubleshoot/releases/download/v0.55.0/support-bundle_linux_amd64.tar.gz \
+  | tar xzO support-bundle >/usr/local/bin/kubectl-supportbundle \
+  && chmod +x /usr/local/bin/kubectl-supportbundle
+
 # Install etcd for smoke tests with external etcd
 RUN curl -L https://github.com/etcd-io/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-$ETCD_ARCH.tar.gz \
   | tar xz -C /opt --strip-components=1

--- a/inttest/footloose-alpine/root/etc/troubleshoot/k0s-inttest.yaml
+++ b/inttest/footloose-alpine/root/etc/troubleshoot/k0s-inttest.yaml
@@ -1,0 +1,24 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: k0s-inttest
+spec:
+  collectors:
+    - clusterResources: {}
+    - clusterInfo: {}
+    - logs: {}
+    - configMap:
+        collectorName: autopilot
+        namespace: autopilot
+        selector: [""] # we want all ConfigMaps
+        includeAllData: true
+    - configMap:
+        collectorName: default
+        namespace: default
+        selector: [""] # we want all ConfigMaps
+        includeAllData: true
+    - configMap:
+        collectorName: kube-system
+        namespace: kube-system
+        selector: [""] # we want all ConfigMaps
+        includeAllData: true

--- a/inttest/footloose-alpine/root/usr/local/bin/troubleshoot-k0s-inttest.sh
+++ b/inttest/footloose-alpine/root/usr/local/bin/troubleshoot-k0s-inttest.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+set -eu
+
+export KUBECONFIG="$1/pki/admin.conf"
+
+[ -f "$KUBECONFIG" ] || {
+  echo "kubeconfig not present: $KUBECONFIG" 1>&2
+  exit 1
+}
+
+bundleDir="$(mktemp -d)"
+trap 'rm -rf -- "$bundleDir"' INT EXIT
+kubectl supportbundle \
+  --debug \
+  --interactive=false \
+  --output="$bundleDir/support-bundle.tar.gz" \
+  /etc/troubleshoot/k0s-inttest.yaml 1>&2
+cat -- "$bundleDir/support-bundle.tar.gz"


### PR DESCRIPTION
## Description

See https://troubleshoot.sh/. This replaces `kubectl cluster-info --dump`. An advantage of the support bundle is that it can be used in conjunction with `sbctl` to spin up a fake API server that reflects the cluster's state at the time of the support bundle creation. This makes it much easier to inspect than having to deal with all the individual JSON files using `find`/`grep`/`jq`. See https://github.com/replicatedhq/sbctl for details on that.

Moreover: Combine all upload CI steps into a single one. No need to have them separately. Only collect the logs if the tests failed. The CI step is also just triggered on failure.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings