### PR TITLE
Add note about k0sctl to the configuration docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,16 @@ k0s supports providing only partial configurations. In case of partial configura
     sudo k0s start
     ```
 
+## Configuring k0s via k0sctl
+
+k0sctl can deploy your configuration options at cluster creation time. Your
+options should be placed in the `spec.k0s.config` section of the k0sctl's
+configuration file. See the section on how to install [k0s via
+k0sctl][k0sctl-install] and the [k0sctl README] for more information.
+
+[k0sctl-install]: ../k0sctl-install
+[k0sctl README]: https://github.com/k0sproject/k0sctl/blob/main/README.md
+
 ## Configuration file reference
 
 **CAUTION**: As many of the available options affect items deep in the stack, you should fully understand the correlation between the configuration file components and your specific environment before making any changes.


### PR DESCRIPTION
## Description

This is to raise attention about the fact that k0s and k0sctl are different executables and have different configuration files (the one embeds config for the other).

Fixes #2719.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings