### PR TITLE
Use contextual logger in OCIBundleReconciler

### DIFF
--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -65,12 +65,12 @@ func (a *OCIBundleReconciler) Start(ctx context.Context) error {
 	err = retry.Do(func() error {
 		client, err = containerd.New(sock, containerd.WithDefaultNamespace("k8s.io"), containerd.WithDefaultPlatform(platforms.OnlyStrict(platforms.DefaultSpec())))
 		if err != nil {
-			logrus.WithError(err).Errorf("can't connect to containerd socket %s", sock)
+			a.log.WithError(err).Errorf("can't connect to containerd socket %s", sock)
 			return err
 		}
 		_, err := client.ListImages(ctx)
 		if err != nil {
-			logrus.WithError(err).Errorf("can't use containerd client")
+			a.log.WithError(err).Errorf("can't use containerd client")
 			return err
 		}
 		return nil
@@ -82,7 +82,7 @@ func (a *OCIBundleReconciler) Start(ctx context.Context) error {
 
 	for _, file := range files {
 		if err := a.unpackBundle(ctx, client, a.k0sVars.OCIBundleDir+"/"+file.Name()); err != nil {
-			logrus.WithError(err).Errorf("can't unpack bundle %s", file.Name())
+			a.log.WithError(err).Errorf("can't unpack bundle %s", file.Name())
 			return fmt.Errorf("can't unpack bundle %s: %w", file.Name(), err)
 		}
 	}
@@ -100,7 +100,7 @@ func (a OCIBundleReconciler) unpackBundle(ctx context.Context, client *container
 		return fmt.Errorf("can't import bundle: %v", err)
 	}
 	for _, i := range images {
-		logrus.Infof("Imported image %s", i.Name)
+		a.log.Infof("Imported image %s", i.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

Seemed to be an oversight. Eases grepping logs for it.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings