### PR TITLE
Check helm version consistency

### DIFF
--- a/pkg/constant/constant_shared_test.go
+++ b/pkg/constant/constant_shared_test.go
@@ -127,6 +127,22 @@ func TestRuncModuleVersions(t *testing.T) {
 	)
 }
 
+func TestHelmModuleVersions(t *testing.T) {
+	helmVersion := getVersion(t, "helm")
+
+	checkPackageModules(t,
+		func(modulePath string) bool {
+			return modulePath == "helm.sh/helm/v3"
+		},
+		func(t *testing.T, pkgPath string, module *packages.Module) bool {
+			return !assert.Equal(t, "v"+helmVersion, module.Version,
+				"Module version for package %s doesn't match: %+#v",
+				pkgPath, module,
+			)
+		},
+	)
+}
+
 func getVersion(t *testing.T, component string) string {
 	cmd := exec.Command("sh", "./vars.sh", component+"_version")
 	cmd.Dir = filepath.Join("..", "..")


### PR DESCRIPTION
## Description

There's the new `helm_version` Makefile variable. Add a unit test that ensures this is in sync with the helm versions referenced in `go.mod`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings