### PR TITLE
Fix airgap bundle caching in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,7 +44,7 @@ jobs:
 
     outputs:
       smoke-test-matrix: ${{ steps.list-smoke-tests.outputs.linux-matrix }}
-      airgap-image-bundle-hash-linux: ${{ steps.create-airgap-image-list.outputs.linux-hash }}
+      airgap-image-bundle-hash-linux: ${{ steps.image-bundle-source.outputs.linux-hash }}
 
     steps:
       - name: Check out code into the Go module directory
@@ -104,20 +104,27 @@ jobs:
               'split(" ") | [ .[] | select(. != "") ] | "${{ matrix.target }}-matrix=" + tojson' >> $GITHUB_OUTPUT
 
       - name: Create airgap image list
-        id: create-airgap-image-list
         if: matrix.airgap-image-bundle
-        # Capture the calculated image bundle hash in a build output, so it can
-        # be shared between the cache actions in this job and in the integration
-        # test matrix. A cleaner solution would have been to use the cache here,
-        # and then upload the cached image bundle, to be downloaded later on in
-        # the integration tests. That's the way it's done for the k0s binary.
-        # Unfortunately, the upload action is significantly slower than the
-        # cache action, for unclear reasons, so stick with this solution for
-        # faster builds. See:
+        run: make airgap-images.txt && cat airgap-images.txt
+
+        # Capture the calculated image bundle source hash in a build output, so
+        # it can be shared between the cache actions in this job and in the
+        # integration test matrix. Do this in a separate step, as the hashFiles
+        # function is evaluated before the step execution. So all the required
+        # files need to exist before that. A cleaner solution would have been to
+        # use the cache here, and then upload the cached image bundle, to be
+        # downloaded later on in the integration tests. That's the way it's done
+        # for the k0s binary. Unfortunately, the upload action is significantly
+        # slower than the cache action, for unclear reasons, so stick with this
+        # solution for faster builds. See:
         # * https://github.com/actions/upload-artifact/issues/199#issuecomment-1190171851
-        run: |
-          make airgap-images.txt
-          echo '${{ matrix.target }}-hash=${{ hashFiles('Makefile', 'airgap-images.txt', 'hack/image-bundler/*') }}' >> $GITHUB_OUTPUT
+      - name: Calculate airgap image bundle source hash
+        id: image-bundle-source
+        if: matrix.airgap-image-bundle
+        env:
+          HASH_KEY: ${{ matrix.target }}-hash
+          HASH_VALUE: ${{ hashFiles('Makefile', 'airgap-images.txt', 'hack/image-bundler/*') }}
+        run: printf '%s=%s\n' "$HASH_KEY" "$HASH_VALUE" >> "$GITHUB_OUTPUT"
 
       - name: Cache airgap image bundle
         id: cache-airgap-image-bundle
@@ -129,7 +136,7 @@ jobs:
         # * https://github.com/actions/cache/issues/321
         # * https://github.com/actions/cache/pull/420
         with:
-          key: ${{ matrix.airgap-image-bundle }}-${{ steps.create-airgap-image-list.outputs[format('{0}-hash', matrix.target)] }}
+          key: ${{ matrix.airgap-image-bundle }}-${{ steps.image-bundle-source.outputs[format('{0}-hash', matrix.target)] }}
           path: ${{ matrix.airgap-image-bundle }}
 
       - name: Create airgap image bundle if not cached


### PR DESCRIPTION
## Description

The current implementation assumed that the evaluation of the `hashFiles` function would happen at script evaluation time, just as every other script command. That assumption is false, as the hashing functionality is not part of the script, but part of the template engine that creates the script's content. That means that all files which should take part in hashing need to be in place during step creation time.

The broken hash calculation lead to the usage of wrong image bundles during CI, since the `airgap-images.txt` file did not change the hash in any way. Fix that by first generating the image list, and calculate the hash in a separate subsequent build step.

Fixes:
* #1969

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings