### PR TITLE
Expose KUBE_VERSION in docs dev container

### DIFF
--- a/docs/Dockerfile.serve-dev
+++ b/docs/Dockerfile.serve-dev
@@ -2,6 +2,8 @@ ARG PYTHON_IMAGE_VERSION
 
 FROM python:${PYTHON_IMAGE_VERSION} as builder
 
+ARG KUBE_VERSION
+
 # Prepare Python virtual env
 ENV PYTHONUNBUFFERED 1
 RUN \
@@ -23,5 +25,6 @@ WORKDIR /k0s
 EXPOSE 8000
 
 # Start development server by default
+ENV KUBE_VERSION=${KUBE_VERSION}
 ENTRYPOINT ["mkdocs"]
 CMD ["serve", "--dev-addr=0.0.0.0:8000"]

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -77,6 +77,7 @@ cli:
 .docker-image.serve-dev.stamp: Dockerfile.serve-dev requirements_pip.txt requirements.txt Makefile.variables
 	docker build \
 	  --build-arg PYTHON_IMAGE_VERSION=$(python_version)-alpine$(alpine_version) \
+	  --build-arg KUBE_VERSION=$(kubernetes_version) \
 	  -t 'k0sdocs$(basename $@)' -f '$<' .
 	touch -- '$@'
 


### PR DESCRIPTION
## Description

So that Kubernetes versions get properly replaced.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings