### PR TITLE
Make airgap tests actually airgapped.

### DIFF
--- a/inttest/airgap/airgap_test.go
+++ b/inttest/airgap/airgap_test.go
@@ -36,6 +36,20 @@ type AirgapSuite struct {
 	common.FootlooseSuite
 }
 
+const network = "airgap"
+
+// SetupSuite creates the required network before starting footloose.
+func (s *AirgapSuite) SetupSuite() {
+	s.Require().NoError(s.CreateNetwork(network))
+	s.FootlooseSuite.SetupSuite()
+}
+
+// TearDownSuite tears down the network created after footloose has finished.
+func (s *AirgapSuite) TearDownSuite() {
+	s.FootlooseSuite.TearDownSuite()
+	s.Require().NoError(s.MaybeDestroyNetwork(network))
+}
+
 func (s *AirgapSuite) TestK0sGetsUp() {
 	(&common.Airgap{
 		SSH:  s.SSH,
@@ -95,8 +109,10 @@ func (s *AirgapSuite) TestK0sGetsUp() {
 func TestAirgapSuite(t *testing.T) {
 	s := AirgapSuite{
 		common.FootlooseSuite{
-			ControllerCount: 1,
-			WorkerCount:     1,
+			ControllerCount:    1,
+			WorkerCount:        1,
+			ControllerNetworks: []string{network},
+			WorkerNetworks:     []string{network},
 
 			AirgapImageBundleMountPoints: []string{"/var/lib/k0s/images/bundle.tar"},
 		},

--- a/inttest/ap-airgap/airgap_test.go
+++ b/inttest/ap-airgap/airgap_test.go
@@ -31,7 +31,7 @@ type airgapSuite struct {
 	common.FootlooseSuite
 }
 
-const network = "airgap"
+const network = "ap-airgap"
 
 // SetupSuite creates the required network before starting footloose.
 func (s *airgapSuite) SetupSuite() {
@@ -74,6 +74,13 @@ func (s *airgapSuite) SetupTest() {
 }
 
 func (s *airgapSuite) TestApply() {
+	(&common.Airgap{
+		SSH:  s.SSH,
+		Logf: s.T().Logf,
+	}).LockdownMachines(s.Context(),
+		s.ControllerNode(0), s.WorkerNode(0),
+	)
+
 	planTemplate := `
 apiVersion: autopilot.k0sproject.io/v1beta2
 kind: Plan


### PR DESCRIPTION
## Description
Since #2711 and prior to this commit the test check-airgap was not airgapped on IPv6. Also the check-ap-airgap was not airgapped at all.

This commit makes sure that both tests are actually airgapped on both IPv4 and have IPv6 entirely disabled, which is an acceptable constraint for this test.


## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings