### PR TITLE
Enable dependabot for hack/tool

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,3 +63,8 @@ updates:
     schedule:
       interval: daily
 
+  - package-ecosystem: gomod
+    directory: /hack/tool
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Description

GitHub files security alerts for the tool's dependencies in the Security tab, so it might make sense to bump them automatically as well.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings