### PR TITLE
Add KUBE_VERSION to mike when publishing docs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -52,7 +52,7 @@ jobs:
       - name: mike deploy head
         if: contains(github.ref, 'refs/heads/main')
         run: |
-          mike deploy --push head
+          KUBE_VERSION="$(./vars.sh kubernetes_version)" mike deploy --push head
 
       # If a release has been published, deploy it as a new version
       - name: mike deploy new version
@@ -64,7 +64,7 @@ jobs:
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
-          mike deploy --push "$VERSION"
+          KUBE_VERSION="$(./vars.sh kubernetes_version)" mike deploy --push "$VERSION"
 
       - name: Update mike version aliases
         if: github.repository == 'k0sproject/k0s'


### PR DESCRIPTION
## Description

mike actually rebuilds the docs. That means that it also needs the env variable set, otherwise all occurrences of k8s_version will show "None".

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings