### PR TITLE
[Backport release-1.25] Bump kine to v0.9.9

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -31,11 +31,11 @@ kubernetes_build_go_flags = "-v"
 #kubernetes_build_go_ldflags =
 kubernetes_build_go_ldflags_extra = "-w -s -extldflags=-static"
 
-kine_version = 0.9.8
+kine_version = 0.9.9
 kine_buildimage = golang:$(go_version)-alpine3.16
 #kine_build_go_tags =
 #kine_build_go_cgo_enabled =
-kine_build_go_cgo_cflags = "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" # Flags taken from https://github.com/k3s-io/kine/blob/v0.9.8/scripts/build#L22
+kine_build_go_cgo_cflags = "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" # Flags taken from https://github.com/k3s-io/kine/blob/v0.9.9/scripts/build#L22
 #kine_build_go_flags =
 kine_build_go_ldflags = "-w -s"
 kine_build_go_ldflags_extra = "-extldflags=-static"


### PR DESCRIPTION
Backport to `release-1.25`:
* #2784
  Fixes some CVEs in its dependencies: CVE-2022-21698, CVE-2022-27191, CVE-2021-44716, CVE-2022-27664, CVE-2021-38561, CVE-2022-32149.

See:
* #2745