### PR TITLE
 Replace Slack with Lens Forums in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,16 @@ If you'd like to try k0s, please jump in to our:
 
 ## Join the Community
 
-- [Community Slack](https://k8slens.slack.com/join/shared_invite/zt-1mizt32hw-bBs7DPqH_ccLhb9m_qmQTA) - Request for support and help from the `k0s` community via Slack (shared Slack channel with Lens).
-- [GitHub Issues](https://github.com/k0sproject/k0s/issues) - Submit your issues and feature requests via GitHub.
+- [Lens Forums] - Request for support and help from the Lens and k0s community.
+- [GitHub Issues] - Submit your issues and feature requests via GitHub.
 
-We welcome your help in building k0s! If you are interested, we invite you to check out the [Contributing Guide](https://docs.k0sproject.io/latest/contributors/overview/) and the [Code of Conduct](https://docs.k0sproject.io/latest/contributors/CODE_OF_CONDUCT/).
+We welcome your help in building k0s! If you are interested, we invite you to
+check out the [Contributing Guide] and the [Code of Conduct].
+
+[Lens Forums]: https://forums.k8slens.dev/
+[GitHub Issues]: https://github.com/k0sproject/k0s/issues
+[Contributing Guide]: https://docs.k0sproject.io/latest/contributors/overview/
+[Code of Conduct]:https://docs.k0sproject.io/latest/contributors/CODE_OF_CONDUCT/
 
 ## Motivation
 


### PR DESCRIPTION
## Description

The Slack workspace is deprecated and will be shutdown in the future. The new place for the community is the Lens Forums. They are indexed by Internet search engines and offer better discoverability than Slack, which requires sign-in even if people just want to read along without actively participating.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings