### PR TITLE
Bypass shared prober through context in controller+worker mode

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -123,10 +123,8 @@ func NewControllerCmd() *cobra.Command {
 }
 
 func (c *command) start(ctx context.Context) error {
-	pr := prober.New()
-	go pr.Run(ctx)
-	c.NodeComponents = manager.New(pr)
-	c.ClusterComponents = manager.New(pr)
+	c.NodeComponents = manager.New(prober.DefaultProber)
+	c.ClusterComponents = manager.New(prober.DefaultProber)
 
 	perfTimer := performance.NewTimer("controller-start").Buffer().Start()
 
@@ -258,7 +256,7 @@ func (c *command) start(ctx context.Context) error {
 		)
 	}
 	c.NodeComponents.Add(ctx, &status.Status{
-		Prober: pr,
+		Prober: prober.DefaultProber,
 		StatusInformation: status.K0sStatus{
 			Pid:           os.Getpid(),
 			Role:          "controller",
@@ -515,7 +513,6 @@ func (c *command) start(ctx context.Context) error {
 
 	if c.EnableWorker {
 		perfTimer.Checkpoint("starting-worker")
-
 		if err := c.startWorker(ctx, c.WorkerProfile); err != nil {
 			logrus.WithError(err).Error("Failed to start controller worker")
 		} else {

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -121,9 +121,7 @@ func (c *Command) Start(ctx context.Context) error {
 		return err
 	}
 
-	pr := prober.New()
-	go pr.Run(ctx)
-	componentManager := manager.New(pr)
+	componentManager := manager.New(prober.DefaultProber)
 
 	var staticPods worker.StaticPods
 
@@ -194,7 +192,7 @@ func (c *Command) Start(ctx context.Context) error {
 		}
 
 		componentManager.Add(ctx, &status.Status{
-			Prober: pr,
+			Prober: prober.DefaultProber,
 			StatusInformation: status.K0sStatus{
 				Pid:           os.Getpid(),
 				Role:          "worker",

--- a/pkg/component/manager/manager_test.go
+++ b/pkg/component/manager/manager_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/k0sproject/k0s/pkg/component/prober"
+	proberPackage "github.com/k0sproject/k0s/pkg/component/prober"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,7 +58,7 @@ func (f *Fake) Ready() error {
 }
 
 func TestManagerSuccess(t *testing.T) {
-	m := New(prober.NopProber{})
+	m := New(proberPackage.NopProber{})
 	require.NotNil(t, m)
 
 	ctx := context.Background()
@@ -84,7 +84,7 @@ func TestManagerSuccess(t *testing.T) {
 }
 
 func TestManagerInitFail(t *testing.T) {
-	m := New(prober.NopProber{})
+	m := New(proberPackage.NopProber{})
 	require.NotNil(t, m)
 
 	ctx := context.Background()
@@ -104,7 +104,7 @@ func TestManagerInitFail(t *testing.T) {
 }
 
 func TestManagerRunFail(t *testing.T) {
-	m := New(prober.NopProber{})
+	m := New(proberPackage.NopProber{})
 	require.NotNil(t, m)
 
 	ctx := context.Background()
@@ -135,7 +135,7 @@ func TestManagerRunFail(t *testing.T) {
 }
 
 func TestManagerHealthyFail(t *testing.T) {
-	m := New(prober.NopProber{})
+	m := New(proberPackage.NopProber{})
 	require.NotNil(t, m)
 	m.ReadyWaitDuration = 1 * time.Millisecond
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
A hacky bypass for the 2795. 
Fixes #2795

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings