### PR TITLE
[release-1.25] Take kube-proxy API address from node config

### DIFF
--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -105,7 +105,7 @@ func (k *KubeProxy) Stop() error {
 func (k *KubeProxy) getConfig(clusterConfig *v1beta1.ClusterConfig) (proxyConfig, error) {
 	cfg := proxyConfig{
 		ClusterCIDR:          clusterConfig.Spec.Network.BuildPodCIDR(),
-		ControlPlaneEndpoint: clusterConfig.Spec.API.APIAddressURL(),
+		ControlPlaneEndpoint: k.nodeConf.Spec.API.APIAddressURL(),
 		Image:                clusterConfig.Spec.Images.KubeProxy.URI(),
 		PullPolicy:           clusterConfig.Spec.Images.DefaultPullPolicy,
 		DualStack:            clusterConfig.Spec.Network.DualStack.Enabled,


### PR DESCRIPTION
## Description

The API spec is not part of the dynamic cluster config. Taking the API address from there will not work properly when dynamic config is enalbed, e.g. when there are port overrides for the API server.

This is already fixed in 1.26 and onwards, but there's no simple commit to be backported. Hence create a new minimal patch for 1.25.

Discovered while trying to backport #2787 to 1.25 in #2813.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings