### PR TITLE
Move AutoMTU into the kuberouter arguments from the cni configuration…

### DIFF
--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -170,7 +170,6 @@ data:
              {{- if not .AutoMTU }}
              "mtu": {{ .MTU }},
              {{- end }}
-             "auto-mtu": {{ .AutoMTU }},
              "bridge":"kube-bridge",
              "isDefaultGateway":true,
              "hairpinMode": {{ .CNIHairpin }},
@@ -284,6 +283,9 @@ spec:
         - "--bgp-graceful-restart=true"
         - "--metrics-port={{ .MetricsPort }}"
         - "--hairpin-mode={{ .GlobalHairpin }}"
+        {{- if not .AutoMTU }}
+        - "--auto-mtu=false"
+        {{- end }}
         {{- if .PeerRouterIPs }}
         - "--peer-router-ips={{ .PeerRouterIPs }}"
         {{- end }}


### PR DESCRIPTION
… file

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Due to invalid location of the AutoMTU field we never able to set up mtu value manually.
The changes use the AutoMTU field as argument for the kube-router preventing kube-router from ignoring passed mtu value. 

Fixes #2822

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings