### PR TITLE
Deprecate api-config component feature gate

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -322,25 +322,27 @@ func (c *command) start(ctx context.Context) error {
 	}
 	defer configSource.Stop()
 
-	if !slices.Contains(c.DisableComponents, constant.APIConfigComponentName) {
+	// The CRDs are only required if the config is stored in the cluster.
+	if configSource.NeedToStoreInitialConfig() {
 		apiConfigSaver, err := controller.NewManifestsSaver("api-config", c.K0sVars.DataDir)
 		if err != nil {
 			return fmt.Errorf("failed to initialize api-config manifests saver: %w", err)
 		}
 
-		cfgReconciler, err := controller.NewClusterConfigReconciler(
-			leaderElector,
-			c.K0sVars,
-			c.ClusterComponents,
-			apiConfigSaver,
-			adminClientFactory,
-			configSource,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to initialize cluster-config reconciler: %w", err)
-		}
-		c.ClusterComponents.Add(ctx, cfgReconciler)
+		c.ClusterComponents.Add(ctx, controller.NewCRD(apiConfigSaver, []string{"v1beta1"}))
 	}
+
+	cfgReconciler, err := controller.NewClusterConfigReconciler(
+		leaderElector,
+		c.K0sVars,
+		c.ClusterComponents,
+		adminClientFactory,
+		configSource,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to initialize cluster-config reconciler: %w", err)
+	}
+	c.ClusterComponents.Add(ctx, cfgReconciler)
 
 	if !slices.Contains(c.DisableComponents, constant.HelmComponentName) {
 		helmSaver, err := controller.NewManifestsSaver("helm", c.K0sVars.DataDir)

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -103,7 +103,18 @@ func (o *ControllerOptions) Normalize() error {
 	// Normalize component names
 	var disabledComponents []string
 	for _, disabledComponent := range o.DisableComponents {
-		if disabledComponent == constant.KubeletConfigComponentName {
+		switch disabledComponent {
+		case constant.APIConfigComponentName:
+			logrus.Warnf("Usage of deprecated component name %q, please switch to %q",
+				constant.APIConfigComponentName, "--enable-dynamic-config=false",
+			)
+			if o.EnableDynamicConfig {
+				logrus.Warnf("Cannot disable component %q, because %q is selected",
+					constant.APIConfigComponentName, "--enable-dynamic-config",
+				)
+			}
+
+		case constant.KubeletConfigComponentName:
 			logrus.Warnf("Usage of deprecated component name %q, please switch to %q",
 				constant.KubeletConfigComponentName, constant.WorkerConfigComponentName,
 			)
@@ -186,7 +197,6 @@ func GetWorkerFlags() *pflag.FlagSet {
 }
 
 var availableComponents = []string{
-	constant.APIConfigComponentName,
 	constant.AutopilotComponentName,
 	constant.ControlAPIComponentName,
 	constant.CoreDNSComponentname,

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -103,7 +103,7 @@ const (
 
 	/* Controller component names */
 
-	APIConfigComponentName             = "api-config"
+	APIConfigComponentName             = "api-config" // Deprecated: just don't use dynamic config
 	APIEndpointReconcilerComponentName = "endpoint-reconciler"
 	ControlAPIComponentName            = "control-api"
 	CoreDNSComponentname               = "coredns"


### PR DESCRIPTION
## Description

The api-config component merely gated the cluster config reconciler. Despite its name, that reconciler is also required to reconcile all components once with their static config. Hence it cannot be safely disabled without breaking k0s.

The effect of not installing the CRDs into the cluster can also be achieved by simply not enabling dynamic configuration. Ignore the api- config component gate and always enable the cluster config reconciler. It will only try to read the config from and write it to the cluster if dynamic configuration is actually enabled. Issue a warning if the api-config component gate is used, and another one if it's conflicting with the dynamic configuration setting.

Moreover, refactor the cluster config CRD application a bit: remove those parts from the reconciler and simply use the CRD saver component used everywhere else.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings