### PR TITLE
Test Autopilot updates for current and previous k0s minor versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -317,10 +317,19 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - id: set-matrix
+      - name: Generate Autopilot test matrix
+        id: set-matrix
         run: |
-          matrix=$(./hack/tools/gen-matrix.sh 1.24.3 1.24.4)
-          echo matrix="$matrix" >> $GITHUB_OUTPUT
+          set -x
+          k8sVersion="$(./vars.sh kubernetes_version)"
+          majorVersion="${k8sVersion%%.*}"
+          minorVersion=${k8sVersion#$majorVersion.}
+          minorVersion="${minorVersion%%.*}"
+
+          {
+            printf matrix=
+            hack/tools/gen-matrix.sh "$majorVersion.$(($minorVersion - 1))" "$majorVersion.$minorVersion"
+          } >> "$GITHUB_OUTPUT"
 
   autopilot-smoketest:
     name: Autopilot smoke test

--- a/hack/tools/gen-matrix.sh
+++ b/hack/tools/gen-matrix.sh
@@ -1,20 +1,38 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
-# Founds the last k0s releases of the given versions and generates json MATRIX_OUTPUT for github actions.
+# Finds the last k0s releases of the given versions and generates json MATRIX_OUTPUT for github actions.
 # Usage:
 #  ./gen-matrix.sh 1.24.2 1.24.3
-# Output: ["v1.24.2+k0s.0","v1.24.3+k0s.0"]
+# Output: ["v1.24.2+k0s.0", "v1.24.3+k0s.0"]
 
-go install github.com/k0sproject/version/cmd/k0s_sort@v0.2.2
-GOBIN="$(go env GOPATH)/bin"
-MATRIX_OUTPUT="["
-COMMA=""
-for i in "$@"; do \
-  RELEASE=$(gh release list -L 100 -R k0sproject/k0s | grep "+k0s." | grep -v Draft | cut -f 1 | $GOBIN/k0s_sort | grep $i | tail -1)
-  MATRIX_OUTPUT+="$COMMA\"$RELEASE\""
-  COMMA=","
-done
+list_k0s_releases() {
+  gh api -X GET /repos/k0sproject/k0s/releases \
+    -F per_page=100 --paginate \
+    --jq '.[] | select(.prerelease == false and .draft == false) | .name'
+}
 
-MATRIX_OUTPUT+="]"
+k0s_sort() {
+  go run github.com/k0sproject/version/cmd/k0s_sort@v0.2.2
+}
 
-echo $MATRIX_OUTPUT
+latest_release() {
+  list_k0s_releases | grep -F "v$1" | k0s_sort | tail -1
+}
+
+json_print_latest_releases() {
+  printf '['
+
+  pattern='"%s"'
+  for i in "$@"; do
+    latestRelease="$(latest_release "$i")"
+    [ -z "$latestRelease" ] || {
+      # shellcheck disable=SC2059
+      printf "$pattern" "$latestRelease"
+      pattern=', "%s"'
+    }
+  done
+
+  echo ']'
+}
+
+json_print_latest_releases "$@"


### PR DESCRIPTION
## Description

Currently, Autopilot update tests are hard-coded to use some 1.24 k0s versions. Use the current Kubernetes version to determine the latest k0s releases for that minor version and the previous minor version. Use these k0s versions as a base for the Autopilot update tests.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings