### PR TITLE
Use `gh` CLI instead of curl/jq when downloading k0s for the docs build

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -37,6 +37,8 @@ jobs:
           pip install --disable-pip-version-check -r docs/requirements.txt
 
       - name: Generate docs
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: make -C docs docs
 
       - name: Upload site/

--- a/.github/workflows/publish-docs-manual.yml
+++ b/.github/workflows/publish-docs-manual.yml
@@ -53,6 +53,8 @@ jobs:
           rm -rf main
 
       - name: Generate docs
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: make -C docs docs clean-k0s
 
       - name: git config

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -40,6 +40,8 @@ jobs:
           go install github.com/k0sproject/version/cmd/k0s_sort@v0.2.2
 
       - name: Generate docs
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: make -C docs docs clean-k0s
 
       - name: git config

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -29,14 +29,15 @@ docs: .require-mkdocs cli
 
 .PHONY: .k0s-download-url .k0s.exe-download-url
 ifeq ($(TARGET_VERSION),latest)
-.k0s-download-url .k0s.exe-download-url: release_metadata_url = $(k0s_releases_url)/latest
+.k0s-download-url .k0s.exe-download-url: release_metadata_path = repos/k0sproject/k0s/releases/latest
 else
-.k0s-download-url .k0s.exe-download-url: release_metadata_url = $(k0s_releases_url)/tags/$(TARGET_VERSION)
+.k0s-download-url .k0s.exe-download-url: release_metadata_path = repos/k0sproject/k0s/releases/tags/$(TARGET_VERSION)
 endif
 .k0s-download-url .k0s.exe-download-url:
 	$(eval binary_suffix = $(patsubst .k0s%,%,$(@:-download-url=)))
-	curl -sS -- '$(release_metadata_url)' \
-	  | jq -r '. as {name: $$ver, assets: $$a} | $$a[] | select(.name == "k0s-"+$$ver+"-amd64$(binary_suffix)") | .browser_download_url'
+	gh api \
+	  --jq '. as {name: $$ver, assets: $$a} | $$a[] | select(.name == "k0s-"+$$ver+"-amd64$(binary_suffix)") | .browser_download_url' \
+	  -- '$(release_metadata_path)'
 
 .PHONY: k0s k0s.exe
 ifeq ($(TARGET_VERSION),local)

--- a/docs/Makefile.variables
+++ b/docs/Makefile.variables
@@ -1,3 +1,1 @@
 python_version = 3.10.9
-
-k0s_releases_url = https://api.github.com/repos/k0sproject/k0s/releases


### PR DESCRIPTION
## Description

There have been some intermittent CI failures when building the docs:

    jq: error (at <stdin>:1): Cannot iterate over null (null)
    make[1]: *** [Makefile:38: .k0s-download-url] Error 5

Supposedly this indicates some sort of network failure. The real error seems to be swallowed by the `curl | jq` construct. Use the `gh` CLI in conjunction with its built-in `--jq` filter instead. Hopefully the error messages will be more descriptive then.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings