### PR TITLE
[Backport release-1.26] TLS server configuration hardening

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -32,6 +33,7 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/config"
+	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/etcd"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 
@@ -106,8 +108,12 @@ func (c *command) start() (err error) {
 	)
 
 	srv := &http.Server{
-		Handler:      router,
-		Addr:         fmt.Sprintf(":%d", c.NodeConfig.Spec.API.K0sAPIPort),
+		Handler: router,
+		Addr:    fmt.Sprintf(":%d", c.NodeConfig.Spec.API.K0sAPIPort),
+		TLSConfig: &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			CipherSuites: constant.AllowedTLS12CipherSuiteIDs,
+		},
 		WriteTimeout: 15 * time.Second,
 		ReadTimeout:  15 * time.Second,
 	}

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -62,7 +62,6 @@ var apiDefaultArgs = map[string]string{
 	"requestheader-username-headers":     "X-Remote-User",
 	"secure-port":                        "6443",
 	"anonymous-auth":                     "false",
-	"tls-cipher-suites":                  "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
 }
 
 const egressSelectorConfigTemplate = `
@@ -109,6 +108,7 @@ func (a *APIServer) Start(_ context.Context) error {
 		"requestheader-client-ca-file":     path.Join(a.K0sVars.CertRootDir, "front-proxy-ca.crt"),
 		"service-account-key-file":         path.Join(a.K0sVars.CertRootDir, "sa.pub"),
 		"service-cluster-ip-range":         a.ClusterConfig.Spec.Network.BuildServiceCIDR(a.ClusterConfig.Spec.API.Address),
+		"tls-min-version":                  "VersionTLS12",
 		"tls-cert-file":                    path.Join(a.K0sVars.CertRootDir, "server.crt"),
 		"tls-private-key-file":             path.Join(a.K0sVars.CertRootDir, "server.key"),
 		"service-account-signing-key-file": path.Join(a.K0sVars.CertRootDir, "sa.key"),
@@ -146,6 +146,10 @@ func (a *APIServer) Start(_ context.Context) error {
 			args[name] = value
 		}
 	}
+	if args["tls-cipher-suites"] == "" {
+		args["tls-cipher-suites"] = constant.AllowedTLS12CipherSuiteNames()
+	}
+
 	if a.DisableEndpointReconciler {
 		args["endpoint-reconciler-type"] = "none"
 	}

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -163,15 +163,20 @@ func (e *Etcd) Start(ctx context.Context) error {
 		"--listen-peer-urls":            peerURL,
 		"--initial-advertise-peer-urls": peerURL,
 		"--name":                        name,
-		"--trusted-ca-file":             etcdCaCert,
-		"--cert-file":                   etcdServerCert,
-		"--key-file":                    etcdServerKey,
-		"--peer-trusted-ca-file":        etcdCaCert,
-		"--peer-key-file":               etcdPeerKey,
-		"--peer-cert-file":              etcdPeerCert,
-		"--log-level":                   e.LogLevel,
-		"--peer-client-cert-auth":       "true",
-		"--enable-pprof":                "false",
+		// Specifying a minimum TLS version is not yet possible in etcd,
+		// although support for it has already been merged upstream. Enable this
+		// flag once it's available in the etcd release that ships with k0s.
+		// https://github.com/etcd-io/etcd/pull/15156
+		// "--tls-min-version": "TLS1.2",
+		"--trusted-ca-file":       etcdCaCert,
+		"--cert-file":             etcdServerCert,
+		"--key-file":              etcdServerKey,
+		"--peer-trusted-ca-file":  etcdCaCert,
+		"--peer-key-file":         etcdPeerKey,
+		"--peer-cert-file":        etcdPeerCert,
+		"--log-level":             e.LogLevel,
+		"--peer-client-cert-auth": "true",
+		"--enable-pprof":          "false",
 	}
 
 	if file.Exists(filepath.Join(e.K0sVars.EtcdDataDir, "member", "snap", "db")) {
@@ -201,6 +206,14 @@ func (e *Etcd) Start(ctx context.Context) error {
 			logrus.Warnf("overriding etcd flag with user provided value: %s", argName)
 		}
 		args[argName] = value
+	}
+
+	// The tls-min-version flag is not yet supported by etcd, but support for it
+	// has already been merged upstream. Once it becomes available, specifying a
+	// minimum version of TLS 1.3 _and_ a list of cipher suites will be rejected.
+	// https://github.com/etcd-io/etcd/pull/15156/files#diff-538c79cd00ec18cb43b5dddd5f36b979d9d050cf478a241304493284739d31bfR810-R813
+	if args["--cipher-suites"] == "" && args["--tls-min-version"] != "TLS1.3" {
+		args["--cipher-suites"] = constant.AllowedTLS12CipherSuiteNames()
 	}
 
 	logrus.Debugf("starting etcd with args: %v", args)

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -144,6 +144,7 @@ func (k *Konnectivity) defaultArgs() stringmap.StringMap {
 		"--delete-existing-uds-file": "true",
 		"--server-id":                machineID.ID(),
 		"--proxy-strategies":         "destHost,default",
+		"--cipher-suites":            constant.AllowedTLS12CipherSuiteNames(),
 	}
 }
 

--- a/pkg/component/controller/kubeletconfig.go
+++ b/pkg/component/controller/kubeletconfig.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -236,22 +237,18 @@ func getDefaultProfile(dnsAddress string, clusterDomain string) unstructuredYaml
 	// - it's easier to merge programatically defined structure
 	// - apart from map[string]interface there is no good way to define free-form mapping
 
+	cipherSuites := make([]string, len(constant.AllowedTLS12CipherSuiteIDs))
+	for i, cipherSuite := range constant.AllowedTLS12CipherSuiteIDs {
+		cipherSuites[i] = tls.CipherSuiteName(cipherSuite)
+	}
+
 	// for the authentication.x509.clientCAFile and volumePluginDir we want to use later binding so we put template placeholder instead of actual value there
 	profile := unstructuredYamlObject{
-		"apiVersion":    "kubelet.config.k8s.io/v1beta1",
-		"kind":          "KubeletConfiguration",
-		"clusterDNS":    []string{dnsAddress},
-		"clusterDomain": clusterDomain,
-		"tlsCipherSuites": []string{
-			"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-			"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
-			"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-			"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-			"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-			"TLS_RSA_WITH_AES_256_GCM_SHA384",
-			"TLS_RSA_WITH_AES_128_GCM_SHA256",
-		},
+		"apiVersion":         "kubelet.config.k8s.io/v1beta1",
+		"kind":               "KubeletConfiguration",
+		"clusterDNS":         []string{dnsAddress},
+		"clusterDomain":      clusterDomain,
+		"tlsCipherSuites":    cipherSuites,
 		"failSwapOn":         false,
 		"rotateCertificates": true,
 		"serverTLSBootstrap": true,

--- a/pkg/component/controller/workerconfig/reconciler_test.go
+++ b/pkg/component/controller/workerconfig/reconciler_test.go
@@ -710,15 +710,14 @@ func makeKubeletConfig(t *testing.T, mods ...func(*kubeletConfig)) string {
 		FailSwapOn:         pointer.Bool(false),
 		RotateCertificates: true,
 		ServerTLSBootstrap: true,
+		TLSMinVersion:      "VersionTLS12",
 		TLSCipherSuites: []string{
 			"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 			"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-			"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+			"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
 			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 			"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-			"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-			"TLS_RSA_WITH_AES_128_GCM_SHA256",
-			"TLS_RSA_WITH_AES_256_GCM_SHA384",
+			"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
 		},
 	}
 

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -17,9 +17,11 @@ limitations under the License.
 package constant
 
 import (
+	"crypto/tls"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // WinDataDirDefault default data-dir for windows
@@ -126,6 +128,33 @@ const (
 	NodeRoleLabelNamespace = "node-role.kubernetes.io"
 	K0SNodeRoleLabel       = "node.k0sproject.io/role"
 )
+
+// The list of allowed TLS v1.2 cipher suites. Those should be used for k0s
+// itself and all embedded components. Note that TLS v1.3 ciphers are currently
+// not configurable in Go.
+//
+// https://ssl-config.mozilla.org/#server=go&config=intermediate
+var AllowedTLS12CipherSuiteIDs = []uint16{
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+}
+
+// A comma-separated string version of [AllowedTLS12CipherSuiteIDs], suitable to
+// be used as CLI arg for binaries.
+func AllowedTLS12CipherSuiteNames() string {
+	var cipherSuites strings.Builder
+	for i, cipherSuite := range AllowedTLS12CipherSuiteIDs {
+		if i > 0 {
+			cipherSuites.WriteRune(',')
+		}
+		cipherSuites.WriteString(tls.CipherSuiteName(cipherSuite))
+	}
+	return cipherSuites.String()
+}
 
 // CfgVars is a struct that holds all the config variables required for K0s
 type CfgVars struct {

--- a/pkg/constant/constant_shared_test.go
+++ b/pkg/constant/constant_shared_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package constant
 
 import (
+	"crypto/tls"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -25,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"golang.org/x/exp/slices"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -44,6 +46,19 @@ func TestConstants(t *testing.T) {
 		kubeMajorMinor := ver[0] + "." + ver[1]
 		assert.Equal(t, kubeMajorMinor, KubernetesMajorMinorVersion)
 	})
+}
+
+func TestTLSCipherSuites(t *testing.T) {
+	// Verify that the ciphers in use are still considered secure by Go.
+	cipherSuites := tls.CipherSuites()
+	for _, cipherSuite := range AllowedTLS12CipherSuiteIDs {
+		idx := slices.IndexFunc(cipherSuites, func(x *tls.CipherSuite) bool {
+			return x.ID == cipherSuite
+		})
+		if idx < 0 {
+			assert.Fail(t, "Not in tls.CipherSuites(), potentially insecure", "(0x%04x) %s", cipherSuite, tls.CipherSuiteName(cipherSuite))
+		}
+	}
 }
 
 func TestKubernetesModuleVersions(t *testing.T) {


### PR DESCRIPTION
Backport to `release-1.26`:
* #2850