### PR TITLE
Make CoreDNS component to use both node config and dynamic config

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -387,7 +387,7 @@ func (c *command) start(ctx context.Context) error {
 	}
 
 	if !slices.Contains(c.DisableComponents, constant.CoreDNSComponentname) {
-		coreDNS, err := controller.NewCoreDNS(c.K0sVars, adminClientFactory)
+		coreDNS, err := controller.NewCoreDNS(c.K0sVars, adminClientFactory, c.NodeConfig)
 		if err != nil {
 			return fmt.Errorf("failed to create CoreDNS reconciler: %w", err)
 		}

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -53,3 +53,4 @@ smoketests := \
 	check-network-conformance-kuberouter \
 	check-network-conformance-calico \
 	check-embedded-binaries \
+	check-custom-cidrs \

--- a/inttest/custom-cidrs/customcidrs_test.go
+++ b/inttest/custom-cidrs/customcidrs_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customcidrs
+
+import (
+	"testing"
+
+	"github.com/k0sproject/k0s/inttest/common"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type CustomCIDRsSuite struct {
+	common.FootlooseSuite
+}
+
+const k0sConfig = `
+spec:
+  storage:
+    type: kine
+  network:
+    serviceCIDR: 10.152.184.0/24
+    podCIDR: 10.3.0.0/16
+`
+
+func (s *CustomCIDRsSuite) TestK0sGetsUp() {
+	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfig)
+	// Metrics disabled as it's super slow to get up properly and interferes with API discovery etc. while it's getting up
+	s.Require().NoError(s.InitController(0, "--config=/tmp/k0s.yaml", "--disable-components metrics-server", "--enable-dynamic-config"))
+	s.Require().NoError(s.RunWorkers())
+
+	token, err := s.GetJoinToken("worker")
+	s.Require().NoError(err)
+	s.NoError(s.RunWorkersWithToken(token))
+
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	if err != nil {
+		s.FailNow("failed to obtain Kubernetes client", err)
+	}
+
+	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
+	s.NoError(err)
+
+	err = s.WaitForNodeReady(s.WorkerNode(1), kc)
+	s.NoError(err)
+
+	s.AssertSomeKubeSystemPods(kc)
+
+	s.T().Log("waiting to see kube-router pods ready")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "kube-router did not start")
+
+}
+
+func TestCustomCIDRsSuite(t *testing.T) {
+	s := CustomCIDRsSuite{
+		common.FootlooseSuite{
+			ControllerCount: 1,
+			WorkerCount:     2,
+		},
+	}
+	suite.Run(t, &s)
+}

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -251,10 +251,12 @@ var _ manager.Reconciler = (*CoreDNS)(nil)
 
 // CoreDNS is the component implementation to manage CoreDNS
 type CoreDNS struct {
+	K0sVars    constant.CfgVars
+	NodeConfig *v1beta1.ClusterConfig
+
 	client                 kubernetes.Interface
 	log                    *logrus.Entry
 	manifestDir            string
-	K0sVars                constant.CfgVars
 	previousConfig         coreDNSConfig
 	stopFunc               context.CancelFunc
 	lastKnownClusterConfig *v1beta1.ClusterConfig
@@ -269,7 +271,7 @@ type coreDNSConfig struct {
 }
 
 // NewCoreDNS creates new instance of CoreDNS component
-func NewCoreDNS(k0sVars constant.CfgVars, clientFactory k8sutil.ClientFactoryInterface) (*CoreDNS, error) {
+func NewCoreDNS(k0sVars constant.CfgVars, clientFactory k8sutil.ClientFactoryInterface, nodeConfig *v1beta1.ClusterConfig) (*CoreDNS, error) {
 	manifestDir := path.Join(k0sVars.ManifestsDir, "coredns")
 
 	client, err := clientFactory.GetClient()
@@ -282,6 +284,7 @@ func NewCoreDNS(k0sVars constant.CfgVars, clientFactory k8sutil.ClientFactoryInt
 		log:         log,
 		K0sVars:     k0sVars,
 		manifestDir: manifestDir,
+		NodeConfig:  nodeConfig,
 	}, nil
 }
 
@@ -319,7 +322,7 @@ func (c *CoreDNS) Start(ctx context.Context) error {
 }
 
 func (c *CoreDNS) getConfig(ctx context.Context, clusterConfig *v1beta1.ClusterConfig) (coreDNSConfig, error) {
-	dns, err := clusterConfig.Spec.Network.DNSAddress()
+	dns, err := c.NodeConfig.Spec.Network.DNSAddress()
 	if err != nil {
 		return coreDNSConfig{}, err
 	}


### PR DESCRIPTION
## Description

The node config has the needed non-reconciliable serviceCIDR config which is needed to calculate the kube-dns services IP.

Added also smoke test for custom pod and service CIDRs.

Fixes #2865

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings