### PR TITLE
Use separate maxCount variables in prober to avoid cutting of events

### DIFF
--- a/pkg/component/prober/prober.go
+++ b/pkg/component/prober/prober.go
@@ -81,6 +81,7 @@ func (p *Prober) State(maxCount int) State {
 		Events:       make(map[string][]Event),
 	}
 	for name, r := range p.healthCheckState {
+		maxCount := maxCount
 		state.HealthProbes[name] = make([]ProbeResult, 0, p.probesTrackLength*len(p.withHealthComponents))
 		r.Do(func(v interface{}) {
 			if v == nil {
@@ -97,6 +98,7 @@ func (p *Prober) State(maxCount int) State {
 		state.HealthProbes[name] = state.HealthProbes[name][0:maxCount]
 	}
 	for name, r := range p.eventState {
+		maxCount := maxCount
 		state.Events[name] = make([]Event, 0, p.eventsTrackLength*len(p.withEventComponents))
 		r.Do(func(v interface{}) {
 			if v == nil {


### PR DESCRIPTION
Use separate maxCount variables in prober to avoid cutting of events or healthchecks based on the invalid amount

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2838 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings