### PR TITLE
Add k0s status command for windows

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -490,6 +490,7 @@ func (c *command) start(ctx context.Context) error {
 		K0sVars:            c.K0sVars,
 		AdminClientFactory: adminClientFactory,
 		EnableWorker:       c.EnableWorker,
+		StatusSocket:       config.StatusSocket,
 	})
 
 	perfTimer.Checkpoint("starting-cluster-components-init")

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -17,12 +17,9 @@ limitations under the License.
 package status
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
-	"net/http"
 	"os"
 	"path/filepath"
 
@@ -86,34 +83,6 @@ func NewStatusSubCmdComponents() *cobra.Command {
 	cmd.Flags().IntVar(&maxCount, "max-count", 1, "how many latest probes to show")
 	return cmd
 
-}
-
-// TODO: move it somewhere else, now here just for quick manual testing
-func GetOverSocket(socketPath string, path string, tgt interface{}) error {
-
-	httpc := http.Client{
-		Transport: &http.Transport{
-			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", socketPath)
-			},
-		},
-	}
-
-	response, err := httpc.Get("http://localhost/" + path)
-	if err != nil {
-		return err
-	}
-	defer response.Body.Close()
-
-	responseData, err := io.ReadAll(response.Body)
-	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal(responseData, tgt); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func printStatus(w io.Writer, status *status.K0sStatus, output string) {

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/k0sproject/k0s/pkg/component/status"
 	"github.com/k0sproject/k0s/pkg/config"
@@ -42,9 +41,6 @@ func NewStatusCmd() *cobra.Command {
 		Example: `The command will return information about system init, PID, k0s role, kubeconfig and similar.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			if runtime.GOOS == "windows" {
-				return fmt.Errorf("currently not supported on windows")
-			}
 
 			statusInfo, err := status.GetStatusInfo(config.StatusSocket)
 			if err != nil {
@@ -74,9 +70,6 @@ func NewStatusSubCmdComponents() *cobra.Command {
 		Example: `The command will return information about k0s components.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			if runtime.GOOS == "windows" {
-				return fmt.Errorf("currently not supported on windows")
-			}
 			fmt.Fprintln(os.Stderr, "!!! per component status is not yet finally ready, information here might be not full yet")
 			state, err := status.GetComponentStatus(config.StatusSocket, maxCount)
 			if err != nil {

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -209,8 +209,9 @@ func (c *Command) Start(ctx context.Context) error {
 	}
 
 	componentManager.Add(ctx, &worker.Autopilot{
-		K0sVars:     c.K0sVars,
-		CertManager: certManager,
+		K0sVars:      c.K0sVars,
+		CertManager:  certManager,
+		StatusSocket: config.StatusSocket,
 	})
 
 	// extract needed components

--- a/pkg/autopilot/controller/root/root.go
+++ b/pkg/autopilot/controller/root/root.go
@@ -23,6 +23,7 @@ import (
 type RootConfig struct {
 	KubeConfig          string
 	K0sDataDir          string
+	K0sStatusSocket     string
 	Mode                string
 	ManagerPort         int
 	MetricsBindAddr     string

--- a/pkg/autopilot/controller/root_controller.go
+++ b/pkg/autopilot/controller/root_controller.go
@@ -74,7 +74,7 @@ func NewRootController(cfg aproot.RootConfig, logger *logrus.Entry, enableWorker
 	c.stopSubHandler = c.stopSubControllers
 	c.leaseWatcherCreator = NewLeaseWatcher
 	c.setupHandler = func(ctx context.Context, cf apcli.FactoryInterface) error {
-		setupController := NewSetupController(c.log, cf, cfg.K0sDataDir, enableWorker)
+		setupController := NewSetupController(c.log, cf, cfg.K0sDataDir, cfg.K0sStatusSocket, enableWorker)
 		return setupController.Run(ctx)
 	}
 
@@ -198,7 +198,7 @@ func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *
 	}
 	clusterID := string(ns.UID)
 
-	if err := apsig.RegisterControllers(ctx, logger, mgr, delegateMap[apdel.ControllerDelegateController], c.cfg.K0sDataDir, clusterID); err != nil {
+	if err := apsig.RegisterControllers(ctx, logger, mgr, delegateMap[apdel.ControllerDelegateController], c.cfg.K0sDataDir, clusterID, c.cfg.K0sStatusSocket); err != nil {
 		logger.WithError(err).Error("unable to register 'signal' controllers")
 		return err
 	}
@@ -208,7 +208,7 @@ func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *
 		return err
 	}
 
-	if err := apupdate.RegisterControllers(ctx, logger, mgr, c.autopilotClientFactory, leaderMode, clusterID); err != nil {
+	if err := apupdate.RegisterControllers(ctx, logger, mgr, c.autopilotClientFactory, leaderMode, clusterID, c.cfg.K0sStatusSocket); err != nil {
 		logger.WithError(err).Error("unable to register 'update' controllers")
 		return err
 	}

--- a/pkg/autopilot/controller/root_worker.go
+++ b/pkg/autopilot/controller/root_worker.go
@@ -106,7 +106,7 @@ func (w *rootWorker) Run(ctx context.Context) error {
 			return fmt.Errorf("unable to register indexers: %w", err)
 		}
 
-		if err := apsig.RegisterControllers(ctx, logger, mgr, apdel.NodeControllerDelegate(), w.cfg.K0sDataDir, clusterID); err != nil {
+		if err := apsig.RegisterControllers(ctx, logger, mgr, apdel.NodeControllerDelegate(), w.cfg.K0sDataDir, clusterID, w.cfg.K0sStatusSocket); err != nil {
 			return fmt.Errorf("unable to register 'controlnodes' controllers: %w", err)
 		}
 		// The controller-runtime start blocks until the context is cancelled.

--- a/pkg/autopilot/controller/signal/init.go
+++ b/pkg/autopilot/controller/signal/init.go
@@ -28,8 +28,8 @@ import (
 
 // RegisterControllers registers all of the autopilot controllers used by both controller
 // and worker modes.
-func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, k0sDataDir, clusterID string) error {
-	if err := apsigk0s.RegisterControllers(ctx, logger, mgr, delegate, clusterID); err != nil {
+func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, k0sDataDir, clusterID, k0sStatusSocket string) error {
+	if err := apsigk0s.RegisterControllers(ctx, logger, mgr, delegate, clusterID, k0sStatusSocket); err != nil {
 		return fmt.Errorf("unable to register k0s controllers: %w", err)
 	}
 

--- a/pkg/autopilot/controller/signal/k0s/init.go
+++ b/pkg/autopilot/controller/signal/k0s/init.go
@@ -43,7 +43,7 @@ const (
 
 // RegisterControllers registers all of the autopilot controllers used for updating `k0s`
 // to the controller-runtime manager.
-func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, clusterID string) error {
+func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, clusterID string, k0sStatusSocket string) error {
 	logger = logger.WithField("controller", delegate.Name())
 
 	hostname, err := apcomm.FindEffectiveHostname()
@@ -59,7 +59,7 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 
 	logger.Infof("Using effective hostname = '%v'", hostname)
 
-	if err := registerSignalController(logger, mgr, signalControllerEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s signal")), delegate, clusterID); err != nil {
+	if err := registerSignalController(logger, mgr, signalControllerEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s signal")), delegate, clusterID, k0sStatusSocket); err != nil {
 		return fmt.Errorf("unable to register k0s 'signal' controller: %w", err)
 	}
 
@@ -75,11 +75,11 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 		return fmt.Errorf("unable to register k0s 'applying-update' controller: %w", err)
 	}
 
-	if err := registerRestart(logger, mgr, restartEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s restart")), delegate); err != nil {
+	if err := registerRestart(logger, mgr, restartEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s restart")), delegate, k0sStatusSocket); err != nil {
 		return fmt.Errorf("unable to register k0s 'restart' controller: %w", err)
 	}
 
-	if err := registerRestarted(logger, mgr, restartedEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s restarted")), delegate); err != nil {
+	if err := registerRestarted(logger, mgr, restartedEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s restarted")), delegate, k0sStatusSocket); err != nil {
 		return fmt.Errorf("unable to register k0s 'restarted' controller: %w", err)
 	}
 

--- a/pkg/autopilot/controller/signal/k0s/restart_windows.go
+++ b/pkg/autopilot/controller/signal/k0s/restart_windows.go
@@ -32,6 +32,6 @@ func restartEventFilter(hostname string, handler apsigpred.ErrorHandler) crpred.
 //
 // This controller is only interested in changes to signal nodes where its signaling
 // status is marked as `Restart`
-func registerRestart(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate) error {
+func registerRestart(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, k0sStatusSocket string) error {
 	return nil
 }

--- a/pkg/autopilot/controller/signal/k0s/restarted_windows.go
+++ b/pkg/autopilot/controller/signal/k0s/restarted_windows.go
@@ -33,6 +33,6 @@ func restartedEventFilter(hostname string, handler apsigpred.ErrorHandler) crpre
 //
 // This controller is only interested in changes to signal nodes where its signaling
 // status is marked as `Restart`
-func registerRestarted(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate) error {
+func registerRestarted(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, _ string) error {
 	return nil
 }

--- a/pkg/autopilot/controller/signal/k0s/signal.go
+++ b/pkg/autopilot/controller/signal/k0s/signal.go
@@ -35,7 +35,6 @@ import (
 
 const (
 	SignalResponseProcessingTimeout = 1 * time.Minute
-	DefaultK0sStatusSocketPath      = "/run/k0s/status.sock"
 )
 
 type k0sVersionHandlerFunc func() (string, error)
@@ -71,7 +70,7 @@ type signalControllerHandler struct {
 //
 // This controller is only interested in changes to its own annotations, and is the main
 // mechanism in identifying incoming autopilot k0s signaling updates.
-func registerSignalController(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, clusterID string) error {
+func registerSignalController(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, clusterID, k0sStatusSocket string) error {
 	logr := logger.WithFields(logrus.Fields{"updatetype": "k0s"})
 
 	logr.Infof("Registering 'signal' reconciler for '%s'", delegate.Name())
@@ -88,7 +87,7 @@ func registerSignalController(logger *logrus.Entry, mgr crman.Manager, eventFilt
 					timeout:   SignalResponseProcessingTimeout,
 					clusterID: clusterID,
 					k0sVersionHandler: func() (string, error) {
-						return getK0sVersion(DefaultK0sStatusSocketPath)
+						return getK0sVersion(k0sStatusSocket)
 					},
 				},
 			),

--- a/pkg/autopilot/controller/updates/updater.go
+++ b/pkg/autopilot/controller/updates/updater.go
@@ -28,7 +28,6 @@ import (
 
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
-	"github.com/k0sproject/k0s/pkg/autopilot/controller/signal/k0s"
 	uc "github.com/k0sproject/k0s/pkg/autopilot/updater"
 	"github.com/k0sproject/k0s/pkg/component/status"
 )
@@ -53,7 +52,7 @@ var patchOpts = []crcli.PatchOption{
 	crcli.ForceOwnership,
 }
 
-func newUpdater(parentCtx context.Context, updateConfig apv1beta2.UpdateConfig, k8sClient crcli.Client, clusterID string, updateServerToken string) (*updater, error) {
+func newUpdater(parentCtx context.Context, updateConfig apv1beta2.UpdateConfig, k8sClient crcli.Client, clusterID string, updateServerToken string, k0sStatusSocket string) (*updater, error) {
 	updateClient, err := uc.NewClient(updateConfig.Spec.UpdateServer, updateServerToken)
 	if err != nil {
 		return nil, err
@@ -64,7 +63,7 @@ func newUpdater(parentCtx context.Context, updateConfig apv1beta2.UpdateConfig, 
 		schedule = defaultCronSchedule
 	}
 
-	status, err := status.GetStatusInfo(k0s.DefaultK0sStatusSocketPath)
+	status, err := status.GetStatusInfo(k0sStatusSocket)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/controller/autopilot.go
+++ b/pkg/component/controller/autopilot.go
@@ -36,6 +36,7 @@ type Autopilot struct {
 	K0sVars            constant.CfgVars
 	AdminClientFactory kubernetes.ClientFactoryInterface
 	EnableWorker       bool
+	StatusSocket       string
 }
 
 func (a *Autopilot) Init(ctx context.Context) error {
@@ -53,6 +54,7 @@ func (a *Autopilot) Start(ctx context.Context) error {
 	autopilotRoot, err := apcont.NewRootController(aproot.RootConfig{
 		KubeConfig:          a.K0sVars.AdminKubeConfigPath,
 		K0sDataDir:          a.K0sVars.DataDir,
+		K0sStatusSocket:     a.StatusSocket,
 		Mode:                "controller",
 		ManagerPort:         8899,
 		MetricsBindAddr:     "0",

--- a/pkg/component/status/client.go
+++ b/pkg/component/status/client.go
@@ -49,10 +49,12 @@ type ProbeStatus struct {
 	Success bool
 }
 
+type dialcontext func(context.Context, string, string) (net.Conn, error)
+
 // GetStatus returns the status of the k0s process using the status socket
 func GetStatusInfo(socketPath string) (*K0sStatus, error) {
 	status := &K0sStatus{}
-	if err := doHTTPRequestViaUnixSocket(socketPath, "status", status); err != nil {
+	if err := doStatusRequest(socketPath, "status", status); err != nil {
 		return nil, err
 	}
 	return status, nil
@@ -61,7 +63,7 @@ func GetStatusInfo(socketPath string) (*K0sStatus, error) {
 // GetComponentStatus returns the per-component events and health-checks
 func GetComponentStatus(socketPath string, maxCount int) (*prober.State, error) {
 	status := &prober.State{}
-	if err := doHTTPRequestViaUnixSocket(socketPath,
+	if err := doStatusRequest(socketPath,
 		fmt.Sprintf("components?maxCount=%d", maxCount),
 		status); err != nil {
 		return nil, err
@@ -69,12 +71,10 @@ func GetComponentStatus(socketPath string, maxCount int) (*prober.State, error) 
 	return status, nil
 }
 
-func doHTTPRequestViaUnixSocket(socketPath string, path string, tgt interface{}) error {
+func doStatusRequest(socketPath string, path string, tgt interface{}) error {
 	httpc := http.Client{
 		Transport: &http.Transport{
-			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", socketPath)
-			},
+			DialContext: httpDialer(socketPath),
 		},
 	}
 

--- a/pkg/component/status/client.go
+++ b/pkg/component/status/client.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	config "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component/prober"
@@ -76,6 +77,7 @@ func doStatusRequest(socketPath string, path string, tgt interface{}) error {
 		Transport: &http.Transport{
 			DialContext: httpDialer(socketPath),
 		},
+		Timeout: 3 * time.Second,
 	}
 
 	response, err := httpc.Get("http://localhost/" + path)

--- a/pkg/component/status/httpdialer.go
+++ b/pkg/component/status/httpdialer.go
@@ -2,7 +2,7 @@
 // +build !windows
 
 /*
-Copyright 2023 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/component/status/httpdialer.go
+++ b/pkg/component/status/httpdialer.go
@@ -2,7 +2,7 @@
 // +build !windows
 
 /*
-Copyright 2021 k0s authors
+Copyright 2023 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,12 +16,21 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package status
 
-import "net"
+import (
+	"context"
+	"fmt"
+	"net"
+)
 
-func init() {
-	listen = func(path string) (net.Listener, error) {
-		return net.Listen("unix", path)
+func httpDialer(socket string) dialcontext {
+	return func(ctx context.Context, _, _ string) (net.Conn, error) {
+		conn, err := (&net.Dialer{}).DialContext(ctx, "unix", socket)
+		if err != nil {
+			return nil, fmt.Errorf("dial socket: %w", err)
+		}
+		return conn, nil
 	}
 }

--- a/pkg/component/status/httpdialer_windows.go
+++ b/pkg/component/status/httpdialer_windows.go
@@ -1,8 +1,5 @@
-//go:build !windows
-// +build !windows
-
 /*
-Copyright 2021 k0s authors
+Copyright 2023 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,12 +13,23 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package status
 
-import "net"
+import (
+	"context"
+	"fmt"
+	"net"
 
-func init() {
-	listen = func(path string) (net.Listener, error) {
-		return net.Listen("unix", path)
+	"github.com/Microsoft/go-winio"
+)
+
+func httpDialer(pipe string) dialcontext {
+	return func(ctx context.Context, _, _ string) (net.Conn, error) {
+		conn, err := winio.DialPipeContext(ctx, pipe)
+		if err != nil {
+			return nil, fmt.Errorf("dial named pipe: %w", err)
+		}
+		return conn, nil
 	}
 }

--- a/pkg/component/status/httpdialer_windows.go
+++ b/pkg/component/status/httpdialer_windows.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/component/status/listen.go
+++ b/pkg/component/status/listen.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/component/status/listen.go
+++ b/pkg/component/status/listen.go
@@ -1,0 +1,27 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright 2021 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package status
+
+import "net"
+
+func init() {
+	listen = func(path string) (net.Listener, error) {
+		return net.Listen("unix", path)
+	}
+}

--- a/pkg/component/status/listen_windows.go
+++ b/pkg/component/status/listen_windows.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 /*
 Copyright 2023 k0s authors
 

--- a/pkg/component/status/listen_windows.go
+++ b/pkg/component/status/listen_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2023 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"net"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func init() {
+	listen = func(path string) (net.Listener, error) {
+		return winio.ListenPipe(path, nil)
+	}
+}

--- a/pkg/component/status/listen_windows.go
+++ b/pkg/component/status/listen_windows.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/component/status/status.go
+++ b/pkg/component/status/status.go
@@ -59,8 +59,6 @@ var _ manager.Component = (*Status)(nil)
 
 var listen func(string) (net.Listener, error) // set by listen.go / listen_windows.go
 
-var listen listenFunc = net.Listen
-
 const defaultMaxEvents = 5
 
 // Init initializes component

--- a/pkg/component/status/status_test.go
+++ b/pkg/component/status/status_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2023 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/k0sproject/k0s/pkg/component/prober"
+	"github.com/k0sproject/k0s/pkg/constant"
+	"github.com/stretchr/testify/require"
+)
+
+type mockProber struct{}
+
+func (m *mockProber) State(maxCount int) prober.State {
+	return prober.State{}
+}
+
+func TestStatusSocket(t *testing.T) {
+	runDir := t.TempDir()
+
+	var socket string
+	if runtime.GOOS == "windows" {
+		socket = `\\.\pipe\k0s-status` + strconv.Itoa(os.Getpid())
+	} else {
+		socket = filepath.Join(runDir, "k0s-status.sock")
+	}
+
+	component := &Status{
+		Socket:            socket,
+		Prober:            &mockProber{},
+		StatusInformation: K0sStatus{Version: "status-socket-test", K0sVars: constant.CfgVars{RunDir: runDir}},
+	}
+
+	require.NoError(t, component.Init(context.Background()))
+	component.L.Logger.SetOutput(io.Discard)
+	require.NoError(t, component.Start(context.Background()))
+	status, err := GetStatusInfo(socket)
+	require.NoError(t, err)
+	require.Equal(t, status.Version, "status-socket-test")
+	require.NoError(t, component.Stop())
+}

--- a/pkg/component/worker/autopilot.go
+++ b/pkg/component/worker/autopilot.go
@@ -41,8 +41,9 @@ const (
 var _ manager.Component = (*Autopilot)(nil)
 
 type Autopilot struct {
-	K0sVars     constant.CfgVars
-	CertManager *CertificateManager
+	K0sVars      constant.CfgVars
+	CertManager  *CertificateManager
+	StatusSocket string
 }
 
 func (a *Autopilot) Init(ctx context.Context) error {
@@ -87,6 +88,7 @@ func (a *Autopilot) Start(ctx context.Context) error {
 	autopilotRoot, err := apcont.NewRootWorker(aproot.RootConfig{
 		KubeConfig:          a.K0sVars.KubeletAuthConfigPath,
 		K0sDataDir:          a.K0sVars.DataDir,
+		K0sStatusSocket:     a.StatusSocket,
 		Mode:                "worker",
 		ManagerPort:         8899,
 		MetricsBindAddr:     "0",

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -157,7 +158,7 @@ func GetPersistentFlagSet() *pflag.FlagSet {
 	flagset.BoolVarP(&Debug, "debug", "d", false, "Debug logging (default: false)")
 	flagset.BoolVarP(&Verbose, "verbose", "v", false, "Verbose logging (default: false)")
 	flagset.StringVar(&DataDir, "data-dir", "", "Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!")
-	flagset.StringVar(&StatusSocket, "status-socket", DefaultStatusSocketPath(), "status.sock"), "Full file path to the socket file.")
+	flagset.StringVar(&StatusSocket, "status-socket", DefaultStatusSocketPath(), "Full file path to the socket file")
 	flagset.StringVar(&DebugListenOn, "debugListenOn", ":6060", "Http listenOn for Debug pprof handler")
 	return flagset
 }

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
-	aproot "github.com/k0sproject/k0s/pkg/autopilot/controller/root"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/constant"
 
@@ -62,7 +61,6 @@ type CLIOptions struct {
 	K0sVars          constant.CfgVars
 	Logging          map[string]string // merged outcome of default log levels and cmdLoglevels
 	Verbose          bool
-	AutopilotRoot    aproot.Root
 }
 
 // Shared controller cli flags
@@ -147,12 +145,19 @@ func DefaultLogLevels() map[string]string {
 	}
 }
 
+func DefaultStatusSocketPath() string {
+	if runtime.GOOS == "windows" {
+		return `\\.\pipe\k0s-status`
+	}
+	return filepath.Join(K0sVars.RunDir, "status.sock")
+}
+
 func GetPersistentFlagSet() *pflag.FlagSet {
 	flagset := &pflag.FlagSet{}
 	flagset.BoolVarP(&Debug, "debug", "d", false, "Debug logging (default: false)")
 	flagset.BoolVarP(&Verbose, "verbose", "v", false, "Verbose logging (default: false)")
 	flagset.StringVar(&DataDir, "data-dir", "", "Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!")
-	flagset.StringVar(&StatusSocket, "status-socket", filepath.Join(K0sVars.RunDir, "status.sock"), "Full file path to the socket file.")
+	flagset.StringVar(&StatusSocket, "status-socket", DefaultStatusSocketPath(), "status.sock"), "Full file path to the socket file.")
 	flagset.StringVar(&DebugListenOn, "debugListenOn", ":6060", "Http listenOn for Debug pprof handler")
 	return flagset
 }


### PR DESCRIPTION
## Description

- The status component will now listen on a named pipe on windows
- The status command is adapted to connect to the pipe on windows, previously it just errored out with a "not supported on windows" message.
- Autopilot used a static k0s status socket path (so does k0s in general if you're root, as [rundir is always /run/k0s for uid==0](https://github.com/k0sproject/k0s/blob/main/pkg/constant/constant_shared.go#L202-L206)) - this got fixed here as a side-effect.

Fixes #2887 

## Type of change

<!-- check the related options -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings