### PR TITLE
Use FORCE_HOST_GO=y when building Kubernetes

### DIFF
--- a/embedded-bins/kubernetes/Dockerfile
+++ b/embedded-bins/kubernetes/Dockerfile
@@ -31,6 +31,7 @@ RUN \
     export KUBE_CGO_OVERRIDES=$commands; \
   fi; \
   mkdir /out; \
+  export FORCE_HOST_GO=y; \
   export KUBE_GIT_VERSION="v$VERSION+k0s"; \
   for cmd in $commands; do \
     make GOFLAGS="${BUILD_GO_FLAGS} -tags=${BUILD_GO_TAGS}" GOLDFLAGS="${BUILD_GO_LDFLAGS_EXTRA}" WHAT=cmd/$cmd; \


### PR DESCRIPTION
## Description

This is to bypass the automatic Go toolchain download which has been added to Kubernetes 1.27 and has been backported to v1.26.3, v1.25.8 and v1.24.12. See kubernetes/kubernetes#115377 for details on that.

This change is only necessary when bumping to the aforementioned Kubernetes versions, but it doesn't hurt to have it in before the version bumps, so this can be backported down to v1.24.

See also: #2879.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings