### PR TITLE
inttests: Use correct arch in footloose image

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -1,6 +1,6 @@
 
-ARCH = $(shell go env GOARCH)
-OS = $(shell go env GOOS)
+ARCH := $(shell go env GOARCH)
+OS := $(shell go env GOOS)
 K0S_UPDATE_TO_VERSION ?= $(shell ../k0s version)
 
 SONOBUOY_VERSION ?= 0.56.11
@@ -12,12 +12,6 @@ bins = bin/sonobuoy
 
 include ../embedded-bins/Makefile.variables
 
-ifeq ($(ARCH),amd64)
-etcd_arch = amd64
-else
-etcd_arch = arm64
-endif
-
 .PHONY: all
 all: $(bins) .footloose-alpine.stamp
 
@@ -27,17 +21,24 @@ bin:
 bin/sonobuoy: | bin
 	$(curl) $(sonobuoy_url) | tar -C bin/ -zxv $(notdir $@)
 
-.footloose-alpine.stamp: footloose-alpine/Dockerfile $(shell find footloose-alpine/root -type f)
-	docker build \
-	  --build-arg ALPINE_VERSION=$(alpine_patch_version) \
-	  --build-arg ETCD_ARCH=$(etcd_arch) \
-	  --build-arg ETCD_VERSION=$(etcd_version) \
-	  --build-arg HELM_VERSION=$(helm_version) \
-	  --build-arg KUBE_VERSION=$(kubernetes_version) \
-	  -t footloose-alpine \
-	  -f footloose-alpine/Dockerfile \
-	  footloose-alpine
+footloose_alpine_build_cmdline := \
+	--build-arg GOLANG_IMAGE=$(golang_buildimage) \
+	--build-arg ALPINE_VERSION=$(alpine_patch_version) \
+	--build-arg ETCD_VERSION=$(etcd_version) \
+	--build-arg HELM_VERSION=$(helm_version) \
+	--build-arg KUBE_VERSION=$(kubernetes_version) \
+	-t footloose-alpine \
+	-f footloose-alpine/Dockerfile \
+	footloose-alpine
+
+.footloose-alpine.stamp:
+	docker build --build-arg TARGETARCH=$(ARCH) $(footloose_alpine_build_cmdline)
 	touch $@
+
+# This is a special target to test the footloose alpine image locally for all supported platforms.
+.PHONY: check-footloose-alpine-buildx
+check-footloose-alpine-buildx:
+	docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 $(footloose_alpine_build_cmdline)
 
 .footloose-k0s.stamp: K0S_PATH ?= $(realpath ../k0s)
 .footloose-k0s.stamp: .footloose-alpine.stamp

--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -1,10 +1,14 @@
 ARG ALPINE_VERSION
+ARG GOLANG_IMAGE
+
 FROM docker.io/library/alpine:$ALPINE_VERSION
 
-ARG ETCD_ARCH
+ARG TARGETARCH
 ARG ETCD_VERSION
 ARG KUBE_VERSION
+ARG TROUBLESHOOT_VERSION=v0.61.0
 ARG HELM_VERSION
+
 # Apply our changes to the image
 COPY root/ /
 
@@ -27,27 +31,34 @@ RUN sed -i -e 's/^\(tty[0-9]\)/# \1/' /etc/inittab
 RUN sed -i -e 's/^root:!:/root::/' /etc/shadow
 
 # Put kubectl into place to ease up debugging
-RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl \
+RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/$TARGETARCH/kubectl \
   && chmod +x /usr/local/bin/kubectl
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
 # Install troublbeshoot support bundle
-RUN curl -Lo - https://github.com/replicatedhq/troubleshoot/releases/download/v0.55.0/support-bundle_linux_amd64.tar.gz \
+RUN curl -Lo - https://github.com/replicatedhq/troubleshoot/releases/download/$TROUBLESHOOT_VERSION/support-bundle_linux_$TARGETARCH.tar.gz \
   | tar xzO support-bundle >/usr/local/bin/kubectl-supportbundle \
   && chmod +x /usr/local/bin/kubectl-supportbundle
 
 # Put helm into place to ease up debugging and for helm integration tests
-RUN curl -L https://get.helm.sh/helm-v$HELM_VERSION-linux-amd64.tar.gz \
-  | tar xz -C /usr/local/bin --strip-components=1 && chmod +x /usr/local/bin/helm
+RUN curl -L https://get.helm.sh/helm-v$HELM_VERSION-linux-$TARGETARCH.tar.gz \
+  | tar xz linux-$TARGETARCH/helm -C /usr/local/bin --strip-components=1 \
+  && chmod +x /usr/local/bin/helm
 
 # Install etcd for smoke tests with external etcd
-RUN curl -L https://github.com/etcd-io/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-$ETCD_ARCH.tar.gz \
-  | tar xz -C /opt --strip-components=1
+# No arm binaries available (check-externaletcd won't work on ARMv7)
+RUN if [ "$TARGETARCH" != arm ]; then \
+    curl -L https://github.com/etcd-io/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-$TARGETARCH.tar.gz \
+      | tar xz -C /opt --strip-components=1; \
+  fi
 
 # Install cri-dockerd shim for custom CRI testing
-RUN curl -sSfLo /tmp/cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.1/cri-dockerd-0.3.1.amd64.tgz \
-  && tar xf /tmp/cri-dockerd.tgz --directory /tmp/ \
-  && mv /tmp/cri-dockerd/cri-dockerd /usr/local/bin/cri-dockerd \
-  && rm -rf /tmp/cri-dockerd \
-  && chmod 755 /usr/local/bin/cri-dockerd
+# No arm binaries available (check-byocri won't work on ARMv7)
+RUN if [ "$TARGETARCH" != arm ]; then \
+    curl -sSfLo /tmp/cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.1/cri-dockerd-0.3.1.$TARGETARCH.tgz \
+      && tar xf /tmp/cri-dockerd.tgz --directory /tmp/ \
+      && mv /tmp/cri-dockerd/cri-dockerd /usr/local/bin/cri-dockerd \
+      && rm -rf /tmp/cri-dockerd \
+      && chmod 755 /usr/local/bin/cri-dockerd; \
+  fi
 ADD cri-dockerd.sh /etc/init.d/cri-dockerd


### PR DESCRIPTION
## Description

(Part of the work that has been done for #2879.)

The downloaded binaries in the footloose Docker image only work on amd64 currently. This is problematic when the inttests fail on non-amd64 arches, since the support bundle collection won't work and there's only limited information available to debug the failures.

Use the automatic platform arg `TARGETARCH` when downloading binaries. Set the `TARGETARCH` arg manually to the value of `GOARCH` for standard builds, as it's only automatically set when using the BuildKit backend.

Add another make target `check-footloose-alpine-buildx` that's intended to test all platforms at once using `docker buildx` when hacking on the Dockerfile locally.

Update troubleshoot to v0.61.0 in order to unlock AArch32 binaries and remove the etcd_arch build arg as it is redundant right now.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings