### PR TITLE
Properly forward CGO settings into Kubernetes build

### DIFF
--- a/embedded-bins/kubernetes/Dockerfile
+++ b/embedded-bins/kubernetes/Dockerfile
@@ -29,6 +29,8 @@ RUN \
   # Ensure that all of the binaries are built with CGO \
   if [ ${BUILD_GO_CGO_ENABLED:-0} -eq 1 ]; then \
     export KUBE_CGO_OVERRIDES=$commands; \
+  else \
+    export KUBE_STATIC_OVERRIDES=$commands; \
   fi; \
   mkdir /out; \
   export FORCE_HOST_GO=y; \


### PR DESCRIPTION
## Description

`KUBE_STATIC_OVERRIDES` is the proper counterpart to `KUBE_CGO_OVERRIDES`. Without setting it, some binaries might not be statically linked. This has been observed with kubelet in v1.27.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings