### PR TITLE
Simplify cloud provider controller manager setup

### DIFF
--- a/inttest/k0scloudprovider/k0scloudprovider_test.go
+++ b/inttest/k0scloudprovider/k0scloudprovider_test.go
@@ -44,9 +44,6 @@ func (s *K0sCloudProviderSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
 	s.Require().NoError(err)
 
-	err = s.WaitForNodeReady(s.WorkerNode(1), kc)
-	s.Require().NoError(err)
-
 	// Test the adding of various addresses using addition via annotations
 	w0Helper := defaultNodeAddValueHelper(s.AddNodeAnnotation)
 	s.testAddAddress(kc, s.WorkerNode(0), "1.2.3.4", w0Helper)
@@ -123,7 +120,7 @@ func TestK0sCloudProviderSuite(t *testing.T) {
 	suite.Run(t, &K0sCloudProviderSuite{
 		common.FootlooseSuite{
 			ControllerCount: 1,
-			WorkerCount:     2,
+			WorkerCount:     1,
 			LaunchMode:      common.LaunchModeOpenRC,
 		},
 	})


### PR DESCRIPTION
## Description

A better way to restrict the to-be-launced controllers is to directly filter down the initFuncConstructors map that's passed into NewCloudControllerManagerCommand. This allows some of the other calls to the cloud provider API to be removed. This makes it compatible with Kubernetes 1.27, which has some breaking changes in the removed API calls.

Also remove the second worker from the inttest, as it wasn't used at all.

See also:
* #2879
* #2906

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings