### PR TITLE
Fix runtime config permissions from 0755 to 0600

### DIFF
--- a/pkg/config/file_config.go
+++ b/pkg/config/file_config.go
@@ -164,7 +164,7 @@ func (rules *ClientConfigLoadingRules) writeConfig(yamlData []byte, storageSpec 
 		return fmt.Errorf("failed to marshal config: %v", err)
 	}
 
-	err = file.WriteContentAtomically(rules.RuntimeConfigPath, data, 0755)
+	err = file.WriteContentAtomically(rules.RuntimeConfigPath, data, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to write runtime config to %s (%v): %v", rules.K0sVars.RunDir, rules.RuntimeConfigPath, err)
 	}


### PR DESCRIPTION
## Description

The runtime config in `{rundir}/k0s.yaml` was being generated with rwx-rw-rw permissions. 

## Type of change

This changes it to 0600 (`-rw------`).

<!-- check the related options -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [X] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [X] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings