### PR TITLE
Disable lint workflow for push events

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,18 +1,5 @@
 name: Go lint
 on:
-  push:
-    branches:
-      - main
-      - release-*
-    paths-ignore:
-      - 'docs/**'
-      - 'examples/**'
-      - '**.md'
-      - LICENSE
-      - '**.svg'
-      - '.github/workflows/docs.yml'
-      - '.github/workflows/mkdocs-set-default-version.yml'
-      - 'mkdocs.yml'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Description

Removes the lint action from push events (on merge to main or release branches). You will only ever know it has failed by looking at the actions tab. Build will run anyway as it is in a different workflow file and thus doesn't depend on lint.