### PR TITLE
[Backport release-1.25] Fix runtime config permissions from 0755 to 0600

### DIFF
--- a/pkg/config/file_config.go
+++ b/pkg/config/file_config.go
@@ -158,7 +158,7 @@ func (rules *ClientConfigLoadingRules) writeConfig(yamlData []byte, storageSpec 
 		return fmt.Errorf("failed to marshal config: %v", err)
 	}
 
-	err = os.WriteFile(rules.RuntimeConfigPath, data, 0755)
+	err = os.WriteFile(rules.RuntimeConfigPath, data, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to write runtime config to %s (%v): %v", rules.K0sVars.RunDir, rules.RuntimeConfigPath, err)
 	}


### PR DESCRIPTION
Backport to `release-1.25`:
* #2925

See:
* #2919