### PR TITLE
Fix config validate

### DIFF
--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -244,15 +244,6 @@ func GetCmdOpts() CLIOptions {
 		K0sVars.DefaultStorageType = "kine"
 	}
 
-	// When CfgFile is set, verify the file can be opened
-	if CfgFile != "" {
-		if fd, err := os.Open(CfgFile); err != nil {
-			logrus.WithError(err).Fatalf("Cannot access config file (%s)", CfgFile)
-		} else {
-			_ = fd.Close()
-		}
-	}
-
 	opts := CLIOptions{
 		ControllerOptions: controllerOpts,
 		WorkerOptions:     workerOpts,


### PR DESCRIPTION
## Description

Fixes #2791
Fixes #2917 

- Passing "-" as configuration name did not work. This was fixed by removing the config file existence check in config.GetCLIOpts. It should be OK to fail on the actual attempt to read the file instead of reading the file to see if it's readable before actually reading it.
- The `k0s config validate` did not use the `--config` flag, it validated the RuntimeConfig, which will be the generated default config when k0s is not running, and it shouldn't be possible to apply an invalid config to dynamic config.

## Type of change

<!-- check the related options -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [X] Auto test added

## Checklist:

- [X] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [X] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
