### PR TITLE
[Backport release-1.24] Fix custom CIDRs usage when dynamic config enabled

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -383,7 +383,7 @@ func (c *CmdOpts) startController(ctx context.Context) error {
 	}
 
 	if !stringslice.Contains(c.DisableComponents, constant.CoreDNSComponentname) {
-		coreDNS, err := controller.NewCoreDNS(c.K0sVars, adminClientFactory)
+		coreDNS, err := controller.NewCoreDNS(c.K0sVars, adminClientFactory, c.NodeConfig)
 		if err != nil {
 			return fmt.Errorf("failed to create CoreDNS reconciler: %w", err)
 		}

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -427,7 +427,7 @@ func (c *CmdOpts) startController(ctx context.Context) error {
 	}
 
 	if !stringslice.Contains(c.DisableComponents, constant.KubeletConfigComponentName) {
-		c.ClusterComponents.Add(ctx, controller.NewKubeletConfig(c.K0sVars, adminClientFactory))
+		c.ClusterComponents.Add(ctx, controller.NewKubeletConfig(c.K0sVars, adminClientFactory, c.NodeConfig))
 	}
 
 	if !stringslice.Contains(c.DisableComponents, constant.SystemRbacComponentName) {

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -41,3 +41,4 @@ smoketests := \
 	check-metricscraper \
 	check-customdomain \
 	check-capitalhostnames \
+	check-custom-cidrs \

--- a/inttest/common/util.go
+++ b/inttest/common/util.go
@@ -26,6 +26,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/constant"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -63,6 +64,45 @@ func WaitForKubeRouterReadyWithContext(ctx context.Context, kc *kubernetes.Clien
 
 func waitForKubeRouterReady(kc *kubernetes.Clientset) wait.ConditionWithContextFunc {
 	return waitForDaemonSet(kc, "kube-router")
+}
+
+// WaitForCoreDNSReady waits to see all coredns pods healthy as long as the context isn't canceled.
+// It also waits to see all the related svc endpoints to be ready to make sure coreDNS is actually
+// ready to serve requests.
+func WaitForCoreDNSReady(ctx context.Context, kc *kubernetes.Clientset) error {
+	err := Poll(ctx, waitForDeployment(kc, "coredns"))
+	if err != nil {
+		return err
+	}
+	// Wait till we see the svc endpoints ready
+	return wait.PollImmediateUntilWithContext(ctx, 100*time.Millisecond, func(ctx context.Context) (bool, error) {
+		epSlices, err := kc.DiscoveryV1().EndpointSlices("kube-system").List(ctx, metav1.ListOptions{
+			LabelSelector: "k8s-app=kube-dns",
+		})
+
+		// NotFound is ok, it might not be created yet
+		if err != nil && !apierrors.IsNotFound(err) {
+			return true, err
+		} else if err != nil {
+			return false, nil
+		}
+
+		if len(epSlices.Items) < 1 {
+			return false, nil
+		}
+
+		// Check that all addresses show ready conditions
+		for _, epSlice := range epSlices.Items {
+			for _, endpoint := range epSlice.Endpoints {
+				if !(*endpoint.Conditions.Ready && *endpoint.Conditions.Serving) {
+					// endpoint not ready&serving yet
+					return false, nil
+				}
+			}
+		}
+
+		return true, nil
+	})
 }
 
 func WaitForMetricsReady(c *rest.Config) error {

--- a/inttest/custom-cidrs/customcidrs_test.go
+++ b/inttest/custom-cidrs/customcidrs_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customcidrs
+
+import (
+	"testing"
+
+	"github.com/k0sproject/k0s/inttest/common"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type CustomCIDRsSuite struct {
+	common.FootlooseSuite
+}
+
+const k0sConfig = `
+spec:
+  storage:
+    type: kine
+  network:
+    serviceCIDR: 10.152.184.0/24
+    podCIDR: 10.3.0.0/16
+`
+
+func (s *CustomCIDRsSuite) TestK0sGetsUp() {
+	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfig)
+	// Metrics disabled as it's super slow to get up properly and interferes with API discovery etc. while it's getting up
+	s.Require().NoError(s.InitController(0, "--config=/tmp/k0s.yaml", "--disable-components metrics-server", "--enable-dynamic-config"))
+	s.Require().NoError(s.RunWorkers())
+
+	token, err := s.GetJoinToken("worker")
+	s.Require().NoError(err)
+	s.NoError(s.RunWorkersWithToken(token))
+
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	if err != nil {
+		s.FailNow("failed to obtain Kubernetes client", err)
+	}
+
+	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
+	s.NoError(err)
+
+	err = s.WaitForNodeReady(s.WorkerNode(1), kc)
+	s.NoError(err)
+
+	s.AssertSomeKubeSystemPods(kc)
+
+	s.T().Log("waiting to see kube-router pods ready")
+	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "kube-router did not start")
+
+}
+
+func TestCustomCIDRsSuite(t *testing.T) {
+	s := CustomCIDRsSuite{
+		common.FootlooseSuite{
+			ControllerCount: 1,
+			WorkerCount:     2,
+		},
+	}
+	suite.Run(t, &s)
+}

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -251,10 +251,12 @@ var _ component.ReconcilerComponent = (*CoreDNS)(nil)
 
 // CoreDNS is the component implementation to manage CoreDNS
 type CoreDNS struct {
+	K0sVars    constant.CfgVars
+	NodeConfig *v1beta1.ClusterConfig
+
 	client                 kubernetes.Interface
 	log                    *logrus.Entry
 	manifestDir            string
-	K0sVars                constant.CfgVars
 	previousConfig         coreDNSConfig
 	stopFunc               context.CancelFunc
 	lastKnownClusterConfig *v1beta1.ClusterConfig
@@ -269,7 +271,7 @@ type coreDNSConfig struct {
 }
 
 // NewCoreDNS creates new instance of CoreDNS component
-func NewCoreDNS(k0sVars constant.CfgVars, clientFactory k8sutil.ClientFactoryInterface) (*CoreDNS, error) {
+func NewCoreDNS(k0sVars constant.CfgVars, clientFactory k8sutil.ClientFactoryInterface, nodeConfig *v1beta1.ClusterConfig) (*CoreDNS, error) {
 	manifestDir := path.Join(k0sVars.ManifestsDir, "coredns")
 
 	client, err := clientFactory.GetClient()
@@ -282,6 +284,7 @@ func NewCoreDNS(k0sVars constant.CfgVars, clientFactory k8sutil.ClientFactoryInt
 		log:         log,
 		K0sVars:     k0sVars,
 		manifestDir: manifestDir,
+		NodeConfig:  nodeConfig,
 	}, nil
 }
 
@@ -319,7 +322,7 @@ func (c *CoreDNS) Run(ctx context.Context) error {
 }
 
 func (c *CoreDNS) getConfig(ctx context.Context, clusterConfig *v1beta1.ClusterConfig) (coreDNSConfig, error) {
-	dns, err := clusterConfig.Spec.Network.DNSAddress()
+	dns, err := c.NodeConfig.Spec.Network.DNSAddress()
 	if err != nil {
 		return coreDNSConfig{}, err
 	}

--- a/pkg/component/controller/kubeletconfig.go
+++ b/pkg/component/controller/kubeletconfig.go
@@ -52,15 +52,17 @@ type KubeletConfig struct {
 	kubeClientFactory k8sutil.ClientFactoryInterface
 	k0sVars           constant.CfgVars
 	previousProfiles  v1beta1.WorkerProfiles
+	nodeConfig        *v1beta1.ClusterConfig
 }
 
 // NewKubeletConfig creates new KubeletConfig reconciler
-func NewKubeletConfig(k0sVars constant.CfgVars, clientFactory k8sutil.ClientFactoryInterface) *KubeletConfig {
+func NewKubeletConfig(k0sVars constant.CfgVars, clientFactory k8sutil.ClientFactoryInterface, nodeConfig *v1beta1.ClusterConfig) *KubeletConfig {
 	return &KubeletConfig{
 		log: logrus.WithFields(logrus.Fields{"component": "kubeletconfig"}),
 
 		kubeClientFactory: clientFactory,
 		k0sVars:           k0sVars,
+		nodeConfig:        nodeConfig,
 	}
 }
 
@@ -122,7 +124,7 @@ func (k *KubeletConfig) defaultProfilesExist(ctx context.Context) (bool, error) 
 }
 
 func (k *KubeletConfig) createProfiles(clusterSpec *v1beta1.ClusterConfig) (*bytes.Buffer, error) {
-	dnsAddress, err := clusterSpec.Spec.Network.DNSAddress()
+	dnsAddress, err := k.nodeConfig.Spec.Network.DNSAddress()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get DNS address for kubelet config: %v", err)
 	}

--- a/pkg/component/controller/kubeletconfig_test.go
+++ b/pkg/component/controller/kubeletconfig_test.go
@@ -32,9 +32,10 @@ import (
 var k0sVars = constant.GetConfig("")
 
 func Test_KubeletConfig(t *testing.T) {
+	cfg := config.DefaultClusterConfig()
 	dnsAddr, _ := cfg.Spec.Network.DNSAddress()
 	t.Run("default_profile_only", func(t *testing.T) {
-		k := NewKubeletConfig(k0sVars, testutil.NewFakeClientFactory())
+		k := NewKubeletConfig(k0sVars, testutil.NewFakeClientFactory(), cfg)
 
 		t.Log("starting to run...")
 		buf, err := k.createProfiles(cfg)
@@ -67,7 +68,7 @@ func Test_KubeletConfig(t *testing.T) {
 		), profile["clusterDomain"])
 	})
 	t.Run("with_user_provided_profiles", func(t *testing.T) {
-		k := defaultConfigWithUserProvidedProfiles(t)
+		k := defaultConfigWithUserProvidedProfiles(t, cfg)
 		buf, err := k.createProfiles(cfg)
 		require.NoError(t, err)
 		manifestYamls := strings.Split(strings.TrimSuffix(buf.String(), "---"), "---")[1:]
@@ -122,8 +123,9 @@ func Test_KubeletConfig(t *testing.T) {
 	})
 }
 
-func defaultConfigWithUserProvidedProfiles(t *testing.T) *KubeletConfig {
-	k := NewKubeletConfig(k0sVars, testutil.NewFakeClientFactory())
+func defaultConfigWithUserProvidedProfiles(t *testing.T, cfg *config.ClusterConfig) *KubeletConfig {
+	k0sVars := constant.GetConfig(t.TempDir())
+	k := NewKubeletConfig(k0sVars, testutil.NewFakeClientFactory(), cfg)
 
 	cfgProfileX := map[string]interface{}{
 		"authentication": map[string]interface{}{


### PR DESCRIPTION
## Description

Backport to `release-1.24`:
* https://github.com/k0sproject/k0s/pull/2874
* #2954

See #2865 
