### PR TITLE
Use mirrors and PGP key verification for iptables

### DIFF
--- a/embedded-bins/iptables/Dockerfile
+++ b/embedded-bins/iptables/Dockerfile
@@ -1,12 +1,26 @@
 ARG BUILDIMAGE
 FROM $BUILDIMAGE AS build
 
-RUN apk add build-base git file curl \
+RUN apk add build-base git file curl gpg gpg-agent gnupg-dirmngr \
 	linux-headers pkgconf bison flex libmnl-dev libmnl-static libnftnl-dev
 
 ARG VERSION
-RUN curl -L https://www.netfilter.org/projects/iptables/files/iptables-$VERSION.tar.bz2 \
-	| tar -C / -jx
+RUN set -eu \
+  && for server in hkps://keyserver.ubuntu.com hkps://pgp.surf.nl hkp://pgp.rediris.es; do \
+    if gpg --keyserver "$server" --keyserver-options timeout=10 --recv-keys D55D978A8A1420E4; then \
+      break; \
+    fi; \
+  done \
+  && for file in iptables-$VERSION.tar.bz2 iptables-$VERSION.tar.bz2.sig; do \
+    for mirror in https://www.netfilter.org/projects/iptables/files https://web.archive.org/web/9999id_/https://www.netfilter.org/projects/iptables/files; do \
+      if curl -Lfo "$file" --retry 3 --connect-timeout 10 --max-time 120 -- "$mirror/$file"; then \
+        break; \
+      fi; \
+    done; \
+  done \
+  && gpg --verify iptables-$VERSION.tar.bz2.sig \
+  && tar xf iptables-$VERSION.tar.bz2 \
+  && echo Done!
 
 ARG TARGET_OS
 RUN cd /iptables-$VERSION && \


### PR DESCRIPTION
## Description

netfilter.org is currently unavailable. Mitigate this by trying a list of mirrors and check the PGP signature for the downloaded file.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings