### PR TITLE
[Backport release-1.24] Use FORCE_HOST_GO=y when building Kubernetes

### DIFF
--- a/embedded-bins/kubernetes/Dockerfile
+++ b/embedded-bins/kubernetes/Dockerfile
@@ -23,6 +23,7 @@ RUN \
 	if [ ${BUILD_GO_CGO_ENABLED:-0} -eq 1 ]; then \
 		export KUBE_CGO_OVERRIDES="${COMMANDS}"; \
 	fi; \
+	export FORCE_HOST_GO=y; \
 	for cmd in $COMMANDS; do \
 		export KUBE_GIT_VERSION="v$VERSION+k0s"; \
 		make GOFLAGS="${BUILD_GO_FLAGS} -tags=${BUILD_GO_TAGS}" GOLDFLAGS="${BUILD_GO_LDFLAGS_EXTRA}" WHAT=cmd/$cmd; \


### PR DESCRIPTION
Backport to `release-1.24`:
* #2935

See:
* #2901