### PR TITLE
Use separate buffers for stdout&err in streams for pod exec in smokes

### DIFF
--- a/inttest/common/pod.go
+++ b/inttest/common/pod.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"bytes"
+	"fmt"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -47,14 +48,16 @@ func PodExecCmdOutput(client kubernetes.Interface, config *restclient.Config, po
 		return "", err
 	}
 
-	var b bytes.Buffer
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
 	err = exec.Stream(remotecommand.StreamOptions{
-		Stdout: &b,
-		Stderr: &b,
+		Stdout: &stdout,
+		Stderr: &stderr,
 	})
+
 	if err != nil {
-		return b.String(), err
+		return stdout.String(), fmt.Errorf("%w: %s", err, stderr.String())
 	}
 
-	return b.String(), nil
+	return stdout.String(), nil
 }


### PR DESCRIPTION
## Description

Using the same stream for both stdout and stderr causes empty results for even commands that are not failing and are expected to have output. I believe this can happen as the stderr stream is empty, and thus get's quickly to EOF, it stops (or otherwise closes) the stream copying.

This will fix some of the flakyness seen in tests such as: https://github.com/k0sproject/k0s/actions/runs/4573945438/jobs/8076046841

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings