### PR TITLE
Chore: small unit-tests fix

### DIFF
--- a/pkg/component/controller/metricserver_test.go
+++ b/pkg/component/controller/metricserver_test.go
@@ -29,22 +29,22 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var cfg = v1beta1.DefaultClusterConfig()
-
 func TestGetConfigWithZeroNodes(t *testing.T) {
+	cfg := v1beta1.DefaultClusterConfig()
 	k0sVars := constant.GetConfig(t.TempDir())
 	fakeFactory := testutil.NewFakeClientFactory()
 	ctx := context.Background()
 
 	metrics := NewMetricServer(k0sVars, fakeFactory)
 	require.NoError(t, metrics.Reconcile(ctx, cfg))
-	cfg, err := metrics.getConfig(ctx)
+	metricsCfg, err := metrics.getConfig(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "10m", cfg.CPURequest)
-	require.Equal(t, "30M", cfg.MEMRequest)
+	require.Equal(t, "10m", metricsCfg.CPURequest)
+	require.Equal(t, "30M", metricsCfg.MEMRequest)
 }
 
 func TestGetConfigWithSomeNodes(t *testing.T) {
+	cfg := v1beta1.DefaultClusterConfig()
 	k0sVars := constant.GetConfig(t.TempDir())
 	fakeFactory := testutil.NewFakeClientFactory()
 	fakeClient, _ := fakeFactory.GetClient()
@@ -62,8 +62,8 @@ func TestGetConfigWithSomeNodes(t *testing.T) {
 
 	metrics := NewMetricServer(k0sVars, fakeFactory)
 	require.NoError(t, metrics.Reconcile(ctx, cfg))
-	cfg, err := metrics.getConfig(ctx)
+	metricsCfg, err := metrics.getConfig(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "100m", cfg.CPURequest)
-	require.Equal(t, "300M", cfg.MEMRequest)
+	require.Equal(t, "100m", metricsCfg.CPURequest)
+	require.Equal(t, "300M", metricsCfg.MEMRequest)
 }


### PR DESCRIPTION
## Description

Global var can by accidentally used in other tests

Fixes #2953

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings