### PR TITLE
Bump Go version to v1.19.8

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.16
 alpine_patch_version = $(alpine_version).3
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.19.7
+go_version = 1.19.8
 
 runc_version = 1.1.5
 runc_buildimage = $(golang_buildimage)


### PR DESCRIPTION
## Description

go1.19.8 (released 2023-04-04) includes security fixes to the go/parser, html/template, mime/multipart, net/http, and net/textproto packages, as well as bug fixes to the linker, the runtime, and the time package
