### PR TITLE
Go version bump 1.20.3

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.17
 alpine_patch_version = $(alpine_version).3
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.20.2
+go_version = 1.20.3
 
 runc_version = 1.1.5
 runc_buildimage = $(golang_buildimage)


### PR DESCRIPTION
## Description
Go version bump.

More context https://groups.google.com/g/golang-announce/c/71Wg3N0IZk0/m/xchF2bEZAgAJ
