### PR TITLE
[release-1.24] Bump Go version to v1.19.8

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,4 +1,4 @@
-go_version = 1.19.7
+go_version = 1.19.8
 
 runc_version = 1.1.5
 runc_buildimage = golang:$(go_version)-alpine3.16


### PR DESCRIPTION
backport to release-1.24, triggered by a label in https://github.com/k0sproject/k0s/pull/2969.