### PR TITLE
Restructure kubectl plugin execution

### DIFF
--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -89,6 +89,13 @@ func NewK0sKubectlCmd() *cobra.Command {
 	cmd := kubectl.NewDefaultKubectlCommandWithArgs(args)
 	cmd.Aliases = []string{"kc"}
 
+	// The basic kubectl command will never accept any arguments. This will be
+	// handled more or less automatically by Cobra when used as a root command.
+	// When run as a subcommand, Cobra will instead pass all of the arguments to
+	// the command's run methods, which will trigger some unexpected output.
+	// Address this by specifying NoArgs for the kubectl command.
+	cmd.Args = cobra.NoArgs
+
 	// Get handle on the original kubectl prerun so we can call it later
 	originalPreRunE := cmd.PersistentPreRunE
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/k0sproject/k0s/pkg/config"
 
@@ -29,9 +30,11 @@ import (
 	"k8s.io/component-base/logs"
 	kubectl "k8s.io/kubectl/pkg/cmd"
 	"k8s.io/kubectl/pkg/cmd/plugin"
+	kubectlutil "k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
 )
 
 func checkKubectlInPath() {
@@ -64,81 +67,105 @@ func (h *kubectlPluginHandler) Execute(executablePath string, cmdArgs, environme
 }
 
 func NewK0sKubectlCmd() *cobra.Command {
-	var idx int
-	for i, arg := range os.Args {
-		if arg == "kubectl" || arg == "kc" {
-			idx = i
-			break
-		}
-	}
-
-	args := kubectl.KubectlOptions{
+	// Create a new kubectl command without a plugin handler.
+	kubectlCmd := kubectl.NewKubectlCommand(kubectl.KubectlOptions{
 		IOStreams: genericclioptions.IOStreams{
 			In:     os.Stdin,
 			Out:    os.Stdout,
 			ErrOut: os.Stderr,
 		},
-		Arguments: os.Args[idx:],
-		PluginHandler: &kubectlPluginHandler{
-			DefaultPluginHandler: kubectl.DefaultPluginHandler{
-				ValidPrefixes: plugin.ValidPluginFilenamePrefixes,
-			},
-		},
-	}
-
-	cmd := kubectl.NewDefaultKubectlCommandWithArgs(args)
-	cmd.Aliases = []string{"kc"}
-
-	// The basic kubectl command will never accept any arguments. This will be
-	// handled more or less automatically by Cobra when used as a root command.
-	// When run as a subcommand, Cobra will instead pass all of the arguments to
-	// the command's run methods, which will trigger some unexpected output.
-	// Address this by specifying NoArgs for the kubectl command.
-	cmd.Args = cobra.NoArgs
+	})
+	kubectlCmd.Aliases = []string{"kc"}
 
 	// Add some additional kubectl flags:
-	persistentFlags := cmd.PersistentFlags()
+	persistentFlags := kubectlCmd.PersistentFlags()
 	logs.AddFlags(persistentFlags)                         // This is done by k8s.io/component-base/cli
 	persistentFlags.AddFlagSet(config.GetKubeCtlFlagSet()) // This is k0s specific
 
-	// Get handle on the original kubectl prerun so we can call it later
-	originalPreRunE := cmd.PersistentPreRunE
-	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+	hookKubectlPluginHandler(kubectlCmd)
+	patchPluginListSubcommand(kubectlCmd)
+
+	return kubectlCmd
+}
+
+// hookKubectlPluginHandler patches the kubectl command in a way that it will
+// execute kubectl's plugin handler before actually executing the command.
+func hookKubectlPluginHandler(kubectlCmd *cobra.Command) {
+	// Intercept kubectl's flag error func, so that kubectl plugins may be
+	// handled properly, e.g. so that `k0s kc foo --bar` works as expected when
+	// there's a `kubectl-foo` plugin installed.
+	originalFlagErrFunc := kubectlCmd.FlagErrorFunc()
+	kubectlCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		handleKubectlPlugins(kubectlCmd)
+		return originalFlagErrFunc(cmd, err)
+	})
+
+	// Intercept kubectl's PreRunE, so that generic k0s flags are honored and
+	// kubectl plugins may be handled properly, e.g. so that `k0s kc foo bar`
+	// works as expected when there's a `kubectl-foo` plugin installed.
+	originalPreRunE := kubectlCmd.PersistentPreRunE
+	kubectlCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		handleKubectlPlugins(kubectlCmd)
+
+		// The basic kubectl command will never accept any arguments. This will
+		// be handled more or less automatically by Cobra when used as a root
+		// command. When run as a subcommand, Cobra will instead pass all of the
+		// arguments to the command's run methods, which will trigger some
+		// unexpected output. Address this by specifying NoArgs for the kubectl
+		// command.
+		if cmd == kubectlCmd {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				return err
+			}
+		}
+
 		// In vanilla kubectl, log initialization and flushing is handled by
 		// k8s.io/component-base/cli. But k0s doesn't use it, so it needs to
 		// deal with that manually.
 		logs.InitLogs()
 		cobra.OnFinalize(logs.FlushLogs)
 
-		if err := fallbackToK0sKubeconfig(cmd); err != nil {
+		if err := config.CallParentPersistentPreRun(kubectlCmd, args); err != nil {
 			return err
 		}
 
-		if err := config.CallParentPersistentPreRun(cmd, args); err != nil {
+		if err := fallbackToK0sKubeconfig(cmd); err != nil {
 			return err
 		}
 
 		return originalPreRunE(cmd, args)
 	}
+}
 
-	originalRun := cmd.Run
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		defer logs.FlushLogs() // This is done by k8s.io/component-base/cli
-
-		if len(args) > 0 {
-			if err := kubectl.HandlePluginCommand(&kubectlPluginHandler{}, args); err != nil {
-				// note: the plugin exec will replace the k0s process and exit on it's own,
-				// the error here is a failure to exec, not the error-exit of the plugin.
-				return fmt.Errorf("kubectl plugin handler failed: %w", err)
-			}
-		}
-
-		originalRun(cmd, args)
-
-		return nil
+// handleKubectlPlugins calls kubectl's plugin handler and execs the plugin
+// without returning if there's any plugin available that handles the given
+// command line arguments. Will simply return otherwise.
+func handleKubectlPlugins(kubectlCmd *cobra.Command) {
+	// Check how the kubectl command has been called on the command line.
+	calledAs := kubectlCmd.CalledAs()
+	if calledAs == "" {
+		return
 	}
 
-	return cmd
+	// Find the first occurrence of the kubectl command on the command line.
+	argOffset := slices.Index(os.Args, calledAs)
+	if argOffset < 0 {
+		return
+	}
+
+	_ = kubectl.NewDefaultKubectlCommandWithArgs(kubectl.KubectlOptions{
+		IOStreams: genericclioptions.IOStreams{
+			In:     kubectlCmd.InOrStdin(),
+			Out:    kubectlCmd.OutOrStdout(),
+			ErrOut: kubectlCmd.ErrOrStderr(),
+		},
+		Arguments: os.Args[argOffset:],
+		PluginHandler: &kubectlPluginHandler{
+			kubectl.DefaultPluginHandler{
+				ValidPrefixes: plugin.ValidPluginFilenamePrefixes,
+			},
+		},
+	})
 }
 
 func fallbackToK0sKubeconfig(cmd *cobra.Command) error {
@@ -168,4 +195,28 @@ func fallbackToK0sKubeconfig(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to set kubeconfig flag: %w", err)
 	}
 	return nil
+}
+
+// patchPluginListSubcommand patches kubectl's "plugin list" command in a way
+// that it will look at the kubectl command, not at the k0s command for
+// detecting shadowed commands. Kubectl's current implementation of that command
+// looks at the root command for detecting collisions. In case of k0s, which
+// embeds kubectl as a subcommand rather than at the top level, this means that,
+// instead of looking at kubectl command itself, the logic would look at k0s and
+// produce the wrong output.
+func patchPluginListSubcommand(kubectlCmd *cobra.Command) {
+	cmd, _, err := kubectlCmd.Find([]string{"plugin", "list"})
+	kubectlutil.CheckErr(err)
+
+	originalRun := cmd.Run
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		// Create a dummy kubectl command to be passed as the root command and
+		// to be used for command lookups.
+		root := kubectl.NewKubectlCommand(kubectl.KubectlOptions{})
+		// Best effort of faking the command name. Cobra will split this on
+		// spaces, hence use dashes instead. This won't be absolutely correct,
+		// but good enough for error reporting on stderr.
+		root.Use = strings.ReplaceAll(kubectlCmd.CommandPath(), " ", "-")
+		originalRun(root, args)
+	}
 }

--- a/inttest/common/filetools.go
+++ b/inttest/common/filetools.go
@@ -75,6 +75,5 @@ func (s *FootlooseSuite) MakeDir(node, path string) {
 	ssh, err := s.SSH(s.Context(), node)
 	s.Require().NoError(err)
 	defer ssh.Disconnect()
-	_, err = ssh.ExecWithOutput(s.Context(), fmt.Sprintf("mkdir %s", path))
-	s.Require().NoError(err)
+	s.Require().NoError(ssh.Exec(s.Context(), fmt.Sprintf("mkdir -p -- %q", path), SSHStreams{}))
 }

--- a/inttest/kubectl/kubectl_test.go
+++ b/inttest/kubectl/kubectl_test.go
@@ -20,8 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
-	"strings"
 	"testing"
 
 	"github.com/k0sproject/k0s/inttest/common"
@@ -29,119 +27,128 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/crypto/ssh"
 )
 
 type KubectlSuite struct {
 	common.FootlooseSuite
 }
 
-const pluginContent = `#!/usr/bin/env sh
+const pluginContent = `#!/bin/sh
 
-echo foo-plugin
+echo "${0##*/}" "$#" "$@"
 `
 
 func (s *KubectlSuite) TestEmbeddedKubectl() {
-	s.Require().NoError(s.InitController(0))
-	s.PutFile(s.ControllerNode(0), "/bin/kubectl-foo", pluginContent)
-
-	ssh, err := s.SSH(s.Context(), s.ControllerNode(0))
+	sshConn, err := s.SSH(s.Context(), s.ControllerNode(0))
 	s.Require().NoError(err, "failed to SSH into controller")
-	defer ssh.Disconnect()
+	defer sshConn.Disconnect()
 
-	_, err = ssh.ExecWithOutput(s.Context(), "chmod +x /bin/kubectl-foo")
-	s.Require().NoError(err)
-	_, err = ssh.ExecWithOutput(s.Context(), "ln -s /usr/local/bin/k0s /usr/bin/kubectl")
-	s.Require().NoError(err)
+	// Create a dummy kubectl plugin for testing
+	s.MakeDir(s.ControllerNode(0), "/inttest/bin")
+	s.PutFile(s.ControllerNode(0), "/inttest/bin/kubectl-foo", pluginContent)
+
+	// Create the kubectl symlink and make plugins executable
+	s.Require().NoError(sshConn.Exec(s.Context(), `
+		mkdir /inttest/symlink &&
+		ln -s /usr/local/bin/k0s /inttest/symlink/kubectl &&
+		chmod +x /inttest/bin/kubectl-*
+	`, common.SSHStreams{}))
+
+	s.Require().NoError(s.InitController(0))
 
 	s.T().Log("Check that different ways to call kubectl subcommand work")
 
 	callingConventions := []struct {
-		name string
-		cmd  []string
+		name    string
+		cmdline string
 	}{
-		{"full_subcommand", []string{"/usr/local/bin/k0s", "kubectl"}},
-		{"short_subcommand", []string{"/usr/local/bin/k0s", "kc"}},
-		{"symlink", []string{"/usr/bin/kubectl"}},
+		{"full_subcommand", "/usr/local/bin/k0s kubectl"},
+		{"short_subcommand", "/usr/local/bin/k0s kc"},
+		{"symlink", "/inttest/symlink/kubectl"},
 	}
 
 	subcommands := []struct {
-		name  string
-		cmd   []string
-		check func(t *testing.T, output string)
+		name    string
+		cmdline string
+		check   func(t *testing.T, stdout, stderr string, err error)
 	}{
-		{"plain", nil, func(t *testing.T, output string) {
-			assert.Contains(t, output, `kubectl controls the Kubernetes cluster manager.`)
+		{"plain", "%s", func(t *testing.T, stdout, stderr string, err error) {
+			assert.NoError(t, err)
+			assert.Contains(t, stdout, "kubectl controls the Kubernetes cluster manager.\n")
+			assert.Empty(t, stderr)
 		}},
 
-		{"JSON_version", []string{"version", "--output=json"}, func(t *testing.T, output string) {
+		{"JSON_version", "%s version --output=json", func(t *testing.T, stdout, stderr string, err error) {
+			assert.NoError(t, err)
 			var versions map[string]any
-			require.NoError(t, json.Unmarshal([]byte(output), &versions))
+			require.NoError(t, json.Unmarshal([]byte(stdout), &versions))
 			checkClientVersion(t, requiredValue[map[string]any](t, versions, "clientVersion"))
 			checkServerVersion(t, requiredValue[map[string]any](t, versions, "serverVersion"))
+			assert.Empty(t, stderr)
 		}},
 
-		{"plugin_loader", []string{"foo"}, func(t *testing.T, output string) {
-			assert.Equal(t, "foo-plugin", output)
+		{"plugin_list", "%s plugin list --name-only", func(t *testing.T, stdout, stderr string, err error) {
+			assert.NoError(t, err)
+			assert.Equal(t, "The following compatible plugins are available:\n\nkubectl-foo\n", stdout)
+			assert.Empty(t, stderr)
+		}},
+
+		{"plugin_loader_foo", "%s foo", func(t *testing.T, stdout, stderr string, err error) {
+			assert.NoError(t, err)
+			assert.Equal(t, "kubectl-foo 0\n", stdout)
+			assert.Empty(t, stderr)
+		}},
+		{"plugin_loader_foo_bar", "%s foo bar", func(t *testing.T, stdout, stderr string, err error) {
+			assert.NoError(t, err)
+			assert.Equal(t, "kubectl-foo 1 bar\n", stdout)
+			assert.Empty(t, stderr)
+		}},
+		{"plugin_loader_foo_bar_arg", "%s foo --bar", func(t *testing.T, stdout, stderr string, err error) {
+			assert.NoError(t, err)
+			assert.Equal(t, "kubectl-foo 1 --bar\n", stdout)
+			assert.Empty(t, stderr)
+		}},
+		{"plugin_loader_bar_arg_foo", "%s --bar foo", func(t *testing.T, stdout, stderr string, err error) {
+			var exitErr *ssh.ExitError
+			if assert.ErrorAs(t, err, &exitErr, "Error doesn't have an exit code") {
+				assert.Equal(t, 1, exitErr.ExitStatus(), "Exit code mismatch")
+			}
+			assert.Empty(t, stdout)
+			assert.Equal(t, "Error: unknown flag: --bar\nSee 'k0s kubectl --help' for usage.\n", stderr)
+		}},
+
+		// This test executes without having kubectl in PATH
+		{"plugin_loader_symlink_warning", "PATH=/inttest/bin %s foo", func(t *testing.T, stdout, stderr string, err error) {
+			assert.NoError(t, err)
+			assert.Equal(t, "kubectl-foo 0\n", stdout)
+			assert.Contains(t, stderr, "You can use k0s as a drop-in replacement")
 		}},
 	}
 
 	for _, callingConvention := range callingConventions {
 		for _, subcommand := range subcommands {
 			s.T().Run(fmt.Sprint(callingConvention.name, "_", subcommand.name), func(t *testing.T) {
-				cmd := strings.Join(append(callingConvention.cmd, subcommand.cmd...), " ")
+				cmd := fmt.Sprintf(subcommand.cmdline, callingConvention.cmdline)
+				cmd = fmt.Sprintf("PATH=/inttest/bin:/inttest/symlink %s", cmd)
 				t.Log("Executing", cmd)
-				output, err := ssh.ExecWithOutput(s.Context(), cmd)
+
+				var stdoutBuf bytes.Buffer
+				var stderrBuf bytes.Buffer
+				err := sshConn.Exec(s.Context(), cmd, common.SSHStreams{Out: &stdoutBuf, Err: &stderrBuf})
+				stdout, stderr := stdoutBuf.String(), stderrBuf.String()
 				t.Cleanup(func() {
 					if t.Failed() {
 						t.Log("Error: ", err)
-						t.Log("Output: ", output)
+						t.Log("Stdout: ", stdout)
+						t.Log("Stderr: ", stderr)
 					}
 				})
-				assert.NoError(t, err)
-				subcommand.check(t, output)
+
+				subcommand.check(t, stdout, stderr, err)
 			})
 		}
 	}
-
-	s.T().Run("plugin list", func(t *testing.T) {
-		require := require.New(t)
-
-		s.PutFile(s.ControllerNode(0), "/bin/kubectl-testplug", "#!/bin/sh\necho \"testplug called with args: $*\"\n")
-		_, err := ssh.ExecWithOutput(s.Context(), "chmod +x /bin/kubectl-testplug")
-		require.NoError(err)
-
-		output, err := ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s kubectl plugin list")
-		require.NoError(err)
-		require.Contains(output, "kubectl-testplug")
-	})
-
-	s.T().Run("plugin arg passing", func(t *testing.T) {
-		out, err := ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s kubectl testplug hello")
-		s.Require().NoError(err)
-		s.Require().Contains(out, "testplug called with args: hello")
-
-		out, err = ssh.ExecWithOutput(s.Context(), "kubectl testplug --help")
-		s.Require().NoError(err)
-		s.Require().Equal("testplug called with args: --help", out)
-	})
-
-	// Try with kubectl symlink, a warning should not be printed
-	var errOut bytes.Buffer
-	streams := common.SSHStreams{In: nil, Out: io.Discard, Err: &errOut}
-	s.Require().NoError(ssh.Exec(s.Context(), "/usr/local/bin/k0s kubectl testplug hello", streams))
-	s.Require().NotContains(errOut.String(), "You can use k0s as a drop-in replacement")
-
-	// Try without kubectl symlink, a warning should be printed
-	_, err = ssh.ExecWithOutput(s.Context(), "rm -f /usr/bin/kubectl /bin/kubectl /usr/local/bin/kubectl")
-	s.Require().NoError(err)
-	_, err = ssh.ExecWithOutput(s.Context(), "command -v kubectl")
-	s.Require().Error(err)
-	errOut.Reset()
-	s.Require().NoError(ssh.Exec(s.Context(), "/usr/local/bin/k0s kubectl testplug hello", streams))
-	s.Require().Contains(errOut.String(), "You can use k0s as a drop-in replacement")
-
-	// restore link for any other tests
-	_, _ = ssh.ExecWithOutput(s.Context(), "ln -s /usr/local/bin/k0s /usr/bin/kubectl")
 }
 
 func requiredValue[V any](t *testing.T, obj map[string]any, key string) V {

--- a/inttest/kubectl/kubectl_test.go
+++ b/inttest/kubectl/kubectl_test.go
@@ -88,6 +88,15 @@ func (s *KubectlSuite) TestEmbeddedKubectl() {
 			assert.Empty(t, stderr)
 		}},
 
+		{"unknown_subcommand", "%s i-dont-exist", func(t *testing.T, stdout, stderr string, err error) {
+			var exitErr *ssh.ExitError
+			if assert.ErrorAs(t, err, &exitErr, "Error doesn't have an exit code") {
+				assert.Equal(t, 1, exitErr.ExitStatus(), "Exit code mismatch")
+			}
+			assert.Empty(t, stdout)
+			assert.Equal(t, "Error: unknown command \"i-dont-exist\" for \"k0s kubectl\"\n", stderr)
+		}},
+
 		{"plugin_list", "%s plugin list --name-only", func(t *testing.T, stdout, stderr string, err error) {
 			assert.NoError(t, err)
 			assert.Equal(t, "The following compatible plugins are available:\n\nkubectl-foo\n", stdout)


### PR DESCRIPTION
## Description

This PR will enable better integration with kubectl plugins and will prepare k0s for [KEP-3638](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/3638-kubectl-plugin-subcommands/README.md). See #2879.

K0s used the `NewDefaultKubectlCommandWithArgs` function to obtain a kubelet command to be embedded into k0s. That function merely executes its plugin logic unconditionally, i.e. it won't wait until that command is being executed by Cobra. This lead to a situation in which kubectl plugins not only shadowed kubectl commands, but also k0s commands. An inttest was added to prove that, before this change, an executable named `kubectl-airgap` would effectively replace the builtin `k0s airgap` command.

Address this by using a two-pass approach when executing the embedded kubectl command. First, during the Cobra bootstrap phase, call `NewKubectlCommand` to create a Cobra command without triggering the plugin execution logic. Then patch the command's callbacks, so that when the command is _actually_ invoked by Cobra, the `NewDefaultKubectlCommandWithArgs` function is called. That function will execute plugins and never return, if any. Otherwise it will just return a new Cobra command, which k0s will simply discard and use the previously created one.

Also don't print kubectl usage on unknown subcommands. The basic kubectl command will never accept any arguments. This will be handled more or less automatically by Cobra when used as a root command. When run as a subcommand, Cobra will instead pass all of the arguments to the command's run methods, which will trigger some unexpected output. Address this by specifying `cobra.NoArgs` for the kubectl command.

Reorder persistent flag registration for `k0s kc`, so that they are grouped together. Also add `InitLogs`/`FlushLogs`, which is done by k8s.io/component-base/cli, which k0s doesn't use.

Streamline kubectl integration test: The common test matrix wasn't checking for stderr contents so far. Address this by capturing both stdout and stderr when executing the test commands and forward those along with the execution error to the check function. Add asserts for stderr contents to all the tests in the matrix. Moreover, the integration test environment wasn't completely isolated. For example, the support-bundle plugin that's installed in the footloose image was leaking into the test setup. Address this by setting up a private PATH and use that when invoking the test commands. That way, the plugin-list and symlink-warning test cases can be integrated into the common test matrix as well.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings