### PR TITLE
Add 1.27.0 API removals

### DIFF
--- a/static/misc/api-resources.yaml
+++ b/static/misc/api-resources.yaml
@@ -226,6 +226,10 @@
   kind: FlowControl
   removed_in: v1.26.0
   version: v1beta1
+- group: storage.k8s.io
+  kind: CSIStorageCapacity
+  removed_in: v1.27.0
+  version: v1beta1
 
 # This is used solely for integration testing.
 - group: autopilot.k0sproject.io


### PR DESCRIPTION

## Description

The only documented API removal is for CSIStorageCapacity.storage.k8s.io/v1beta1 https://kubernetes.io/blog/2023/04/11/kubernetes-v1-27-release/#deprecations-and-removals


See https://github.com/k0sproject/k0s/issues/2879

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings