### PR TITLE
Fix mkdoc-material to use custom colours from our CSS

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,8 @@ theme:
   logo: img/k0s_social.png
   palette:
     - scheme: default
+      primary: custom
+      accent: custom
       toggle:
         icon: material/toggle-switch
         name: Switch to light mode


### PR DESCRIPTION
## Description

Mkdocs-material changed the way custom CSS colours are taken into use starting from 9.1.7. This PR fixes that by explicitly saying to mkdocs to use `custom` colours.

For reference see https://github.com/squidfunk/mkdocs-material/discussions/5424#discussioncomment-5728139

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings