### PR TITLE
[Backport release-1.24] Bump Go to v1.19.9

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,4 +1,4 @@
-go_version = 1.19.8
+go_version = 1.19.9
 
 runc_version = 1.1.6
 runc_buildimage = golang:$(go_version)-alpine3.16


### PR DESCRIPTION
Backport to `release-1.24`:
* #3061

See:
* #3059