### PR TITLE
[Backport release-1.26] Helm upgrade bug fix

### DIFF
--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -62,7 +62,7 @@ func (as *AddonsSuite) TestHelmBasedAddons() {
 		},
 	}
 	as.doTestAddonUpdate(addonName, values)
-	chart := as.waitForTestRelease(addonName, "0.4.0", 2)
+	chart := as.waitForTestRelease(addonName, "0.6.0", 2)
 	as.Require().NoError(as.checkCustomValues(chart.Status.ReleaseName))
 	as.doPrometheusDelete(chart)
 }
@@ -174,7 +174,7 @@ func (as *AddonsSuite) doTestAddonUpdate(addonName string, values map[string]int
 			Name:      "test-addon",
 			ChartName: "ealenn/echo-server",
 			Values:    string(valuesBytes),
-			Version:   "0.4.0",
+			Version:   "0.5.0",
 			TargetNS:  "default",
 		},
 	}

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -266,7 +266,7 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart v1bet
 		if cr.chartNeedsUpgrade(chart) {
 			// update
 			chartRelease, err = cr.helm.UpgradeChart(chart.Spec.ChartName,
-				chart.Status.Version,
+				chart.Spec.Version,
 				chart.Status.ReleaseName,
 				chart.Status.Namespace,
 				chart.Spec.YamlValues(),


### PR DESCRIPTION
Backport to release-1.26, triggered by a label in https://github.com/k0sproject/k0s/pull/3082.
See https://github.com/k0sproject/k0s/issues/3071.