### PR TITLE
Use verbose logging in conformance tests run to qualify for k8s-conformance repository requirements

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -62,6 +62,7 @@ check-network: bin/sonobuoy
 check-conformance: bin/sonobuoy
 	$(realpath bin/sonobuoy) run --wait=1200 \
 		--mode=certified-conformance \
+		--plugin-env=e2e.E2E_EXTRA_ARGS="--ginkgo.v" \
 		--kubernetes-version=v$(kubernetes_version)
 
 get-conformance-results: bin/sonobuoy

--- a/inttest/sonobuoy/README.md
+++ b/inttest/sonobuoy/README.md
@@ -151,6 +151,7 @@ Example Output:
 ➜ make check-conformance
 /home/ubuntu/k0s/inttest/bin/sonobuoy run --wait=1200 \
         --mode=certified-conformance \
+        --plugin-env=e2e.E2E_EXTRA_ARGS="--ginkgo.v" \
         --kubernetes-version=v1.27.1
 INFO[0000] create request issued                         name=sonobuoy namespace= resource=namespaces
 INFO[0000] create request issued                         name=sonobuoy-serviceaccount namespace=sonobuoy resource=serviceaccounts

--- a/inttest/toolsuite/tests/conformance_test.go
+++ b/inttest/toolsuite/tests/conformance_test.go
@@ -53,6 +53,7 @@ func TestConformanceSuite(t *testing.T) {
 				tsops.SonobuoyConfig{
 					Parameters: []string{
 						"--mode=certified-conformance",
+						"--plugin-env=e2e.E2E_EXTRA_ARGS=\"--ginkgo.v\"",
 						fmt.Sprintf("--kubernetes-version=%s", config.KubernetesVersion),
 					},
 				},


### PR DESCRIPTION
The repo [k8s-confo](https://github.com/cncf/k8s-conformance) expects the full verbose log to be sent as a part of the PR but the default setting for conformance tests runner have been changed. To qualify we need to explicitly pass verbose argument to test runner.