### PR TITLE
Make multicontroller inttest be fail-fast

### DIFF
--- a/inttest/multicontroller/multicontroller_test.go
+++ b/inttest/multicontroller/multicontroller_test.go
@@ -34,27 +34,29 @@ func (s *MultiControllerSuite) TestK0sGetsUp() {
 	s.T().Logf("ip address: %s", ipAddress)
 
 	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
-	s.NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
+	s.Require().NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
 
 	token, err := s.GetJoinToken("controller")
 	s.Require().NoError(err)
 	s.PutFile(s.ControllerNode(1), "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
-	s.NoError(s.InitController(1, "--config=/tmp/k0s.yaml", token))
+	s.Require().NoError(s.InitController(1, "--config=/tmp/k0s.yaml", token))
 
 	s.PutFile(s.ControllerNode(2), "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithMultiController, ipAddress))
-	s.NoError(s.InitController(2, "--config=/tmp/k0s.yaml", token))
-	s.NoError(s.RunWorkers())
+	s.Require().NoError(s.InitController(2, "--config=/tmp/k0s.yaml", token))
+	s.Require().NoError(s.RunWorkers())
 
 	kc, err := s.KubeClient(s.ControllerNode(0))
 	s.Require().NoError(err)
 
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
-	s.NoError(err)
+	s.Require().NoError(err)
 
-	s.AssertSomeKubeSystemPods(kc)
+	if !s.AssertSomeKubeSystemPods(kc) {
+		return
+	}
 
 	s.T().Log("waiting to see CNI pods ready")
-	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "CNI did not start")
+	s.Require().NoError(common.WaitForKubeRouterReady(s.Context(), kc), "CNI did not start")
 }
 
 func TestMultiControllerSuite(t *testing.T) {


### PR DESCRIPTION
## Description

This is to prevent noisy subsequent test error logs.

Example: https://github.com/k0sproject/k0s/actions/runs/4934627217/jobs/8820454009#step:8:292

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings