### PR TITLE
[Backport release-1.24] Clear error in Helm chart status after successful reconciliation

### DIFF
--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -289,6 +289,8 @@ func (cr *ChartReconciler) updateStatus(ctx context.Context, chart v1beta1.Chart
 	chart.Status.Updated = time.Now().String()
 	if err != nil {
 		chart.Status.Error = err.Error()
+	} else {
+		chart.Status.Error = ""
 	}
 	if updErr := cr.Client.Status().Update(ctx, &chart); updErr != nil {
 		cr.L.WithError(updErr).Error("Failed to update status for chart release", chart.Name)


### PR DESCRIPTION
Backport to `release-1.24`:
* #3097

See:
* #3053
* #3045