### PR TITLE
Use filepath.Join directly for Windows UNC paths

### DIFF
--- a/pkg/supervisor/pingpong_windows.go
+++ b/pkg/supervisor/pingpong_windows.go
@@ -51,10 +51,8 @@ func makePingPong(t *testing.T) *pingPong {
 	require.NoError(t, err)
 	namespace := t.Name() + "_" + guid.String()
 
-	// filepath.Clean is broken for Win32 Device Namespaces ...
-	// https://github.com/golang/go/issues/23467
-	pingPath := `\\.\` + filepath.Join("pipe", namespace, "ping")
-	pongPath := `\\.\` + filepath.Join("pipe", namespace, "pong")
+	pingPath := filepath.Join(`\\.\pipe`, namespace, "ping")
+	pongPath := filepath.Join(`\\.\pipe`, namespace, "pong")
 
 	ping, err := winio.ListenPipe(pingPath, nil)
 	require.NoError(t, err, "Failed to listen ping pipe")


### PR DESCRIPTION
## Description

golang/go#23467 has apparently been fixed by [CL 444280](https://go-review.googlesource.com/c/go/+/444280).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings