### PR TITLE
[Backport release-1.26] Bump pymdown-extensions from 9.9.1 to 10.0 in /docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,7 +18,7 @@ MarkupSafe==2.1.1
 mergedeep==1.3.4
 packaging==23.0
 Pygments==2.14.0
-pymdown-extensions==9.9.1
+pymdown-extensions==9.9.2
 pyparsing==3.0.9
 python-dateutil==2.8.2
 PyYAML==6.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,7 +18,7 @@ MarkupSafe==2.1.1
 mergedeep==1.3.4
 packaging==23.0
 Pygments==2.14.0
-pymdown-extensions==9.10
+pymdown-extensions==9.11
 pyparsing==3.0.9
 python-dateutil==2.8.2
 PyYAML==6.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,7 +18,7 @@ MarkupSafe==2.1.1
 mergedeep==1.3.4
 packaging==23.0
 Pygments==2.14.0
-pymdown-extensions==9.11
+pymdown-extensions==10.0
 pyparsing==3.0.9
 python-dateutil==2.8.2
 PyYAML==6.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,7 +18,7 @@ MarkupSafe==2.1.1
 mergedeep==1.3.4
 packaging==23.0
 Pygments==2.14.0
-pymdown-extensions==9.9.2
+pymdown-extensions==9.10
 pyparsing==3.0.9
 python-dateutil==2.8.2
 PyYAML==6.0


### PR DESCRIPTION
Backport to `release-1.26`:
* #2628
* #2860
* #2983
* #3135

See:
* #3123

Fixes CVE-2023-32309.