### PR TITLE
Add missing prerequisites to footlose Docker image

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -31,7 +31,7 @@ footloose_alpine_build_cmdline := \
 	-f footloose-alpine/Dockerfile \
 	footloose-alpine
 
-.footloose-alpine.stamp:
+.footloose-alpine.stamp: $(shell find footloose-alpine -type f)
 	docker build --build-arg TARGETARCH=$(ARCH) $(footloose_alpine_build_cmdline)
 	touch $@
 


### PR DESCRIPTION
## Description

Without it, make won't rebuild the Docker image on changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings