### PR TITLE
[Backport release-1.24] Bump pymdown-extensions from 9.4 to 10.0 in /docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,7 +13,7 @@ mkdocs-material==8.3.8
 mkdocs_material_extensions==1.0.3
 packaging==21.3
 Pygments==2.12
-pymdown_extensions==9.4
+pymdown-extensions==10.0
 pyparsing==3.0.7
 python_dateutil==2.8.2
 PyYAML==6.0


### PR DESCRIPTION
Backport to `release-1.24`:
* #3150

See:
* #2036 (The 9.5 bump)
* #3123

Fixes CVE-2023-32309.