### PR TITLE
[Backport release-1.24] Bump sonobuoy to v0.56.16

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -2,7 +2,7 @@
 ARCH = $(shell go env GOARCH)
 OS = $(shell go env GOOS)
 
-sonobuoy_url = https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.56.6/sonobuoy_0.56.6_$(OS)_$(ARCH).tar.gz
+sonobuoy_url = https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.56.16/sonobuoy_0.56.16_$(OS)_$(ARCH).tar.gz
 
 curl = curl -L --silent
 


### PR DESCRIPTION
## Description

Sonobuoy v0.56.6 points to the old registry which does not have the image for conformance testing required for kubernetes v1.24.14.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings