### PR TITLE
Correctly join PATH on windows

### DIFF
--- a/cmd/ctr/ctr.go
+++ b/cmd/ctr/ctr.go
@@ -17,10 +17,10 @@ limitations under the License.
 package ctr
 
 import (
-	"fmt"
 	"os"
 	"path"
 
+	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/pkg/config"
 
 	"github.com/containerd/containerd/cmd/ctr/app"
@@ -45,9 +45,7 @@ func NewCtrCommand() *cobra.Command {
 			}
 			setDefaultValues(opts.K0sVars.RunDir, containerdCtr.Flags)
 			args := extractCtrCommand(os.Args)
-			newPath := fmt.Sprintf("%s%s%s", opts.K0sVars.BinDir,
-				string(os.PathListSeparator),
-				os.Getenv(pathEnv))
+			newPath := dir.PathListJoin(opts.K0sVars.BinDir, os.Getenv(pathEnv))
 			os.Setenv(pathEnv, newPath)
 			return containerdCtr.Run(args)
 		},

--- a/internal/pkg/dir/dir.go
+++ b/internal/pkg/dir/dir.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 )
 
 // IsDirectory check the given path exists and is a directory
@@ -57,4 +58,9 @@ func Init(path string, perm os.FileMode) error {
 		return err
 	}
 	return os.Chmod(path, perm)
+}
+
+// PathListJoin uses the OS path list separator to join a list of strings for things like PATH=x:y:z
+func PathListJoin(elem ...string) string {
+	return strings.Join(elem, string(os.PathListSeparator))
 }

--- a/internal/pkg/dir/dir_windows_test.go
+++ b/internal/pkg/dir/dir_windows_test.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build windows
+// +build windows
 
 /*
 Copyright 2023 k0s authors
@@ -20,38 +20,12 @@ limitations under the License.
 package dir_test
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
-	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sys/unix"
 )
-
-func TestInit(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	foo := filepath.Join(tmpDir, "foo")
-	require.NoError(t, dir.Init(foo, 0700), "failed to create temp dir foo")
-
-	checkPermissions(t, foo, 0700)
-
-	oldUmask := unix.Umask(0027)
-	t.Cleanup(func() { unix.Umask(oldUmask) })
-
-	bar := filepath.Join(tmpDir, "bar")
-	require.NoError(t, dir.Init(bar, 0755), "failed to create temp dir bar")
-	checkPermissions(t, bar, 0755)
-}
-
-// CheckPermissions checks the correct permissions
-func checkPermissions(t *testing.T, path string, want os.FileMode) {
-	info, err := os.Stat(path)
-	require.NoError(t, err, path)
-	assert.Equalf(t, want, info.Mode().Perm(), "%s has unexpected permissions", path)
-}
 
 func TestPathListJoin(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
@@ -61,6 +35,6 @@ func TestPathListJoin(t *testing.T) {
 		require.Equal(t, "foo", dir.PathListJoin("foo"))
 	})
 	t.Run("multiple", func(t *testing.T) {
-		require.Equal(t, "foo:bar:baz", dir.PathListJoin("foo", "bar", "baz"))
+		require.Equal(t, "foo;bar;baz", dir.PathListJoin("foo", "bar", "baz"))
 	})
 }

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -284,9 +284,11 @@ func getEnv(dataDir, component string, keepEnvPrefix bool) []string {
 				overrides[k] = struct{}{}
 			}
 		}
-		env[i] = fmt.Sprintf("%s=%s", k, v)
-		if k == "PATH" {
-			env[i] = fmt.Sprintf("PATH=%s:%s", path.Join(dataDir, "bin"), v)
+		switch k {
+		case "PATH":
+			env[i] = fmt.Sprintf("PATH=%s", dir.PathListJoin(path.Join(dataDir, "bin"), v))
+		default:
+			env[i] = fmt.Sprintf("%s=%s", k, v)
 		}
 		i++
 	}

--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -122,13 +122,13 @@ func TestGetEnv(t *testing.T) {
 
 	env := getEnv("/var/lib/k0s", "foo", false)
 	sort.Strings(env)
-	expected := "[HTTPS_PROXY=a.b.c:1080 PATH=/var/lib/k0s/bin:/usr/local/bin _K0S_MANAGED=yes k1=v1 k2=foo_v2 k3=foo_v3 k4=v4]"
+	expected := fmt.Sprintf("[HTTPS_PROXY=a.b.c:1080 PATH=/var/lib/k0s/bin%c/usr/local/bin _K0S_MANAGED=yes k1=v1 k2=foo_v2 k3=foo_v3 k4=v4]", os.PathListSeparator)
 	actual := fmt.Sprintf("%s", env)
 	assert.Equal(t, expected, actual)
 
 	env = getEnv("/var/lib/k0s", "foo", true)
 	sort.Strings(env)
-	expected = "[FOO_PATH=/usr/local/bin FOO_k2=foo_v2 FOO_k3=foo_v3 HTTPS_PROXY=a.b.c:1080 PATH=/var/lib/k0s/bin:/bin _K0S_MANAGED=yes k1=v1 k2=v2 k3=v3 k4=v4]"
+	expected = fmt.Sprintf("[FOO_PATH=/usr/local/bin FOO_k2=foo_v2 FOO_k3=foo_v3 HTTPS_PROXY=a.b.c:1080 PATH=/var/lib/k0s/bin%c/bin _K0S_MANAGED=yes k1=v1 k2=v2 k3=v3 k4=v4]", os.PathListSeparator)
 	actual = fmt.Sprintf("%s", env)
 	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
## Description

As go stdlib does not have `path.JoinList` or equivalent, `dir.PathListJoin` was added to make `PATH` joining work correctly across operating systems and the usages were updated to use the function.

## Type of change

<!-- check the related options -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [X] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [X] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [X] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

