### PR TITLE
Improve github workflow embedded binaries caching

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -68,16 +68,25 @@ jobs:
       - name: Terraform Init
         run: terraform init
 
+      - name: Generate embedded binaries cache key
+        id: embedded-bins-hash
+        run: |
+          hash=$(find embedded-bins/ -type f -not -path "embedded-bins/staging/*" -print0 | xargs -0 cat | md5sum | awk '{print $1}')
+          echo "hash=$hash" >> $GITHUB_OUTPUT
+          echo "Generated hash key: $hash"
+
       - name: Cache embedded binaries
         uses: actions/cache@v3
         with:
-          key: ${{ runner.os }}-embedded-bins-linux-${{ hashFiles('embedded-bins/**/*') }}
+          key: linux-embedded-bins-${{ steps.embedded-bins-hash.outputs.hash }}
+          restore-keys: |
+            linux-embedded-bins-
           path: |
             .bins.linux.stamp
             bindata_linux
             embedded-bins/staging/linux/bin/
-            embedded-bins/Makefile.variables
             pkg/assets/zz_generated_offsets_linux.go
+      
       - name: Cache GOCACHE
         uses: actions/cache@v3
         with:
@@ -86,6 +95,7 @@ jobs:
             ${{ runner.os }}-build-gocache-linux-${{ github.ref_name }}-
           path: |
             build/cache/go/build
+     
       - name: Cache GOMODCACHE
         uses: actions/cache@v3
         with:

--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -85,6 +85,7 @@ jobs:
             .bins.linux.stamp
             bindata_linux
             embedded-bins/staging/linux/bin/
+            embedded-bins/Makefile.variables
             pkg/assets/zz_generated_offsets_linux.go
       
       - name: Cache GOCACHE

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -56,15 +56,23 @@ jobs:
       - name: Prepare build environment
         run: .github/workflows/prepare-build-env.sh
 
+      - name: Generate embedded binaries cache key
+        id: embedded-bins-hash
+        run: |
+          hash=$(find embedded-bins/ -type f -not -path "embedded-bins/staging/*" -print0 | xargs -0 cat | md5sum | awk '{print $1}')
+          echo "::set-output name=hash::$hash"
+
       - name: Cache embedded binaries
         uses: actions/cache@v3
         with:
-          key: ${{ runner.os }}-embedded-bins-${{ matrix.target }}-${{ hashFiles('embedded-bins/**/*') }}
+          key: ${{ runner.os }}-embedded-bins-${{ matrix.target }}-${{ steps.embedded-bins-hash.hash }}
+          restore-keys: |
+            ${{ runner.os }}-embedded-bins-${{ matrix.target }}-${{ steps.embedded-bins-hash.hash }}
+            ${{ runner.os }}-embedded-bins-${{ matrix.target }}-
           path: |
             .bins.${{ matrix.target }}.stamp
             bindata_${{ matrix.target }}
             embedded-bins/staging/${{ matrix.target }}/bin/
-            embedded-bins/Makefile.variables
             pkg/assets/zz_generated_offsets_${{ matrix.target }}.go
 
       - name: Cache GOCACHE

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,10 +66,10 @@ jobs:
       - name: Cache embedded binaries
         uses: actions/cache@v3
         with:
-          key: ${{ runner.os }}-embedded-bins-${{ matrix.target }}-${{ steps.embedded-bins-hash.hash }}
+          key: ${{ matrix.target }}-embedded-bins-${{ steps.embedded-bins-hash.hash }}
           restore-keys: |
-            ${{ runner.os }}-embedded-bins-${{ matrix.target }}-${{ steps.embedded-bins-hash.hash }}
-            ${{ runner.os }}-embedded-bins-${{ matrix.target }}-
+            ${{ matrix.target }}-embedded-bins-${{ steps.embedded-bins-hash.hash }}
+            ${{ matrix-target }}-embedded-bins-
           path: |
             .bins.${{ matrix.target }}.stamp
             bindata_${{ matrix.target }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -73,6 +73,7 @@ jobs:
             .bins.${{ matrix.target }}.stamp
             bindata_${{ matrix.target }}
             embedded-bins/staging/${{ matrix.target }}/bin/
+            embedded-bins/Makefile.variables
             pkg/assets/zz_generated_offsets_${{ matrix.target }}.go
 
       - name: Cache GOCACHE

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,9 +66,9 @@ jobs:
       - name: Cache embedded binaries
         uses: actions/cache@v3
         with:
-          key: ${{ matrix.target }}-embedded-bins-${{ steps.embedded-bins-hash.hash }}
+          key: ${{ matrix.target }}-embedded-bins-${{ steps.embedded-bins-hash.outputs.hash }}
           restore-keys: |
-            ${{ matrix.target }}-embedded-bins-${{ steps.embedded-bins-hash.hash }}
+            ${{ matrix.target }}-embedded-bins-${{ steps.embedded-bins-hash.outputs.hash }}
             ${{ matrix.target }}-embedded-bins-
           path: |
             .bins.${{ matrix.target }}.stamp

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -60,7 +60,7 @@ jobs:
         id: embedded-bins-hash
         run: |
           hash=$(find embedded-bins/ -type f -not -path "embedded-bins/staging/*" -print0 | xargs -0 cat | md5sum | awk '{print $1}')
-          echo "::set-output name=hash::$hash"
+          echo "hash=$hash" >> $GITHUB_OUTPUT
 
       - name: Cache embedded binaries
         uses: actions/cache@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           hash=$(find embedded-bins/ -type f -not -path "embedded-bins/staging/*" -print0 | xargs -0 cat | md5sum | awk '{print $1}')
           echo "hash=$hash" >> $GITHUB_OUTPUT
+          echo "Generated hash key: $hash"
 
       - name: Cache embedded binaries
         uses: actions/cache@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -69,7 +69,7 @@ jobs:
           key: ${{ matrix.target }}-embedded-bins-${{ steps.embedded-bins-hash.hash }}
           restore-keys: |
             ${{ matrix.target }}-embedded-bins-${{ steps.embedded-bins-hash.hash }}
-            ${{ matrix-target }}-embedded-bins-
+            ${{ matrix.target }}-embedded-bins-
           path: |
             .bins.${{ matrix.target }}.stamp
             bindata_${{ matrix.target }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           key: ${{ matrix.target }}-embedded-bins-${{ steps.embedded-bins-hash.outputs.hash }}
           restore-keys: |
-            ${{ matrix.target }}-embedded-bins-${{ steps.embedded-bins-hash.outputs.hash }}
             ${{ matrix.target }}-embedded-bins-
           path: |
             .bins.${{ matrix.target }}.stamp


### PR DESCRIPTION
## Description

Looks to me like the workflow embedded-bins caching can be slightly improved.

### cache key

The cache key was:

```yaml
          key: ${{ runner.os }}-embedded-bins-${{ matrix.target }}-${{ hashFiles('embedded-bins/**/*') }}
```

To me looks like that would include `embedded-bins/staging/` which is what we actually want to restore instead of rebuild. I guess it still works because at the start of a build there's nothing there, but to be explicit, I added a step that generates a hash key from `embedded-bins/**/*` excluding `embedded-bins/staging/`.

### restore key

I don't think an exact match is necessary for the cache to be beneficial, it should be ok to restore a partly outdated cache and then only rebuild bins that have changed.

### list of paths

The paths to restore included `embedded-bins/Makefile.variables` - I don't think it should be restored, especially not when restoring a partially outdated cache as described above. When restoring an exact match, it should already be identical.
