### PR TITLE
Remove special-case for setup-go on ARMv7

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -415,31 +415,10 @@ jobs:
       - name: Prepare build environment
         run: .github/workflows/prepare-build-env.sh
 
-      # We cannot rely on this for arm: https://github.com/actions/setup-go/issues/106
       - name: Set up Go
-        if: matrix.arch != 'arm'
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      # Install Go manually for arm. See above.
-      - name: Set up Go for armv6l
-        if: matrix.arch == 'arm'
-        run: |
-          echo "Setup go stable version $GO_VERSION"
-          rm -rf -- "$HOME/.local/go"
-          mkdir -p -- "$HOME/.local/go"
-          curl --silent -L "https://go.dev/dl/go${GO_VERSION%%.0}.linux-armv6l.tar.gz" | tar -C "$HOME/.local" -xz
-
-          echo "$HOME/.local/go/bin" >>"$GITHUB_PATH"
-          export PATH="$PATH:$HOME/.local/go/bin"
-          echo Added go to the path
-
-          echo "Successfully setup go version $GO_VERSION"
-          go version
-          echo ::group::go env
-          go env
-          echo ::endgroup::
 
       - name: Cache embedded binaries
         uses: actions/cache@v3


### PR DESCRIPTION
## Description

The setup-go action should now be capable of installing Go on AArch32.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings