### PR TITLE
Clean up embedded-bins stamp files even when Docker fails

### DIFF
--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -24,12 +24,13 @@ all: $(addprefix $(bindir)/, $(bins))
 clean:
 	for i in .container.*; do \
 	  [ -f "$$i" ] || continue; \
-	  docker rm -- $$(cat -- "$$i") && rm -- "$$i"; \
+	  docker rm -- "$$(cat -- "$$i")"; \
+	  rm -- "$$i"; \
 	done
 	for i in .docker-image.*.stamp; do \
 	  [ -f "$$i" ] || continue; \
-	  tags=$$(docker inspect --format='{{range $$tag := .RepoTags}}{{$$tag}} {{end}}' -- $$(cat -- "$$i")) && \
-	  docker rmi -f -- $$tags && \
+	  tags=$$(docker inspect --format='{{range $$tag := .RepoTags}}{{$$tag}} {{end}}' -- "$$(cat -- "$$i")") && \
+	  docker rmi -f -- "$$tags"; \
 	  rm -f -- "$$i"; \
 	done
 	rm -rf staging


### PR DESCRIPTION
## Description

This may be the case when images and containers have already been removed manually. In that case, `make clean` won't remove the stamp files, preventing a correct rebuild and forcing users to do something like `git clean -x -f`, which can easily delete local precious non-versioned stuff by accident.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings