### PR TITLE
Use Docker iid files consequently in builds

### DIFF
--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -17,22 +17,20 @@ else
 bins = ${posix_bins}
 endif
 
+.DELETE_ON_ERROR:
+
 .PHONY: all
 all: $(addprefix $(bindir)/, $(bins))
 
 .PHONY: clean
+clean: IID_FILES = .docker-image.*.stamp
 clean:
 	for i in .container.*; do \
 	  [ -f "$$i" ] || continue; \
 	  docker rm -- "$$(cat -- "$$i")"; \
 	  rm -- "$$i"; \
 	done
-	for i in .docker-image.*.stamp; do \
-	  [ -f "$$i" ] || continue; \
-	  tags=$$(docker inspect --format='{{range $$tag := .RepoTags}}{{$$tag}} {{end}}' -- "$$(cat -- "$$i")") && \
-	  docker rmi -f -- "$$tags"; \
-	  rm -f -- "$$i"; \
-	done
+	$(clean-iid-files)
 	rm -rf staging
 	@echo 'cleaned up; you may want to run `docker system prune` in order to free dangling resources ...'
 
@@ -60,8 +58,7 @@ $(addprefix $(bindir)/, $(bins)): | $(bindir)
 	docker export $$(cat $<) | tar -C $(dir $(bindir)) -xv bin/$(notdir $@) && touch $@
 
 build_docker_container = \
-	docker create --entrypoint=/dev/null $(shell cat -- $<) > $@.tmp \
-	&& mv $@.tmp $@
+	docker create --cidfile='$@' --entrypoint=/dev/null '$(shell cat -- $<)'
 
 .container.%: .docker-image.%.stamp
 	$(build_docker_container)
@@ -70,7 +67,7 @@ build_docker_container = \
 	$(build_docker_container)
 
 build_docker_image = \
-	docker build -t k0sbuild$(basename $@):latest \
+	docker build --iidfile '$@' -t k0sbuild$(basename $@):latest \
 	  --build-arg TARGET_OS=$(if $(findstring .windows.stamp,$@),windows,linux) \
 	  --build-arg VERSION=$($(patsubst %/Dockerfile,%,$<)_version) \
 	  --build-arg BUILDIMAGE=$($(patsubst %/Dockerfile,%,$<)_buildimage) \
@@ -81,9 +78,7 @@ build_docker_image = \
 	  --build-arg BUILD_GO_FLAGS=$($(patsubst %/Dockerfile,%,$<)_build_go_flags) \
 	  --build-arg BUILD_GO_LDFLAGS=$($(patsubst %/Dockerfile,%,$<)_build_go_ldflags) \
 	  --build-arg BUILD_GO_LDFLAGS_EXTRA=$($(patsubst %/Dockerfile,%,$<)_build_go_ldflags_extra) \
-	  -- $(dir $<) \
-	&& docker images -q k0sbuild$(basename $@):latest > $@.tmp \
-	&& mv $@.tmp $@
+	  -- $(dir $<)
 
 .docker-image.%.stamp: %/Dockerfile Makefile.variables
 	$(build_docker_image)

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -61,3 +61,11 @@ konnectivity_build_go_ldflags_extra = "-extldflags=-static"
 
 iptables_version = 1.8.7
 iptables_buildimage = docker.io/library/alpine:$(alpine_patch_version)
+
+clean-iid-files = \
+	for i in $(IID_FILES); do \
+	  [ -f "$$i" ] || continue; \
+	  tags=$$(docker inspect --format='{{range $$i,$$tag := .RepoTags}}{{if $$i}} {{end}}{{$$tag}}{{end}}' -- "$$(cat -- "$$i")") && \
+	  [ -z "$$tags" ] || docker rmi -f -- $$tags; \
+	  rm -f -- "$$i"; \
+	done


### PR DESCRIPTION
## Description

Docker has the capability of writing out the image IDs to dedicated files. This is easier and more integrated than doing it via shell commands and output redirection.

Use the content of those iid files instead of the hard-coded image tags. This has the advantage of being consistent, especially on development machines when hacking on different k0s versions in different folders in parallel.

Reuse the snippet used to clean up the iid files for the embedded binaries also in the main k0s build.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings