### PR TITLE
correct typo in metallb helm override causing failure

### DIFF
--- a/docs/examples/traefik-ingress.md
+++ b/docs/examples/traefik-ingress.md
@@ -27,7 +27,7 @@ extensions:
       chartname: bitnami/metallb
       version: "2.5.4"
       namespace: default
-      values: |2
+      values: |
         configInline:
           address-pools:
           - name: generic-cluster-pool


### PR DESCRIPTION
## Description

Fix a typo in doc for traefik and metallb extension, specifically in the helm override of metallb. if specified, k0s won't install the metallb chart because the config has a typo.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Just a doc change

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings