### PR TITLE
DNS fixes in docker entrypoint for both legacy and nft

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,34 +1,49 @@
 #!/bin/sh
 
+set -eu
+
 # Ensure we have some semi-random machine-id
-if [ ! -f  /etc/machine-id ]; then
-    dd if=/dev/urandom status=none bs=16 count=1 | md5sum | cut -d' ' -f1 > /etc/machine-id
+if [ ! -f /etc/machine-id ]; then
+  head -c16 /dev/urandom | hexdump -v -e '16/1 "%02x""\n"' >/etc/machine-id
 fi
 
-# Network fixups adapted from kind: https://github.com/kubernetes-sigs/kind/blob/master/images/base/files/usr/local/bin/entrypoint#L176
-docker_embedded_dns_ip='127.0.0.11'
-# first we need to detect an IP to use for reaching the docker host
-docker_host_ip="$(ip -4 route show default | cut -d' ' -f3)"
+# DNS fixup adapted from kind
+# https://github.com/kubernetes-sigs/kind/blob/7568bf728147c1253e651f25edfd0e0a75534b8a/images/base/files/usr/local/bin/entrypoint#L447-L487
 
-# patch docker's iptables rules to switch out the DNS IP
-iptables-save \
-  | sed \
-    `# switch docker DNS DNAT rules to our chosen IP` \
-    -e "s/-d ${docker_embedded_dns_ip}/-d ${docker_host_ip}/g" \
-    `# we need to also apply these rules to non-local traffic (from pods)` \
-    -e 's/-A OUTPUT \(.*\) -j DOCKER_OUTPUT/\0\n-A PREROUTING \1 -j DOCKER_OUTPUT/' \
-    `# switch docker DNS SNAT rules rules to our chosen IP` \
-    -e "s/--to-source :53/--to-source ${docker_host_ip}:53/g"\
-  | iptables-restore
+# well-known docker embedded DNS is at 127.0.0.11:53
+docker_embedded_dns_ip=127.0.0.11
+
+# first we need to detect an IP to use for reaching the docker host
+docker_host_ip=$(timeout 5 getent ahostsv4 host.docker.internal | head -n1 | cut -d' ' -f1 || true)
+# if the ip doesn't exist or is a loopback address use the default gateway
+case "$docker_host_ip" in
+'' | 127.*) docker_host_ip=$(ip -4 route show default | cut -d' ' -f3) ;;
+esac
+
+for iptables in iptables iptables-nft; do
+  # patch docker's iptables rules to switch out the DNS IP
+  "$iptables"-save \
+    | sed \
+      `# switch docker DNS DNAT rules to our chosen IP` \
+      -e "s/-d ${docker_embedded_dns_ip}/-d ${docker_host_ip}/g" \
+      `# we need to also apply these rules to non-local traffic (from pods)` \
+      -e 's/-A OUTPUT \(.*\) -j DOCKER_OUTPUT/\0\n-A PREROUTING \1 -j DOCKER_OUTPUT/' \
+      `# switch docker DNS SNAT rules rules to our chosen IP` \
+      -e "s/--to-source :53/--to-source ${docker_host_ip}:53/g" \
+      `# nftables incompatibility between 1.8.8 and 1.8.7 omit the --dport flag on DNAT rules` \
+      `# ensure --dport on DNS rules, due to https://github.com/kubernetes-sigs/kind/issues/3054` \
+      -e "s/p -j DNAT --to-destination ${docker_embedded_dns_ip}/p --dport 53 -j DNAT --to-destination ${docker_embedded_dns_ip}/g" \
+    | "$iptables"-restore
+done
 
 # now we can ensure that DNS is configured to use our IP
 cp /etc/resolv.conf /etc/resolv.conf.original
 sed -e "s/${docker_embedded_dns_ip}/${docker_host_ip}/g" /etc/resolv.conf.original >/etc/resolv.conf
 
 # write config from environment variable
-if [ ! -z "$K0S_CONFIG" ]; then
+if [ -n "${K0S_CONFIG-}" ]; then
   mkdir -p /etc/k0s
-  echo -n "$K0S_CONFIG" > /etc/k0s/config.yaml
+  printf %s "$K0S_CONFIG" >/etc/k0s/config.yaml
 fi
 
-exec $@
+exec "$@"


### PR DESCRIPTION
## Description

Docker might use nf_tables instead of legacy iptables mode. This breaks the k0s-in-docker scenario when k0s is used on a non-default bridge networking. Fix this by simply trying to fix both modes. One of them will probably be empty, so the sed will be a no-op.

Also update the references to the kind scripts where the fix is originating from.

See:
* #3179

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings