### PR TITLE
Don't mention latest Docker tag in docs

### DIFF
--- a/docs/k0s-in-docker.md
+++ b/docs/k0s-in-docker.md
@@ -10,8 +10,8 @@ You will require a [Docker environment](https://docs.docker.com/get-docker/) run
 
 The k0s containers are published both on Docker Hub and GitHub. For reasons of simplicity, the examples given here use Docker Hub (GitHub requires a separate authentication that is not covered). Alternative links include:
 
-- docker.io/k0sproject/k0s:latest
-- docker.pkg.github.com/k0sproject/k0s/k0s:"version"
+- docker.io/k0sproject/k0s:{{{ extra.k8s_version }}}-k0s.0
+- ghcr.io/k0sproject/k0s:{{{ extra.k8s_version }}}-k0s.0
 
 **Note:** Due to Docker Hub tag validation scheme, we have to use `-` as the k0s version separator instead of the usual `+`. So for example k0s version `v{{{ extra.k8s_version }}}+k0s.0` is tagged as `docker.io/k0sproject/k0s:v{{{ extra.k8s_version }}}-k0s.0`.
 


### PR DESCRIPTION
## Description

The latest tag isn't published anymore for quite a long time already. Adjust the docs accordingly. Also correct the GitHub image name.

See:
* #3179

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings