### PR TITLE
Fix typo in function name

### DIFF
--- a/internal/pkg/sysinfo/probes/linux/cgroup_controllers.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroup_controllers.go
@@ -94,7 +94,7 @@ type cgroupControllerProber struct {
 	err         error
 }
 
-func (p *cgroupControllerProber) probeContoller(s cgroupSystem, controllerName string) (cgroupControllerAvailable, error) {
+func (p *cgroupControllerProber) probeController(s cgroupSystem, controllerName string) (cgroupControllerAvailable, error) {
 	p.once.Do(func() {
 		p.controllers = make(map[string]cgroupControllerAvailable)
 		p.err = s.loadControllers(func(name, msg string) {

--- a/internal/pkg/sysinfo/probes/linux/cgroup_v1.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroup_v1.go
@@ -34,11 +34,11 @@ func (*cgroupV1) String() string {
 	return "version 1"
 }
 
-func (s *cgroupV1) probeController(controllerName string) (cgroupControllerAvailable, error) {
-	return s.controllers.probeContoller(s, controllerName)
+func (g *cgroupV1) probeController(controllerName string) (cgroupControllerAvailable, error) {
+	return g.controllers.probeController(g, controllerName)
 }
 
-func (s *cgroupV1) loadControllers(seen func(name, msg string)) error {
+func (g *cgroupV1) loadControllers(seen func(name, msg string)) error {
 	// Get the available controllers from /proc/cgroups.
 	// See https://www.man7.org/linux/man-pages/man7/cgroups.7.html#NOTES
 

--- a/internal/pkg/sysinfo/probes/linux/cgroup_v2.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroup_v2.go
@@ -39,17 +39,17 @@ func (*cgroupV2) String() string {
 	return "version 2"
 }
 
-func (s *cgroupV2) probeController(controllerName string) (cgroupControllerAvailable, error) {
-	return s.controllers.probeContoller(s, controllerName)
+func (g *cgroupV2) probeController(controllerName string) (cgroupControllerAvailable, error) {
+	return g.controllers.probeController(g, controllerName)
 }
 
-func (s *cgroupV2) loadControllers(seen func(string, string)) error {
+func (g *cgroupV2) loadControllers(seen func(string, string)) error {
 	// Some controllers are implicitly enabled by the kernel. Those controllers
 	// do not appear in /sys/fs/cgroup/cgroup.controllers. Their availability is
 	// assumed based on the kernel version, as it is hard to detect them
 	// directly.
 	// https://github.com/torvalds/linux/blob/v5.3/kernel/cgroup/cgroup.c#L433-L434
-	if major, minor, err := parseKernelRelease(s.probeUname); err == nil {
+	if major, minor, err := parseKernelRelease(g.probeUname); err == nil {
 		/* devices: since 4.15 */ if major > 4 || (major == 4 && minor >= 15) {
 			seen("devices", "assumed")
 		}
@@ -60,7 +60,7 @@ func (s *cgroupV2) loadControllers(seen func(string, string)) error {
 		return err
 	}
 
-	controllerData, err := os.ReadFile(filepath.Join(s.mountPoint, "cgroup.controllers"))
+	controllerData, err := os.ReadFile(filepath.Join(g.mountPoint, "cgroup.controllers"))
 	if err != nil {
 		return err
 	}
@@ -69,9 +69,9 @@ func (s *cgroupV2) loadControllers(seen func(string, string)) error {
 		seen(controllerName, "")
 		switch controllerName {
 		case "cpu": // This is the successor to the version 1 cpu and cpuacct controllers.
-			seen("cpuacct", "via cpu in "+s.String())
+			seen("cpuacct", "via cpu in "+g.String())
 		case "io": // This is the successor of the version 1 blkio controller.
-			seen("blkio", "via io in "+s.String())
+			seen("blkio", "via io in "+g.String())
 		}
 	}
 


### PR DESCRIPTION
## Description

* probeContoller -> probeController
* Change receiver var for cgroupsv1/2 from `s` - which seems random - to `g` for "group"

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings