### PR TITLE
Add bird-live/ready for live/readinessProbe in bird mode

### DIFF
--- a/static/manifests/calico/DaemonSet/calico-node.yaml
+++ b/static/manifests/calico/DaemonSet/calico-node.yaml
@@ -252,6 +252,9 @@ spec:
               command:
               - /bin/calico-node
               - -felix-live
+              {{- if eq .Mode "bird" }}
+              - -bird-live
+              {{- end }}
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
@@ -261,6 +264,9 @@ spec:
               command:
               - /bin/calico-node
               - -felix-ready
+              {{- if eq .Mode "bird" }}
+              - -bird-ready
+              {{- end }}
             periodSeconds: 10
             timeoutSeconds: 10
           volumeMounts:


### PR DESCRIPTION
Run bird-live as livenessProbe and bird-ready as readinessProbe when bird mode is activated in calico.

Those were likely removed unintentionally.

See upstream config:
- https://github.com/projectcalico/calico/blob/23440dc0e9df11fae198d9c3c8a5d3815bf3525f/manifests/calico.yaml#L4862
- https://github.com/projectcalico/calico/blob/23440dc0e9df11fae198d9c3c8a5d3815bf3525f/manifests/calico.yaml#L4872

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings