### PR TITLE
Add sysinfo probe for name resolution of localhost

### DIFF
--- a/internal/pkg/sysinfo/probes/network.go
+++ b/internal/pkg/sysinfo/probes/network.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2023 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probes
+
+import (
+	"errors"
+	"fmt"
+	"net"
+)
+
+func RequireNameResolution(p Probes, lookupIP func(host string) ([]net.IP, error), host string) {
+	p.Set(fmt.Sprintf("nameResolution:%s", host), func(path ProbePath, _ Probe) Probe {
+		return ProbeFn(func(r Reporter) error {
+			desc := NewProbeDesc(fmt.Sprintf("Name resolution: %s", host), path)
+			ips, err := lookupIP(host)
+			if err != nil {
+				return r.Error(desc, err)
+			}
+			if len(ips) < 1 {
+				return r.Error(desc, errors.New("no IP addresses"))
+			}
+
+			return r.Pass(desc, ipProp(ips))
+		})
+	})
+}
+
+type ipProp []net.IP
+
+func (p ipProp) String() string {
+	return fmt.Sprintf("%v", ([]net.IP)(p))
+}

--- a/internal/pkg/sysinfo/probes/network_test.go
+++ b/internal/pkg/sysinfo/probes/network_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2023 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probes_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+
+	test_sysinfo "github.com/k0sproject/k0s/internal/testutil/sysinfo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestRequireNameResolution(t *testing.T) {
+	matchDesc := mock.MatchedBy(func(desc probes.ProbeDesc) bool {
+		assert.Equal(t, "Name resolution: some-host", desc.DisplayName())
+		return true
+	})
+
+	for _, test := range []struct {
+		name            string
+		ips             []net.IP
+		err             error
+		setExpectations func(*test_sysinfo.MockReporter)
+		probeErr        error
+	}{
+		{"someIPAddress",
+			[]net.IP{{127, 99, 99, 10}}, nil,
+			func(r *test_sysinfo.MockReporter) {
+				r.On("Pass", matchDesc, mock.MatchedBy(func(prop probes.ProbedProp) bool {
+					assert.Equal(t, "[127.99.99.10]", prop.String())
+					return true
+				})).Return(nil)
+			},
+			nil,
+		},
+		{"noIPAddresses",
+			nil, nil,
+			func(r *test_sysinfo.MockReporter) {
+				r.On("Error", matchDesc, mock.MatchedBy(func(err error) bool {
+					if assert.Error(t, err) {
+						assert.Equal(t, "no IP addresses", err.Error())
+					}
+					return true
+				})).Return(nil)
+			},
+			nil,
+		},
+		{"lookupError",
+			nil, assert.AnError,
+			func(r *test_sysinfo.MockReporter) {
+				r.On("Error", matchDesc, assert.AnError).Return(assert.AnError)
+			},
+			assert.AnError,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			reporter := new(test_sysinfo.MockReporter)
+			p := probes.NewRootProbes()
+			probes.RequireNameResolution(p, func(host string) ([]net.IP, error) {
+				assert.Equal(t, "some-host", host)
+				return test.ips, test.err
+			}, "some-host")
+			test.setExpectations(reporter)
+
+			err := p.Probe(reporter)
+
+			reporter.AssertExpectations(t)
+			if test.probeErr != nil {
+				assert.ErrorIs(t, err, test.probeErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/pkg/sysinfo/sysinfo.go
+++ b/internal/pkg/sysinfo/sysinfo.go
@@ -19,6 +19,7 @@ package sysinfo
 import (
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
@@ -73,6 +74,7 @@ func (s *K0sSysinfoSpec) NewSysinfoProbes() probes.Probes {
 		minFreeDiskSpace = minFreeDiskSpace + 1300*probes.Mi
 	}
 	probes.AssertFreeDiskSpace(p, s.DataDir, minFreeDiskSpace)
+	probes.RequireNameResolution(p, net.LookupIP, "localhost")
 
 	s.addHostSpecificProbes(p)
 


### PR DESCRIPTION
## Description

K0s will have a hard time when localhost cannot be resolved, so having a probe for it is probably a good aid when troubleshooting.

See:
* #3351

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings