### PR TITLE
added debian_12 for ostests

### DIFF
--- a/hack/ostests/README.md
+++ b/hack/ostests/README.md
@@ -72,6 +72,7 @@ terraform apply
 * `centos_9`: CentOS Stream 9
 * `debian_10`: Debian GNU/Linux 10 (buster)
 * `debian_11`: Debian GNU/Linux 11 (bullseye)
+* `debian_12`: Debian GNU/Linux 12 (bookworm)
 * `fcos_38`: Fedora CoreOS 38
 * `fedora_38`: Fedora Linux 38 (Cloud Edition)
 * `flatcar`: Flatcar Container Linux by Kinvolk

--- a/hack/ostests/modules/os/main.tf
+++ b/hack/ostests/modules/os/main.tf
@@ -8,6 +8,7 @@ locals {
     centos_9    = local.os_centos_9
     debian_10   = local.os_debian_10
     debian_11   = local.os_debian_11
+    debian_12   = local.os_debian_12
     fcos_38     = local.os_fcos_38
     fedora_38   = local.os_fedora_38
     flatcar     = local.os_flatcar

--- a/hack/ostests/modules/os/os_debian_12.tf
+++ b/hack/ostests/modules/os/os_debian_12.tf
@@ -1,0 +1,48 @@
+# https://wiki.debian.org/Cloud/AmazonEC2Image/Bookworm
+
+data "aws_ami" "debian_12" {
+  count = var.os == "debian_12" ? 1 : 0
+
+  owners      = ["136693071363"]
+  name_regex  = "^debian-12-amd64-\\d+-\\d+$"
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["debian-12-amd64-*-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+locals {
+  os_debian_12 = var.os != "debian_12" ? {} : {
+    node_configs = {
+      default = {
+        ami_id = one(data.aws_ami.debian_12.*.id)
+
+        user_data = format("#cloud-config\n%s", jsonencode({
+          runcmd = ["truncate -s0 /etc/motd", ]
+        })),
+
+        connection = {
+          type     = "ssh"
+          username = "admin"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

https://github.com/k0sproject/k0s/pull/3249 introduced os testing.
I noticed Debian 12 was not include this list.

Debian 12 was released on July 22nd, 2023.
Debian 11 is oldstable now. So I'd like to use k0s on Debian 12.

https://www.debian.org/releases/index.html

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings