### PR TITLE
Typo fix for external-runtime-deps.md

### DIFF
--- a/docs/external-runtime-deps.md
+++ b/docs/external-runtime-deps.md
@@ -183,7 +183,7 @@ accounts.
 
 #### modprobe
 
-On k0s worker will `modprobe` be executed to load missing kernel modules if they
+On k0s worker `modprobe` will be executed to load missing kernel modules if they
 are not detected.
 
 #### id


### PR DESCRIPTION
## Description

Just a tiny typo fix in external deps doc: "will `modprobe` be..." => "`modprobe` will be".

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
