### PR TITLE
Actually merge CRI configs from drop-ins instead of concatenating them

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/k0sproject/dig v0.2.0
 	github.com/kardianos/service v1.2.2
 	github.com/logrusorgru/aurora/v3 v3.0.0
+	github.com/mesosphere/toml-merge v0.2.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/image-spec v1.1.0-rc4

--- a/go.sum
+++ b/go.sum
@@ -601,6 +601,8 @@ github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mesosphere/toml-merge v0.2.0 h1:stCUgrwbictiebeHRqEJ1NfQl/h5noyFKR0LBWjWXxQ=
+github.com/mesosphere/toml-merge v0.2.0/go.mod h1:WYpgeqeG5puUtv2NREGyOIqTnYuWswyo7CBgx6QK80s=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.25 h1:dFwPR6SfLtrSwgDcIq2bcU/gVutB4sNApq2HBdqcakg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/pkg/component/worker/containerd/criconfig.go
+++ b/pkg/component/worker/containerd/criconfig.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	"github.com/mesosphere/toml-merge/pkg/patch"
 	"github.com/pelletier/go-toml"
 	"github.com/sirupsen/logrus"
 
@@ -69,6 +70,8 @@ func (c *CRIConfigurer) HandleImports() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	finalConfig := criConfigBuffer.String()
 	for _, file := range files {
 		data, err := os.ReadFile(file)
 		if err != nil {
@@ -80,13 +83,11 @@ func (c *CRIConfigurer) HandleImports() ([]string, error) {
 			return nil, err
 		}
 		if hasCRI {
-			c.log.Debugf("found CRI plugin config in %s, appending to CRI config", file)
-			// Append all CRI plugin configs into single file
-			// and add it to imports
-			criConfigBuffer.WriteString(fmt.Sprintf("# appended from %s\n", file))
-			_, err := criConfigBuffer.Write(data)
+			c.log.Infof("found CRI plugin config in %s, merging to CRI config", file)
+			// Merge to the existing CRI config
+			finalConfig, err = patch.TOMLString(finalConfig, patch.FilePatches(file))
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to merge CRI config from %s: %w", file, err)
 			}
 		} else {
 			c.log.Debugf("adding %s as-is to imports", file)
@@ -96,7 +97,7 @@ func (c *CRIConfigurer) HandleImports() ([]string, error) {
 	}
 
 	// Write the CRI config to a file and add it to imports
-	err = os.WriteFile(c.criRuntimePath, criConfigBuffer.Bytes(), 0644)
+	err = os.WriteFile(c.criRuntimePath, []byte(finalConfig), 0644)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Uses https://github.com/mesosphere/toml-merge for merging the CRI config snippets. If a config drop-in is not a CRI config, it behaves as previously and just adds it to imports.

Fixes #3283

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings