### PR TITLE
Build k0s Docker image on GitHub managed runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,20 +348,10 @@ jobs:
       - x64
       - arm64
       - armv7
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-22.04
     steps:
-      # docker context must be created prior to setting up Docker Buildx
-      # https://github.com/actions-runner-controller/actions-runner-controller/issues/893
-      - name: Set up Docker Context for Buildx
-        shell: bash
-        id: buildx-context
-        run: |
-          docker context inspect buildx-context -f ' ' || docker context create buildx-context
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          endpoint: buildx-context
 
       - name: Run git checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description

There's no need to do it on the self-hosted runners and makes the job's maintenance easier. In fact, docker-buildx is not working properly on the self-hosted runners at the moment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings