### PR TITLE
[Backport release-1.24] Build k0s Docker image on GitHub managed runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,20 +342,10 @@ jobs:
       - x64
       - arm64
       - armv7
-    runs-on: [self-hosted,linux,x64]
+    runs-on: ubuntu-22.04
     steps:
-      # docker context must be created prior to setting up Docker Buildx
-      # https://github.com/actions-runner-controller/actions-runner-controller/issues/893
-      - name: Set up Docker Context for Buildx
-        shell: bash
-        id: buildx-context
-        run: |
-          docker context inspect buildx-context -f ' ' || docker context create buildx-context
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          endpoint: buildx-context
 
       - name: Run git checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Backport to `release-1.24`:
* #3423

See:
* #3419