### PR TITLE
Bump k0sctl to v0.15.5

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -15,7 +15,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: eu-west-1
       TF_VERSION: 1.2.2
-      K0SCTL_VERSION: 0.13.2
+      K0SCTL_VERSION: 0.15.5
       KUBECONFIG: ${{ github.workspace }}/kubeconfig
 
     name: "K8s Network Conformance Testing"

--- a/.github/workflows/ostests-e2e.yaml
+++ b/.github/workflows/ostests-e2e.yaml
@@ -31,7 +31,7 @@ on:
       k0sctl-version:
         type: string
         description: The k0sctl version to use when bootstrapping the test cluster.
-        default: 0.15.0 # k0sproject/k0sctl#495
+        default: 0.15.5
     secrets:
       aws-access-key-id:
         description: The AWS access key ID to use when provisioning test resources.

--- a/hack/ostests/modules/os/os_alpine_3_17_userdata.tftpl
+++ b/hack/ostests/modules/os/os_alpine_3_17_userdata.tftpl
@@ -11,4 +11,5 @@ rc-update add cgroups boot
 
 # k0sctl currently doesn't support BusyBox/doas properly.
 apk add coreutils sudo && apk del doas
+apk add bash # Remove after https://github.com/k0sproject/rig/pull/94
 echo 'alpine ALL=(ALL:ALL) NOPASSWD: ALL' >/etc/sudoers.d/alpine-all-access


### PR DESCRIPTION
## Description

This addresses a probably SELinux related provisioning problem noticed on Fedora CoreOS 38.20230826.20.0.

Not touching the release workflow, as that one is hard to test and I don't want to introduce a regression.

Also add bash to the Alpine VMs in the OS tests to satisfy k0sctl's/ rig's new hard dependency on bash.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings