### PR TITLE
[Backport release-1.26] Bump metrics-server to v0.6.4

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -440,10 +440,10 @@ images:
     version: v3.16.2
   metricsserver:
     image: registry.k8s.io/metrics-server/metrics-server
-    version: v0.6.2
+    version: v0.6.4
 ```
 
-In the runtime the image names are calculated as `my.own.repo/calico/kube-controllers:v3.16.2` and `my.own.repo/metrics-server/metrics-server:v0.6.2`. This only affects the the imgages pull location, and thus omitting an image specification here will not disable component deployment.
+In the runtime the image names are calculated as `my.own.repo/calico/kube-controllers:v3.16.2` and `my.own.repo/metrics-server/metrics-server:v0.6.4`. This only affects the the imgages pull location, and thus omitting an image specification here will not disable component deployment.
 
 ### `spec.extensions.helm`
 

--- a/docs/raspberry-pi4.md
+++ b/docs/raspberry-pi4.md
@@ -501,7 +501,7 @@ node/ubuntu   Ready    <none>   5m1s   v1.26.8+k0s   10.152.56.54   <none>      
 
 NAMESPACE     NAME                             READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS       IMAGES                                                 SELECTOR
 kube-system   deployment.apps/coredns          1/1     1            1           33m   coredns          registry.k8s.io/coredns/coredns:v1.7.0                 k8s-app=kube-dns
-kube-system   deployment.apps/metrics-server   1/1     1            1           33m   metrics-server   registry.k8s.io/metrics-server/metrics-server:v0.6.2   k8s-app=metrics-server
+kube-system   deployment.apps/metrics-server   1/1     1            1           33m   metrics-server   registry.k8s.io/metrics-server/metrics-server:v0.6.4   k8s-app=metrics-server
 
 NAMESPACE     NAME                                  READY   STATUS    RESTARTS   AGE    IP             NODE     NOMINATED NODE   READINESS GATES
 kube-system   pod/coredns-88b745646-pkk5w           1/1     Running   0          33m    10.244.0.5     ubuntu   <none>           <none>

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -83,7 +83,7 @@ const (
 	PushGatewayImage                   = "quay.io/k0sproject/pushgateway-ttl"
 	PushGatewayImageVersion            = "1.4.0-k0s.0"
 	MetricsImage                       = "registry.k8s.io/metrics-server/metrics-server"
-	MetricsImageVersion                = "v0.6.2"
+	MetricsImageVersion                = "v0.6.4"
 	KubeProxyImage                     = "registry.k8s.io/kube-proxy"
 	KubeProxyImageVersion              = "v1.26.8"
 	CoreDNSImage                       = "docker.io/coredns/coredns"


### PR DESCRIPTION
Backport to `release-1.26`:
* #3400

See:
* #3395