### PR TITLE
Fix hanging start-stop-daemon in footloose Alpine

### DIFF
--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -23,7 +23,8 @@ RUN rc-update add local default
 RUN rc-update add nginx default
 # Ensures that /usr/local/bin/k0s is seeded from /dist at startup
 RUN rc-update add k0s-seed default
-
+# Prevent start-stop-daemon from hanging when max_fds is huge
+RUN sed -Ei -e 's/^[# ](rc_ulimit)=.*/\1="-n 1048576"/' /etc/rc.conf
 # remove -docker keyword so we actually mount cgroups in container
 RUN sed -i -e '/keyword/s/-docker//' /etc/init.d/cgroups
 # disable ttys


### PR DESCRIPTION
## Description

Some distributions package Docker in a way that allows for a vast number of open file descriptors, often achieved through systemd's `LimitNOFILE=infinity` configuration. This situation leads to `start-stop-daemon` appearing to hang, consequently blocking the OpenRC init sequence. However, the issue is not an actual hang; rather, it attempts to close all open file descriptors, resulting in a loop with approximately one billion iterations of the `close()` syscall. This behavior effectively renders the footloose machine unable to boot.

Mitigate this by setting the open file descriptor limit to 1 Mi in OpenRC's `rc.conf`.

See:
* https://github.com/moby/moby/commit/8db61095a3d0bcb0733580734ba5d54bc27a614d
* https://github.com/OpenRC/openrc/blob/eb8831a1416ab2ee8123b3add78421c2aa316b39/src/start-stop-daemon/start-stop-daemon.c#L1104-L1105
* OpenRC/openrc#645

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings