### PR TITLE
Remove cid file before invoking docker build

### DIFF
--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -58,6 +58,7 @@ $(addprefix $(bindir)/, $(bins)): | $(bindir)
 	docker export $$(cat $<) | tar -C $(dir $(bindir)) -xv bin/$(notdir $@) && touch $@
 
 build_docker_container = \
+	rm -f -- '$@'; \
 	docker create --cidfile='$@' --entrypoint=/dev/null '$(shell cat -- $<)'
 
 .container.%: .docker-image.%.stamp


### PR DESCRIPTION
## Description

Docker will refuse to overwrite the file if it already exists. This breaks the build if make figures out that the containers need to be recreated.

Example error message:

> container ID file found, make sure the other container isn't running or delete .container.runc

Fixes:
* #3241

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings