### PR TITLE
Lower disk space eviction limits for network conformance inttest

### DIFF
--- a/inttest/network-conformance/network_test.go
+++ b/inttest/network-conformance/network_test.go
@@ -153,4 +153,11 @@ const k0sConfig = `
 spec:
   network:
     provider: %s
+  workerProfiles:
+    - name: default
+      values:
+        # GitHub runners may get low on disk space
+        evictionHard:
+          nodefs.available: 200Mi
+          imagefs.available: 200Mi
 `


### PR DESCRIPTION
## Description

Recently, the network conformance inttest has been failing regularly. This is because the sonobuoy pods are being evicted when the available disk space on the GitHub runners falls below the default eviction limits. Mitigate this by lowering the eviction limits.

This is a duct-tape solution. It's unclear whether the reduced amount of free disk space on the GitHub runners is due to changes made by GitHub or to changes in k0s.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings