### PR TITLE
Fix log collection in cli inttest

### DIFF
--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -148,6 +148,10 @@ func TestCliCommandSuite(t *testing.T) {
 	s := CliSuite{
 		common.FootlooseSuite{
 			ControllerCount: 1,
+			// The tests start and stop k0s manually. Setting the launch mode to
+			// OpenRC here anyways, so that the log collection will pick up the
+			// right paths.
+			LaunchMode: common.LaunchModeOpenRC,
 		},
 	}
 	suite.Run(t, &s)


### PR DESCRIPTION
## Description

The cli inttest does not utilize the inttest framework to start and stop k0s. Instead, it manages these operations independently through the k0s command line.

However, in cases of test failures, the inttest framework attempts to collect log files from its default paths, which is incorrect when using 'k0s start' and 'k0s stop'. To resolve this issue, set the LaunchMode to OpenRC so that the logs are collected appropriately.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings