### PR TITLE
Change kubelet args passed in CLI inttest

### DIFF
--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -73,7 +73,7 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 
 	s.T().Run("k0sInstall", func(t *testing.T) {
 		// Install with some arbitrary kubelet flags so we see those get properly passed to the kubelet
-		out, err := ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s install controller --enable-worker --disable-components konnectivity-server,metrics-server --kubelet-extra-args='--event-qps=7 --enable-load-reader=true'")
+		out, err := ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s install controller --enable-worker --disable-components konnectivity-server,metrics-server --kubelet-extra-args='--housekeeping-interval=10s --log-flush-frequency=5s'")
 		assert.NoError(t, err)
 		assert.Equal(t, "", out)
 	})
@@ -114,9 +114,9 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 
 		// Check that the kubelet extra flags are properly set
 		kubeletCmdLine, err := s.GetKubeletCMDLine(s.ControllerNode(0))
-		s.Require().NoError(err)
-		s.Require().Contains(kubeletCmdLine, "--event-qps=7")
-		s.Require().Contains(kubeletCmdLine, "--enable-load-reader=true")
+		require.NoError(err)
+		assert.Contains(kubeletCmdLine, "--housekeeping-interval=10s")
+		assert.Contains(kubeletCmdLine, "--log-flush-frequency=5s")
 	})
 
 	s.T().Log("waiting for k0s to terminate")

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -1062,19 +1062,19 @@ func (s *FootlooseSuite) initializeFootlooseCluster() error {
 }
 
 // Verifies that kubelet process has the address flag set
-func (s *FootlooseSuite) GetKubeletCMDLine(node string) (string, error) {
+func (s *FootlooseSuite) GetKubeletCMDLine(node string) ([]string, error) {
 	ssh, err := s.SSH(s.Context(), node)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer ssh.Disconnect()
 
 	output, err := ssh.ExecWithOutput(s.Context(), `cat /proc/$(pidof kubelet)/cmdline`)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return output, nil
+	return strings.Split(output, "\x00"), nil
 }
 
 func (s *FootlooseSuite) initializeFootlooseClusterInDir(dir string) error {


### PR DESCRIPTION
## Description

The randomly selected kubelet arguments used in the CLI inttest lead to kubelet crash-looping on 6.x kernels (observed on 6.1 and 6.2), whereas they worked just fine on 5.15 kernels. Since GitHub updated the kernels of its Ubuntu managed GitHub action runners from 5.15 to 6.2 a few days ago, the CLI test started to fail constantly.

Select some other flags that won't induce a crash-loop for the test. Also make a slight improvement to the command line assertion: Check for whole args instead of substrings, and use the right testing.T pointer to report failures on.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings