### PR TITLE
Fixes for kernel >= 6.0

### DIFF
--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -73,7 +73,7 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 
 	s.T().Run("k0sInstall", func(t *testing.T) {
 		// Install with some arbitrary kubelet flags so we see those get properly passed to the kubelet
-		out, err := ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s install controller --enable-worker --disable-components konnectivity-server,metrics-server --kubelet-extra-args='--event-qps=7 --enable-load-reader=true'")
+		out, err := ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s install controller --enable-worker --disable-components konnectivity-server,metrics-server --kubelet-extra-args='--housekeeping-interval=10s --log-flush-frequency=5s'")
 		assert.NoError(t, err)
 		assert.Equal(t, "", out)
 	})
@@ -114,9 +114,9 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 
 		// Check that the kubelet extra flags are properly set
 		kubeletCmdLine, err := s.GetKubeletCMDLine(s.ControllerNode(0))
-		s.Require().NoError(err)
-		s.Require().Contains(kubeletCmdLine, "--event-qps=7")
-		s.Require().Contains(kubeletCmdLine, "--enable-load-reader=true")
+		require.NoError(err)
+		assert.Contains(kubeletCmdLine, "--housekeeping-interval=10s")
+		assert.Contains(kubeletCmdLine, "--log-flush-frequency=5s")
 	})
 
 	s.T().Log("waiting for k0s to terminate")

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -1062,19 +1062,19 @@ func (s *FootlooseSuite) initializeFootlooseCluster() error {
 }
 
 // Verifies that kubelet process has the address flag set
-func (s *FootlooseSuite) GetKubeletCMDLine(node string) (string, error) {
+func (s *FootlooseSuite) GetKubeletCMDLine(node string) ([]string, error) {
 	ssh, err := s.SSH(s.Context(), node)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer ssh.Disconnect()
 
 	output, err := ssh.ExecWithOutput(s.Context(), `cat /proc/$(pidof kubelet)/cmdline`)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return output, nil
+	return strings.Split(output, "\x00"), nil
 }
 
 func (s *FootlooseSuite) initializeFootlooseClusterInDir(dir string) error {

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -84,7 +84,7 @@ const (
 	EnvoyProxyImage                    = "quay.io/k0sproject/envoy-distroless"
 	EnvoyProxyImageVersion             = "v1.24.1"
 	CalicoImage                        = "quay.io/k0sproject/calico-cni"
-	CalicoComponentImagesVersion       = "v3.26.1-0"
+	CalicoComponentImagesVersion       = "v3.26.1-1"
 	CalicoNodeImage                    = "quay.io/k0sproject/calico-node"
 	KubeControllerImage                = "quay.io/k0sproject/calico-kube-controllers"
 	KubeRouterCNIImage                 = "quay.io/k0sproject/kube-router"


### PR DESCRIPTION
## Description


### Change kubelet args passed in CLI inttest

The randomly selected kubelet arguments used in the CLI inttest lead to kubelet crash-looping on 6.x kernels (observed on 6.1 and 6.2), whereas they worked just fine on 5.15 kernels. Since GitHub updated the kernels of its Ubuntu managed GitHub action runners from 5.15 to 6.2 a few days ago, the CLI test started to fail constantly.

Select some other flags that won't induce a crash-loop for the test. Also make a slight improvement to the command line assertion: Check for whole args instead of substrings, and use the right testing.T pointer to report failures on.

### Use new Calico images using ipset 7.17

On kernels >= 6.2, there's a new bitmask parameter for ipset. Newer ipset versions support and use that, leading to the effect that older ipset versions won't be able to cope with that. The error message is:

    Kernel and userspace incompatible: settype hash:ip with revision 6 not supported by userspace.

K0s's current kube-proxy image ships ipset v7.17, whereas K0s's current calico-node image ships ipset v7.15. That fails on newer kernels, if kube-proxy uses IPVS.

Fix this by updating to new Calico images that ship v7.17, too.

See:
* https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=e9374524950512a1769f610a868fcdf89ea59b8e

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings