### PR TITLE
[Backport release-1.26] Change kubelet args passed in CLI inttest

### DIFF
--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -73,7 +73,7 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 
 	s.T().Run("k0sInstall", func(t *testing.T) {
 		// Install with some arbitrary kubelet flags so we see those get properly passed to the kubelet
-		out, err := ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s install controller --enable-worker --disable-components konnectivity-server,metrics-server --kubelet-extra-args='--event-qps=7 --enable-load-reader=true'")
+		out, err := ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s install controller --enable-worker --disable-components konnectivity-server,metrics-server --kubelet-extra-args='--housekeeping-interval=10s --log-flush-frequency=5s'")
 		assert.NoError(t, err)
 		assert.Equal(t, "", out)
 	})
@@ -114,9 +114,9 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 
 		// Check that the kubelet extra flags are properly set
 		kubeletCmdLine, err := s.GetKubeletCMDLine(s.ControllerNode(0))
-		s.Require().NoError(err)
-		s.Require().Contains(kubeletCmdLine, "--event-qps=7")
-		s.Require().Contains(kubeletCmdLine, "--enable-load-reader=true")
+		require.NoError(err)
+		assert.Contains(kubeletCmdLine, "--housekeeping-interval=10s")
+		assert.Contains(kubeletCmdLine, "--log-flush-frequency=5s")
 	})
 
 	s.T().Log("waiting for k0s to terminate")

--- a/inttest/common/footloosesuite.go
+++ b/inttest/common/footloosesuite.go
@@ -1021,19 +1021,19 @@ func (s *FootlooseSuite) initializeFootlooseCluster() error {
 }
 
 // Verifies that kubelet process has the address flag set
-func (s *FootlooseSuite) GetKubeletCMDLine(node string) (string, error) {
+func (s *FootlooseSuite) GetKubeletCMDLine(node string) ([]string, error) {
 	ssh, err := s.SSH(node)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer ssh.Disconnect()
 
 	output, err := ssh.ExecWithOutput(s.Context(), `cat /proc/$(pidof kubelet)/cmdline`)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return output, nil
+	return strings.Split(output, "\x00"), nil
 }
 
 func (s *FootlooseSuite) initializeFootlooseClusterInDir(dir string) error {


### PR DESCRIPTION
Backport to `release-1.26`:
* #3511

See:
* #3510