### PR TITLE
Fix wrong controller port used for pre-generated tokens command

### DIFF
--- a/docs/custom-ca.md
+++ b/docs/custom-ca.md
@@ -30,3 +30,11 @@ k0s token pre-shared --role worker --cert /var/lib/k0s/pki/ca.crt --url https://
 
 The command above generates a join token and a Secret. A Secret should be deployed to the cluster to authorize the token.
 For example, you can put the Secret under the [manifest](manifests.md) directory and it will be deployed automatically.
+
+Please note that if you are generating a join token for a controller, the port number needs to be 9443 instead of 6443.
+Controller bootstrapping requires talking to the k0s-apiserver instead of the kube-apiserver.
+Here's an example of a command for pre-generating a token for a controller.
+
+```shell
+k0s token pre-shared --role controller --cert /var/lib/k0s/pki/ca.crt --url https://<controller-ip>:9443/
+```


### PR DESCRIPTION
## Description

The port number of controller used in the custom CA cert doc's pre-generated tokens section is wrong. It's using `6443`, that's for `kube-apiserver`. But what we need here is `9443` actually (the k0s-api). Took me a while debugging to find out that k0s is trying to join the controller server with a wrong port 😅

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings