### PR TITLE
Use release ID in checksums step of release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       tag_name: ${{ steps.branch_name.outputs.TAG_NAME }}
+      release_id: ${{ steps.create_release.outputs.id }}
       image_tag: ${{ steps.image_tag.outputs.IMAGE_TAGS }}
     steps:
       # Ugly hack to get the tag name
@@ -353,7 +354,7 @@ jobs:
       - name: Download assets for generating checksums
         uses: robinraju/release-downloader@v1.8
         with:
-          tag: ${{ needs.release.outputs.tag_name }}
+          releaseId: ${{ needs.release.outputs.release_id }}
           filename: "*"
           out-file-path: release_assets
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

The tag name doesn't seem to work for draft releases. So try the release ID as retunred from the create-release action.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings