### PR TITLE
Update kubernetes pause image to v3.9, for real

### DIFF
--- a/pkg/constant/constant_posix.go
+++ b/pkg/constant/constant_posix.go
@@ -25,7 +25,7 @@ const (
 	KubeletVolumePluginDir         = "/usr/libexec/k0s/kubelet-plugins/volume/exec"
 	KineSocket                     = "kine/kine.sock:2379"
 	KubePauseContainerImage        = "registry.k8s.io/pause"
-	KubePauseContainerImageVersion = "3.8"
+	KubePauseContainerImageVersion = "3.9"
 	K0sConfigPathDefault           = "/etc/k0s/k0s.yaml"
 	RuntimeConfigPathDefault       = "/run/k0s/k0s.yaml"
 )


### PR DESCRIPTION
## Description

This fixes the oversight of bumping the pause image version _only_ on Windows.

Fixes:
* #3533

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings