### PR TITLE
Disable race checker conditionally in Makefile

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -382,10 +382,6 @@ jobs:
           path: |
             build/cache/go/mod
 
-      - name: Disable race checker
-        if: matrix.arch == 'arm'
-        run: echo GO_TEST_RACE= >>"$GITHUB_ENV"
-
       - name: Build
         run: |
           make bindata

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,11 @@ $(smoketests): k0s
 smoketests: $(smoketests)
 
 .PHONY: check-unit
+ifneq (, $(filter $(HOST_ARCH), arm))
+check-unit: GO_TEST_RACE ?=
+else
 check-unit: GO_TEST_RACE ?= -race
+endif
 check-unit: go.sum codegen
 	$(GO) test -tags=hack $(GO_TEST_RACE) -ldflags='$(LD_FLAGS)' `$(GO) list -tags=hack $(GO_CHECK_UNIT_DIRS)`
 


### PR DESCRIPTION
## Description

Instead of doing it in the CI. The Makefile is already architecture-aware, hence it makes sense to implement the conditional switch there. This gives a better experience when building and testing k0s directly on those architectures.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings