### PR TITLE
Forward SOURCE_DATE_EPOCH to embedded k8s binaries

### DIFF
--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -6,6 +6,10 @@ export GOOS
 TARGET_OS ?= linux
 export TARGET_OS
 
+# https://reproducible-builds.org/docs/source-date-epoch/#makefile
+# https://reproducible-builds.org/docs/source-date-epoch/#git
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct || date -u +%s)
+
 bindir = staging/${TARGET_OS}/bin
 posix_bins = runc kubelet containerd containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2 kube-apiserver kube-scheduler kube-controller-manager etcd kine konnectivity-server xtables-legacy-multi xtables-nft-multi
 windows_bins = kubelet.exe kube-proxy.exe containerd.exe containerd-shim-runhcs-v1.exe
@@ -79,6 +83,7 @@ build_docker_image = \
 	  --build-arg CONTAINERD_BINS="$(containerd_bins)" \
 	  --build-arg KUBERNETES_BINS="$(kubernetes_bins)" \
 	  --build-arg VERSION=$($(patsubst %/Dockerfile,%,$<)_version) \
+	  --build-arg SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
 	  --build-arg BUILDIMAGE=$($(patsubst %/Dockerfile,%,$<)_buildimage) \
 	  --build-arg BUILD_GO_TAGS=$($(patsubst %/Dockerfile,%,$<)_build_go_tags) \
 	  --build-arg BUILD_GO_CGO_ENABLED=$($(patsubst %/Dockerfile,%,$<)_build_go_cgo_enabled) \

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -30,7 +30,7 @@ kubernetes_build_go_tags = "providerless"
 #kubernetes_build_go_cgo_cflags =
 kubernetes_build_go_flags = "-v"
 #kubernetes_build_go_ldflags =
-kubernetes_build_go_ldflags_extra = "-w -s -extldflags=-static"
+kubernetes_build_go_ldflags_extra = "-extldflags=-static"
 
 kine_version = 0.10.3
 kine_buildimage = $(golang_buildimage)

--- a/embedded-bins/kubernetes/Dockerfile
+++ b/embedded-bins/kubernetes/Dockerfile
@@ -9,6 +9,7 @@ RUN git -c advice.detachedHead=false clone -b v$VERSION --depth=1 https://github
 WORKDIR /go/src/github.com/kubernetes/kubernetes
 
 ARG TARGET_OS \
+  SOURCE_DATE_EPOCH \
   BUILD_GO_TAGS \
   BUILD_GO_CGO_ENABLED \
   BUILD_GO_FLAGS \
@@ -17,7 +18,7 @@ ARG TARGET_OS \
   KUBERNETES_BINS
 
 RUN \
-  set -e; \
+  set -ex; \
   export GOPATH=/go; \
   if [ "${TARGET_OS}" = windows ]; then \
     commands="${KUBERNETES_BINS}"; \
@@ -34,7 +35,9 @@ RUN \
     export KUBE_STATIC_OVERRIDES=$commands; \
   fi; \
   mkdir /out; \
+  export SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH; \
   export FORCE_HOST_GO=y; \
+  export KUBE_VERBOSE=9; \
   export KUBE_GIT_VERSION="v$VERSION+k0s"; \
   for cmd in $commands; do \
     make GOFLAGS="${BUILD_GO_FLAGS} -tags=${BUILD_GO_TAGS}" GOLDFLAGS="${BUILD_GO_LDFLAGS_EXTRA}" WHAT=cmd/$cmd; \


### PR DESCRIPTION
## Description

Make it possible for embedded binaries to pick up the `SOURCE_DATE_EPOCH` with which k0s is built. If supported, the embedded binaries will display the same build date as the k0s binary.

Currently, only Kubernetes binaries will get the timestamp. It still needs to be checked what other binaries embed the build date.

Also remove some Go build flags that get added by default in the Kubernetes build.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings