### PR TITLE
Make "k0s config validate" display errors

### DIFF
--- a/cmd/config/validate.go
+++ b/cmd/config/validate.go
@@ -57,15 +57,9 @@ func NewValidateCmd() *cobra.Command {
 				return fmt.Errorf("failed to read config: %w", err)
 			}
 
-			errs := cfg.Validate()
-			if len(errs) > 0 {
-				return fmt.Errorf("config validation failed: %w", errors.Join(errs...))
-			}
-
-			return nil
+			return errors.Join(cfg.Validate()...)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		SilenceUsage: true,
 	}
 
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())

--- a/cmd/config/validate.go
+++ b/cmd/config/validate.go
@@ -40,7 +40,7 @@ func NewValidateCmd() *cobra.Command {
 			// config.CfgFile is the global value holder for --config flag, set by cobra/pflag
 			switch config.CfgFile {
 			case "-":
-				reader = os.Stdin
+				reader = cmd.InOrStdin()
 			case "":
 				return errors.New("--config can't be emmpty")
 			default:

--- a/cmd/config/validate.go
+++ b/cmd/config/validate.go
@@ -42,7 +42,7 @@ func NewValidateCmd() *cobra.Command {
 			case "-":
 				reader = cmd.InOrStdin()
 			case "":
-				return errors.New("--config can't be emmpty")
+				return errors.New("--config can't be empty")
 			default:
 				f, err := os.Open(config.CfgFile)
 				if err != nil {

--- a/cmd/config/validate_test.go
+++ b/cmd/config/validate_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2023 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/yaml"
+)
+
+func validConfig() []byte {
+	config := v1beta1.DefaultClusterConfig()
+	cfg, _ := yaml.Marshal(config)
+	return cfg
+}
+
+func invalidConfig() []byte {
+	config := v1beta1.DefaultClusterConfig()
+	config.Spec.Extensions.Storage.Type = "external_storage"
+	//  CreateDefaultStorageClass is not supported with external_storage
+	config.Spec.Extensions.Storage.CreateDefaultStorageClass = true
+	cfg, _ := yaml.Marshal(config)
+	return cfg
+}
+
+func TestValidateCmd(t *testing.T) {
+	t.Run("stdin", func(t *testing.T) {
+		cmd := NewValidateCmd()
+		cmd.SetArgs([]string{"--config", "-"})
+		cmd.SetIn(bytes.NewReader(invalidConfig()))
+		errOut := bytes.NewBuffer(nil)
+		cmd.SetErr(errOut)
+		assert.Error(t, cmd.Execute())
+		assert.Contains(t, errOut.String(), "default storage class for external_storage")
+		errOut.Reset()
+		cmd.SetIn(bytes.NewReader(validConfig()))
+		assert.NoError(t, cmd.Execute())
+		assert.Empty(t, errOut.String())
+	})
+
+	t.Run("empty config argument", func(t *testing.T) {
+		cmd := NewValidateCmd()
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs([]string{"--config", ""})
+		assert.ErrorContains(t, cmd.Execute(), "empty")
+	})
+
+	t.Run("nonexisting config file", func(t *testing.T) {
+		cmd := NewValidateCmd()
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs([]string{"--config", "/path/to/nonexistent/file"})
+		assert.ErrorIs(t, cmd.Execute(), os.ErrNotExist)
+	})
+
+	t.Run("malformed config from file", func(t *testing.T) {
+		cmd := NewValidateCmd()
+		tmpfile, _ := os.CreateTemp("", "testconfig")
+		defer os.Remove(tmpfile.Name())
+		_, _ = tmpfile.WriteString("malformed yaml")
+		cmd.SetArgs([]string{"--config", tmpfile.Name()})
+		errOut := bytes.NewBuffer(nil)
+		cmd.SetErr(errOut)
+		assert.ErrorContains(t, cmd.Execute(), "cannot unmarshal")
+		assert.Contains(t, errOut.String(), "cannot unmarshal")
+	})
+
+	t.Run("valid config from file", func(t *testing.T) {
+		cmd := NewValidateCmd()
+		tmpfile, _ := os.CreateTemp("", "testconfig")
+		defer os.Remove(tmpfile.Name())
+		_, _ = tmpfile.Write(validConfig())
+		cmd.SetArgs([]string{"--config", tmpfile.Name()})
+		errOut := bytes.NewBuffer(nil)
+		cmd.SetErr(errOut)
+		assert.NoError(t, cmd.Execute())
+		assert.Empty(t, errOut.String())
+	})
+}


### PR DESCRIPTION
## Description

Makes `k0s config validate` display error messsages.

The reason was that `SilenceErrors` was `true`.

Fixes #3563 

## Type of change

<!-- check the related options -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [X] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [X] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [X] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings