### PR TITLE
Reclaim GitHub Runner disk space

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -213,6 +213,9 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
 
+      - name: Reclaim runner disk space
+        run: .github/workflows/reclaim-runner-disk-space.bash
+
       - name: Prepare build environment
         run: .github/workflows/prepare-build-env.sh
 
@@ -285,6 +288,9 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
+
+      - name: Reclaim runner disk space
+        run: .github/workflows/reclaim-runner-disk-space.bash
 
       - name: Prepare build environment
         run: .github/workflows/prepare-build-env.sh

--- a/.github/workflows/reclaim-runner-disk-space.bash
+++ b/.github/workflows/reclaim-runner-disk-space.bash
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set +eux
+
+if [ -z "$GITHUB_RUN_ID" ]; then
+  echo "Cowardly refusing to destroy a machine that doesn't look like a GitHub runner." >&2
+  exit 0
+fi
+
+df -h /
+
+docker system prune --all --force &
+sudo rm -rf /imagegeneration/installers &
+sudo rm -rf -- "${ANDROID_SDK_ROOT-/opt/nevermind}" &
+
+wait
+
+df -h /

--- a/inttest/network-conformance/network_test.go
+++ b/inttest/network-conformance/network_test.go
@@ -153,11 +153,4 @@ const k0sConfig = `
 spec:
   network:
     provider: %s
-  workerProfiles:
-    - name: default
-      values:
-        # GitHub runners may get low on disk space
-        evictionHard:
-          nodefs.available: 200Mi
-          imagefs.available: 200Mi
 `


### PR DESCRIPTION
## Description

GitHub runners provide 14GB of guaranteed available disk space, which is typically sufficient for running k0s's integration tests. However, when free space drops below 15%, Kubernetes initiates pod eviction, leaving only 5GB left on an 84GB disk until it kicks in. In response, streamline disk space usage and remove non-essential data. That's easier than globally overriding Kubernetes eviction defaults for all integration tests.

Also revert #3470 which was another workaround that solved the problem for a single integration test.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings