### PR TITLE
Remove remnants of latest k0s Docker image tags in docs

### DIFF
--- a/docs/examples/ambassador-ingress.md
+++ b/docs/examples/ambassador-ingress.md
@@ -13,7 +13,7 @@ As you need to create a custom configuration file to install Ambassador Gateway,
 1. Run k0s under Docker:
 
     ```shell
-    docker run -d --name k0s --hostname k0s --privileged -v /var/lib/k0s -p 6443:6443 docker.io/k0sproject/k0s:latest
+    docker run -d --name k0s --hostname k0s --privileged -v /var/lib/k0s -p 6443:6443 docker.io/k0sproject/k0s:{{{ extra.k8s_version }}}-k0s.0
     ```
 
 2. Export the default k0s configuration file:
@@ -77,7 +77,7 @@ As you need to create a custom configuration file to install Ambassador Gateway,
 3. Retart your k0s container, this time with additional ports and the above config file mapped into it:
 
     ```shell
-    docker run --name k0s --hostname k0s --privileged -v /var/lib/k0s -v "$PWD"/k0s.yaml:/k0s.yaml -p 6443:6443 -p 80:80 -p 443:443 -p 8080:8080 docker.io/k0sproject/k0s:latest
+    docker run --name k0s --hostname k0s --privileged -v /var/lib/k0s -v "$PWD"/k0s.yaml:/k0s.yaml -p 6443:6443 -p 80:80 -p 443:443 -p 8080:8080 docker.io/k0sproject/k0s:{{{ extra.k8s_version }}}-k0s.0
     ```
 
     After some time, you will be able to list the Ambassador Services:

--- a/docs/k0s-in-docker.md
+++ b/docs/k0s-in-docker.md
@@ -22,7 +22,7 @@ The k0s containers are published both on Docker Hub and GitHub. For reasons of s
 You can run your own k0s in Docker:
 
 ```sh
-docker run -d --name k0s --hostname k0s --privileged -v /var/lib/k0s -p 6443:6443 docker.io/k0sproject/k0s:latest
+docker run -d --name k0s --hostname k0s --privileged -v /var/lib/k0s -p 6443:6443 docker.io/k0sproject/k0s:{{{ extra.k8s_version }}}-k0s.0
 ```
 
 **Note:** If you are using Docker Desktop as the runtime, starting from 4.3.0 version it's using cgroups v2 in the VM that runs the engine. This means you have to add some extra flags to the above command to get kubelet and containerd to properly work with cgroups v2:
@@ -46,7 +46,7 @@ For each required worker:
 2. Run the container to create and join the new worker:
 
     ```sh
-    docker run -d --name k0s-worker1 --hostname k0s-worker1 --privileged -v /var/lib/k0s docker.io/k0sproject/k0s:latest k0s worker $token
+    docker run -d --name k0s-worker1 --hostname k0s-worker1 --privileged -v /var/lib/k0s docker.io/k0sproject/k0s:{{{ extra.k8s_version }}}-k0s.0 k0s worker $token
     ```
 
 ### 3. Access your cluster
@@ -68,7 +68,7 @@ version: "3.9"
 services:
   k0s:
     container_name: k0s
-    image: docker.io/k0sproject/k0s:latest
+    image: docker.io/k0sproject/k0s:{{{ extra.k8s_version }}}-k0s.0
     command: k0s controller --config=/etc/k0s/config.yaml --enable-worker
     hostname: k0s
     privileged: true


### PR DESCRIPTION
## Description

There are _still_ some mentions of the latest tag for the k0s Docker image in the docs. Remove them.

Fixes:
* #3269

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings