### PR TITLE
Remove custom Docker networks from integration tests

### DIFF
--- a/inttest/airgap/airgap_test.go
+++ b/inttest/airgap/airgap_test.go
@@ -39,20 +39,6 @@ type AirgapSuite struct {
 	common.FootlooseSuite
 }
 
-const network = "airgap"
-
-// SetupSuite creates the required network before starting footloose.
-func (s *AirgapSuite) SetupSuite() {
-	s.Require().NoError(s.CreateNetwork(network))
-	s.FootlooseSuite.SetupSuite()
-}
-
-// TearDownSuite tears down the network created after footloose has finished.
-func (s *AirgapSuite) TearDownSuite() {
-	s.FootlooseSuite.TearDownSuite()
-	s.Require().NoError(s.MaybeDestroyNetwork(network))
-}
-
 func (s *AirgapSuite) TestK0sGetsUp() {
 	err := (&common.Airgap{
 		SSH:  s.SSH,
@@ -122,10 +108,8 @@ func (s *AirgapSuite) TestK0sGetsUp() {
 func TestAirgapSuite(t *testing.T) {
 	s := AirgapSuite{
 		common.FootlooseSuite{
-			ControllerCount:    1,
-			WorkerCount:        1,
-			ControllerNetworks: []string{network},
-			WorkerNetworks:     []string{network},
+			ControllerCount: 1,
+			WorkerCount:     1,
 
 			AirgapImageBundleMountPoints: []string{"/var/lib/k0s/images/bundle.tar"},
 		},

--- a/inttest/ap-airgap/airgap_test.go
+++ b/inttest/ap-airgap/airgap_test.go
@@ -31,20 +31,6 @@ type airgapSuite struct {
 	common.FootlooseSuite
 }
 
-const network = "ap-airgap"
-
-// SetupSuite creates the required network before starting footloose.
-func (s *airgapSuite) SetupSuite() {
-	s.Require().NoError(s.CreateNetwork(network))
-	s.FootlooseSuite.SetupSuite()
-}
-
-// TearDownSuite tears down the network created after footloose has finished.
-func (s *airgapSuite) TearDownSuite() {
-	s.FootlooseSuite.TearDownSuite()
-	s.Require().NoError(s.MaybeDestroyNetwork(network))
-}
-
 // SetupTest prepares the controller and filesystem, getting it into a consistent
 // state which we can run tests against.
 func (s *airgapSuite) SetupTest() {
@@ -157,9 +143,6 @@ func TestAirgapSuite(t *testing.T) {
 			LaunchMode:      common.LaunchModeOpenRC,
 
 			AirgapImageBundleMountPoints: []string{"/dist/bundle.tar"},
-
-			ControllerNetworks: []string{network},
-			WorkerNetworks:     []string{network},
 		},
 	})
 }

--- a/inttest/ap-ha3x3/ha3x3_test.go
+++ b/inttest/ap-ha3x3/ha3x3_test.go
@@ -40,20 +40,6 @@ spec:
     externalAddress: %s
 `
 
-const network = "ha3x3net"
-
-// SetupSuite creates the required network before starting footloose.
-func (s *ha3x3Suite) SetupSuite() {
-	s.Require().NoError(s.CreateNetwork(network))
-	s.FootlooseSuite.SetupSuite()
-}
-
-// TearDownSuite tears down the network created after footloose has finished.
-func (s *ha3x3Suite) TearDownSuite() {
-	s.FootlooseSuite.TearDownSuite()
-	s.Require().NoError(s.MaybeDestroyNetwork(network))
-}
-
 // SetupTest prepares the controller and filesystem, getting it into a consistent
 // state which we can run tests against.
 func (s *ha3x3Suite) SetupTest() {
@@ -195,9 +181,6 @@ func TestHA3x3Suite(t *testing.T) {
 			WorkerCount:     3,
 			WithLB:          true,
 			LaunchMode:      common.LaunchModeOpenRC,
-
-			ControllerNetworks: []string{network},
-			WorkerNetworks:     []string{network},
 		},
 	})
 }

--- a/inttest/ap-quorum/quorum_test.go
+++ b/inttest/ap-quorum/quorum_test.go
@@ -38,20 +38,6 @@ spec:
     externalAddress: %s
 `
 
-const network = "quorumnet"
-
-// SetupSuite creates the required network before starting footloose.
-func (s *quorumSuite) SetupSuite() {
-	s.Require().NoError(s.CreateNetwork(network))
-	s.FootlooseSuite.SetupSuite()
-}
-
-// TearDownSuite tears down the network created after footloose has finished.
-func (s *quorumSuite) TearDownSuite() {
-	s.FootlooseSuite.TearDownSuite()
-	s.Require().NoError(s.MaybeDestroyNetwork(network))
-}
-
 // SetupTest prepares the controller and filesystem, getting it into a consistent
 // state which we can run tests against.
 func (s *quorumSuite) SetupTest() {
@@ -152,9 +138,6 @@ func TestQuorumSuite(t *testing.T) {
 			ControllerCount: 3,
 			WorkerCount:     0,
 			LaunchMode:      common.LaunchModeOpenRC,
-
-			ControllerNetworks: []string{network},
-			WorkerNetworks:     []string{network},
 		},
 	})
 }

--- a/inttest/ap-quorumsafety/quorumsafety_test.go
+++ b/inttest/ap-quorumsafety/quorumsafety_test.go
@@ -38,20 +38,6 @@ spec:
     externalAddress: %s
 `
 
-const network = "quorumsafetynet"
-
-// SetupSuite creates the required network before starting footloose.
-func (s *quorumSafetySuite) SetupSuite() {
-	s.Require().NoError(s.CreateNetwork(network))
-	s.FootlooseSuite.SetupSuite()
-}
-
-// TearDownSuite tears down the network created after footloose has finished.
-func (s *quorumSafetySuite) TearDownSuite() {
-	s.FootlooseSuite.TearDownSuite()
-	s.Require().NoError(s.MaybeDestroyNetwork(network))
-}
-
 // SetupTest prepares the controller and filesystem, getting it into a consistent
 // state which we can run tests against.
 func (s *quorumSafetySuite) SetupTest() {
@@ -163,9 +149,6 @@ func TestQuorumSafetySuite(t *testing.T) {
 			ControllerCount: 2,
 			WorkerCount:     0,
 			LaunchMode:      common.LaunchModeOpenRC,
-
-			ControllerNetworks: []string{network},
-			WorkerNetworks:     []string{network},
 		},
 	})
 }

--- a/inttest/ap-selector/selector_test.go
+++ b/inttest/ap-selector/selector_test.go
@@ -39,20 +39,6 @@ spec:
     externalAddress: %s
 `
 
-const network = "selectornet"
-
-// SetupSuite creates the required network before starting footloose.
-func (s *selectorSuite) SetupSuite() {
-	s.Require().NoError(s.CreateNetwork(network))
-	s.FootlooseSuite.SetupSuite()
-}
-
-// TearDownSuite tears down the network created after footloose has finished.
-func (s *selectorSuite) TearDownSuite() {
-	s.FootlooseSuite.TearDownSuite()
-	s.Require().NoError(s.MaybeDestroyNetwork(network))
-}
-
 // SetupTest prepares the controller and filesystem, getting it into a consistent
 // state which we can run tests against.
 func (s *selectorSuite) SetupTest() {

--- a/inttest/kubeletcertrotate/kubeletcertrotate_test.go
+++ b/inttest/kubeletcertrotate/kubeletcertrotate_test.go
@@ -35,20 +35,6 @@ type kubeletCertRotateSuite struct {
 	common.FootlooseSuite
 }
 
-const network = "kubeletcertrotatenet"
-
-// SetupSuite creates the required network before starting footloose.
-func (s *kubeletCertRotateSuite) SetupSuite() {
-	s.Require().NoError(s.CreateNetwork(network))
-	s.FootlooseSuite.SetupSuite()
-}
-
-// TearDownSuite tears down the network created after footloose has finished.
-func (s *kubeletCertRotateSuite) TearDownSuite() {
-	s.FootlooseSuite.TearDownSuite()
-	s.Require().NoError(s.MaybeDestroyNetwork(network))
-}
-
 type statusJSON struct {
 	WorkerToAPIConnectionStatus status.ProbeStatus
 }
@@ -189,9 +175,6 @@ func TestKubeletCertRotateSuite(t *testing.T) {
 			ControllerCount: 1,
 			WorkerCount:     1,
 			LaunchMode:      common.LaunchModeOpenRC,
-
-			ControllerNetworks: []string{network},
-			WorkerNetworks:     []string{network},
 		},
 	})
 }


### PR DESCRIPTION
## Description

Using custom networks makes CoreDNS's loop plugin detect a loop and fail. Fix this by simply ripping out all custom network functionality from the inttests. An alternative would have been to apply the workarounds in k0s's Docker entrypoint also inside the inttests, but, since the custom networks apparently didn't serve any special purpose, deleting code is better than adding code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings