### PR TITLE
Add label selector also when watching

### DIFF
--- a/pkg/kubernetes/watch/watcher.go
+++ b/pkg/kubernetes/watch/watcher.go
@@ -288,6 +288,7 @@ func (w *Watcher[T]) watch(ctx context.Context, resourceVersion string, conditio
 		ResourceVersion:     resourceVersion,
 		AllowWatchBookmarks: true,
 		FieldSelector:       w.fieldSelector,
+		LabelSelector:       w.labelSelector,
 		TimeoutSeconds:      pointer.Int64(maxWatchDurationSecs),
 	})
 	if err != nil {

--- a/pkg/kubernetes/watch/watcher.go
+++ b/pkg/kubernetes/watch/watcher.go
@@ -154,7 +154,7 @@ func (w *Watcher[T]) WithObjectName(name string) *Watcher[T] {
 // [Kubernetes codebase].
 //
 // [concept]: https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
-// [Kubernetes codebase]: https://sourcegraph.com/search?q=lang:go+AddFieldLabelConversionFunc(...)+repo:^github\.com/kubernetes/kubernetes%24+-file:_test\.go%24+select:content&patternType=structural
+// [Kubernetes codebase]: https://sourcegraph.com/search?q=lang:go+AddFieldLabelConversionFunc%28...%29+repo:%5Egithub%5C.com/kubernetes/kubernetes%24+-file:_test%5C.go%24+select:content&patternType=structural
 func (w *Watcher[T]) WithFieldSelector(selector fields.Selector) *Watcher[T] {
 	w.fieldSelector = selector.String()
 	return w


### PR DESCRIPTION
## Description

The watcher was not respecting its label selector when watching, only when listing.

Fixes:
* #2624

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings