### PR TITLE
[Backport release-1.26] Bump Go to v1.20.10

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.17
 alpine_patch_version = $(alpine_version).4
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.20.8
+go_version = 1.20.9
 
 runc_version = 1.1.9
 runc_buildimage = $(golang_buildimage)

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.17
 alpine_patch_version = $(alpine_version).4
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.20.9
+go_version = 1.20.10
 
 runc_version = 1.1.9
 runc_buildimage = $(golang_buildimage)


### PR DESCRIPTION
Backport to `release-1.26`:
* #3571

Fixes:
* CVE-2023-39323
* CVE-2023-39325

See:
* #3558
* #3570