### PR TITLE
Add Amazon Linux 2023 to OS testing matrix

### DIFF
--- a/.github/workflows/ostests-matrix.yaml
+++ b/.github/workflows/ostests-matrix.yaml
@@ -22,6 +22,7 @@ on:
         required: true
         default: >-
           [
+            "al2023",
             "alpine_3_17",
             "centos_7", "centos_8", "centos_9",
             "debian_10", "debian_11", "debian_12",

--- a/hack/ostests/README.md
+++ b/hack/ostests/README.md
@@ -67,6 +67,7 @@ terraform apply
 
 ### `os`: Operating system stack
 
+* `al2023`: Amazon Linux 2023
 * `alpine_3_17`: Alpine Linux 3.17
 * `centos_7`: CentOS Linux 7 (Core)
 * `centos_8`: CentOS Stream 8

--- a/hack/ostests/modules/os/main.tf
+++ b/hack/ostests/modules/os/main.tf
@@ -2,6 +2,7 @@ locals {
   # Boilerplate to make terraform a little bit dynamic
 
   os = {
+    al2023      = local.os_al2023
     alpine_3_17 = local.os_alpine_3_17
     centos_7    = local.os_centos_7
     centos_8    = local.os_centos_8

--- a/hack/ostests/modules/os/os_al2023.tf
+++ b/hack/ostests/modules/os/os_al2023.tf
@@ -1,0 +1,44 @@
+# https://docs.aws.amazon.com/linux/al2023/ug/naming-and-versioning.html
+
+data "aws_ami" "al2023" {
+  count = var.os == "al2023" ? 1 : 0
+
+  owners      = ["137112412989"]
+  name_regex  = "^al2023-ami-2023.\\d+.\\d+.\\d+-.*-x86_64"
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023.*-x86_64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+locals {
+  os_al2023 = var.os != "al2023" ? {} : {
+    node_configs = {
+      default = {
+        ami_id = one(data.aws_ami.al2023.*.id)
+
+        connection = {
+          type     = "ssh"
+          username = "ec2-user"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

But don't add it to the nightly job yet. It seems that k0s is currently not working out of the box on that distro, for unclear reasons. Somehow the container networking is broken, for both kube-router and Calico.

See:
* #3596

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings