### PR TITLE
Add option to skip k0s provisioning in ostests Terraform module

### DIFF
--- a/hack/ostests/README.md
+++ b/hack/ostests/README.md
@@ -90,6 +90,27 @@ terraform apply
 * `ubuntu_2204`: Ubuntu 22.04 LTS
 * `ubuntu_2304`: Ubuntu 23.04
 
+### `k0sctl_skip`: Skip k0s provisioning altogether
+
+Just provision the infrastructure, but no k0s cluster. This may be used for
+development and testing purposes.
+
+Assuming the AWS credentials are available, it can be used like this:
+
+```sh
+terraform init
+export TF_VAR_os=alpine_3_17
+export TF_VAR_k0sctl_skip=true
+terraform apply
+terraform output -json | jq -r '
+  (.ssh_private_key_filename.value | @sh) as $keyFile
+    | .hosts.value[]
+    | select(.connection.type = "ssh")
+    | . as {name: $host, ipv4: $ip, connection: {username: $user}}
+    | "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i \($keyFile) \($user)@\($ip) # \($host)"
+'
+```
+
 ### `k0s_version`: The k0s version to deploy
 
 This may be a fixed version number, "stable" or "latest".

--- a/hack/ostests/outputs.tf
+++ b/hack/ostests/outputs.tf
@@ -1,20 +1,20 @@
 output "hosts" {
-  value       = module.k0sctl.hosts
+  value       = var.k0sctl_skip ? local.hosts : module.k0sctl[0].hosts
   description = "The hosts that have been provisioned by k0sctl."
 }
 
 output "ssh_private_key_filename" {
-  value       = module.k0sctl.ssh_private_key_filename
+  value       = var.k0sctl_skip ? local.ssh_private_key_filename : module.k0sctl[0].ssh_private_key_filename
   description = "The name of the private key file that has been used to authenticate via SSH."
 }
 
 output "k0sctl_config" {
-  value       = module.k0sctl.k0sctl_config
+  value       = var.k0sctl_skip ? null : module.k0sctl[0].k0sctl_config
   description = "The k0sctl config that has been used."
 }
 
 output "k0s_kubeconfig" {
-  value       = module.k0sctl.k0s_kubeconfig
+  value       = var.k0sctl_skip ? null : module.k0sctl[0].k0s_kubeconfig
   description = "The k0s admin kubeconfig that may be used to connect to the cluster."
   sensitive   = true
 }

--- a/hack/ostests/variables.tf
+++ b/hack/ostests/variables.tf
@@ -35,6 +35,13 @@ variable "os" {
   description = "The underlying OS for the to-be-provisioned cluster."
 }
 
+variable "k0sctl_skip" {
+  type        = bool
+  description = "Skip k0s provisoning altogether."
+  default     = false
+  nullable    = false
+}
+
 variable "k0sctl_executable_path" {
   type        = string
   description = "Path to the k0sctl executable to use for local-exec provisioning."
@@ -62,6 +69,7 @@ variable "k0s_version" {
   type        = string
   nullable    = false
   description = "The k0s version to deploy on the nodes. May be an exact version, \"stable\" or \"latest\"."
+  default     = "stable"
 
   validation {
     condition     = length(var.k0s_version) != 0


### PR DESCRIPTION
## Description

This can be handy during development and testing.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings