### PR TITLE
Fix helm race condition

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -373,8 +373,6 @@ func (c *command) start(ctx context.Context) error {
 			c.K0sVars,
 			adminClientFactory,
 			leaderElector,
-			// Hardcode until the config loading is fixed
-			10,
 		))
 	}
 

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -354,10 +354,8 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
 		},
-		Logger: logrusr.New(ec.L),
-		Controller: ctrlconfig.Controller{
-			GroupKindConcurrency: map[string]int{gk.String(): 10},
-		},
+		Logger:     logrusr.New(ec.L),
+		Controller: ctrlconfig.Controller{},
 	})
 	if err != nil {
 		return fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -224,7 +224,7 @@ func (cr *ChartReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 	return reconcile.Result{}, nil
 }
 func (cr *ChartReconciler) uninstall(ctx context.Context, chart v1beta1.Chart) error {
-	if err := cr.helm.UninstallRelease(chart.Status.ReleaseName, chart.Status.Namespace); err != nil {
+	if err := cr.helm.UninstallRelease(ctx, chart.Status.ReleaseName, chart.Status.Namespace); err != nil {
 		return fmt.Errorf("can't uninstall release `%s/%s`: %w", chart.Status.Namespace, chart.Status.ReleaseName, err)
 	}
 	return nil
@@ -252,7 +252,8 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart v1bet
 	if chart.Status.ReleaseName == "" {
 		// new chartRelease
 		cr.L.Tracef("Start update or install %s", chart.Spec.ChartName)
-		chartRelease, err = cr.helm.InstallChart(chart.Spec.ChartName,
+		chartRelease, err = cr.helm.InstallChart(ctx,
+			chart.Spec.ChartName,
 			chart.Spec.Version,
 			chart.Spec.ReleaseName,
 			chart.Spec.Namespace,
@@ -265,7 +266,8 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart v1bet
 	} else {
 		if cr.chartNeedsUpgrade(chart) {
 			// update
-			chartRelease, err = cr.helm.UpgradeChart(chart.Spec.ChartName,
+			chartRelease, err = cr.helm.UpgradeChart(ctx,
+				chart.Spec.ChartName,
 				chart.Spec.Version,
 				chart.Status.ReleaseName,
 				chart.Status.Namespace,

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -52,26 +52,24 @@ import (
 
 // Helm watch for Chart crd
 type ExtensionsController struct {
-	concurrencyLevel int
-	saver            manifestsSaver
-	L                *logrus.Entry
-	helm             *helm.Commands
-	kubeConfig       string
-	leaderElector    leaderelector.Interface
+	saver         manifestsSaver
+	L             *logrus.Entry
+	helm          *helm.Commands
+	kubeConfig    string
+	leaderElector leaderelector.Interface
 }
 
 var _ manager.Component = (*ExtensionsController)(nil)
 var _ manager.Reconciler = (*ExtensionsController)(nil)
 
 // NewExtensionsController builds new HelmAddons
-func NewExtensionsController(s manifestsSaver, k0sVars *config.CfgVars, kubeClientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface, concurrencyLevel int) *ExtensionsController {
+func NewExtensionsController(s manifestsSaver, k0sVars *config.CfgVars, kubeClientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface) *ExtensionsController {
 	return &ExtensionsController{
-		concurrencyLevel: concurrencyLevel,
-		saver:            s,
-		L:                logrus.WithFields(logrus.Fields{"component": "extensions_controller"}),
-		helm:             helm.NewCommands(k0sVars),
-		kubeConfig:       k0sVars.AdminKubeConfigPath,
-		leaderElector:    leaderElector,
+		saver:         s,
+		L:             logrus.WithFields(logrus.Fields{"component": "extensions_controller"}),
+		helm:          helm.NewCommands(k0sVars),
+		kubeConfig:    k0sVars.AdminKubeConfigPath,
+		leaderElector: leaderElector,
 	}
 }
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -41,6 +41,7 @@ import (
 )
 
 // Commands run different helm command in the same way as CLI tool
+// This struct isn't thread-safe. Check on a per function basis.
 type Commands struct {
 	repoFile     string
 	helmCacheDir string
@@ -206,6 +207,8 @@ func (hc *Commands) isInstallable(chart *chart.Chart) bool {
 	return true
 }
 
+// InstallChart installs a helm chart
+// InstallChart, UpgradeChart and UninstallRelease(releaseName are *NOT* thread-safe
 func (hc *Commands) InstallChart(chartName string, version string, releaseName string, namespace string, values map[string]interface{}, timeout time.Duration) (*release.Release, error) {
 	cfg, err := hc.getActionCfg(namespace)
 	if err != nil {
@@ -253,6 +256,8 @@ func (hc *Commands) InstallChart(chartName string, version string, releaseName s
 	return chartRelease, nil
 }
 
+// UpgradeChart upgrades a helm chart.
+// InstallChart, UpgradeChart and UninstallRelease(releaseName are *NOT* thread-safe
 func (hc *Commands) UpgradeChart(chartName string, version string, releaseName string, namespace string, values map[string]interface{}, timeout time.Duration) (*release.Release, error) {
 	cfg, err := hc.getActionCfg(namespace)
 	if err != nil {
@@ -308,6 +313,8 @@ func (hc *Commands) ListReleases(namespace string) ([]*release.Release, error) {
 	return helmAction.Run()
 }
 
+// UninstallRelease uninstalls a release.
+// InstallChart, UpgradeChart and UninstallRelease(releaseName are *NOT* thread-safe
 func (hc *Commands) UninstallRelease(releaseName string, namespace string) error {
 	cfg, err := hc.getActionCfg(namespace)
 	if err != nil {

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -17,6 +17,7 @@ limitations under the License.
 package helm
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -209,7 +210,7 @@ func (hc *Commands) isInstallable(chart *chart.Chart) bool {
 
 // InstallChart installs a helm chart
 // InstallChart, UpgradeChart and UninstallRelease(releaseName are *NOT* thread-safe
-func (hc *Commands) InstallChart(chartName string, version string, releaseName string, namespace string, values map[string]interface{}, timeout time.Duration) (*release.Release, error) {
+func (hc *Commands) InstallChart(ctx context.Context, chartName string, version string, releaseName string, namespace string, values map[string]interface{}, timeout time.Duration) (*release.Release, error) {
 	cfg, err := hc.getActionCfg(namespace)
 	if err != nil {
 		return nil, fmt.Errorf("can't create action configuration: %v", err)
@@ -249,7 +250,7 @@ func (hc *Commands) InstallChart(chartName string, version string, releaseName s
 	if err != nil {
 		return nil, fmt.Errorf("can't reload loadedChart `%s`: %v", chartDir, err)
 	}
-	chartRelease, err := install.Run(loadedChart, values)
+	chartRelease, err := install.RunWithContext(ctx, loadedChart, values)
 	if err != nil {
 		return nil, fmt.Errorf("can't install loadedChart `%s`: %v", loadedChart.Name(), err)
 	}
@@ -258,7 +259,7 @@ func (hc *Commands) InstallChart(chartName string, version string, releaseName s
 
 // UpgradeChart upgrades a helm chart.
 // InstallChart, UpgradeChart and UninstallRelease(releaseName are *NOT* thread-safe
-func (hc *Commands) UpgradeChart(chartName string, version string, releaseName string, namespace string, values map[string]interface{}, timeout time.Duration) (*release.Release, error) {
+func (hc *Commands) UpgradeChart(ctx context.Context, chartName string, version string, releaseName string, namespace string, values map[string]interface{}, timeout time.Duration) (*release.Release, error) {
 	cfg, err := hc.getActionCfg(namespace)
 	if err != nil {
 		return nil, fmt.Errorf("can't create action configuration: %v", err)
@@ -292,7 +293,7 @@ func (hc *Commands) UpgradeChart(chartName string, version string, releaseName s
 		return nil, fmt.Errorf("can't reload loadedChart `%s`: %v", chartDir, err)
 	}
 
-	chartRelease, err := upgrade.Run(releaseName, loadedChart, values)
+	chartRelease, err := upgrade.RunWithContext(ctx, releaseName, loadedChart, values)
 	if err != nil {
 		return nil, fmt.Errorf("can't upgrade loadedChart `%s`: %v", loadedChart.Metadata.Name, err)
 	}
@@ -315,12 +316,17 @@ func (hc *Commands) ListReleases(namespace string) ([]*release.Release, error) {
 
 // UninstallRelease uninstalls a release.
 // InstallChart, UpgradeChart and UninstallRelease(releaseName are *NOT* thread-safe
-func (hc *Commands) UninstallRelease(releaseName string, namespace string) error {
+func (hc *Commands) UninstallRelease(ctx context.Context, releaseName string, namespace string) error {
 	cfg, err := hc.getActionCfg(namespace)
 	if err != nil {
 		return fmt.Errorf("can't create helmAction configuration: %v", err)
 	}
 	helmAction := action.NewUninstall(cfg)
+	deadline, ok := ctx.Deadline()
+	if ok {
+		helmAction.Timeout = time.Until(deadline)
+	}
+
 	if _, err := helmAction.Run(releaseName); err != nil {
 		return fmt.Errorf("can't uninstall release `%s`: %v", releaseName, err)
 	}


### PR DESCRIPTION
## Description

The PR includes three commits.

The first commit removes the field concurrencyLevel in helm controller. This field isn't honored at all and we want to remove concurrent reconciliation anyway so entirely remove the field.

The second commit makes extensions controller thread-safe. Helm is unable to reconcile multiple charts at the same time because /var/lib/k0s/helmhome/cache/ is shared between charts and helm cache was not designed to be safe to be used concurrently. To fix it we document some functions of the Commands struct are not thread safe (they couldn't have a local lock unless it was shared across all instances) and modify the controller not concurrent.

The third commit implements timeouts, we were already passing a context but this wasn't used at all. This is to prevent a reconciler being stuck forever 

Requirement to fix #3282 and #3433

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings