### PR TITLE
Rename pkg/context to k0scontext to avoid named imports

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -50,7 +50,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/component/worker"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
-	k0sctx "github.com/k0sproject/k0s/pkg/context"
+	"github.com/k0sproject/k0s/pkg/k0scontext"
 	"github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/pkg/performance"
 	"github.com/k0sproject/k0s/pkg/telemetry"
@@ -144,7 +144,7 @@ func (c *command) start(ctx context.Context) error {
 	}
 
 	// Add the node config to the context so it can be used by components deep in the "stack"
-	ctx = context.WithValue(ctx, k0sctx.ContextNodeConfigKey, nodeConfig)
+	ctx = context.WithValue(ctx, k0scontext.ContextNodeConfigKey, nodeConfig)
 
 	nodeComponents := manager.New(prober.DefaultProber)
 	clusterComponents := manager.New(prober.DefaultProber)

--- a/pkg/autopilot/controller/updates/clusterinfo.go
+++ b/pkg/autopilot/controller/updates/clusterinfo.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/build"
-	k0sctx "github.com/k0sproject/k0s/pkg/context"
+	"github.com/k0sproject/k0s/pkg/k0scontext"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -73,7 +73,7 @@ func CollectData(ctx context.Context, kc kubernetes.Interface) (*ClusterInfo, er
 	ci.K0sVersion = build.Version
 	ci.Arch = runtime.GOARCH
 
-	nodeConfig := k0sctx.FromContext[v1beta1.ClusterConfig](ctx, k0sctx.ContextNodeConfigKey)
+	nodeConfig := k0scontext.FromContext[v1beta1.ClusterConfig](ctx, k0scontext.ContextNodeConfigKey)
 	if nodeConfig != nil {
 		ci.CNIProvider = nodeConfig.Spec.Network.Provider
 		ci.StorageType = nodeConfig.Spec.Storage.Type

--- a/pkg/k0scontext/context.go
+++ b/pkg/k0scontext/context.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package context
+package k0scontext
 
 import (
 	"context"


### PR DESCRIPTION
## Description

Since stdlib's `"context"` is imported almost everywhere, having an internal package called `context` forces almost always importing it with a label like `k0sctx`.

Here it is renamed to `k0scontext` to avoid having to do so.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [X] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [X] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings