### PR TITLE
[Backport release-1.26] Fix helm race condition

### DIFF
--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -225,7 +225,7 @@ func (cr *ChartReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 	return reconcile.Result{}, nil
 }
 func (cr *ChartReconciler) uninstall(ctx context.Context, chart v1beta1.Chart) error {
-	if err := cr.helm.UninstallRelease(chart.Status.ReleaseName, chart.Status.Namespace); err != nil {
+	if err := cr.helm.UninstallRelease(ctx, chart.Status.ReleaseName, chart.Status.Namespace); err != nil {
 		return fmt.Errorf("can't uninstall release `%s/%s`: %w", chart.Status.Namespace, chart.Status.ReleaseName, err)
 	}
 	return nil
@@ -253,7 +253,8 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart v1bet
 	if chart.Status.ReleaseName == "" {
 		// new chartRelease
 		cr.L.Tracef("Start update or install %s", chart.Spec.ChartName)
-		chartRelease, err = cr.helm.InstallChart(chart.Spec.ChartName,
+		chartRelease, err = cr.helm.InstallChart(ctx,
+			chart.Spec.ChartName,
 			chart.Spec.Version,
 			chart.Spec.ReleaseName,
 			chart.Spec.Namespace,
@@ -266,7 +267,8 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart v1bet
 	} else {
 		if cr.chartNeedsUpgrade(chart) {
 			// update
-			chartRelease, err = cr.helm.UpgradeChart(chart.Spec.ChartName,
+			chartRelease, err = cr.helm.UpgradeChart(ctx,
+				chart.Spec.ChartName,
 				chart.Spec.Version,
 				chart.Status.ReleaseName,
 				chart.Status.Namespace,

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -17,6 +17,7 @@ limitations under the License.
 package helm
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -206,7 +207,9 @@ func (hc *Commands) isInstallable(chart *chart.Chart) bool {
 	return true
 }
 
-func (hc *Commands) InstallChart(chartName string, version string, releaseName string, namespace string, values map[string]interface{}, timeout time.Duration) (*release.Release, error) {
+// InstallChart installs a helm chart
+// InstallChart, UpgradeChart and UninstallRelease(releaseName are *NOT* thread-safe
+func (hc *Commands) InstallChart(ctx context.Context, chartName string, version string, releaseName string, namespace string, values map[string]interface{}, timeout time.Duration) (*release.Release, error) {
 	cfg, err := hc.getActionCfg(namespace)
 	if err != nil {
 		return nil, fmt.Errorf("can't create action configuration: %v", err)
@@ -246,14 +249,16 @@ func (hc *Commands) InstallChart(chartName string, version string, releaseName s
 	if err != nil {
 		return nil, fmt.Errorf("can't reload loadedChart `%s`: %v", chartDir, err)
 	}
-	chartRelease, err := install.Run(loadedChart, values)
+	chartRelease, err := install.RunWithContext(ctx, loadedChart, values)
 	if err != nil {
 		return nil, fmt.Errorf("can't install loadedChart `%s`: %v", loadedChart.Name(), err)
 	}
 	return chartRelease, nil
 }
 
-func (hc *Commands) UpgradeChart(chartName string, version string, releaseName string, namespace string, values map[string]interface{}, timeout time.Duration) (*release.Release, error) {
+// UpgradeChart upgrades a helm chart.
+// InstallChart, UpgradeChart and UninstallRelease(releaseName are *NOT* thread-safe
+func (hc *Commands) UpgradeChart(ctx context.Context, chartName string, version string, releaseName string, namespace string, values map[string]interface{}, timeout time.Duration) (*release.Release, error) {
 	cfg, err := hc.getActionCfg(namespace)
 	if err != nil {
 		return nil, fmt.Errorf("can't create action configuration: %v", err)
@@ -287,7 +292,7 @@ func (hc *Commands) UpgradeChart(chartName string, version string, releaseName s
 		return nil, fmt.Errorf("can't reload loadedChart `%s`: %v", chartDir, err)
 	}
 
-	chartRelease, err := upgrade.Run(releaseName, loadedChart, values)
+	chartRelease, err := upgrade.RunWithContext(ctx, releaseName, loadedChart, values)
 	if err != nil {
 		return nil, fmt.Errorf("can't upgrade loadedChart `%s`: %v", loadedChart.Metadata.Name, err)
 	}
@@ -308,12 +313,19 @@ func (hc *Commands) ListReleases(namespace string) ([]*release.Release, error) {
 	return helmAction.Run()
 }
 
-func (hc *Commands) UninstallRelease(releaseName string, namespace string) error {
+// UninstallRelease uninstalls a release.
+// InstallChart, UpgradeChart and UninstallRelease(releaseName are *NOT* thread-safe
+func (hc *Commands) UninstallRelease(ctx context.Context, releaseName string, namespace string) error {
 	cfg, err := hc.getActionCfg(namespace)
 	if err != nil {
 		return fmt.Errorf("can't create helmAction configuration: %v", err)
 	}
 	helmAction := action.NewUninstall(cfg)
+	deadline, ok := ctx.Deadline()
+	if ok {
+		helmAction.Timeout = time.Until(deadline)
+	}
+
 	if _, err := helmAction.Run(releaseName); err != nil {
 		return fmt.Errorf("can't uninstall release `%s`: %v", releaseName, err)
 	}


### PR DESCRIPTION
## Description

Manual backport of https://github.com/k0sproject/k0s/pull/3633. In 1.26 and 1.25 the race condition is not present but a helm chart could get stuck.