### PR TITLE
Bump spf13/cobra to 1.8.0 and adapt PersistentPreRun usage

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -52,10 +52,9 @@ func NewAPICmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "api",
 		Short: "Run the controller API",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			logrus.SetOutput(cmd.OutOrStdout())
 			k0slog.SetInfoLevel()
-			return config.CallParentPersistentPreRun(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts, err := config.GetCmdOpts(cmd)

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -76,10 +76,9 @@ func NewControllerCmd() *cobra.Command {
 	or CLI flag:
 	$ k0s controller --token-file [path_to_file]
 	Note: Token can be passed either as a CLI argument or as a flag`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			logrus.SetOutput(cmd.OutOrStdout())
 			k0slog.SetInfoLevel()
-			return config.CallParentPersistentPreRun(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts, err := config.GetCmdOpts(cmd)

--- a/cmd/etcd/etcd.go
+++ b/cmd/etcd/etcd.go
@@ -30,10 +30,6 @@ func NewEtcdCmd() *cobra.Command {
 		Use:   "etcd",
 		Short: "Manage etcd cluster",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := config.CallParentPersistentPreRun(cmd, args); err != nil {
-				return err
-			}
-
 			opts, err := config.GetCmdOpts(cmd)
 			if err != nil {
 				return err

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -125,10 +125,6 @@ func hookKubectlPluginHandler(kubectlCmd *cobra.Command) {
 		logs.InitLogs()
 		cobra.OnFinalize(logs.FlushLogs)
 
-		if err := config.CallParentPersistentPreRun(kubectlCmd, args); err != nil {
-			return err
-		}
-
 		if err := fallbackToK0sKubeconfig(cmd); err != nil {
 			return err
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -194,6 +194,7 @@ $ k0s completion fish > ~/.config/fish/completions/k0s.fish
 }
 
 func Execute() {
+	cobra.EnableTraverseRunHooks = true
 	if err := NewRootCmd().Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -58,10 +58,9 @@ func NewWorkerCmd() *cobra.Command {
 	or CLI flag:
 	$ k0s worker --token-file [path_to_file]
 	Note: Token can be passed either as a CLI argument or as a flag`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			logrus.SetOutput(cmd.OutOrStdout())
 			k0slog.SetInfoLevel()
-			return config.CallParentPersistentPreRun(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts, err := config.GetCmdOpts(cmd)

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -28,7 +28,6 @@ import (
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/k0scloudprovider"
 
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -245,35 +244,4 @@ func GetCmdOpts(cobraCmd command) (*CLIOptions, error) {
 		K0sVars:          k0sVars,
 		DebugListenOn:    DebugListenOn,
 	}, nil
-}
-
-// CallParentPersistentPreRun runs the parent command's persistent pre-run.
-// Cobra does not do this automatically.
-//
-// See: https://github.com/spf13/cobra/issues/216
-// See: https://github.com/spf13/cobra/blob/v1.4.0/command.go#L833-L843
-func CallParentPersistentPreRun(cmd *cobra.Command, args []string) error {
-	for p := cmd.Parent(); p != nil; p = p.Parent() {
-		preRunE := p.PersistentPreRunE
-		preRun := p.PersistentPreRun
-
-		p.PersistentPreRunE = nil
-		p.PersistentPreRun = nil
-
-		defer func() {
-			p.PersistentPreRunE = preRunE
-			p.PersistentPreRun = preRun
-		}()
-
-		if preRunE != nil {
-			return preRunE(cmd, args)
-		}
-
-		if preRun != nil {
-			preRun(cmd, args)
-			return nil
-		}
-	}
-
-	return nil
 }


### PR DESCRIPTION
* Bumps [github.com/spf13/cobra](https://github.com/spf13/cobra) from 1.7.0 to 1.8.0.
* Adapts the use of `PersistentPreRun`, removed the `CallParentPersistentPreRun` and enabled `cobra.EnableTraverseRunHooks` - see https://github.com/spf13/cobra/pull/2044

<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/spf13/cobra/releases">github.com/spf13/cobra's releases</a>.</em></p>
<blockquote>
<h2>v1.8.0</h2>
<h2>✨ Features</h2>
<ul>
<li>Support usage as plugin for tools like kubectl by <a href="https://github.com/nirs"><code>@​nirs</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/2018">spf13/cobra#2018</a> - this means that programs that utilize a &quot;plugin-like&quot; structure have much better support and usage (like for completions, command paths, etc.)</li>
<li>Move documentation sources to site/content by <a href="https://github.com/umarcor"><code>@​umarcor</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/1428">spf13/cobra#1428</a></li>
<li>Add 'one required flag' group by <a href="https://github.com/marevers"><code>@​marevers</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/1952">spf13/cobra#1952</a> - this includes a new <code>MarkFlagsOneRequired</code> API for flags which can be used to mark a flag group as required and cause command failure if at least one is not used when invoked.</li>
<li>Customizable error message prefix by <a href="https://github.com/5ouma"><code>@​5ouma</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/2023">spf13/cobra#2023</a> - This adds the <code>SetErrPrefix</code> and <code>ErrPrefix</code> APIs on the <code>Command</code> struct to allow for setting a custom prefix for errors</li>
<li>feat: add getters for flag completions by <a href="https://github.com/avirtopeanu-ionos"><code>@​avirtopeanu-ionos</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/1943">spf13/cobra#1943</a></li>
<li>Feature: allow running persistent run hooks of all parents by <a href="https://github.com/vkhoroz"><code>@​vkhoroz</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/2044">spf13/cobra#2044</a></li>
<li>Improve API to get flag completion function by <a href="https://github.com/marckhouzam"><code>@​marckhouzam</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/2063">spf13/cobra#2063</a></li>
</ul>
<h2>🐛 Bug fixes</h2>
<ul>
<li>Fix typo in fish completions by <a href="https://github.com/twpayne"><code>@​twpayne</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/1945">spf13/cobra#1945</a></li>
<li>Fix grammar: 'allows to' by <a href="https://github.com/supertassu"><code>@​supertassu</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/1978">spf13/cobra#1978</a></li>
<li>powershell: escape variable with curly brackets by <a href="https://github.com/Luap99"><code>@​Luap99</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/1960">spf13/cobra#1960</a></li>
<li>Don't complete --help flag when flag parsing disabled by <a href="https://github.com/marckhouzam"><code>@​marckhouzam</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/2061">spf13/cobra#2061</a></li>
<li>Replace all non-alphanumerics in active help env var program prefix by <a href="https://github.com/scop"><code>@​scop</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/1940">spf13/cobra#1940</a></li>
</ul>
<h2>🔧 Maintenance</h2>
<ul>
<li>build(deps): bump golangci/golangci-lint-action from 3.4.0 to 3.5.0 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/1971">spf13/cobra#1971</a></li>
<li>build(deps): bump golangci/golangci-lint-action from 3.5.0 to 3.6.0 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/1976">spf13/cobra#1976</a></li>
<li>build(deps): bump golangci/golangci-lint-action from 3.6.0 to 3.7.0 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/2021">spf13/cobra#2021</a></li>
<li>build(deps): bump actions/setup-go from 3 to 4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/1934">spf13/cobra#1934</a></li>
<li>build(deps): bump github.com/cpuguy83/go-md2man/v2 from 2.0.2 to 2.0.3 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/2047">spf13/cobra#2047</a></li>
<li>build(deps): bump actions/checkout from 3 to 4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/2028">spf13/cobra#2028</a></li>
<li>command: temporarily disable G602 due to <a href="https://redirect.github.com/securego/gosec/issues/1005">securego/gosec#1005</a> by <a href="https://github.com/umarcor"><code>@​umarcor</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/2022">spf13/cobra#2022</a></li>
</ul>
<h2>🧪 Testing &amp; CI/CD</h2>
<ul>
<li>test: make fish_completions_test more robust by <a href="https://github.com/branchvincent"><code>@​branchvincent</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/1980">spf13/cobra#1980</a></li>
<li>golangci: enable 'unused' and disable deprecated replaced by it by <a href="https://github.com/umarcor"><code>@​umarcor</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/1983">spf13/cobra#1983</a></li>
<li>cleanup: minor corrections to unit tests by <a href="https://github.com/JunNishimura"><code>@​JunNishimura</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/2003">spf13/cobra#2003</a></li>
<li>ci: test golang 1.21 by <a href="https://github.com/nunoadrego"><code>@​nunoadrego</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/2024">spf13/cobra#2024</a></li>
<li>Fix linter errors by <a href="https://github.com/marckhouzam"><code>@​marckhouzam</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/2052">spf13/cobra#2052</a></li>
<li>Add tests for flag completion registration by <a href="https://github.com/marckhouzam"><code>@​marckhouzam</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/2053">spf13/cobra#2053</a></li>
</ul>
<h2>✏️ Documentation</h2>
<ul>
<li>doc: fix typo, Deperecated -&gt; Deprecated by <a href="https://github.com/callthingsoff"><code>@​callthingsoff</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/2000">spf13/cobra#2000</a></li>
<li>Add notes to doc about the execution condition of *PreRun and *PostRun functions by <a href="https://github.com/haoming29"><code>@​haoming29</code></a> in <a href="https://redirect.github.com/spf13/cobra/pull/2041">spf13/cobra#2041</a></li>
</ul>
<hr />
<p>Thank you everyone who contributed to this release and all your hard work! Cobra and this community would never be possible without all of you!!!! 🐍</p>
<p><strong>Full Changelog</strong>: <a href="https://github.com/spf13/cobra/compare/v1.7.0...v1.8.0">https://github.com/spf13/cobra/compare/v1.7.0...v1.8.0</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/spf13/cobra/commit/a0a6ae020bb3899ff0276067863e50523f897370"><code>a0a6ae0</code></a> Improve API to get flag completion function (<a href="https://redirect.github.com/spf13/cobra/issues/2063">#2063</a>)</li>
<li><a href="https://github.com/spf13/cobra/commit/890302a35f578311404a462b3cdd404f34db3720"><code>890302a</code></a> Support usage as plugin for tools like kubectl (<a href="https://redirect.github.com/spf13/cobra/issues/2018">#2018</a>)</li>
<li><a href="https://github.com/spf13/cobra/commit/48cea5c87b5299b68c3f5b7f2c67ea948717276f"><code>48cea5c</code></a> build(deps): bump actions/checkout from 3 to 4 (<a href="https://redirect.github.com/spf13/cobra/issues/2028">#2028</a>)</li>
<li><a href="https://github.com/spf13/cobra/commit/22953d88453ec9343b4a78b9d67400a3326f3138"><code>22953d8</code></a> Replace all non-alphanumerics in active help env var program prefix (<a href="https://redirect.github.com/spf13/cobra/issues/1940">#1940</a>)</li>
<li><a href="https://github.com/spf13/cobra/commit/00b68a1c260eaf2b9bcb10a3178d36cec81548ca"><code>00b68a1</code></a> Add tests for flag completion registration (<a href="https://redirect.github.com/spf13/cobra/issues/2053">#2053</a>)</li>
<li><a href="https://github.com/spf13/cobra/commit/b711e8760b73c6aa1b4aa1bef3a26da5926f175d"><code>b711e87</code></a> Don't complete --help flag when flag parsing disabled (<a href="https://redirect.github.com/spf13/cobra/issues/2061">#2061</a>)</li>
<li><a href="https://github.com/spf13/cobra/commit/8b1eba47616566fc4d258a93da48d5d8741865f0"><code>8b1eba4</code></a> Fix linter errors (<a href="https://redirect.github.com/spf13/cobra/issues/2052">#2052</a>)</li>
<li><a href="https://github.com/spf13/cobra/commit/4cafa37bc4bb85633b4245aa118280fe5a9edcd5"><code>4cafa37</code></a> Allow running persistent run hooks of all parents (<a href="https://redirect.github.com/spf13/cobra/issues/2044">#2044</a>)</li>
<li><a href="https://github.com/spf13/cobra/commit/5c962a221e70fd6b12296e5d7075f28b422f98b2"><code>5c962a2</code></a> build(deps): bump github.com/cpuguy83/go-md2man/v2 from 2.0.2 to 2.0.3 (<a href="https://redirect.github.com/spf13/cobra/issues/2047">#2047</a>)</li>
<li><a href="https://github.com/spf13/cobra/commit/efe8fa3e4453e41d6419b26c9769a51e42825632"><code>efe8fa3</code></a> build(deps): bump actions/setup-go from 3 to 4 (<a href="https://redirect.github.com/spf13/cobra/issues/1934">#1934</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/spf13/cobra/compare/v1.7.0...v1.8.0">compare view</a></li>
</ul>
</details>
<br />

