### PR TITLE
Add Amazon Linux 2023 to nightly OS test runs

### DIFF
--- a/.github/workflows/ostests-nightly.yaml
+++ b/.github/workflows/ostests-nightly.yaml
@@ -10,6 +10,7 @@ on:
 env:
   DISTRIBUTIONS: >-
     [
+      ["al2023"],
       ["alpine_3_17"],
       ["centos_7", "centos_8", "centos_9"],
       ["debian_10", "debian_11", "debian_12"],


### PR DESCRIPTION
## Description

The networking issue has been fixed upstream and tests are now passing with the most recent AMI (for iptables at least).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings