### PR TITLE
[Backport release-1.26] Bump Go to 1.20.11

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.17
 alpine_patch_version = $(alpine_version).4
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.20.10
+go_version = 1.20.11
 
 runc_version = 1.1.10
 runc_buildimage = $(golang_buildimage)


### PR DESCRIPTION
Backport to `release-1.26`:
* #3722

See:
* #3715

Fixes CVE-2023-45283 and CVE-2023-45284.