### PR TITLE
Don't unmount data-dir on k0s reset

### DIFF
--- a/inttest/backup/backup_test.go
+++ b/inttest/backup/backup_test.go
@@ -96,10 +96,8 @@ func (s *BackupSuite) TestK0sGetsUp() {
 	s.Require().NoError(s.StopController(s.ControllerNode(0)))
 	_ = s.StopController(s.ControllerNode(1)) // No error check as k0s might have actually exited since etcd is not really happy
 
-	// Reset will return an error because after starting the controller with --enable-worker
-	// k0s reset will try to delete /var/lib/k0s, which is not possible because it's a volume in docker.
-	_ = s.Reset(s.ControllerNode(0))
-	_ = s.Reset(s.ControllerNode(1))
+	s.Require().NoError(s.Reset(s.ControllerNode(0)))
+	s.Require().NoError(s.Reset(s.ControllerNode(1)))
 
 	s.Require().NoError(s.restoreFunc())
 	s.Require().NoError(s.InitController(0, "--enable-worker"))

--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -130,9 +130,7 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 		resetOutput, err := ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s reset --debug")
 		s.T().Logf("Reset executed with output:\n%s", resetOutput)
 
-		// k0s reset will always exit with an error on bootloose, since it's unable to remove /var/lib/k0s
-		// that is an expected behaviour. therefore, we're only checking if the contents of /var/lib/k0s is empty
-		assert.Error(err)
+		assert.NoError(err)
 
 		fileCount, err := ssh.ExecWithOutput(s.Context(), "find /var/lib/k0s -type f | wc -l")
 		assert.NoError(err)


### PR DESCRIPTION
## Description

It wasn't k0s that mounted the data-dir so k0s shouldn't try to unmount it either.

If it is a mountpoint, it can't be removed using os.RemoveAll without getting a `PathError`. 

This will also stop `k0s reset` erroring out when data-dir is a mountpoint.

Fixes #3726

## Type of change

<!-- check the related options -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [X] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [X] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [X] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings