### PR TITLE
fetch node object from apiserver when (un)cordoning

### DIFF
--- a/pkg/autopilot/controller/signal/k0s/cordon.go
+++ b/pkg/autopilot/controller/signal/k0s/cordon.go
@@ -148,10 +148,19 @@ func (r *cordoning) moveToNextState(ctx context.Context, signalNode crcli.Object
 func (r *cordoning) drainNode(ctx context.Context, signalNode crcli.Object) error {
 	logger := r.log.WithField("signalnode", signalNode.GetName()).WithField("phase", "drain")
 
-	//get node from client
 	node := &corev1.Node{}
-	if err := r.client.Get(ctx, crcli.ObjectKey{Name: signalNode.GetName()}, node); err != nil {
-		return fmt.Errorf("failed to get node: %w", err)
+	// if signalNode is a Node cast it to *corev1.Node
+	if signalNode.GetObjectKind().GroupVersionKind().Kind == "Node" {
+		var ok bool
+		node, ok = signalNode.(*corev1.Node)
+		if !ok {
+			return fmt.Errorf("failed to cast signalNode to *corev1.Node")
+		}
+	} else {
+		//otherwise get node from client
+		if err := r.client.Get(ctx, crcli.ObjectKey{Name: signalNode.GetName()}, node); err != nil {
+			return fmt.Errorf("failed to get node: %w", err)
+		}
 	}
 
 	drainer := &drain.Helper{

--- a/pkg/autopilot/controller/signal/k0s/cordon.go
+++ b/pkg/autopilot/controller/signal/k0s/cordon.go
@@ -147,9 +147,11 @@ func (r *cordoning) moveToNextState(ctx context.Context, signalNode crcli.Object
 // draining ignores daemonsets
 func (r *cordoning) drainNode(ctx context.Context, signalNode crcli.Object) error {
 	logger := r.log.WithField("signalnode", signalNode.GetName()).WithField("phase", "drain")
-	node, ok := signalNode.(*corev1.Node)
-	if !ok {
-		return fmt.Errorf("failed to covert signalNode to Node")
+
+	//get node from client
+	node := &corev1.Node{}
+	if err := r.client.Get(ctx, crcli.ObjectKey{Name: signalNode.GetName()}, node); err != nil {
+		return fmt.Errorf("failed to get node: %w", err)
 	}
 
 	drainer := &drain.Helper{

--- a/pkg/autopilot/controller/signal/k0s/uncordon.go
+++ b/pkg/autopilot/controller/signal/k0s/uncordon.go
@@ -146,9 +146,11 @@ func (r *uncordoning) moveToNextState(ctx context.Context, signalNode crcli.Obje
 // unCordonNode un-cordons a node
 func (r *uncordoning) unCordonNode(ctx context.Context, signalNode crcli.Object) error {
 	logger := r.log.WithField("signalnode", signalNode.GetName()).WithField("phase", "uncordon")
-	node, ok := signalNode.(*corev1.Node)
-	if !ok {
-		return fmt.Errorf("failed to covert signalNode to Node")
+
+	//get node from client
+	node := &corev1.Node{}
+	if err := r.client.Get(ctx, crcli.ObjectKey{Name: signalNode.GetName()}, node); err != nil {
+		return fmt.Errorf("failed to get node: %w", err)
 	}
 
 	drainer := &drain.Helper{

--- a/pkg/autopilot/controller/signal/k0s/uncordon.go
+++ b/pkg/autopilot/controller/signal/k0s/uncordon.go
@@ -147,10 +147,20 @@ func (r *uncordoning) moveToNextState(ctx context.Context, signalNode crcli.Obje
 func (r *uncordoning) unCordonNode(ctx context.Context, signalNode crcli.Object) error {
 	logger := r.log.WithField("signalnode", signalNode.GetName()).WithField("phase", "uncordon")
 
-	//get node from client
 	node := &corev1.Node{}
-	if err := r.client.Get(ctx, crcli.ObjectKey{Name: signalNode.GetName()}, node); err != nil {
-		return fmt.Errorf("failed to get node: %w", err)
+
+	// if signalNode is a Node cast it to *corev1.Node
+	if signalNode.GetObjectKind().GroupVersionKind().Kind == "Node" {
+		var ok bool
+		node, ok = signalNode.(*corev1.Node)
+		if !ok {
+			return fmt.Errorf("failed to convert signalNode to Node")
+		}
+	} else {
+		//otherwise get node from client
+		if err := r.client.Get(ctx, crcli.ObjectKey{Name: signalNode.GetName()}, node); err != nil {
+			return fmt.Errorf("failed to get node: %w", err)
+		}
 	}
 
 	drainer := &drain.Helper{


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

when cordoning/uncordoning controlNodes for autopilot, fetch Node object from APIserver instead of trying to cast from signalNode.

Fixes #3739

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings