### PR TITLE
Fix k0s controller args in autopilot inttests

### DIFF
--- a/inttest/ap-platformselect/platformselect_test.go
+++ b/inttest/ap-platformselect/platformselect_test.go
@@ -38,7 +38,7 @@ func (s *platformSelectSuite) SetupTest() {
 	ctx := s.Context()
 	s.Require().NoError(s.WaitForSSH(s.ControllerNode(0), 2*time.Minute, 1*time.Second))
 
-	s.Require().NoError(s.InitController(0), "--disable-components=metrics-server")
+	s.Require().NoError(s.InitController(0, "--disable-components=metrics-server"))
 	s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(0)))
 
 	client, err := s.ExtensionsClient(s.ControllerNode(0))

--- a/inttest/ap-single/single_test.go
+++ b/inttest/ap-single/single_test.go
@@ -49,7 +49,7 @@ func (s *plansSingleControllerSuite) SetupTest() {
 	_, err = ssh.ExecWithOutput(ctx, "cp /dist/k0s /tmp/k0s")
 	s.Require().NoError(err)
 
-	s.Require().NoError(s.InitController(0), "--disable-components=metrics-server")
+	s.Require().NoError(s.InitController(0, "--disable-components=metrics-server"))
 	s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(0)))
 
 	client, err := s.ExtensionsClient(s.ControllerNode(0))

--- a/inttest/ap-updater-periodic/updater_test.go
+++ b/inttest/ap-updater-periodic/updater_test.go
@@ -59,7 +59,7 @@ func (s *plansSingleControllerSuite) SetupTest() {
 	}
 	s.PutFileTemplate(s.ControllerNode(0), "/etc/conf.d/k0scontroller", envTemplate, vars)
 
-	s.Require().NoError(s.InitController(0), "--disable-components=metrics-server")
+	s.Require().NoError(s.InitController(0, "--disable-components=metrics-server"))
 	s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(0)))
 
 	kc, err := s.KubeClient(s.ControllerNode(0))

--- a/inttest/ap-updater/updater_test.go
+++ b/inttest/ap-updater/updater_test.go
@@ -42,7 +42,7 @@ func (s *plansSingleControllerSuite) SetupTest() {
 	ctx := s.Context()
 	s.Require().NoError(s.WaitForSSH(s.ControllerNode(0), 2*time.Minute, 1*time.Second))
 
-	s.Require().NoError(s.InitController(0), "--disable-components=metrics-server")
+	s.Require().NoError(s.InitController(0, "--disable-components=metrics-server"))
 	s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(0)))
 
 	client, err := s.ExtensionsClient(s.ControllerNode(0))


### PR DESCRIPTION
## Description

The controller args were erroneously passed to the asserting function, not to the test suite's controller init function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings