### PR TITLE
Don't print usage for regular k0s kubeconfig admin errors

### DIFF
--- a/cmd/kubeconfig/admin.go
+++ b/cmd/kubeconfig/admin.go
@@ -45,15 +45,17 @@ func kubeConfigAdminCmd() *cobra.Command {
 				return err
 			}
 
+			nodeConfig, err := opts.K0sVars.NodeConfig()
+			if err != nil {
+				return err
+			}
+
+			cmd.SilenceUsage = true
 			content, err := os.ReadFile(opts.K0sVars.AdminKubeConfigPath)
 			if err != nil {
 				return fmt.Errorf("failed to read admin config, check if the control plane is initialized on this node: %w", err)
 			}
 
-			nodeConfig, err := opts.K0sVars.NodeConfig()
-			if err != nil {
-				return err
-			}
 			clusterAPIURL := nodeConfig.Spec.API.APIAddressURL()
 			newContent := strings.Replace(string(content), "https://localhost:6443", clusterAPIURL, -1)
 			_, err = cmd.OutOrStdout().Write([]byte(newContent))


### PR DESCRIPTION
## Description

Silence the usage printing when the error doesn't seem to be the wrong usage of CLI flags and args.

This was observable in the inttest logs, when  the `GetKubeConfig` function was called before k0s was able to generate the required files.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings