### PR TITLE
Use a real single node in the ap-single inttest

### DIFF
--- a/inttest/ap-single/single_test.go
+++ b/inttest/ap-single/single_test.go
@@ -17,7 +17,6 @@ package single
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
@@ -39,24 +38,24 @@ type plansSingleControllerSuite struct {
 // SetupTest prepares the controller and filesystem, getting it into a consistent
 // state which we can run tests against.
 func (s *plansSingleControllerSuite) SetupTest() {
-	ctx := s.Context()
-	s.Require().NoError(s.WaitForSSH(s.ControllerNode(0), 2*time.Minute, 1*time.Second))
+	ctx, nodeName, require := s.Context(), s.ControllerNode(0), s.Require()
 
 	// Move the k0s binary to a new location, so we can check the binary location detection
-	ssh, err := s.SSH(s.Context(), s.ControllerNode(0))
-	s.Require().NoError(err)
+	ssh, err := s.SSH(ctx, nodeName)
+	require.NoError(err)
 	defer ssh.Disconnect()
-	_, err = ssh.ExecWithOutput(ctx, "cp /dist/k0s /tmp/k0s")
-	s.Require().NoError(err)
+	require.NoError(ssh.Exec(ctx, "cp /dist/k0s /tmp/k0s", common.SSHStreams{}))
 
-	s.Require().NoError(s.InitController(0, "--disable-components=metrics-server"))
-	s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(0)))
+	require.NoError(s.InitController(0, "--single", "--disable-components=metrics-server"))
 
-	client, err := s.ExtensionsClient(s.ControllerNode(0))
-	s.Require().NoError(err)
+	client, err := s.KubeClient(nodeName)
+	require.NoError(err)
+	require.NoError(s.WaitForNodeReady(nodeName, client))
 
-	s.Require().NoError(aptest.WaitForCRDByName(ctx, client, "plans"))
-	s.Require().NoError(aptest.WaitForCRDByName(ctx, client, "controlnodes"))
+	xClient, err := s.ExtensionsClient(nodeName)
+	require.NoError(err)
+	require.NoError(aptest.WaitForCRDByName(ctx, xClient, "plans"))
+	require.NoError(aptest.WaitForCRDByName(ctx, xClient, "controlnodes"))
 }
 
 // TestApply applies a well-formed `plan` yaml, and asserts that all of the correct values
@@ -98,7 +97,7 @@ spec:
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
 	plan, err := aptest.WaitForPlanState(s.Context(), client, apconst.AutopilotName, appc.PlanCompleted)
-	s.Require().NoError(err)
+	s.Require().NoError(err, "While waiting for plan to complete")
 
 	s.Equal(1, len(plan.Status.Commands))
 	cmd := plan.Status.Commands[0]


### PR DESCRIPTION
## Description

Previously, despite its name, the ap-single inttest used a bare controller that didn't have workloads enabled. Change this by adding the `--single` flag to the controller flags. That way, this test is the first one to really test Autopilot in conjunction with controller+worker nodes, which was broken until recently.

See:
* #3741

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings