### PR TITLE
Silence CLI usage printing on errors at the root command

### DIFF
--- a/cmd/airgap/airgap.go
+++ b/cmd/airgap/airgap.go
@@ -28,7 +28,6 @@ func NewAirgapCmd() *cobra.Command {
 		Short: "Manage airgap setup",
 	}
 
-	cmd.SilenceUsage = true
 	cmd.AddCommand(NewAirgapListImagesCmd())
 	cmd.PersistentFlags().AddFlagSet(config.FileInputFlag())
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -79,7 +79,6 @@ func NewAPICmd() *cobra.Command {
 			return (&command{CLIOptions: opts}).start()
 		},
 	}
-	cmd.SilenceUsage = true
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	return cmd
 }

--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -62,7 +62,6 @@ func NewBackupCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&savePath, "save-path", "", "destination directory path for backup assets, use '-' for stdout")
-	cmd.SilenceUsage = true
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	return cmd
 }

--- a/cmd/backup/backup_windows.go
+++ b/cmd/backup/backup_windows.go
@@ -25,13 +25,11 @@ import (
 var savePath string
 
 func NewBackupCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "backup",
 		Short: "Back-Up k0s configuration. Not supported on Windows OS",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("unsupported Operating System for this command")
 		},
 	}
-	cmd.SilenceUsage = true
-	return cmd
 }

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -29,6 +29,5 @@ func NewConfigCmd() *cobra.Command {
 	cmd.AddCommand(NewEditCmd())
 	cmd.AddCommand(NewStatusCmd())
 	cmd.AddCommand(NewValidateCmd())
-	cmd.SilenceUsage = true
 	return cmd
 }

--- a/cmd/config/validate.go
+++ b/cmd/config/validate.go
@@ -59,7 +59,6 @@ func NewValidateCmd() *cobra.Command {
 
 			return errors.Join(cfg.Validate()...)
 		},
-		SilenceUsage: true,
 	}
 
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -107,7 +107,6 @@ func NewControllerCmd() *cobra.Command {
 				c.TokenArg = string(bytes)
 			}
 			c.Logging = stringmap.Merge(c.CmdLogLevels, c.DefaultLogLevels)
-			cmd.SilenceUsage = true
 
 			if err := (&sysinfo.K0sSysinfoSpec{
 				ControllerRoleEnabled: true,

--- a/cmd/etcd/etcd.go
+++ b/cmd/etcd/etcd.go
@@ -51,7 +51,6 @@ func NewEtcdCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.SilenceUsage = true
 	cmd.AddCommand(etcdLeaveCmd())
 	cmd.AddCommand(etcdListCmd())
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())

--- a/cmd/install/controller.go
+++ b/cmd/install/controller.go
@@ -54,13 +54,11 @@ With the controller subcommand you can setup a single node cluster by running:
 			}
 
 			if err := c.convertFileParamsToAbsolute(); err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 			flagsAndVals := []string{"controller"}
 			flagsAndVals = append(flagsAndVals, cmdFlagsToArgs(cmd)...)
 			if err := c.setup("controller", flagsAndVals, installFlags); err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 			return nil

--- a/cmd/install/worker.go
+++ b/cmd/install/worker.go
@@ -37,14 +37,12 @@ Windows flags like "--api-server", "--cidr-range" and "--cluster-dns" will be ig
 			}
 			c := (*command)(opts)
 			if err := c.convertFileParamsToAbsolute(); err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 
 			flagsAndVals := []string{"worker"}
 			flagsAndVals = append(flagsAndVals, cmdFlagsToArgs(cmd)...)
 			if err := c.setup("worker", flagsAndVals, installFlags); err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 

--- a/cmd/kubeconfig/kubeconfig.go
+++ b/cmd/kubeconfig/kubeconfig.go
@@ -26,11 +26,7 @@ func NewKubeConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kubeconfig [command]",
 		Short: "Create a kubeconfig file for a specified user",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmd.Usage()
-		},
 	}
-	cmd.SilenceUsage = true
 	cmd.AddCommand(kubeconfigCreateCmd())
 	cmd.AddCommand(kubeConfigAdminCmd())
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())

--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -47,7 +47,6 @@ func NewResetCmd() *cobra.Command {
 			return c.reset()
 		},
 	}
-	cmd.SilenceUsage = true
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	cmd.Flags().AddFlagSet(config.GetCriSocketFlag())
 	cmd.Flags().AddFlagSet(config.FileInputFlag())

--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -61,8 +61,6 @@ func NewRestoreCmd() *cobra.Command {
 		},
 	}
 
-	cmd.SilenceUsage = true
-
 	cwd, err := os.Getwd()
 	if err != nil {
 		logrus.Fatal("failed to get local path")

--- a/cmd/restore/restore_windows.go
+++ b/cmd/restore/restore_windows.go
@@ -25,14 +25,11 @@ import (
 var restoredConfigPath string
 
 func NewRestoreCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "restore",
 		Short: "restore k0s state from given backup archive. Not supported in Windows OS",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("unsupported Operating System for this command")
 		},
 	}
-
-	cmd.SilenceUsage = true
-	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,8 +54,10 @@ func NewRootCmd() *cobra.Command {
 	var longDesc string
 
 	cmd := &cobra.Command{
-		Use:   "k0s",
-		Short: "k0s - Zero Friction Kubernetes",
+		Use:          "k0s",
+		Short:        "k0s - Zero Friction Kubernetes",
+		SilenceUsage: true,
+
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if config.Verbose {
 				k0slog.SetInfoLevel()

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -40,7 +40,6 @@ func NewStartCmd() *cobra.Command {
 			}
 			status, _ := svc.Status()
 			if status == service.StatusRunning {
-				cmd.SilenceUsage = true
 				return fmt.Errorf("already running")
 			}
 			return svc.Start()

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -41,7 +41,6 @@ func NewStatusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cmd.SilenceUsage = true
 			if runtime.GOOS == "windows" {
 				return fmt.Errorf("currently not supported on windows")
 			}
@@ -59,7 +58,6 @@ func NewStatusCmd() *cobra.Command {
 		},
 	}
 
-	cmd.SilenceUsage = true
 	cmd.PersistentFlags().StringVarP(&output, "out", "o", "", "sets type of output to json or yaml")
 	cmd.PersistentFlags().StringVar(&config.StatusSocket, "status-socket", filepath.Join(config.K0sVars.RunDir, "status.sock"), "Full file path to the socket file.")
 	cmd.AddCommand(NewStatusSubCmdComponents())
@@ -77,7 +75,6 @@ func NewStatusSubCmdComponents() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cmd.SilenceUsage = true
 			if runtime.GOOS == "windows" {
 				return fmt.Errorf("currently not supported on windows")
 			}

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -43,7 +43,6 @@ func NewStopCmd() *cobra.Command {
 				return err
 			}
 			if status == service.StatusStopped {
-				cmd.SilenceUsage = true
 				return fmt.Errorf("already stopped")
 			}
 			return svc.Stop()

--- a/cmd/sysinfo/sysinfo.go
+++ b/cmd/sysinfo/sysinfo.go
@@ -39,8 +39,6 @@ func NewSysinfoCmd() *cobra.Command {
 		Short: "Display system information",
 		Long:  `Runs k0s's pre-flight checks and issues the results to stdout.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-
 			sysinfoSpec.AddDebugProbes = true
 			probes := sysinfoSpec.NewSysinfoProbes()
 			out := cmd.OutOrStdout()

--- a/cmd/token/create.go
+++ b/cmd/token/create.go
@@ -45,11 +45,7 @@ func tokenCreateCmd() *cobra.Command {
 k0s token create --role worker --expiry 10m  //sets expiration time to 10 minutes
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			err := checkTokenRole(createTokenRole)
-			if err != nil {
-				cmd.SilenceUsage = true
-			}
-			return err
+			return checkTokenRole(createTokenRole)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts, err := config.GetCmdOpts(cmd)
@@ -81,7 +77,6 @@ k0s token create --role worker --expiry 10m  //sets expiration time to 10 minute
 				}
 				if err = ensureTokenCreationAcceptable(createTokenRole, statusInfo); err != nil {
 					waitCreate = false
-					cmd.SilenceUsage = true
 					return err
 				}
 

--- a/cmd/token/list.go
+++ b/cmd/token/list.go
@@ -35,11 +35,7 @@ func tokenListCmd() *cobra.Command {
 		Short:   "List join tokens",
 		Example: `k0s token list --role worker // list worker tokens`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			err := checkTokenRole(listTokenRole)
-			if err != nil {
-				cmd.SilenceUsage = true
-			}
-			return err
+			return checkTokenRole(listTokenRole)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts, err := config.GetCmdOpts(cmd)

--- a/cmd/token/preshared.go
+++ b/cmd/token/preshared.go
@@ -51,15 +51,12 @@ func preSharedCmd() *cobra.Command {
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			err := checkTokenRole(preSharedRole)
 			if err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 			if certPath == "" {
-				cmd.SilenceUsage = true
 				return fmt.Errorf("please, provide --cert argument")
 			}
 			if joinURL == "" {
-				cmd.SilenceUsage = true
 				return fmt.Errorf("please, provide --url argument")
 			}
 

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -30,7 +30,6 @@ func NewTokenCmd() *cobra.Command {
 		Short: "Manage join tokens",
 	}
 
-	cmd.SilenceUsage = true
 	cmd.AddCommand(tokenCreateCmd())
 	cmd.AddCommand(tokenListCmd())
 	cmd.AddCommand(tokenInvalidateCmd())

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -30,7 +30,6 @@ func NewValidateCmd() *cobra.Command {
 		Hidden: true,
 	}
 	cmd.AddCommand(newConfigCmd())
-	cmd.SilenceUsage = true
 	return cmd
 }
 

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -84,7 +84,6 @@ func NewWorkerCmd() *cobra.Command {
 				}
 				c.TokenArg = string(bytes)
 			}
-			cmd.SilenceUsage = true
 
 			if err := (&sysinfo.K0sSysinfoSpec{
 				ControllerRoleEnabled: false,


### PR DESCRIPTION
## Description

There were lots of places where the `SilenceUsage` flag was set already. All the other commands are most probably also better off with that setting enabled. At least it shouldn't cause much harm.

See:
* #3744

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings