### PR TITLE
Bump golangci-lint to v1.55.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,16 +25,24 @@ linters:
 
 linters-settings:
   depguard:
-    packages:
-      - gopkg.in/yaml*
-    additional-guards:
-      # Only allow usages of the k8s cloud provider from within the k0s cloud
-      # provider package. This is to ensure that it's not leaking global flags
-      # into k0s.
-      - packages:
-          - k8s.io/cloud-provider*
-        ignore-file-rules:
-          - "**/pkg/k0scloudprovider/*.go"
+    rules:
+      yaml:
+        list-mode: lax
+        deny:
+          - pkg: gopkg.in/yaml.v2
+            desc: Use sigs.k8s.io/yaml.
+          - pkg: gopkg.in/yaml.v3
+            desc: Use sigs.k8s.io/yaml.
+      cloud-provider:
+        list-mode: lax
+        files:
+          - "!**/pkg/k0scloudprovider/*.go"
+        deny:
+          - pkg: k8s.io/cloud-provider
+            desc: >-
+              Usages of the k8s cloud provider are only allowed from within the
+              k0s cloud provider package. This is to ensure that it's not
+              leaking global flags into k0s.
   golint:
     min-confidence: 0
   goheader:
@@ -42,6 +50,12 @@ linters-settings:
     values:
       regexp:
         year: 202[0-9]
+
+  revive:
+    rules:
+      # This forbids to name variables "close", which seems natural for "close" functions.
+      - name: redefines-builtin-id
+        disabled: true
 
 issues:
   max-issues-per-linter: 0

--- a/hack/tools/Makefile.variables
+++ b/hack/tools/Makefile.variables
@@ -1,3 +1,3 @@
 controller-gen_version = 0.13.0
 go-bindata_version = 3.23.0+incompatible
-golangci-lint_version = 1.51.2
+golangci-lint_version = 1.55.2

--- a/internal/pkg/sysinfo/probes/linux/cgroup_controllers.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroup_controllers.go
@@ -55,6 +55,7 @@ type cgroupControllerProbe struct {
 
 func (c *cgroupControllerProbe) Probe(reporter probes.Reporter) error {
 	desc := probes.NewProbeDesc(fmt.Sprintf("cgroup controller %q", c.name), c.path)
+	//revive:disable:indent-error-flow
 	if sys, err := c.probeSystem(); err != nil {
 		return reportCgroupSystemErr(reporter, desc, err)
 	} else if available, err := sys.probeController(c.name); err != nil {

--- a/internal/pkg/sysinfo/probes/linux/kernel.go
+++ b/internal/pkg/sysinfo/probes/linux/kernel.go
@@ -37,6 +37,7 @@ func (l *LinuxProbes) AssertKernelRelease(assert func(string) string) {
 	l.Set("kernelRelease", func(path probes.ProbePath, current probes.Probe) probes.Probe {
 		return probes.ProbeFn(func(r probes.Reporter) error {
 			desc := probes.NewProbeDesc("Linux kernel release", path)
+			//revive:disable:indent-error-flow
 			if uname, err := l.probeUname(); err != nil {
 				return r.Error(desc, err)
 			} else if uname.osRelease.truncated {

--- a/internal/pkg/sysinfo/probes/linux/linux.go
+++ b/internal/pkg/sysinfo/probes/linux/linux.go
@@ -70,6 +70,7 @@ func (l *LinuxProbes) Probe(reporter probes.Reporter) error {
 
 func (l *LinuxProbes) probe(reporter probes.Reporter) error {
 	desc := probes.NewProbeDesc("Operating system", l.path)
+	//revive:disable:indent-error-flow
 	if uname, err := l.probeUname(); err != nil {
 		return reporter.Error(desc, err)
 	} else if uname.osName.value == "Linux" {


### PR DESCRIPTION
## Description

Adapt to updated linters:

* Update configuration
* Silence some opinionated new warnings

https://github.com/golangci/golangci-lint/releases/tag/v1.52.0
https://github.com/golangci/golangci-lint/releases/tag/v1.52.1
https://github.com/golangci/golangci-lint/releases/tag/v1.52.2
https://github.com/golangci/golangci-lint/releases/tag/v1.53.0
https://github.com/golangci/golangci-lint/releases/tag/v1.53.1
https://github.com/golangci/golangci-lint/releases/tag/v1.53.2
https://github.com/golangci/golangci-lint/releases/tag/v1.53.3
https://github.com/golangci/golangci-lint/releases/tag/v1.54.0
https://github.com/golangci/golangci-lint/releases/tag/v1.54.1
https://github.com/golangci/golangci-lint/releases/tag/v1.54.2
https://github.com/golangci/golangci-lint/releases/tag/v1.55.0
https://github.com/golangci/golangci-lint/releases/tag/v1.55.1
https://github.com/golangci/golangci-lint/releases/tag/v1.55.2

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings