### PR TITLE
Check if Extensions.Storage exists before accessing Type key

### DIFF
--- a/pkg/apis/k0s/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types.go
@@ -239,6 +239,9 @@ func (c *ClusterConfig) UnmarshalJSON(data []byte) error {
 	if jc.Spec.Extensions == nil {
 		jc.Spec.Extensions = DefaultExtensions()
 	}
+	if jc.Spec.Extensions.Storage == nil {
+		jc.Spec.Extensions.Storage = DefaultStorageExtension()
+	}
 	if jc.Spec.Network == nil {
 		jc.Spec.Network = DefaultNetwork()
 	}

--- a/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
@@ -196,6 +196,15 @@ spec:
   telemetry: null
   konnectivity: null
 `
+	extensionsYamlData := `
+apiVersion: k0s.k0sproject.io/v1beta1
+kind: ClusterConfig
+metadata:
+  name: foobar
+spec:
+  extensions:
+    storage: null
+`
 
 	c, err := ConfigFromString(yamlData)
 	assert.NoError(t, err)
@@ -210,6 +219,10 @@ spec:
 	assert.Equal(t, DefaultInstallSpec(), c.Spec.Install)
 	assert.Equal(t, DefaultClusterTelemetry(), c.Spec.Telemetry)
 	assert.Equal(t, DefaultKonnectivitySpec(), c.Spec.Konnectivity)
+
+	e, err := ConfigFromString(extensionsYamlData)
+	assert.NoError(t, err)
+	assert.Equal(t, DefaultExtensions(), e.Spec.Extensions)
 }
 
 func TestWorkerProfileConfig(t *testing.T) {

--- a/pkg/apis/k0s/v1beta1/extensions.go
+++ b/pkg/apis/k0s/v1beta1/extensions.go
@@ -159,13 +159,17 @@ func (e *ClusterExtensions) Validate() []error {
 	return errs
 }
 
+func DefaultStorageExtension() *StorageExtension {
+	return &StorageExtension{
+		Type:                      ExternalStorage,
+		CreateDefaultStorageClass: false,
+	}
+}
+
 // DefaultExtensions default values
 func DefaultExtensions() *ClusterExtensions {
 	return &ClusterExtensions{
-		Storage: &StorageExtension{
-			Type:                      ExternalStorage,
-			CreateDefaultStorageClass: false,
-		},
+		Storage: DefaultStorageExtension(),
 		Helm: &HelmExtensions{
 			ConcurrencyLevel: 5,
 		},

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -84,13 +84,17 @@ func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0
 
 	helmSettings := clusterConfig.Spec.Extensions.Helm
 	var err error
-	switch clusterConfig.Spec.Extensions.Storage.Type {
-	case k0sAPI.OpenEBSLocal:
-		helmSettings, err = addOpenEBSHelmExtension(helmSettings, clusterConfig.Spec.Extensions.Storage)
-		if err != nil {
-			ec.L.WithError(err).Error("Can't add openebs helm extension")
+	if clusterConfig.Spec.Extensions.Storage != nil {
+		switch clusterConfig.Spec.Extensions.Storage.Type {
+		case k0sAPI.OpenEBSLocal:
+			helmSettings, err = addOpenEBSHelmExtension(helmSettings, clusterConfig.Spec.Extensions.Storage)
+			if err != nil {
+				ec.L.WithError(err).Error("Can't add openebs helm extension")
+			}
+		default:
 		}
-	default:
+	} else {
+		ec.L.Debug("Storage extension is not configured")
 	}
 
 	if err := ec.reconcileHelmExtensions(helmSettings); err != nil {

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -84,17 +84,13 @@ func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0
 
 	helmSettings := clusterConfig.Spec.Extensions.Helm
 	var err error
-	if clusterConfig.Spec.Extensions.Storage != nil {
-		switch clusterConfig.Spec.Extensions.Storage.Type {
-		case k0sAPI.OpenEBSLocal:
-			helmSettings, err = addOpenEBSHelmExtension(helmSettings, clusterConfig.Spec.Extensions.Storage)
-			if err != nil {
-				ec.L.WithError(err).Error("Can't add openebs helm extension")
-			}
-		default:
+	switch clusterConfig.Spec.Extensions.Storage.Type {
+	case k0sAPI.OpenEBSLocal:
+		helmSettings, err = addOpenEBSHelmExtension(helmSettings, clusterConfig.Spec.Extensions.Storage)
+		if err != nil {
+			ec.L.WithError(err).Error("Can't add openebs helm extension")
 		}
-	} else {
-		ec.L.Debug("Storage extension is not configured")
+	default:
 	}
 
 	if err := ec.reconcileHelmExtensions(helmSettings); err != nil {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes a scenario in which k0s will panic when `spec.extensions.storage` is set to `null`

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings