### PR TITLE
Remove unused methods from BootlooseSuite

### DIFF
--- a/inttest/k0scloudprovider/k0scloudprovider_test.go
+++ b/inttest/k0scloudprovider/k0scloudprovider_test.go
@@ -18,15 +18,20 @@ package k0scloudprovider
 
 import (
 	"context"
+	"fmt"
 	"testing"
-	"time"
 
 	"github.com/k0sproject/k0s/inttest/common"
 	"github.com/k0sproject/k0s/pkg/k0scloudprovider"
-	"github.com/stretchr/testify/suite"
-	v1 "k8s.io/api/core/v1"
+	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
+
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/go-openapi/jsonpointer"
+	"github.com/stretchr/testify/suite"
 )
 
 type K0sCloudProviderSuite struct {
@@ -34,7 +39,9 @@ type K0sCloudProviderSuite struct {
 }
 
 func (s *K0sCloudProviderSuite) TestK0sGetsUp() {
-	s.Require().NoError(s.InitController(0, "--enable-k0s-cloud-provider", "--k0s-cloud-provider-update-frequency=5s"))
+	ctx := s.Context()
+
+	s.Require().NoError(s.InitController(0, "--enable-k0s-cloud-provider", "--k0s-cloud-provider-update-frequency=1s"))
 	s.Require().NoError(s.RunWorkers("--enable-cloud-provider"))
 
 	kc, err := s.KubeClient(s.ControllerNode(0))
@@ -44,76 +51,41 @@ func (s *K0sCloudProviderSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
 	s.Require().NoError(err)
 
-	// Test the adding of various addresses using addition via annotations
-	w0Helper := defaultNodeAddValueHelper(s.AddNodeAnnotation)
-	s.testAddAddress(kc, s.WorkerNode(0), "1.2.3.4", w0Helper)
-	s.testAddAddress(kc, s.WorkerNode(0), "2041:0000:140F::875B:131B", w0Helper)
-	s.testAddAddress(kc, s.WorkerNode(0), "GIGO", w0Helper)
+	s.testAddAddress(ctx, kc, s.WorkerNode(0), "1.2.3.4")
+	s.testAddAddress(ctx, kc, s.WorkerNode(0), "2041:0000:140F::875B:131B")
+	s.testAddAddress(ctx, kc, s.WorkerNode(0), "GIGO")
 }
 
-// nodeAddValueFunc defines how a key/value can be added to a node
-type nodeAddValueFunc func(node string, kc *kubernetes.Clientset, key string, value string) (*v1.Node, error)
+// testAddAddress adds the provided address to a node and ensures that the
+// cloud-provider will set it on the node.
+func (s *K0sCloudProviderSuite) testAddAddress(ctx context.Context, client kubernetes.Interface, nodeName string, ip string) {
+	// Adds or sets the special ExternalIPAnnotation with an IP address to the worker
+	// node, and after a few seconds the IP address should be listed as a NodeExternalIP.
+	patch := fmt.Sprintf(
+		`[{"op":"add", "path":"/metadata/annotations/%s", "value":"%s"}]`,
+		jsonpointer.Escape(k0scloudprovider.ExternalIPAnnotation), jsonpointer.Escape(ip),
+	)
+	_, err := client.CoreV1().Nodes().Patch(ctx, nodeName, types.JSONPatchType, []byte(patch), metav1.PatchOptions{})
+	s.Require().NoError(err, "Failed to add or set the annotation for the external IP address")
 
-// nodeAddValueHelper provides all of the callback functions needed to test
-// the addition of addresses into the provider (pre, add, post)
-type nodeAddValueHelper struct {
-	addressFoundPre  func(ctx context.Context, kc *kubernetes.Clientset, node string, addr string, addrType v1.NodeAddressType) (bool, error)
-	addressAdd       nodeAddValueFunc
-	addressFoundPost func(ctx context.Context, kc *kubernetes.Clientset, node string, addr string, addrType v1.NodeAddressType) (bool, error)
-}
+	// Need to ensure that a matching 'ExternalIP' address has been added,
+	// indicating that k0s-cloud-provider properly processed the annotation.
+	s.T().Logf("Waiting for k0s-cloud-provider to update the external IP on node %s to %s", nodeName, ip)
+	s.Require().NoError(watch.Nodes(client.CoreV1().Nodes()).
+		WithObjectName(nodeName).
+		WithErrorCallback(common.RetryWatchErrors(s.T().Logf)).
+		Until(ctx, func(node *corev1.Node) (bool, error) {
+			for _, nodeAddr := range node.Status.Addresses {
+				if nodeAddr.Type == corev1.NodeExternalIP {
+					if nodeAddr.Address == ip {
+						return true, nil
+					}
+					break
+				}
+			}
 
-// defaultNodeAddValueHelper creates a nodeAddValueHelper using the provided
-// adder function (ie. labels, or annotation add functions)
-func defaultNodeAddValueHelper(adder nodeAddValueFunc) nodeAddValueHelper {
-	return nodeAddValueHelper{
-		addressFoundPre:  nodeHasAddressWithType,
-		addressAdd:       adder,
-		addressFoundPost: nodeHasAddressWithType,
-	}
-}
-
-// testAddAddress adds the provided address to a node via a helper. This ensures that
-// the address doesn't already exist, can be added successfully, and exists after addition.
-func (s *K0sCloudProviderSuite) testAddAddress(kc *kubernetes.Clientset, node string, addr string, helper nodeAddValueHelper) {
-	s.T().Logf("Testing add address - node=%s, addr=%s", node, addr)
-
-	addrFound, err := helper.addressFoundPre(s.Context(), kc, node, addr, v1.NodeExternalIP)
-	s.Require().NoError(err)
-	s.Require().False(addrFound, "ExternalIP=%s already exists on node=%s", addr, node)
-
-	// Now, add the special 'k0sproject.io/node-ip-external' key with an IP address to the
-	// worker node, and after a few seconds the IP address should be listed as an 'ExternalIP'
-	w, err := helper.addressAdd(node, kc, k0scloudprovider.ExternalIPAnnotation, addr)
-	s.Require().NoError(err)
-	s.Require().NotNil(w)
-
-	// The k0s-cloud-provider is configured to update every 5s, so wait for 10s and then
-	// look for the external IP.
-	s.T().Logf("waiting 10s for the next k0s-cloud-provider update (testAddAddress: node=%s, addr=%s)", node, addr)
-	time.Sleep(10 * time.Second)
-
-	// Need to ensure that a matching 'ExternalIP' address has been added, indicating that
-	// k0s-cloud-provider properly processed the annotation.
-	foundPostUpdate, err := helper.addressFoundPost(s.Context(), kc, node, addr, v1.NodeExternalIP)
-	s.Require().NoError(err)
-	s.Require().True(foundPostUpdate, "unable to find ExternalIP=%s on node=%s", addr, node)
-}
-
-// nodeHasAddressWithType is a helper for fetching all of the addresses associated to
-// the provided node, and asserting that an IP matches by address + type.
-func nodeHasAddressWithType(ctx context.Context, kc *kubernetes.Clientset, node string, addr string, addrType v1.NodeAddressType) (bool, error) {
-	n, err := kc.CoreV1().Nodes().Get(ctx, node, metav1.GetOptions{})
-	if err != nil {
-		return false, err
-	}
-
-	for _, naddr := range n.Status.Addresses {
-		if naddr.Type == addrType && naddr.Address == addr {
-			return true, nil
-		}
-	}
-
-	return false, nil
+			return false, nil
+		}), "While waiting for k0s-cloud-provider to update the external IP on node %s to %s", nodeName, ip)
 }
 
 func TestK0sCloudProviderSuite(t *testing.T) {


### PR DESCRIPTION
## Description

Inline the single use of AddAnnotation in the k0scloudprovider inttest and simplify that test a lot. Inline the GetHTTPStatus method into its only caller and pull out common setup stuff out of the retry loop.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings