### PR TITLE
Move K0sUpdateVersion from BootlooseSuite into inttest

### DIFF
--- a/inttest/ap-ha3x3/ha3x3_test.go
+++ b/inttest/ap-ha3x3/ha3x3_test.go
@@ -16,6 +16,7 @@ package ha3x3
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -92,6 +93,9 @@ func (s *ha3x3Suite) SetupTest() {
 // TestApply applies a well-formed `plan` yaml, and asserts that
 // all of the correct values across different objects + controllers are correct.
 func (s *ha3x3Suite) TestApply() {
+	k0sUpdateVersion := os.Getenv("K0S_UPDATE_TO_VERSION")
+	s.Require().NotEmpty(k0sUpdateVersion, "env var not set or empty: K0S_UPDATE_TO_VERSION")
+
 	planTemplate := `
 apiVersion: autopilot.k0sproject.io/v1beta2
 kind: Plan
@@ -102,7 +106,7 @@ spec:
   timestamp: now
   commands:
     - k0supdate:
-        version: ` + s.K0sUpdateVersion + `
+        version: ` + k0sUpdateVersion + `
         platforms:
           linux-amd64:
             url: http://localhost/dist/k0s-new
@@ -162,7 +166,7 @@ spec:
 	}
 
 	if version, err := s.GetK0sVersion(s.ControllerNode(0)); s.NoError(err) {
-		s.Equal(s.K0sUpdateVersion, version)
+		s.Equal(k0sUpdateVersion, version)
 	}
 
 	out, err = ssh.ExecWithOutput(s.Context(), "/var/lib/k0s/bin/iptables-save -V")

--- a/inttest/common/bootloosesuite.go
+++ b/inttest/common/bootloosesuite.go
@@ -75,8 +75,6 @@ const (
 	k0sBindMountFullPath     = "/dist/k0s"
 	k0sNewBindMountFullPath  = "/dist/k0s-new"
 
-	defaultK0sUpdateVersion = "v0.0.0"
-
 	defaultBootLooseImage = "bootloose-alpine"
 )
 
@@ -102,7 +100,6 @@ type BootlooseSuite struct {
 	WorkerCount                     int
 	K0smotronWorkerCount            int
 	WithUpdateServer                bool
-	K0sUpdateVersion                string
 	BootLooseImage                  string
 
 	ctx      context.Context
@@ -137,11 +134,6 @@ func (s *BootlooseSuite) initializeDefaults() {
 	}
 	if s.LaunchMode == "" {
 		s.LaunchMode = LaunchModeStandalone
-	}
-
-	s.K0sUpdateVersion = os.Getenv("K0S_UPDATE_TO_VERSION")
-	if s.K0sUpdateVersion == "" {
-		s.K0sUpdateVersion = defaultK0sUpdateVersion
 	}
 
 	switch s.LaunchMode {


### PR DESCRIPTION
## Description

It is only used once in the Autopilot inttest, so it makes sense to simply lookup the env var there.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings