### PR TITLE
Sync the arm release workflow with the arm64 release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,6 +334,10 @@ jobs:
       - name: "Pre: Fixup directories"
         run: find . -type d -not -perm /u+w -exec chmod u+w '{}' \;
 
+      - name: Clean Docker before build
+        run: |
+          docker system prune --all --volumes --force
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
 
@@ -360,23 +364,10 @@ jobs:
             --tlog-upload=false \
             /k0s/k0s --output-file /k0s/k0s.sig
 
-      # Need to install Go manually: https://github.com/actions/setup-go/issues/106
-      - name: Set up Go for smoke tests (armv6l)
-        run: |
-          echo "Setup go stable version $GO_VERSION"
-          rm -rf -- "$HOME/.local/go"
-          mkdir -p -- "$HOME/.local/go"
-          curl --silent -L "https://go.dev/dl/go${GO_VERSION%%.0}.linux-armv6l.tar.gz" | tar -C "$HOME/.local" -xz
-
-          echo "$HOME/.local/go/bin" >>"$GITHUB_PATH"
-          export PATH="$PATH:$HOME/.local/go/bin"
-          echo Added go to the path
-
-          echo "Successfully setup go version $GO_VERSION"
-          go version
-          echo ::group::go env
-          go env
-          echo ::endgroup::
+      - name: Set up Go for smoke tests
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Run basic smoke test
         run: make check-basic
@@ -423,6 +414,11 @@ jobs:
           asset_path: ./airgap-image-bundle-linux-arm.tar
           asset_name: k0s-airgap-bundle-${{ needs.release.outputs.tag_name }}-arm
           asset_content_type: application/octet-stream
+
+      - name: Clean Docker after build
+        if: always()
+        run: |
+          docker system prune --all --volumes --force
 
       # https://github.com/actions/checkout/issues/273#issuecomment-642908752
       # Golang mod cache tends to set directories to read-only, which breaks any


### PR DESCRIPTION
## Description

This mainly addresses the installation of Go, which can now be done with the official setup-go action. A similar change has been done in #3193 for the standard Go build workflow.

See:
* #3193
* #3362

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings