### PR TITLE
Error out in Applier even for Not Found errors

### DIFF
--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -18,9 +18,7 @@ package applier
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os"
 	"path"
 	"path/filepath"
 
@@ -162,12 +160,9 @@ func (a *Applier) parseFiles(files []string) ([]*unstructured.Unstructured, erro
 
 	objects, err := r.Infos()
 	if err != nil {
-		// don't return an error on file removal
-		if !errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("enable to get object infos: %w", err)
-		}
-
+		return nil, fmt.Errorf("unable to build resources: %w", err)
 	}
+
 	for _, o := range objects {
 		item := o.Object.(*unstructured.Unstructured)
 		if item.GetAPIVersion() != "" && item.GetKind() != "" {


### PR DESCRIPTION
## Description

The stack applier has a backoff retry in place. This would start over with a new attempt to apply the stack in case some files have intermittently been deleted, which seems more resilient than a potential complete deletion of the stack.

Also adjust the tests a bit to honor error conditions better and by removing some double-checks.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings