### PR TITLE
Remove necessity to suppress NotFound errors in Applier

### DIFF
--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -103,9 +103,9 @@ func (as *AddonsSuite) deleteRelease(chart *v1beta1.Chart) {
 	k8sclient, err := k8s.NewForConfig(cfg)
 	as.Require().NoError(err)
 	as.Require().NoError(wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(pollCtx context.Context) (done bool, err error) {
-		as.T().Logf("Expecting have no secrets left for release %s/%s", chart.Namespace, chart.Name)
-		items, err := k8sclient.CoreV1().Secrets("default").List(pollCtx, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("name=%s", chart.Name),
+		as.T().Logf("Expecting have no secrets left for release %s/%s", chart.Status.Namespace, chart.Status.ReleaseName)
+		items, err := k8sclient.CoreV1().Secrets(chart.Status.Namespace).List(pollCtx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("name=%s", chart.Status.ReleaseName),
 		})
 		if err != nil {
 			if ctxErr := context.Cause(ctx); ctxErr != nil {
@@ -114,7 +114,7 @@ func (as *AddonsSuite) deleteRelease(chart *v1beta1.Chart) {
 			as.T().Log("Error while listing secrets:", err)
 			return false, nil
 		}
-		if len(items.Items) > 1 {
+		if len(items.Items) > 0 {
 			return false, nil
 		}
 		as.T().Log("Release uninstalled successfully")


### PR DESCRIPTION
## Description

Use a fresh resource builder for each stack application. The cached resource builder kept around references to all the files that have been added to it. Using a fresh one eliminates the need to suppress NotFound errors, previously arising from attempts to load files no longer present in the stack's folder.

Correct the corresponding integration test which used the wrong label selector. The test mistakenly used the name of the chart resource instead of the name of the helm release, so that the test always passed, even if the uninstall didn't happen.

Also adjust the unit tests to better respond to error conditions and remove some duplicate checks.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings