### PR TITLE
Patch away chart finalizers

### DIFF
--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -136,7 +136,7 @@ func (as *AddonsSuite) deleteRelease(chart *v1beta1.Chart) {
 		err := chartClient.Get(ctx, client.ObjectKey{Namespace: chart.Namespace, Name: chart.Name}, &found)
 		switch {
 		case err == nil:
-			if lastResourceVersion != found.ResourceVersion {
+			if lastResourceVersion == "" || lastResourceVersion != found.ResourceVersion {
 				as.T().Log("Chart not yet deleted")
 				lastResourceVersion = found.ResourceVersion
 			}


### PR DESCRIPTION
## Description

The previous approach was using a standard update and was prone to be failing due to optimistic locking. However, we _want_ the finalizer to disappear after the Helm release has been uninstalled, so instead use a patch that explicitly targets the finalizer, ignoring any intermediate resource updates.

Also check that chart resources get deleted in the addons inttest. The previous checks only verifed that the Helm release had been uninstalled, but didn't take into account the chart resource itself. Due to the aforementioned finalizer removal problem, the deleted chart was never purged from the API server.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings