### PR TITLE
Assume Helm release has been uninstalled if not found

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -319,7 +319,7 @@ func (hc *Commands) ListReleases(namespace string) ([]*release.Release, error) {
 func (hc *Commands) UninstallRelease(ctx context.Context, releaseName string, namespace string) error {
 	cfg, err := hc.getActionCfg(namespace)
 	if err != nil {
-		return fmt.Errorf("can't create helmAction configuration: %v", err)
+		return fmt.Errorf("can't create helmAction configuration: %w", err)
 	}
 	helmAction := action.NewUninstall(cfg)
 	deadline, ok := ctx.Deadline()
@@ -328,7 +328,7 @@ func (hc *Commands) UninstallRelease(ctx context.Context, releaseName string, na
 	}
 
 	if _, err := helmAction.Run(releaseName); err != nil {
-		return fmt.Errorf("can't uninstall release `%s`: %v", releaseName, err)
+		return fmt.Errorf("can't uninstall release `%s`: %w", releaseName, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

During the deletion of chart resources, it might happen that the Helm release has already been uninstalled by a previous reconciliation loop, or maybe manually by a cluster administrator.

Accomodate for that by treating release not found errors as a sign that the release has already been uninstalled and continue with the chart deletion process.

Add inttest for assuming non-existent releases as uninstalled.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings