### PR TITLE
Set controller-runtime logger in inttest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/estesp/manifest-tool/v2 v2.1.3
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/fsnotify/fsnotify v1.7.0
+	github.com/go-logr/logr v1.2.4
 	github.com/go-openapi/jsonpointer v0.20.0
 	github.com/go-playground/validator/v10 v10.16.0
 	github.com/google/go-cmp v0.6.0
@@ -145,7 +146,6 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
-	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.4 // indirect


### PR DESCRIPTION
## Description

This suppresses log messages like the following:

    [controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
    Detected at:
    	>  goroutine 48 [running]:
    	>  runtime/debug.Stack()
    	>  	/opt/hostedtoolcache/go/1.21.4/x64/src/runtime/debug/stack.go:24 +0x5e
    	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
    	>  	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/log/log.go:60 +0xcd
    	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc00034c0c0, {0x1b69724, 0x14})
    	>  	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/log/deleg.go:147 +0x45
    	>  github.com/go-logr/logr.Logger.WithName({{0x1de3cf0, 0xc00034c0c0}, 0x0}, {0x1b69724?, 0x1b57b4c?})
    	>  	/home/runner/go/pkg/mod/github.com/go-logr/logr@v1.2.4/logr.go:336 +0x3d
    	>  sigs.k8s.io/controller-runtime/pkg/client.newClient(0x531cde?, {0x0, 0xc000156540, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
    	>  	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/client/client.go:122 +0xec
    	>  sigs.k8s.io/controller-runtime/pkg/client.New(0xc0003f7c70?, {0x0, 0xc000156540, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
    	>  	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/client/client.go:103 +0x7d
    	>  github.com/k0sproject/k0s/inttest/addons.(*AddonsSuite).waitForTestRelease(0xc0004476c0, {0x1b5cb0b, 0xa}, {0x1b588f7, 0x5}, {0x1b59cd3, 0x7}, 0x1)
    	>  	/home/runner/work/k0s/k0s/inttest/addons/addons_test.go:129 +0x24a
    	>  github.com/k0sproject/k0s/inttest/addons.(*AddonsSuite).TestHelmBasedAddons(0xc0004476c0)
    	>  	/home/runner/work/k0s/k0s/inttest/addons/addons_test.go:57 +0x3b6
    	>  reflect.Value.call({0xc0003b7880?, 0xc00039c718?, 0x13?}, {0x1b583b1, 0x4}, {0xc0000d9e70, 0x1, 0x1?})
    	>  	/opt/hostedtoolcache/go/1.21.4/x64/src/reflect/value.go:596 +0xce7
    	>  reflect.Value.Call({0xc0003b7880?, 0xc00039c718?, 0xc0004476c0?}, {0xc000502e70?, 0x52c66d?, 0x2630f58?})
    	>  	/opt/hostedtoolcache/go/1.21.4/x64/src/reflect/value.go:380 +0xb9
    	>  github.com/stretchr/testify/suite.Run.func1(0xc0004621a0)
    	>  	/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.8.4/suite/suite.go:197 +0x467
    	>  testing.tRunner(0xc0004621a0, 0xc0004081b0)
    	>  	/opt/hostedtoolcache/go/1.21.4/x64/src/testing/testing.go:1595 +0xff
    	>  created by testing.(*T).Run in goroutine 5
    	>  	/opt/hostedtoolcache/go/1.21.4/x64/src/testing/testing.go:1648 +0x3ad

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings