### PR TITLE
Fix doc configuration.md spec.workerProfiles examples misplaced

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -330,51 +330,6 @@ Note that there are several fields that cannot be overridden:
 
 [kubelet-config]: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
 
-### `spec.featureGates`
-
-Available components are:
-
-- kube-apiserver
-- kube-controller-manager
-- kubelet
-- kube-scheduler
-- kube-proxy
-
-If `components` are omitted, propagates to all kube components.
-
-Modifies extraArgs.
-
-#### Example
-
-```yaml
-spec:
-    featureGates:
-      - name: feature-gate-0
-        enabled: true
-        components: ["kube-apiserver", "kube-controller-manager", "kubelet", "kube-scheduler"]
-      - name: feature-gate-1
-        enabled: true
-      - name: feature-gate-2
-        enabled: false
-```
-
-#### Kubelet feature gates example
-
-The below is an example of a k0s config with feature gates enabled:
-
-```yaml
-spec:
-    featureGates:
-      - name: DevicePlugins
-        enabled: true
-        components: ["kubelet"]
-      - name: Accelerators
-        enabled: true
-        components: ["kubelet"]
-      - name: AllowExtTrafficLocalEndpoints
-        enabled: false
-```
-
 #### Configuration examples
 
 ##### Custom volumePluginDir
@@ -413,6 +368,53 @@ spec:
       values:
         allowedUnsafeSysctls:
           - fs.inotify.max_user_instances
+```
+
+### `spec.featureGates`
+
+Available components are:
+
+- kube-apiserver
+- kube-controller-manager
+- kubelet
+- kube-scheduler
+- kube-proxy
+
+If `components` are omitted, propagates to all kube components.
+
+Modifies extraArgs.
+
+#### Examples
+
+##### Generic feature gates example
+
+```yaml
+spec:
+    featureGates:
+      - name: feature-gate-0
+        enabled: true
+        components: ["kube-apiserver", "kube-controller-manager", "kubelet", "kube-scheduler"]
+      - name: feature-gate-1
+        enabled: true
+      - name: feature-gate-2
+        enabled: false
+```
+
+##### Kubelet feature gates example
+
+The below is an example of a k0s config with feature gates enabled:
+
+```yaml
+spec:
+    featureGates:
+      - name: DevicePlugins
+        enabled: true
+        components: ["kubelet"]
+      - name: Accelerators
+        enabled: true
+        components: ["kubelet"]
+      - name: AllowExtTrafficLocalEndpoints
+        enabled: false
 ```
 
 ### `spec.images`


### PR DESCRIPTION
## Description

Exemples related to spec.workerProfiles are in spec.featureGates section which make them impossible to find.
Initially spec.featureGates was a sub section of spec.workerProfiles. When it became a section, exemples specific to spec.workerProfiles were left after spec.featureGates. 

Fixes # (issue)

Moved up the exemples inside spec.workeProfiles section.

## Type of change

Documentation.

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings