### PR TITLE
[Backport release-1.26] Add DefaultStorageExtension() and test

### DIFF
--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
@@ -240,6 +240,9 @@ func (c *ClusterConfig) UnmarshalJSON(data []byte) error {
 	if jc.Spec.Extensions == nil {
 		jc.Spec.Extensions = DefaultExtensions()
 	}
+	if jc.Spec.Extensions.Storage == nil {
+		jc.Spec.Extensions.Storage = DefaultStorageExtension()
+	}
 	if jc.Spec.Network == nil {
 		jc.Spec.Network = DefaultNetwork()
 	}

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types_test.go
@@ -195,6 +195,15 @@ spec:
   telemetry: null
   konnectivity: null
 `
+	extensionsYamlData := `
+apiVersion: k0s.k0sproject.io/v1beta1
+kind: ClusterConfig
+metadata:
+  name: foobar
+spec:
+  extensions:
+    storage: null
+`
 
 	c, err := ConfigFromString(yamlData)
 	assert.NoError(t, err)
@@ -209,6 +218,10 @@ spec:
 	assert.Equal(t, DefaultInstallSpec(), c.Spec.Install)
 	assert.Equal(t, DefaultClusterTelemetry(), c.Spec.Telemetry)
 	assert.Equal(t, DefaultKonnectivitySpec(), c.Spec.Konnectivity)
+
+	e, err := ConfigFromString(extensionsYamlData)
+	assert.NoError(t, err)
+	assert.Equal(t, DefaultExtensions(), e.Spec.Extensions)
 }
 
 func TestWorkerProfileConfig(t *testing.T) {

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/extensions.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/extensions.go
@@ -151,13 +151,17 @@ func (e *ClusterExtensions) Validate() []error {
 	return errs
 }
 
+func DefaultStorageExtension() *StorageExtension {
+	return &StorageExtension{
+		Type:                      ExternalStorage,
+		CreateDefaultStorageClass: false,
+	}
+}
+
 // DefaultExtensions default values
 func DefaultExtensions() *ClusterExtensions {
 	return &ClusterExtensions{
-		Storage: &StorageExtension{
-			Type:                      ExternalStorage,
-			CreateDefaultStorageClass: false,
-		},
-		Helm: &HelmExtensions{},
+		Storage: DefaultStorageExtension(),
+		Helm:    &HelmExtensions{},
 	}
 }


### PR DESCRIPTION
Backport to `release-1.26`:
* #3796

See:
* #3761