### PR TITLE
Add ControlNode deletion to docs on how to remove a controller node

### DIFF
--- a/docs/remove_controller.md
+++ b/docs/remove_controller.md
@@ -15,6 +15,12 @@ k0s kubectl drain --ignore-daemonsets --delete-emptydir-data <controller>
 k0s kubectl delete node <controller>
 ```
 
+Delete Autopilot's `ControlNode` object for the controller node:
+
+```console
+k0s kubectl delete controlnode.autopilot.k0sproject.io <controller>
+```
+
 Then you need to remove it from the Etcd cluster.
 For example, if you want to remove `controller01` from a cluster with 3 controllers:
 


### PR DESCRIPTION
## Description

There's nothing that would handle automatic removal of those objects, currently. Documenting the manual deletion is the least we can do about this.

See:
* #3808

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings