### PR TITLE
Ignore pre-flight checks for workers in basic inttest

### DIFF
--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -67,7 +67,17 @@ func (s *BasicSuite) TestK0sGetsUp() {
 
 	token, err := s.GetJoinToken("worker", dataDirOpt)
 	s.Require().NoError(err)
-	s.NoError(s.RunWorkersWithToken(token, `--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args=" --address=0.0.0.0  --event-burst=10"`))
+	s.NoError(s.RunWorkersWithToken(token,
+		// To check that node labels will be applied
+		"--labels=k0sproject.io/foo=bar",
+
+		// To check that kubelet args get processed correctly
+		"--kubelet-extra-args='--address=0.0.0.0 --event-burst=10'",
+
+		// FIXME remove this once the self-hosted GitHub Runner setup passes the
+		// pre-flight checks again.
+		"--ignore-pre-flight-checks",
+	))
 
 	kc, err := s.KubeClient(s.ControllerNode(0), dataDirOpt)
 	if err != nil {


### PR DESCRIPTION
## Description

The pre-flight checks are currently erroring out on some of the self-hosted GitHub Runners. Apply some duct tape to make the integration tests pass again until a proper solution has been figured out.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings