### PR TITLE
Fix `k0s kubeconfig create` command to utilize cluster name from config

### DIFF
--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -38,13 +38,13 @@ clusters:
 - cluster:
     server: {{.JoinURL}}
     certificate-authority-data: {{.CACert}}
-  name: k0s
+  name: {{.Name}}
 contexts:
 - context:
-    cluster: k0s
+    cluster: {{.Name}}
     user: {{.User}}
-  name: k0s
-current-context: k0s
+  name: {{.Name}}
+current-context: {{.Name}}
 kind: Config
 preferences: {}
 users:
@@ -115,12 +115,14 @@ Note: A certificate once signed cannot be revoked for a particular user`,
 				ClientKey  string
 				User       string
 				JoinURL    string
+				Name       string
 			}{
 				CACert:     base64.StdEncoding.EncodeToString(caCert),
 				ClientCert: base64.StdEncoding.EncodeToString([]byte(userCert.Cert)),
 				ClientKey:  base64.StdEncoding.EncodeToString([]byte(userCert.Key)),
 				User:       username,
 				JoinURL:    clusterAPIURL,
+				Name:       nodeConfig.Name,
 			}
 
 			var buf bytes.Buffer

--- a/cmd/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeconfig/kubeconfig_test.go
@@ -135,12 +135,14 @@ yJm2KSue0toWmkBFK8WMTjAvmAw3Z/qUhJRKoqCu3k6Mf8DNl6t+Uw==
 		ClientKey  string
 		User       string
 		JoinURL    string
+		Name       string
 	}{
 		CACert:     base64.StdEncoding.EncodeToString([]byte(caCert)),
 		ClientCert: base64.StdEncoding.EncodeToString([]byte(userCert.Cert)),
 		ClientKey:  base64.StdEncoding.EncodeToString([]byte(userCert.Key)),
 		User:       "test-user",
 		JoinURL:    clusterAPIURL,
+		Name:       "test-cluster",
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Utilize cluster name from config when creating kubeconfig

Fixes #3787

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings