### PR TITLE
Fix Code of Conduct linking in docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - mkdocs.yml
       - embedded-bins/Makefile.variables
+      - CODE_OF_CONDUCT.md
       - docs/**
 
 jobs:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
-# k0s Community Code Of Conduct
+# K0s Community Code of Conduct
 
-Please refer to our [contributor code of conduct](docs/contributors/CODE_OF_CONDUCT.md).
+K0s follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,1 +1,0 @@
-../CODE_OF_CONDUCT.md

--- a/docs/contributors/CODE_OF_CONDUCT.md
+++ b/docs/contributors/CODE_OF_CONDUCT.md
@@ -1,3 +1,1 @@
-# k0s Community Code of Conduct
-
-k0s follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+../../CODE_OF_CONDUCT.md

--- a/docs/contributors/overview.md
+++ b/docs/contributors/overview.md
@@ -8,7 +8,7 @@ When contributing to this repository, please consider first discussing the chang
 
 Our code of conduct can be found in the link below. Please follow it in all your interactions with the project.
 
-- [Code Of Conduct](./CODE_OF_CONDUCT.md)
+- [Code of Conduct](./CODE_OF_CONDUCT.md)
 
 ## GitHub Workflow
 


### PR DESCRIPTION
## Description

There was a symlink that pulled in the Code of Conduct from the repository root into the docs build. The link in the Code of Conduct was supposed to be working from within the docs.

Cleanup that situation by removing one Code of Conduct file and update the symlink. Also let changes to the Code of Conduct trigger the docs build workflow, so that these errors might be caught earlier in the future.

Fixes:
* #3815

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings