### PR TITLE
Fix configuration validation documentation

### DIFF
--- a/docs/configuration-validation.md
+++ b/docs/configuration-validation.md
@@ -3,10 +3,10 @@
 k0s command-line interface has the ability to validate config syntax:
 
 ```shell
-k0s validate config --config path/to/config/file
+k0s config validate --config path/to/config/file
 ```
 
-`validate config` sub-command can validate the following:
+`config validate` sub-command can validate the following:
 
 1. YAML formatting
 2. [SAN addresses](/configuration/#specapi)


### PR DESCRIPTION
## Description

Using `k0s validate config`, as previously done, produces the warning message

> Command "config" is deprecated, use 'k0s config validate' instead

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

```bash
$ k0s validate config --config k0sctl.yaml       
Command "config" is deprecated, use 'k0s config validate' instead
Error: failed to read config: error unmarshaling JSON: while decoding JSON: json: unknown field "hosts"
                                                                                                                                                        
$ k0s config validate --config k0sctl.yaml 
Error: failed to read config: error unmarshaling JSON: while decoding JSON: json: unknown field "hosts"
```

## Checklist:

- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have checked my code and corrected any misspellings