### PR TITLE
[Backport release-1.26] Bump Go to v1.20.12

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.17
 alpine_patch_version = $(alpine_version).4
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.20.11
+go_version = 1.20.12
 
 runc_version = 1.1.10
 runc_buildimage = $(golang_buildimage)


### PR DESCRIPTION
Backport to `release-1.27`:
* #3821

See:
* #3788

Fixes CVE-2023-39326, CVE-2023-45285 and CVE-2023-45283.