### PR TITLE
Add CoreDNS deployment to ostests pre-flight checks

### DIFF
--- a/hack/ostests/modules/k0sctl/main.tf
+++ b/hack/ostests/modules/k0sctl/main.tf
@@ -27,10 +27,10 @@ locals {
   num_workers     = length([for h in terraform_data.k0sctl_apply.output.hosts : h if h.is_worker])
 }
 
-resource "terraform_data" "konnectivity_available" {
+resource "terraform_data" "pre_flight_checks" {
   triggers_replace = [
     sha256(jsonencode(terraform_data.k0sctl_apply.output.k0sctl_config)),
-    sha256(file("${path.module}/wait-for-konnectivity.sh")),
+    sha256(file("${path.module}/pre-flight-checks.sh")),
   ]
 
   input = {
@@ -51,7 +51,7 @@ resource "terraform_data" "konnectivity_available" {
     inline = [
       "#!/usr/bin/env sh",
       format("set -- %d %d", local.num_controllers, local.num_workers),
-      file("${path.module}/wait-for-konnectivity.sh"),
+      file("${path.module}/pre-flight-checks.sh"),
     ]
   }
 }

--- a/hack/ostests/modules/k0sctl/outputs.tf
+++ b/hack/ostests/modules/k0sctl/outputs.tf
@@ -1,15 +1,15 @@
 output "hosts" {
-  value       = terraform_data.konnectivity_available.output.hosts
+  value       = terraform_data.pre_flight_checks.output.hosts
   description = "The hosts that have been provisioned by k0sctl."
 }
 
 output "ssh_private_key_filename" {
-  value       = terraform_data.konnectivity_available.output.ssh_private_key_filename
+  value       = terraform_data.pre_flight_checks.output.ssh_private_key_filename
   description = "The name of the private key file that has been used to authenticate via SSH."
 }
 
 output "k0sctl_config" {
-  value       = terraform_data.konnectivity_available.output.k0sctl_config
+  value       = terraform_data.pre_flight_checks.output.k0sctl_config
   description = "The k0sctl config that has been used."
 }
 


### PR DESCRIPTION
## Description

Sonobuoy expects the DNS pods to be running during its pre-flight tests. In addition to check for konnectivity, also check for the CoreDNS deployment, so that there are less CI failures due to bad timing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings