### PR TITLE
Use reflect.DeepEqual for CoreDNS config comparison

### DIFF
--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"path"
 	"path/filepath"
+	"reflect"
 	"time"
 
 	"github.com/k0sproject/k0s/pkg/component/manager"
@@ -429,7 +430,7 @@ func (c *CoreDNS) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterC
 	if err != nil {
 		return fmt.Errorf("error calculating coredns configs: %v. will retry", err)
 	}
-	if cfg == c.previousConfig {
+	if reflect.DeepEqual(c.previousConfig, cfg) {
 		c.log.Infof("current cfg matches existing, not gonna do anything")
 		return nil
 	}


### PR DESCRIPTION
## Description

Since k0s uses a PDB for CoreDNS, the simple double equals equality check wasn't appropriate to check if the CoreDNS configuration has changed. The struct now contains a pointer which is always different for newly constructed structs.

This caused a useless manifest regeneration every ten seconds.

Fixes:
* #3585

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings