### PR TITLE
Remove some workarounds for self-hosted arm64 runners

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -345,6 +345,7 @@ jobs:
     steps:
       # https://github.com/actions/checkout/issues/273#issuecomment-642908752 (see below)
       - name: "Pre: Fixup directories"
+        if: matrix.arch == 'arm'
         run: find . -type d -not -perm /u+w -exec chmod u+w '{}' \;
 
       - name: Check out code into the Go module directory
@@ -447,9 +448,9 @@ jobs:
       # post build action. So, as a workaround, ensure that all subdirectories
       # are writable.
       - name: "Post: Fixup directories"
-        if: always()
+        if: always() && matrix.arch == 'arm'
         run: find . -type d -not -perm /u+w -exec chmod u+w '{}' \;
 
       - name: "Docker prune"
-        if: always()
+        if: always() && matrix.arch == 'arm'
         run: docker system prune --force --filter "until=$((24*7))h"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,14 +222,6 @@ jobs:
       SEGMENT_TOKEN: ${{ secrets.SEGMENT_WRITE_KEY_PROD }}
       EULA_NOTICE: ${{ secrets.EULA_NOTICE }}
     steps:
-      # https://github.com/actions/checkout/issues/273#issuecomment-642908752 (see below)
-      - name: "Pre: Fixup directories"
-        run: find . -type d -not -perm /u+w -exec chmod u+w '{}' \;
-
-      - name: Clean Docker before build
-        run: |
-          docker system prune --all --volumes --force
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
@@ -306,22 +298,6 @@ jobs:
           asset_path: ./airgap-image-bundle-linux-arm64.tar
           asset_name: k0s-airgap-bundle-${{ needs.release.outputs.tag_name }}-arm64
           asset_content_type: application/octet-stream
-
-      - name: Clean Docker after build
-        if: always()
-        run: |
-          docker system prune --all --volumes --force
-
-      # https://github.com/actions/checkout/issues/273#issuecomment-642908752
-      # Golang mod cache tends to set directories to read-only, which breaks any
-      # attempts to simply remove those directories. The `make clean-gocache`
-      # target takes care of this, but the mod cache can't be deleted here,
-      # since it shall be cached across builds, and caching takes place as a
-      # post build action. So, as a workaround, ensure that all subdirectories
-      # are writable.
-      - name: "Post: Fixup directories"
-        if: always()
-        run: find . -type d -not -perm /u+w -exec chmod u+w '{}' \;
 
   armv7:
     needs: release


### PR DESCRIPTION
## Description

The new self-hosted arm64 runners are ephemeral one-shot runners. No more manual cleanup required.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings