### PR TITLE
Automate k0sctl version setting across test suites

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -15,7 +15,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_TERRAFORM_KEY }}
       AWS_DEFAULT_REGION: eu-west-1
       TF_VERSION: 1.2.2
-      K0SCTL_VERSION: 0.17.2
       KUBECONFIG: ${{ github.workspace }}/kubeconfig
 
     name: "K8s Network Conformance Testing"
@@ -131,11 +130,16 @@ jobs:
 
           terraform apply -auto-approve
 
+      - name: Set k0sctl version
+        run: |
+          version=$(cd hack/tool; go list -m -f '{{.Version}}' github.com/k0sproject/k0sctl)
+          echo "K0SCTL_VERSION=${version}" >> $GITHUB_ENV
+
       - name: Create k0s Cluster using k0sctl
         id: k0sctl
         run: |
           # download k0sctl
-          curl --silent -L "https://github.com/k0sproject/k0sctl/releases/download/v${K0SCTL_VERSION}/k0sctl-linux-x64" -o k0sctl
+          curl --silent -L "https://github.com/k0sproject/k0sctl/releases/download/${K0SCTL_VERSION}/k0sctl-linux-x64" -o k0sctl
           chmod +x ./k0sctl
           ./k0sctl apply -c k0sctl.yaml
 

--- a/.github/workflows/ostests-e2e.yaml
+++ b/.github/workflows/ostests-e2e.yaml
@@ -32,6 +32,9 @@ on:
         type: string
         description: The Terraform version to use when provisioning test resources.
         default: 1.4.6
+      k0sctl-version:
+        type: string
+        description: The k0sctl version to use when bootstrapping the test cluster.
     secrets:
       aws-access-key-id:
         description: The AWS access key ID to use when provisioning test resources.
@@ -91,8 +94,13 @@ jobs:
 
       - name: Set k0sctl version
         run: |
-          version=$(grep k0sproject/k0sctl hack/tool/go.mod|cut -d" " -f2)
-          echo "Detected k0sctl dependency version ${version}"
+          if [ -z "${{ inputs.k0sctl-version }}" ]; then
+            version=$(grep k0sproject/k0sctl hack/tool/go.mod|cut -d" " -f2)
+            echo "Detected k0sctl dependency version ${version}"
+          else
+            version="${{ inputs.k0sctl-version }}"
+            echo "Using given k0sctl version ${version}"
+          fi
           echo "K0SCTL_VERSION=${version}" >> $GITHUB_ENV
 
       - name: "Terraform :: Requisites :: Prepare"

--- a/.github/workflows/ostests-e2e.yaml
+++ b/.github/workflows/ostests-e2e.yaml
@@ -32,10 +32,6 @@ on:
         type: string
         description: The Terraform version to use when provisioning test resources.
         default: 1.4.6
-      k0sctl-version:
-        type: string
-        description: The k0sctl version to use when bootstrapping the test cluster.
-        default: 0.17.2
     secrets:
       aws-access-key-id:
         description: The AWS access key ID to use when provisioning test resources.
@@ -93,9 +89,14 @@ jobs:
           name: k0s-linux-amd64
           path: ${{ github.workspace }}/.cache
 
+      - name: Set k0sctl version
+        run: |
+          version=$(grep k0sproject/k0sctl hack/tool/go.mod|cut -d" " -f2)
+          echo "Detected k0sctl dependency version ${version}"
+          echo "K0SCTL_VERSION=${version}" >> $GITHUB_ENV
+
       - name: "Terraform :: Requisites :: Prepare"
         env:
-          K0SCTL_VERSION: ${{ inputs.k0sctl-version }}
           K0S_VERSION: ${{ inputs.k0s-version }}
           K0S_EXECUTABLE_PATH: ${{ github.workspace }}/.cache/k0s
         run: |
@@ -103,7 +104,7 @@ jobs:
           jq --version
 
           mkdir -p "$(dirname -- "$TF_VAR_k0sctl_executable_path")"
-          curl -sSLo "$TF_VAR_k0sctl_executable_path" "https://github.com/k0sproject/k0sctl/releases/download/v${K0SCTL_VERSION}/k0sctl-linux-x64"
+          curl -sSLo "$TF_VAR_k0sctl_executable_path" "https://github.com/k0sproject/k0sctl/releases/download/${K0SCTL_VERSION}/k0sctl-linux-x64"
           chmod +x -- "$TF_VAR_k0sctl_executable_path"
           "$TF_VAR_k0sctl_executable_path" version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - v* # Push events to matching v*, i.e. v1.0, v20.15.10
 
-env:
-  K0SCTL_VERSION: 0.13.2
-
 jobs:
   release:
     env:
@@ -612,11 +609,16 @@ jobs:
 
           terraform apply -auto-approve
 
+      - name: Set k0sctl version
+        run: |
+          version=$(cd hack/tool; go list -m -f '{{.Version}}' github.com/k0sproject/k0sctl)
+          echo "K0SCTL_VERSION=${version}" >> $GITHUB_ENV
+
       - name: Create k0s Cluster using k0sctl
         id: k0sctl
         run: |
           # download k0sctl
-          curl --silent -L "https://github.com/k0sproject/k0sctl/releases/download/v${K0SCTL_VERSION}/k0sctl-linux-x64" -o k0sctl
+          curl --silent -L "https://github.com/k0sproject/k0sctl/releases/download/${K0SCTL_VERSION}/k0sctl-linux-x64" -o k0sctl
           chmod +x ./k0sctl
           ./k0sctl apply -c k0sctl.yaml
 

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -115,6 +115,7 @@ check-nllb: TIMEOUT=15m
 include Makefile.variables
 
 $(smoketests): K0S_PATH ?= $(realpath ../k0s)
+$(smoketests): K0SCTL_VERSION ?= $(shell grep k0sproject/k0sctl ../hack/tool/go.mod | cut -d" " -f2)
 $(smoketests): K0S_IMAGES_BUNDLE ?= $(realpath ../airgap-image-bundle-linux-$(ARCH).tar)
 $(smoketests): .bootloose-alpine.stamp
 $(smoketests): TEST_PACKAGE ?= $(subst check-,,$@)
@@ -123,6 +124,7 @@ $(smoketests):
 	K0S_UPDATE_FROM_PATH='$(K0S_UPDATE_FROM_PATH)' \
 	K0S_IMAGES_BUNDLE='$(K0S_IMAGES_BUNDLE)' \
 	K0S_UPDATE_TO_VERSION='$(K0S_UPDATE_TO_VERSION)' \
+	K0SCTL_VERSION='$(K0SCTL_VERSION)' \
 	go test -count=1 -v -timeout $(TIMEOUT) github.com/k0sproject/k0s/inttest/$(TEST_PACKAGE)
 .PHONY: clean
 


### PR DESCRIPTION
## Description

Removes the need to make manual changes for k0sctl version bumps. The version is obtained from hack/tool/go.mod which is updated automatically by dependabot. All the other suites that use k0sctl now get their k0sctl version by reading it from hack/tool/go.mod.

The change to `docs/nllb.md` in previous bumps is omitted here - the version number there is cosmetic.

This should make a dependabot PR like #3906 be enough for bumping the k0sctl dependency.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings