### PR TITLE
[Backport release-1.27] Bump Go to v1.20.13

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.17
 alpine_patch_version = $(alpine_version).4
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine3.18
-go_version = 1.20.12
+go_version = 1.20.13
 
 runc_version = 1.1.11
 runc_buildimage = $(golang_buildimage)


### PR DESCRIPTION
Backport to `release-1.27`:
* #3910