### PR TITLE
[Backport release-1.26] Bump Go to v1.20.13

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.17
 alpine_patch_version = $(alpine_version).4
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine3.18
-go_version = 1.20.12
+go_version = 1.20.13
 
 runc_version = 1.1.11
 runc_buildimage = $(golang_buildimage)

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,6 +1,6 @@
 alpine_version = 3.17
 alpine_patch_version = $(alpine_version).4
-golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
+golang_buildimage=docker.io/library/golang:$(go_version)-alpine3.18
 go_version = 1.20.12
 
 runc_version = 1.1.11


### PR DESCRIPTION
Backport to `release-1.26`:
* #3384
* #3911

See:
* #3351
* #3910