### PR TITLE
Use upload/download to share airgap bundles between tests

### DIFF
--- a/.github/workflows/build-airgap-image-bundle.yml
+++ b/.github/workflows/build-airgap-image-bundle.yml
@@ -20,9 +20,6 @@ jobs:
     name: "${{ inputs.target-os }}-${{ inputs.target-arch }}"
     runs-on: ubuntu-22.04
 
-    outputs:
-      cache-key: ${{ steps.cache-airgap-image-bundle-calc-key.outputs.cache-key }}
-
     env:
       TARGET_OS: ${{ inputs.target-os }}
       TARGET_ARCH: ${{ inputs.target-arch }}
@@ -38,11 +35,9 @@ jobs:
         with:
           name: airgap-image-list-${{ inputs.target-os }}-${{ inputs.target-arch }}
 
-        # Capture the calculated image bundle source hash in a build output, so
-        # it can be shared between the cache actions in this job and in the
-        # smoketests. Do this in a separate step, as the hashFiles function is
-        # evaluated before the step execution. So all the required files need to
-        # exist before that.
+        # Capture the calculated image bundle source hash in a separate step, as
+        # the hashFiles function is evaluated before the step execution. So all
+        # the required files need to exist before that.
       - name: "Cache :: Airgap image bundle :: Calculate cache key"
         id: cache-airgap-image-bundle-calc-key
         env:
@@ -56,7 +51,6 @@ jobs:
         with:
           key: ${{ steps.cache-airgap-image-bundle-calc-key.outputs.cache-key }}
           path: airgap-image-bundle-${{ inputs.target-os }}-${{ inputs.target-arch }}.tar
-          lookup-only: true
 
       - name: "Build :: Airgap image bundle"
         if: steps.cache-airgap-image-bundle.outputs.cache-hit != 'true'
@@ -64,3 +58,10 @@ jobs:
           mkdir -p "embedded-bins/staging/$TARGET_OS/bin"
           make --touch airgap-images.txt
           make "airgap-image-bundle-$TARGET_OS-$TARGET_ARCH.tar"
+
+      - name: "Upload :: Airgap image bundle"
+        uses: actions/upload-artifact@v4
+        with:
+          name: airgap-image-bundle-${{ inputs.target-os }}-${{ inputs.target-arch }}
+          path: airgap-image-bundle-${{ inputs.target-os }}-${{ inputs.target-arch }}.tar
+          compression: 0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -235,23 +235,14 @@ jobs:
           chmod +x k0s
           ./k0s sysinfo
 
-      - name: Cache airgap image bundle
-        id: cache-airgap-image-bundle
+      - name: Download airgap image bundle
         if: contains(matrix.smoke-suite, 'airgap')
-        uses: actions/cache@v3
+        uses: actions/download-artifact@v4
         with:
-          key: ${{ needs.build-airgap-image-bundle.outputs.cache-key }}
-          path: airgap-image-bundle-linux-amd64.tar
+          name: airgap-image-bundle-linux-amd64
 
       - name: Run inttest
-        env:
-          NEEDS_AIRGAP_IMAGE_BUNDLE: ${{ contains(matrix.smoke-suite, 'airgap') }}
-        run: |
-          [ "$NEEDS_AIRGAP_IMAGE_BUNDLE" != true ] || [ -f airgap-image-bundle-linux-amd64.tar ] || {
-            echo Airgap image bundle file missing!
-            exit 1
-          }
-          make -C inttest ${{ matrix.smoke-suite }}
+        run: make -C inttest ${{ matrix.smoke-suite }}
 
       - name: Collect k0s logs and support bundle
         if: failure()


### PR DESCRIPTION
## Description

This removes the cache hack that was used to share the prebuilt image bundles with the integration tests. The upload/download action is now reasonably fast.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings