### PR TITLE
Add k0sctl version lookup to vars.sh

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -130,11 +130,6 @@ jobs:
 
           terraform apply -auto-approve
 
-      - name: Set k0sctl version
-        run: |
-          version=$(cd hack/tool; go list -m -f '{{.Version}}' github.com/k0sproject/k0sctl)
-          echo "K0SCTL_VERSION=${version}" >> $GITHUB_ENV
-
       - name: Create k0s Cluster using k0sctl
         id: k0sctl
         run: |

--- a/.github/workflows/ostests-e2e.yaml
+++ b/.github/workflows/ostests-e2e.yaml
@@ -81,9 +81,15 @@ jobs:
 
       - name: "Workflow run :: Prepare"
         working-directory: ./
+        env:
+          K0SCTL_VERSION: ${{ inputs.k0sctl-version }}
         run: |
           kubernetesVersion="$(./vars.sh kubernetes_version)"
+          k0sctlVersion="${K0SCTL_VERSION:-$(./vars.sh FROM=hack/tool k0sctl_version)}"
+
+          set -x
           echo KUBERNETES_VERSION="$kubernetesVersion" >>"$GITHUB_ENV"
+          echo K0SCTL_VERSION="$k0sctlVersion" >>"$GITHUB_ENV"
 
       - name: "Terraform :: Requisites :: Download k0s"
         if: inputs.k0s-version == ''
@@ -91,17 +97,6 @@ jobs:
         with:
           name: k0s-linux-amd64
           path: ${{ github.workspace }}/.cache
-
-      - name: Set k0sctl version
-        run: |
-          if [ -z "${{ inputs.k0sctl-version }}" ]; then
-            version=$(grep k0sproject/k0sctl hack/tool/go.mod|cut -d" " -f2)
-            echo "Detected k0sctl dependency version ${version}"
-          else
-            version="${{ inputs.k0sctl-version }}"
-            echo "Using given k0sctl version ${version}"
-          fi
-          echo "K0SCTL_VERSION=${version}" >> $GITHUB_ENV
 
       - name: "Terraform :: Requisites :: Prepare"
         env:

--- a/.github/workflows/prepare-build-env.sh
+++ b/.github/workflows/prepare-build-env.sh
@@ -3,18 +3,21 @@
 set -eu
 
 goVersion="$(./vars.sh go_version)"
+k0sctlVersion="$(./vars.sh FROM=hack/tool k0sctl_version)"
 golangciLintVersion="$(./vars.sh FROM=hack/tools golangci-lint_version)"
 pythonVersion="$(./vars.sh FROM=docs python_version)"
 
 cat <<EOF >>"$GITHUB_ENV"
 GO_VERSION=$goVersion
 GOLANGCI_LINT_VERSION=$golangciLintVersion
+K0SCTL_VERSION=$k0sctlVersion
 PYTHON_VERSION=$pythonVersion
 EOF
 
-# shellcheck disable=SC1090
-. "$GITHUB_ENV"
-
 echo ::group::OS Environment
 env | sort
+echo ::endgroup::
+
+echo ::group::Build Environment
+cat -- "$GITHUB_ENV"
 echo ::endgroup::

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -609,11 +609,6 @@ jobs:
 
           terraform apply -auto-approve
 
-      - name: Set k0sctl version
-        run: |
-          version=$(cd hack/tool; go list -m -f '{{.Version}}' github.com/k0sproject/k0sctl)
-          echo "K0SCTL_VERSION=${version}" >> $GITHUB_ENV
-
       - name: Create k0s Cluster using k0sctl
         id: k0sctl
         run: |

--- a/vars.sh
+++ b/vars.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+#shellcheck disable=SC3043
 
 set -eu
 
@@ -10,6 +11,18 @@ print_usage() {
   echo
   echo "  $0 go_version"
   echo "  $0 FROM=docs python_version"
+}
+
+version_from_go_mod() {
+  local pkg version rest
+  while read -r pkg version rest; do
+    if [ "$pkg" = "$1" ]; then
+      printf %s "$version"
+      return 0
+    fi
+  done
+
+  return 1
 }
 
 fail() {
@@ -40,6 +53,11 @@ done
 
 [ -n "$var" ] || fail Makefile variable not given
 [ -n "$from" ] || from=embedded-bins
+
+if [ "$var" = k0sctl_version ]; then
+  version_from_go_mod github.com/k0sproject/k0sctl <"$from"/go.mod
+  exit 0
+fi
 
 exec make --no-print-directory -r -s -f - <<EOF
 include $from/Makefile.variables


### PR DESCRIPTION
## Description

The vars.sh script is used to obtain variables from Makefile variables in scripts. Even if the k0sctl version is not maintained in a Makefile, but rather in a go.mod file, we can use the same interface for scripts. This makes the origin transparent and we can special-case anything in the vars.sh script, instead of introducing other ad-hoc mechanisms.

Moreover, include the k0sctl version in the build-env by default. It's fast and safe enough to be included by default, even if not required.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings