### PR TITLE
Remove api-config component flag

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -511,8 +511,8 @@ users to build a minimal Kubernetes control plane and use what ever components
 they need to fulfill their need for the control plane. Disabling the system
 components happens through a command line flag for the controller process:
 
-```sh
---disable-components strings                     disable components (valid items: api-config,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,worker-config)
+```text
+--disable-components strings                     disable components (valid items: autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,worker-config)
 ```
 
 **Note:** As of k0s 1.26, the kubelet-config component has been replaced by the

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -27,7 +27,6 @@ import (
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/k0scloudprovider"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/exp/slices"
@@ -95,18 +94,6 @@ func (o *ControllerOptions) Normalize() error {
 	// Normalize component names
 	var disabledComponents []string
 	for _, disabledComponent := range o.DisableComponents {
-		switch disabledComponent {
-		case constant.APIConfigComponentName:
-			logrus.Warnf("Usage of deprecated component name %q, please switch to %q",
-				constant.APIConfigComponentName, "--enable-dynamic-config=false",
-			)
-			if o.EnableDynamicConfig {
-				logrus.Warnf("Cannot disable component %q, because %q is selected",
-					constant.APIConfigComponentName, "--enable-dynamic-config",
-				)
-			}
-		}
-
 		if !slices.Contains(availableComponents, disabledComponent) {
 			return fmt.Errorf("unknown component %s", disabledComponent)
 		}

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -96,7 +96,6 @@ const (
 
 	/* Controller component names */
 
-	APIConfigComponentName             = "api-config" // Deprecated: just don't use dynamic config
 	APIEndpointReconcilerComponentName = "endpoint-reconciler"
 	ControlAPIComponentName            = "control-api"
 	CoreDNSComponentname               = "coredns"


### PR DESCRIPTION
## Description

It has been deprecated in k0s 1.27. Time to remove it.

See:
* #2845

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings