### PR TITLE
Use KUBERNETES_VERSION consistently

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -54,7 +54,7 @@ jobs:
       - name: mike deploy head
         if: contains(github.ref, 'refs/heads/main')
         run: |
-          KUBE_VERSION="$(./vars.sh kubernetes_version)" mike deploy --push head
+          KUBERNETES_VERSION="$(./vars.sh kubernetes_version)" mike deploy --push head
 
       # If a release has been published, deploy it as a new version
       - name: mike deploy new version
@@ -66,7 +66,7 @@ jobs:
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
-          KUBE_VERSION="$(./vars.sh kubernetes_version)" mike deploy --push "$VERSION"
+          KUBERNETES_VERSION="$(./vars.sh kubernetes_version)" mike deploy --push "$VERSION"
 
       - name: Update mike version aliases
         if: github.repository == 'k0sproject/k0s'

--- a/Makefile
+++ b/Makefile
@@ -285,6 +285,7 @@ docs-serve-dev: DOCS_DEV_PORT ?= 8000
 docs-serve-dev:
 	$(MAKE) -C docs .docker-image.serve-dev.stamp
 	docker run --rm \
+	  -e KUBERNETES_VERSION='$(kubernetes_version)' \
 	  -v "$(CURDIR):/k0s:ro" \
 	  -p '$(DOCS_DEV_PORT):8000' \
 	  k0sdocs.docker-image.serve-dev

--- a/docs/Dockerfile.serve-dev
+++ b/docs/Dockerfile.serve-dev
@@ -2,8 +2,6 @@ ARG PYTHON_IMAGE_VERSION
 
 FROM python:${PYTHON_IMAGE_VERSION} as builder
 
-ARG KUBE_VERSION
-
 # Prepare Python virtual env
 ENV PYTHONUNBUFFERED 1
 RUN \
@@ -25,6 +23,5 @@ WORKDIR /k0s
 EXPOSE 8000
 
 # Start development server by default
-ENV KUBE_VERSION=${KUBE_VERSION}
 ENTRYPOINT ["mkdocs"]
 CMD ["serve", "--dev-addr=0.0.0.0:8000"]

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,7 +18,7 @@ TARGET_VERSION ?= latest
 # gives: "Error: The 'docs_dir' should not be the parent directory of the config file."
 # even if docs_dir is "."
 docs: .require-mkdocs cli
-	cd .. && KUBE_VERSION=$(kubernetes_version) mkdocs build --strict
+	cd .. && KUBERNETES_VERSION=$(kubernetes_version) mkdocs build --strict
 
 .PHONY: .require-mkdocs
 .require-mkdocs:
@@ -75,10 +75,9 @@ cli:
 	sed $(sedopt) '/\[k0s kubectl /d' cli/k0s_kubectl.md
 	ln -s k0s.md cli/README.md
 
-.docker-image.serve-dev.stamp: Dockerfile.serve-dev requirements_pip.txt requirements.txt Makefile.variables
+.docker-image.serve-dev.stamp: Dockerfile.serve-dev requirements_pip.txt requirements.txt Makefile.variables ../embedded-bins/Makefile.variables
 	docker build \
 	  --build-arg PYTHON_IMAGE_VERSION=$(python_version)-alpine$(alpine_version) \
-	  --build-arg KUBE_VERSION=$(kubernetes_version) \
 	  -t 'k0sdocs$(basename $@)' -f '$<' .
 	touch -- '$@'
 

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -24,7 +24,7 @@ bootloose_alpine_build_cmdline := \
 	--build-arg ALPINE_VERSION=$(alpine_patch_version) \
 	--build-arg ETCD_VERSION=$(etcd_version) \
 	--build-arg HELM_VERSION=$(helm_version) \
-	--build-arg KUBE_VERSION=$(kubernetes_version) \
+	--build-arg KUBERNETES_VERSION=$(kubernetes_version) \
 	-t bootloose-alpine \
 	-f bootloose-alpine/Dockerfile \
 	bootloose-alpine

--- a/inttest/bootloose-alpine/Dockerfile
+++ b/inttest/bootloose-alpine/Dockerfile
@@ -6,7 +6,7 @@ FROM docker.io/library/alpine:$ALPINE_VERSION
 ARG TARGETARCH
 ARG CRI_DOCKERD_VERSION=0.3.8
 ARG ETCD_VERSION
-ARG KUBE_VERSION
+ARG KUBERNETES_VERSION
 ARG TROUBLESHOOT_VERSION=v0.78.1
 ARG HELM_VERSION
 
@@ -38,7 +38,7 @@ RUN sed -i -e 's/^\(tty[0-9]\)/# \1/' /etc/inittab
 RUN sed -i -e 's/^root:!:/root::/' /etc/shadow
 
 # Put kubectl into place to ease up debugging
-RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/$TARGETARCH/kubectl \
+RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBERNETES_VERSION/bin/linux/$TARGETARCH/kubectl \
   && chmod +x /usr/local/bin/kubectl
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,7 +134,7 @@ markdown_extensions:
   - footnotes
 
 extra:
-  k8s_version: !!python/object/apply:os.getenv ["KUBE_VERSION"]
+  k8s_version: !!python/object/apply:os.getenv ["KUBERNETES_VERSION"]
   generator: false
   social:
     - icon: fontawesome/brands/github


### PR DESCRIPTION
## Description

There were different environment variables in use to transport the current Kubernetes version. Unify that by replacing all KUBE_VERSION usages with KUBERNETES_VERSION.

Don't embed the Kuberntes version in the docs helper Docker container. It's not used during build time. It's required during runtime, though. Hence pass this as an -e parameter to the docker run command instead. Let the Docker container build also depend on the embedded-bins Makefile variables, as the Alpine version is defined over there.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings