### PR TITLE
Add progress=plain to all docker build commands

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -336,6 +336,16 @@ jobs:
       - name: "Pre: Fixup directories"
         run: find . -type d -not -perm /u+w -exec chmod u+w '{}' \;
 
+      - name: Set up Docker Context for Buildx
+        if: matrix.arch != 'arm'
+        run: docker context create builders
+
+      - name: Set up Docker Buildx
+        if: matrix.arch != 'arm'
+        uses: docker/setup-buildx-action@v3
+        with:
+          endpoint: builders
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ $(K0S_GO_BUILD_CACHE):
 	mkdir -p -- '$@'
 
 .k0sbuild.docker-image.k0s: build/Dockerfile embedded-bins/Makefile.variables | $(K0S_GO_BUILD_CACHE)
-	docker build --iidfile '$@' \
+	docker build --progress=plain --iidfile '$@' \
 	  --build-arg BUILDIMAGE=$(GOLANG_IMAGE) \
 	  -t k0sbuild.docker-image.k0s - <build/Dockerfile
 
@@ -227,7 +227,7 @@ airgap-image-bundle-linux-arm.tar: .k0sbuild.image-bundler.stamp airgap-images.t
 	  '$(shell cat .k0sbuild.image-bundler.stamp)' < airgap-images.txt > '$@'
 
 .k0sbuild.image-bundler.stamp: hack/image-bundler/* embedded-bins/Makefile.variables
-	docker build --iidfile '$@' \
+	docker build --progress=plain --iidfile '$@' \
 	  --build-arg ALPINE_VERSION=$(alpine_patch_version) \
 	  -t k0sbuild.image-bundler -- hack/image-bundler
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -76,7 +76,7 @@ cli:
 	ln -s k0s.md cli/README.md
 
 .docker-image.serve-dev.stamp: Dockerfile.serve-dev requirements_pip.txt requirements.txt Makefile.variables ../embedded-bins/Makefile.variables
-	docker build \
+	docker build --progress=plain \
 	  --build-arg PYTHON_IMAGE_VERSION=$(python_version)-alpine$(alpine_version) \
 	  -t 'k0sdocs$(basename $@)' -f '$<' .
 	touch -- '$@'

--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -78,7 +78,7 @@ build_docker_container = \
 	$(build_docker_container)
 
 build_docker_image = \
-	docker build --iidfile '$@' -t k0sbuild$(basename $@):latest \
+	docker build --progress=plain --iidfile '$@' -t k0sbuild$(basename $@):latest \
 	  --build-arg TARGET_OS=$(if $(findstring .windows.stamp,$@),windows,linux) \
 	  --build-arg CONTAINERD_BINS="$(containerd_bins)" \
 	  --build-arg KUBERNETES_BINS="$(kubernetes_bins)" \

--- a/examples/bootloose-ha-controllers/Makefile
+++ b/examples/bootloose-ha-controllers/Makefile
@@ -5,7 +5,7 @@ build:
 
 .PHONY: create-cluster
 create-cluster: build
-	docker build -t k0s-bootloose .
+	docker build --progress=plain -t k0s-bootloose .
 	envsubst < bootloose.yaml.tpl > bootloose.yaml
 	bootloose create
 

--- a/hack/tool/Makefile
+++ b/hack/tool/Makefile
@@ -13,4 +13,4 @@ endif
 endif
 
 image:
-	docker build --build-arg ARCH=${HOST_ARCH} --build-arg HARDWARE=${HOST_HARDWARE} -t tool -f ./Dockerfile .
+	docker build --progress=plain --build-arg ARCH=${HOST_ARCH} --build-arg HARDWARE=${HOST_HARDWARE} -t tool -f ./Dockerfile .

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -30,17 +30,17 @@ bootloose_alpine_build_cmdline := \
 	bootloose-alpine
 
 .bootloose-alpine.stamp: $(shell find bootloose-alpine -type f)
-	docker build --build-arg TARGETARCH=$(ARCH) $(bootloose_alpine_build_cmdline)
+	docker build --progress=plain --build-arg TARGETARCH=$(ARCH) $(bootloose_alpine_build_cmdline)
 	touch $@
 
 # This is a special target to test the bootloose alpine image locally for all supported platforms.
 .PHONY: check-bootloose-alpine-buildx
 check-bootloose-alpine-buildx:
-	docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 $(bootloose_alpine_build_cmdline)
+	docker buildx build --progress=plain --platform linux/amd64,linux/arm64,linux/arm/v7 $(bootloose_alpine_build_cmdline)
 
 .bootloose-k0s.stamp: K0S_PATH ?= $(realpath ../k0s)
 .bootloose-k0s.stamp: .bootloose-alpine.stamp
-	docker build \
+	docker build --progress=plain \
 	  --build-arg K0S_PATH=$(notdir $(K0S_PATH)) \
 	  -t bootloose-k0s \
 	  -f bootloose-k0s/Dockerfile \
@@ -48,7 +48,7 @@ check-bootloose-alpine-buildx:
 	touch $@
 
 .update-server.stamp: .bootloose-alpine.stamp update-server/Dockerfile $(wildcard update-server/html/**/*.html)
-	docker build -t update-server --build-arg BASE=bootloose-alpine -f update-server/Dockerfile update-server
+	docker build --progress=plain -t update-server --build-arg BASE=bootloose-alpine -f update-server/Dockerfile update-server
 	touch $@
 
 check-network: bin/sonobuoy


### PR DESCRIPTION
## Description

This makes build output readable for Docker 24.x, which has a special terminal output that's not a good choice when run as part of an automated build.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings