### PR TITLE
Use downloaded cosign binary in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,14 +87,9 @@ jobs:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
-          echo $COSIGN_KEY | base64 -d > cosign.key
-          docker run --rm \
-            -v "$(CURDIR):/k0s" \
-            gcr.io/projectsigstore/cosign:v2.2.0 \
-            sign-blob \
-            --key /k0s/cosign.key \
-            --tlog-upload=false \
-            /k0s/k0s --output-file /k0s/k0s.sig
+          curl -sSLo cosign https://github.com/sigstore/cosign/releases/download/v2.2.0/cosign-linux-amd64
+          chmod +x ./cosign
+          ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false k0s | tee k0s.sig
 
       - name: Upload Release Assets - Binary
         uses: shogo82148/actions-upload-release-asset@v1.7.2
@@ -167,14 +162,9 @@ jobs:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
-          echo $COSIGN_KEY | base64 -d > cosign.key
-          docker run --rm \
-            -v "$(CURDIR):/k0s" \
-            gcr.io/projectsigstore/cosign:v2.2.0 \
-            sign-blob \
-            --key /k0s/cosign.key \
-            --tlog-upload=false \
-            /k0s/k0s.exe --output-file /k0s/k0s.exe.sig
+          curl -sSLo cosign https://github.com/sigstore/cosign/releases/download/v2.2.0/cosign-linux-amd64
+          chmod +x ./cosign
+          ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false k0s.exe | tee k0s.exe.sig
 
       - name: Clean Docker
         run: |
@@ -239,14 +229,9 @@ jobs:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
-          echo $COSIGN_KEY | base64 -d > cosign.key
-          docker run --rm \
-            -v "$(CURDIR):/k0s" \
-            gcr.io/projectsigstore/cosign:v2.2.0 \
-            sign-blob \
-            --key /k0s/cosign.key \
-            --tlog-upload=false \
-            /k0s/k0s --output-file /k0s/k0s.sig
+          curl -sSLo cosign https://github.com/sigstore/cosign/releases/download/v2.2.0/cosign-linux-arm64
+          chmod +x ./cosign
+          ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false k0s | tee k0s.sig
 
       - name: Set up Go for smoke tests
         uses: actions/setup-go@v3
@@ -344,14 +329,9 @@ jobs:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
-          echo $COSIGN_KEY | base64 -d > cosign.key
-          docker run --rm \
-            -v "$(CURDIR):/k0s" \
-            gcr.io/projectsigstore/cosign:v2.2.0 \
-            sign-blob \
-            --key /k0s/cosign.key \
-            --tlog-upload=false \
-            /k0s/k0s --output-file /k0s/k0s.sig
+          curl -sSLo cosign https://github.com/sigstore/cosign/releases/download/v2.2.0/cosign-linux-arm
+          chmod +x ./cosign
+          ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false k0s | tee k0s.sig
 
       - name: Set up Go for smoke tests
         uses: actions/setup-go@v3


### PR DESCRIPTION
## Description

This simplifies its usage, as Docker is not required. Also fixes the CURDIR issue:

    /runner/_work/_temp/942db570-3c25-43c3-8cce-9dbabc9f9633.sh: line 2: CURDIR: command not found
    docker: invalid spec: :/k0s: empty section between colons.
    See 'docker run --help'.

Fixes:
* #3536

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings