### PR TITLE
Don't cache embedded binaries twice

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -356,10 +356,8 @@ jobs:
           key: ${{ runner.os }}-embedded-bins-${{ matrix.arch }}-${{ hashFiles('**/embedded-bins/**/*') }}
           path: |
             .bins.linux.stamp
-            bindata_linux
             embedded-bins/staging/linux/bin/
             embedded-bins/Makefile.variables
-            pkg/assets/zz_generated_offsets_linux.go
 
       - name: Cache GOCACHE
         uses: actions/cache@v4


### PR DESCRIPTION
## Description

Don't cache the concatenated embedded bins files, which would actually double the cache size. This means that make will compress and catenate them again for each build, but that's not taking too long, and will reduce cache sizes and hopefully reduce cache eviction.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings