### PR TITLE
Base64-decode cosign key in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,8 @@ jobs:
         run: |
           curl -sSLo cosign https://github.com/sigstore/cosign/releases/download/v2.2.0/cosign-linux-amd64
           chmod +x ./cosign
-          ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false k0s | tee k0s.sig
+          COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false --output-file=k0s.sig k0s
+          cat k0s.sig
 
       - name: Upload Release Assets - Binary
         uses: shogo82148/actions-upload-release-asset@v1.7.2
@@ -164,7 +165,8 @@ jobs:
         run: |
           curl -sSLo cosign https://github.com/sigstore/cosign/releases/download/v2.2.0/cosign-linux-amd64
           chmod +x ./cosign
-          ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false k0s.exe | tee k0s.exe.sig
+          COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false --output-file=k0s.exe.sig k0s.exe
+          cat k0s.exe.sig
 
       - name: Clean Docker
         run: |
@@ -231,7 +233,8 @@ jobs:
         run: |
           curl -sSLo cosign https://github.com/sigstore/cosign/releases/download/v2.2.0/cosign-linux-arm64
           chmod +x ./cosign
-          ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false k0s | tee k0s.sig
+          COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false --output-file=k0s.sig k0s
+          cat k0s.sig
 
       - name: Set up Go for smoke tests
         uses: actions/setup-go@v3
@@ -331,7 +334,8 @@ jobs:
         run: |
           curl -sSLo cosign https://github.com/sigstore/cosign/releases/download/v2.2.0/cosign-linux-arm
           chmod +x ./cosign
-          ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false k0s | tee k0s.sig
+          COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false --output-file=k0s.sig k0s
+          cat k0s.sig
 
       - name: Set up Go for smoke tests
         uses: actions/setup-go@v3


### PR DESCRIPTION
## Description

The cosign key is stored in base64-encoded form. This way it cannot be directly consumed by cosign.

Fixes:
* #3970

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings