### PR TITLE
Install less packages in k0s Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ ARG ALPINE_VERSION
 FROM docker.io/library/${ARCH}alpine:$ALPINE_VERSION
 ARG TARGETARCH
 
-RUN apk add --no-cache bash coreutils findutils iptables curl tini
+RUN apk add --no-cache iptables tini
 
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
 ADD docker-entrypoint.sh /entrypoint.sh
 ADD ./k0s-${TARGETARCH}/k0s /usr/local/bin/k0s
 
-ENTRYPOINT ["/sbin/tini", "--", "/bin/sh", "/entrypoint.sh" ]
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh" ]
 
 CMD ["k0s", "controller", "--enable-worker"]


### PR DESCRIPTION
## Description

The only packages that are really required are tini (so that there's a proper init process) and iptables (for the anti-Docker-DNS-interception hack).

Also strip the redundant /bin/sh from the entrypoint.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings