### PR TITLE
Add k0s default users to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ ARG ALPINE_VERSION
 FROM docker.io/library/${ARCH}alpine:$ALPINE_VERSION
 ARG TARGETARCH
 
-RUN apk add --no-cache iptables tini
+RUN apk add --no-cache iptables tini \
+  && for u in etcd kube-apiserver kube-scheduler konnectivity-server; do \
+    adduser --system --shell /sbin/nologin --no-create-home --home /var/lib/k0s --disabled-password --gecos '' "$u"; \
+  done
 
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 

--- a/inttest/bootloose-alpine/Dockerfile
+++ b/inttest/bootloose-alpine/Dockerfile
@@ -68,4 +68,9 @@ RUN if [ "$TARGETARCH" != arm ]; then \
       && rm -rf /tmp/cri-dockerd \
       && chmod 755 /usr/local/bin/cri-dockerd; \
   fi
+
+RUN for u in etcd kube-apiserver kube-scheduler konnectivity-server; do \
+    adduser --system --shell /sbin/nologin --no-create-home --home /var/lib/k0s --disabled-password --gecos '' "$u"; \
+  done
+
 ADD cri-dockerd.sh /etc/init.d/cri-dockerd


### PR DESCRIPTION
## Description

K0s tries to run certain executables as non-root users by default. Add those users to the Docker image. Do the same for the integration tests to make sure it actually works permission-wise.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings