### PR TITLE
Pin markdownlint-cli version in GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,12 +7,16 @@ on:
       - release-*
     paths:
       - '**.md'
+      - .github/workflows/docs.yml
+      - .github/workflows/markdownlint-config.jsonc
   pull_request:
     branches:
       - main
       - release-*
     paths:
       - '**.md'
+      - .github/workflows/docs.yml
+      - .github/workflows/markdownlint-config.jsonc
 jobs:
   lint:
     name: Lint markdown
@@ -21,5 +25,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: articulate/actions-markdownlint@v1
         with:
-          config: .github/workflows/markdownlint-config.json
+          config: .github/workflows/markdownlint-config.jsonc
           ignore: autopilot
+          version: 0.39.0

--- a/.github/workflows/markdownlint-config.jsonc
+++ b/.github/workflows/markdownlint-config.jsonc
@@ -4,5 +4,7 @@
   "no-bare-urls": false,
   "first-line-h1": false,
   "single-trailing-newline": false,
-  "ol-prefix": "one_or_ordered"
+  "ol-prefix": "one_or_ordered",
+  "MD055": false, // broken
+  "MD056": false // broken
 }


### PR DESCRIPTION
## Description

The latest release introduced two new lints that appear to be broken. Ignore these lints and pin the CLI to the current version to prevent CI bugs from creeping in for the future.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings