### PR TITLE
[release-1.28] Build containerd using runc v1.1.12

### DIFF
--- a/embedded-bins/containerd/Dockerfile
+++ b/embedded-bins/containerd/Dockerfile
@@ -23,14 +23,17 @@ ARG TARGET_OS \
   CONTAINERD_BINS
 
 RUN go version
-RUN make \
-	CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
-	SHIM_CGO_ENABLED=${BUILD_SHIM_GO_CGO_ENABLED} \
-	GO_TAGS="-tags=${BUILD_GO_TAGS}" \
-	COMMANDS="${CONTAINERD_BINS}" \
-	GO_BUILD_FLAGS="${BUILD_GO_FLAGS}" \
-	EXTRA_LDFLAGS="${BUILD_GO_LDFLAGS_EXTRA}" \
-	GOOS="${TARGET_OS}"
+RUN set -ex \
+  && go get github.com/opencontainers/runc@v1.1.12 \
+  && make \
+    CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
+    SHIM_CGO_ENABLED=${BUILD_SHIM_GO_CGO_ENABLED} \
+    GO_TAGS="-tags=${BUILD_GO_TAGS}" \
+    COMMANDS="${CONTAINERD_BINS}" \
+    GO_BUILD_FLAGS="${BUILD_GO_FLAGS}" \
+    EXTRA_LDFLAGS="${BUILD_GO_LDFLAGS_EXTRA}" \
+    GOOS="${TARGET_OS}" \
+    vendor all
 
 FROM scratch
 COPY --from=build /go/src/github.com/containerd/containerd/bin/* /bin/


### PR DESCRIPTION
## Description

Fixes CVE-2024-21626 for the bundled containerd binaries.

K0s cannot use any containerd release past v1.7.8 due to dependency conflicts. Hence ensure that the binary is built linking against a non-vulnerable version of runc at least.

See:
* #3987
* #3989

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings