### PR TITLE
[Backport release-1.27] Build containerd using runc v1.1.12

### DIFF
--- a/embedded-bins/containerd/Dockerfile
+++ b/embedded-bins/containerd/Dockerfile
@@ -22,13 +22,16 @@ ARG TARGET_OS \
   BUILD_GO_LDFLAGS_EXTRA
 
 RUN go version
-RUN make \
-	CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
-	SHIM_CGO_ENABLED=${BUILD_SHIM_GO_CGO_ENABLED} \
-	GO_TAGS="-tags=${BUILD_GO_TAGS}" \
-	COMMANDS="containerd containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2" \
-	GO_BUILD_FLAGS="${BUILD_GO_FLAGS}" \
-	EXTRA_LDFLAGS="${BUILD_GO_LDFLAGS_EXTRA}"
+RUN set -ex \
+  && go get github.com/opencontainers/runc@v1.1.12 \
+  && make \
+    CGO_ENABLED=${BUILD_GO_CGO_ENABLED} \
+    SHIM_CGO_ENABLED=${BUILD_SHIM_GO_CGO_ENABLED} \
+    GO_TAGS="-tags=${BUILD_GO_TAGS}" \
+    COMMANDS="containerd containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2" \
+    GO_BUILD_FLAGS="${BUILD_GO_FLAGS}" \
+    EXTRA_LDFLAGS="${BUILD_GO_LDFLAGS_EXTRA}" \
+    vendor all
 
 FROM scratch
 COPY --from=build /go/src/github.com/containerd/containerd/bin/* /bin/


### PR DESCRIPTION
Backport to `release-1.27`:
* #3995

See:
* #3987
* #3989