### PR TITLE
Replace deprecated usages of k8s.io/utils/pointer

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,11 @@ linters-settings:
               Usages of the k8s cloud provider are only allowed from within the
               k0s cloud provider package. This is to ensure that it's not
               leaking global flags into k0s.
+      deprecations:
+        list-mode: lax
+        deny:
+          - pkg: k8s.io/utils/pointer
+            desc: Use k8s.io/utils/ptr.
   golint:
     min-confidence: 0
   goheader:

--- a/internal/pkg/sysinfo/probes/linux/cgroup_v2.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroup_v2.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/containerd/cgroups/v3/cgroup2"
@@ -92,8 +92,8 @@ func attachDummyDeviceFilter(mountPoint string) (err error) {
 	insts, license, err := cgroup2.DeviceFilter([]specs.LinuxDeviceCgroup{{
 		Allow:  true,
 		Type:   "a",
-		Major:  pointer.Int64(-1),
-		Minor:  pointer.Int64(-1),
+		Major:  ptr.To(int64(-1)),
+		Minor:  ptr.To(int64(-1)),
 		Access: "rwm",
 	}})
 	if err != nil {

--- a/inttest/psp/psp_test.go
+++ b/inttest/psp/psp_test.go
@@ -25,7 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -78,7 +78,7 @@ func (s *PSPSuite) TestK0sGetsUp() {
 					Name:  "pause",
 					Image: "registry.k8s.io/pause",
 					SecurityContext: &corev1.SecurityContext{
-						RunAsUser: pointer.Int64(0),
+						RunAsUser: ptr.To(int64(0)),
 					},
 				},
 			},

--- a/pkg/apis/k0s/v1beta1/nllb.go
+++ b/pkg/apis/k0s/v1beta1/nllb.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // NodeLocalLoadBalancing defines the configuration options related to k0s's
@@ -180,7 +180,7 @@ func (p *EnvoyProxy) setDefaults() {
 		p.APIServerBindPort = 7443
 	}
 	if p.KonnectivityServerBindPort == nil {
-		p.KonnectivityServerBindPort = pointer.Int32(7132)
+		p.KonnectivityServerBindPort = ptr.To(int32(7132))
 	}
 }
 

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -31,7 +31,7 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
@@ -397,7 +397,7 @@ func (c *CoreDNS) getConfig(ctx context.Context, clusterConfig *v1beta1.ClusterC
 		// to 7 replicas, it would be the same as the default, and for
 		// deployments with 8 or more replicas, this would artificially
 		// constrain the rolling update speed.
-		config.MaxUnavailableReplicas = pointer.Uint(1)
+		config.MaxUnavailableReplicas = ptr.To(uint(1))
 
 	}
 

--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -48,7 +48,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/sirupsen/logrus"
 	"go.uber.org/multierr"
@@ -510,11 +510,11 @@ func (r *Reconciler) buildConfigMaps(snapshot *snapshot) ([]*corev1.ConfigMap, e
 	workerProfiles := make(map[string]*workerconfig.Profile)
 
 	workerProfile := r.buildProfile(snapshot)
-	workerProfile.KubeletConfiguration.CgroupsPerQOS = pointer.Bool(true)
+	workerProfile.KubeletConfiguration.CgroupsPerQOS = ptr.To(true)
 	workerProfiles["default"] = workerProfile
 
 	workerProfile = r.buildProfile(snapshot)
-	workerProfile.KubeletConfiguration.CgroupsPerQOS = pointer.Bool(false)
+	workerProfile.KubeletConfiguration.CgroupsPerQOS = ptr.To(false)
 	workerProfiles["default-windows"] = workerProfile
 
 	for _, profile := range snapshot.profiles {
@@ -605,10 +605,10 @@ func (r *Reconciler) buildProfile(snapshot *snapshot) *workerconfig.Profile {
 			ClusterDomain:      r.clusterDomain,
 			TLSMinVersion:      "VersionTLS12",
 			TLSCipherSuites:    cipherSuites,
-			FailSwapOn:         pointer.Bool(false),
+			FailSwapOn:         ptr.To(false),
 			RotateCertificates: true,
 			ServerTLSBootstrap: true,
-			EventRecordQPS:     pointer.Int32(0),
+			EventRecordQPS:     ptr.To(int32(0)),
 		},
 		PauseImage:             snapshot.pauseImage.DeepCopy(),
 		NodeLocalLoadBalancing: snapshot.nodeLocalLoadBalancing.DeepCopy(),

--- a/pkg/component/controller/workerconfig/reconciler_test.go
+++ b/pkg/component/controller/workerconfig/reconciler_test.go
@@ -38,7 +38,7 @@ import (
 
 	k8stesting "k8s.io/client-go/testing"
 	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -374,17 +374,17 @@ func TestReconciler_ResourceGeneration(t *testing.T) {
 
 	configMaps := map[string]func(t *testing.T, expected *kubeletConfig){
 		"worker-config-default-1.29": func(t *testing.T, expected *kubeletConfig) {
-			expected.CgroupsPerQOS = pointer.Bool(true)
+			expected.CgroupsPerQOS = ptr.To(true)
 			expected.FeatureGates = map[string]bool{"kubelet-feature": true}
 		},
 
 		"worker-config-default-windows-1.29": func(t *testing.T, expected *kubeletConfig) {
-			expected.CgroupsPerQOS = pointer.Bool(false)
+			expected.CgroupsPerQOS = ptr.To(false)
 			expected.FeatureGates = map[string]bool{"kubelet-feature": true}
 		},
 
 		"worker-config-profile_XXX-1.29": func(t *testing.T, expected *kubeletConfig) {
-			expected.Authentication.Anonymous.Enabled = pointer.Bool(true)
+			expected.Authentication.Anonymous.Enabled = ptr.To(true)
 			expected.FeatureGates = map[string]bool{"kubelet-feature": true}
 		},
 
@@ -747,8 +747,8 @@ func makeKubeletConfig(t *testing.T, mods ...func(*kubeletConfig)) string {
 		},
 		ClusterDNS:         []string{"99.99.99.10"},
 		ClusterDomain:      "test.local",
-		EventRecordQPS:     pointer.Int32(0),
-		FailSwapOn:         pointer.Bool(false),
+		EventRecordQPS:     ptr.To(int32(0)),
+		FailSwapOn:         ptr.To(false),
 		RotateCertificates: true,
 		ServerTLSBootstrap: true,
 		TLSMinVersion:      "VersionTLS12",

--- a/pkg/component/worker/config/config_test.go
+++ b/pkg/component/worker/config/config_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	logsv1 "k8s.io/component-base/logs/api/v1"
 	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -151,7 +151,7 @@ var roundtripTests = []roundtripTest{
 					},
 					ImagePullPolicy:            corev1.PullAlways,
 					APIServerBindPort:          4711,
-					KonnectivityServerBindPort: pointer.Int32(1337),
+					KonnectivityServerBindPort: ptr.To(int32(1337)),
 				},
 			},
 			Konnectivity: Konnectivity{AgentPort: 1337},

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -42,7 +42,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
@@ -236,8 +236,8 @@ func (k *Kubelet) prepareLocalKubeletConfig(kubeletConfigData kubeletConfig) (st
 	preparedConfig.VolumePluginDir = kubeletConfigData.VolumePluginDir               // k.K0sVars.KubeletVolumePluginDir
 	preparedConfig.KubeReservedCgroup = kubeletConfigData.KubeReservedCgroup
 	preparedConfig.KubeletCgroups = kubeletConfigData.KubeletCgroups
-	preparedConfig.ResolverConfig = pointer.String(kubeletConfigData.ResolvConf)
-	preparedConfig.CgroupsPerQOS = pointer.Bool(kubeletConfigData.CgroupsPerQOS)
+	preparedConfig.ResolverConfig = ptr.To(kubeletConfigData.ResolvConf)
+	preparedConfig.CgroupsPerQOS = ptr.To(kubeletConfigData.CgroupsPerQOS)
 	preparedConfig.StaticPodURL = kubeletConfigData.StaticPodURL
 
 	if k.CRISocket == "" && runtime.GOOS != "windows" {

--- a/pkg/component/worker/nllb/envoy.go
+++ b/pkg/component/worker/nllb/envoy.go
@@ -38,7 +38,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/sirupsen/logrus"
 	"go.uber.org/multierr"
@@ -276,7 +276,7 @@ func makePodManifest(params *envoyParams, podParams *envoyPodParams) corev1.Pod 
 		Spec: corev1.PodSpec{
 			HostNetwork: true,
 			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: pointer.Bool(true),
+				RunAsNonRoot: ptr.To(true),
 			},
 			Containers: []corev1.Container{{
 				Name:            "nllb",
@@ -284,9 +284,9 @@ func makePodManifest(params *envoyParams, podParams *envoyPodParams) corev1.Pod 
 				ImagePullPolicy: podParams.pullPolicy,
 				Ports:           ports,
 				SecurityContext: &corev1.SecurityContext{
-					ReadOnlyRootFilesystem:   pointer.Bool(true),
-					Privileged:               pointer.Bool(false),
-					AllowPrivilegeEscalation: pointer.Bool(false),
+					ReadOnlyRootFilesystem:   ptr.To(true),
+					Privileged:               ptr.To(false),
+					AllowPrivilegeEscalation: ptr.To(false),
 					Capabilities: &corev1.Capabilities{
 						Drop: []corev1.Capability{"ALL"},
 					},
@@ -312,7 +312,7 @@ func makePodManifest(params *envoyParams, podParams *envoyPodParams) corev1.Pod 
 				VolumeSource: corev1.VolumeSource{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: params.configDir,
-						Type: (*corev1.HostPathType)(pointer.String(string(corev1.HostPathDirectory))),
+						Type: (*corev1.HostPathType)(ptr.To(string(corev1.HostPathDirectory))),
 					},
 				}},
 			},

--- a/pkg/kubernetes/watch/watcher.go
+++ b/pkg/kubernetes/watch/watcher.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 type VersionedResource interface {
@@ -259,7 +259,7 @@ func (w *Watcher[T]) list(ctx context.Context, condition Condition[T]) (*startWa
 	resourceVersion, items, err := w.List(ctx, metav1.ListOptions{
 		FieldSelector:  w.fieldSelector,
 		LabelSelector:  w.labelSelector,
-		TimeoutSeconds: pointer.Int64(maxListDurationSecs),
+		TimeoutSeconds: ptr.To(int64(maxListDurationSecs)),
 	})
 	if err != nil {
 		return nil, err
@@ -289,7 +289,7 @@ func (w *Watcher[T]) watch(ctx context.Context, resourceVersion string, conditio
 		AllowWatchBookmarks: true,
 		FieldSelector:       w.fieldSelector,
 		LabelSelector:       w.labelSelector,
-		TimeoutSeconds:      pointer.Int64(maxWatchDurationSecs),
+		TimeoutSeconds:      ptr.To(int64(maxWatchDurationSecs)),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/kubernetes/watch/watcher_test.go
+++ b/pkg/kubernetes/watch/watcher_test.go
@@ -31,7 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apiwatch "k8s.io/apimachinery/pkg/watch"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestWatcher(t *testing.T) {
@@ -237,7 +237,7 @@ func TestWatcher(t *testing.T) {
 		provider.watch = func(opts metav1.ListOptions) error {
 			assert.Equal(t, t.Name(), opts.ResourceVersion)
 			assert.True(t, opts.AllowWatchBookmarks)
-			assert.Equal(t, opts.TimeoutSeconds, pointer.Int64(120))
+			assert.Equal(t, opts.TimeoutSeconds, ptr.To(int64(120)))
 
 			provider.ch = openEventChanWith(
 				apiwatch.Event{

--- a/pkg/leaderelection/lease_pool_test.go
+++ b/pkg/leaderelection/lease_pool_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	fakecoordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1/fake"
 	k8stesting "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestLeasePoolWatcherTriggersOnLeaseAcquisition(t *testing.T) {
@@ -176,10 +176,10 @@ func TestSecondWatcherAcquiresReleasedLease(t *testing.T) {
 			Name: "test",
 		},
 		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity:       pointer.String("pool1"),
+			HolderIdentity:       ptr.To("pool1"),
 			AcquireTime:          &now,
 			RenewTime:            &now,
-			LeaseDurationSeconds: pointer.Int32(60 * 60), // block lease for a very long time
+			LeaseDurationSeconds: ptr.To(int32((1 * time.Hour).Seconds())), // block lease for a very long time
 		},
 	}, metav1.CreateOptions{})
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

There's the new k8s.io/utils/ptr package that leverages generics.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings