### PR TITLE
Wrap errors correctly

### DIFF
--- a/cmd/backup/backup_unix.go
+++ b/cmd/backup/backup_unix.go
@@ -72,11 +72,11 @@ func (c *command) backup(savePath string, out io.Writer) error {
 	}
 
 	if savePath != "-" && !dir.IsDirectory(savePath) {
-		return fmt.Errorf("the save-path directory (%v) does not exist", savePath)
+		return fmt.Errorf("the save-path directory (%s) does not exist", savePath)
 	}
 
 	if !dir.IsDirectory(c.K0sVars.DataDir) {
-		return fmt.Errorf("cannot find data-dir (%v). check your environment and/or command input and try again", c.K0sVars.DataDir)
+		return fmt.Errorf("cannot find data-dir (%s). check your environment and/or command input and try again", c.K0sVars.DataDir)
 	}
 
 	status, err := status.GetStatusInfo(c.K0sVars.StatusSocketPath)

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -157,7 +157,7 @@ func (c *command) start(ctx context.Context) error {
 	}
 	// let's make sure run-dir exists
 	if err := dir.Init(c.K0sVars.RunDir, constant.RunDirMode); err != nil {
-		return fmt.Errorf("failed to initialize dir: %v", err)
+		return fmt.Errorf("failed to initialize dir: %w", err)
 	}
 
 	rtc, err := config.NewRuntimeConfig(c.K0sVars)
@@ -180,7 +180,7 @@ func (c *command) start(ctx context.Context) error {
 	if c.TokenArg != "" && c.needToJoin() {
 		joinClient, err = joinController(ctx, c.TokenArg, c.K0sVars.CertRootDir)
 		if err != nil {
-			return fmt.Errorf("failed to join controller: %v", err)
+			return fmt.Errorf("failed to join controller: %w", err)
 		}
 	}
 

--- a/cmd/etcd/list.go
+++ b/cmd/etcd/list.go
@@ -48,11 +48,11 @@ func etcdListCmd() *cobra.Command {
 			ctx := cmd.Context()
 			etcdClient, err := etcd.NewClient(opts.K0sVars.CertRootDir, opts.K0sVars.EtcdCertDir, nodeConfig.Spec.Storage.Etcd)
 			if err != nil {
-				return fmt.Errorf("can't list etcd cluster members: %v", err)
+				return fmt.Errorf("can't list etcd cluster members: %w", err)
 			}
 			members, err := etcdClient.ListMembers(ctx)
 			if err != nil {
-				return fmt.Errorf("can't list etcd cluster members: %v", err)
+				return fmt.Errorf("can't list etcd cluster members: %w", err)
 			}
 			return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]interface{}{"members": members})
 		},

--- a/cmd/install/controller.go
+++ b/cmd/install/controller.go
@@ -46,7 +46,7 @@ With the controller subcommand you can setup a single node cluster by running:
 
 			nodeConfig, err := c.K0sVars.NodeConfig()
 			if err != nil {
-				return fmt.Errorf("failed to load node config: %v", err)
+				return fmt.Errorf("failed to load node config: %w", err)
 			}
 
 			if errs := nodeConfig.Validate(); len(errs) > 0 {

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -66,12 +66,12 @@ func (c *command) setup(role string, args []string, installFlags *installFlags) 
 
 	if role == "controller" {
 		if err := install.CreateControllerUsers(nodeConfig, c.K0sVars); err != nil {
-			return fmt.Errorf("failed to create controller users: %v", err)
+			return fmt.Errorf("failed to create controller users: %w", err)
 		}
 	}
 	err = install.EnsureService(args, installFlags.envVars, installFlags.force)
 	if err != nil {
-		return fmt.Errorf("failed to install k0s service: %v", err)
+		return fmt.Errorf("failed to install k0s service: %w", err)
 	}
 	return nil
 }

--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -66,7 +66,7 @@ func (c *command) reset() error {
 	// Get Cleanup Config
 	cfg, err := cleanup.NewConfig(c.K0sVars, c.CfgFile, c.WorkerOptions.CriSocket)
 	if err != nil {
-		return fmt.Errorf("failed to configure cleanup: %v", err)
+		return fmt.Errorf("failed to configure cleanup: %w", err)
 	}
 
 	err = cfg.Cleanup()

--- a/inttest/common/bootloosesuite.go
+++ b/inttest/common/bootloosesuite.go
@@ -656,7 +656,7 @@ func (s *BootlooseSuite) GetJoinToken(role string, extraArgs ...string) (string,
 	tokenCmd := fmt.Sprintf("%s token create --role=%s %s 2>/dev/null", s.K0sFullPath, role, strings.Join(extraArgs, " "))
 	token, err := ssh.ExecWithOutput(s.Context(), tokenCmd)
 	if err != nil {
-		return "", fmt.Errorf("can't get join token: %v", err)
+		return "", fmt.Errorf("can't get join token: %w", err)
 	}
 	outputParts := strings.Split(token, "\n")
 	// in case of no k0s.conf given, there might be warnings on the first few lines
@@ -678,7 +678,7 @@ func (s *BootlooseSuite) ImportK0smotronImages(ctx context.Context) error {
 
 		_, err = sshWorker.ExecWithOutput(ctx, fmt.Sprintf("k0s ctr images import %s", s.K0smotronImageBundleMountPoints[0]))
 		if err != nil {
-			return fmt.Errorf("failed to import k0smotron images: %v", err)
+			return fmt.Errorf("failed to import k0smotron images: %w", err)
 		}
 	}
 	return nil

--- a/pkg/apis/k0s/v1beta1/network.go
+++ b/pkg/apis/k0s/v1beta1/network.go
@@ -159,7 +159,7 @@ func (n *Network) InternalAPIAddresses() ([]string, error) {
 	for i, ip := range parsedCIDRs {
 		apiIP, err := utilnet.GetIndexedIP(ip, 1)
 		if err != nil {
-			return nil, fmt.Errorf("can't build internal API address: %v", err)
+			return nil, fmt.Errorf("can't build internal API address: %w", err)
 		}
 		stringifiedAddresses[i] = apiIP.String()
 	}

--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -104,7 +104,7 @@ func (s *Stack) Apply(ctx context.Context, prune bool) error {
 				err = s.patchResource(ctx, drClient, serverResource, resource)
 			}
 			if err != nil {
-				return fmt.Errorf("can't update resource:%v", err)
+				return fmt.Errorf("can't update resource: %w", err)
 			}
 		}
 		s.keepResource(resource)

--- a/pkg/autopilot/controller/readyprober.go
+++ b/pkg/autopilot/controller/readyprober.go
@@ -108,7 +108,7 @@ func (p readyProber) probeOne(target apv1beta2.PlanCommandTargetStatus) error {
 
 	address := controlnode.Status.GetInternalIP()
 	if address == "" {
-		return fmt.Errorf("no internal IP address found for %v", target.Name)
+		return fmt.Errorf("no internal IP address found for %s", target.Name)
 	}
 
 	probe := k8shttpprobe.NewWithTLSConfig(p.tlsConfig, false /* followNonLocalRedirects */)
@@ -120,13 +120,13 @@ func (p readyProber) probeOne(target apv1beta2.PlanCommandTargetStatus) error {
 	// The body content is not interesting at the moment.
 	res, _, err := probe.Probe(req, p.timeout)
 	if err != nil {
-		return fmt.Errorf("failed to HTTP probe '%v/%v': %w", target.Name, address, err)
+		return fmt.Errorf("failed to HTTP probe '%s/%s': %w", target.Name, address, err)
 	}
 
 	if res != k8sprobe.Success {
-		return fmt.Errorf("failed to probe '%v/%v': result=%v", target.Name, address, res)
+		return fmt.Errorf("failed to probe '%s/%s': result=%v", target.Name, address, res)
 	}
 
-	p.log.Infof("Probing %v done: %v", target.Name, res)
+	p.log.Infof("Probing %s done: %v", target.Name, res)
 	return nil
 }

--- a/pkg/autopilot/controller/root_controller.go
+++ b/pkg/autopilot/controller/root_controller.go
@@ -174,7 +174,7 @@ func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *
 
 	prober, err := NewReadyProber(logger, c.autopilotClientFactory, mgr.GetConfig(), 1*time.Minute)
 	if err != nil {
-		logger.WithError(err).Error("unable to create controller prober: %w")
+		logger.WithError(err).Error("unable to create controller prober")
 		return err
 	}
 

--- a/pkg/autopilot/controller/updates/clusterinfo.go
+++ b/pkg/autopilot/controller/updates/clusterinfo.go
@@ -84,7 +84,7 @@ func CollectData(ctx context.Context, kc kubernetes.Interface) (*ClusterInfo, er
 		"kube-system",
 		metav1.GetOptions{})
 	if err != nil {
-		return ci, fmt.Errorf("can't find kube-system namespace: %v", err)
+		return ci, fmt.Errorf("can't find kube-system namespace: %w", err)
 	}
 
 	ci.ClusterID = fmt.Sprintf("kube-system:%s", ns.UID)
@@ -123,7 +123,7 @@ func CollectData(ctx context.Context, kc kubernetes.Interface) (*ClusterInfo, er
 	// Collect control plane node count
 	ci.ControlPlaneNodesCount, err = kubeutil.GetControlPlaneNodeCount(ctx, kc)
 	if err != nil {
-		return ci, fmt.Errorf("can't collect control plane nodes count: %v", err)
+		return ci, fmt.Errorf("can't collect control plane nodes count: %w", err)
 	}
 
 	return ci, nil

--- a/pkg/backup/sqlitedb_unix.go
+++ b/pkg/backup/sqlitedb_unix.go
@@ -67,12 +67,12 @@ func (s *sqliteStep) Backup() (StepResult, error) {
 	logrus.Debugf("exporting kine db to %v", path)
 	_, err = os.Create(path)
 	if err != nil {
-		return StepResult{}, fmt.Errorf("failed to create kine backup: %v", err)
+		return StepResult{}, fmt.Errorf("failed to create kine backup: %w", err)
 	}
 	// create a hot backup of the kine db
 	err = kineDB.Backup(path)
 	if err != nil {
-		return StepResult{}, fmt.Errorf("failed to back-up kine db: %v", err)
+		return StepResult{}, fmt.Errorf("failed to back-up kine db: %w", err)
 	}
 	return StepResult{filesForBackup: []string{path}}, nil
 }
@@ -102,7 +102,7 @@ func (s *sqliteStep) Restore(restoreFrom string, _ string) error {
 func (s *sqliteStep) getKineDBPath() (string, error) {
 	u, err := url.Parse(s.dataSource)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse Kind datasource string: %v", err)
+		return "", fmt.Errorf("failed to parse Kind datasource string: %w", err)
 	}
 	return u.Path, nil
 }

--- a/pkg/backup/util_unix.go
+++ b/pkg/backup/util_unix.go
@@ -44,7 +44,7 @@ func createArchive(archive io.Writer, files []string, baseDir string) error {
 	for _, file := range files {
 		err := addToArchive(tw, file, baseDir)
 		if err != nil {
-			return fmt.Errorf("failed to add file to backup archive: %v", err)
+			return fmt.Errorf("failed to add file to backup archive: %w", err)
 		}
 	}
 	return nil
@@ -54,26 +54,26 @@ func addToArchive(tw *tar.Writer, filename string, baseDir string) error {
 	// Open the file which will be written into the archive
 	file, err := os.Open(filename)
 	if err != nil {
-		return fmt.Errorf("failed to open file: %v", err)
+		return fmt.Errorf("failed to open file: %w", err)
 	}
 	defer file.Close()
 
 	// Get FileInfo about our file providing file size, mode, etc.
 	info, err := file.Stat()
 	if err != nil {
-		return fmt.Errorf("failed to fetch file info: %v", err)
+		return fmt.Errorf("failed to fetch file info: %w", err)
 	}
 
 	// Create a tar Header from the FileInfo data
 	header, err := tar.FileInfoHeader(info, info.Name())
 	if err != nil {
-		return fmt.Errorf("failed to create tar header: %v", err)
+		return fmt.Errorf("failed to create tar header: %w", err)
 	}
 	if strings.Contains(filename, baseDir) {
 		// calculate relative path of items inside the archive
 		rel, err := filepath.Rel(baseDir, filename)
 		if err != nil {
-			return fmt.Errorf("failed to fetch relative path in tar archive: %v", err)
+			return fmt.Errorf("failed to fetch relative path in tar archive: %w", err)
 		}
 		header.Name = rel
 	}
@@ -81,14 +81,14 @@ func addToArchive(tw *tar.Writer, filename string, baseDir string) error {
 	// Write file header to the tar archive
 	err = tw.WriteHeader(header)
 	if err != nil {
-		return fmt.Errorf("failed to write file header to archive: %v", err)
+		return fmt.Errorf("failed to write file header to archive: %w", err)
 	}
 
 	if !dir.IsDirectory(filename) {
 		// Copy file content to tar archive
 		_, err = io.Copy(tw, file)
 		if err != nil {
-			return fmt.Errorf("failed to copy file contents info archive: %v", err)
+			return fmt.Errorf("failed to copy file contents info archive: %w", err)
 		}
 	}
 	return nil

--- a/pkg/cleanup/bridge_linux.go
+++ b/pkg/cleanup/bridge_linux.go
@@ -38,7 +38,7 @@ func (b *bridge) Run() error {
 
 	lnks, err := netlink.LinkList()
 	if err != nil {
-		return fmt.Errorf("failed to get link list from netlink: %v", err)
+		return fmt.Errorf("failed to get link list from netlink: %w", err)
 	}
 
 	for _, l := range lnks {

--- a/pkg/cleanup/cleanup_unix.go
+++ b/pkg/cleanup/cleanup_unix.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cleanup
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 
@@ -74,7 +75,7 @@ func NewConfig(k0sVars *config.CfgVars, cfgFile string, criSocketPath string) (*
 }
 
 func (c *Config) Cleanup() error {
-	var msg []error
+	var errs []error
 	cleanupSteps := []Step{
 		&containers{Config: c},
 		&users{Config: c},
@@ -89,11 +90,11 @@ func (c *Config) Cleanup() error {
 		err := step.Run()
 		if err != nil {
 			logrus.Debug(err)
-			msg = append(msg, err)
+			errs = append(errs, err)
 		}
 	}
-	if len(msg) > 0 {
-		return fmt.Errorf("errors received during clean-up: %v", msg)
+	if len(errs) > 0 {
+		return fmt.Errorf("errors occurred during clean-up: %w", errors.Join(errs...))
 	}
 	return nil
 }

--- a/pkg/cleanup/cni.go
+++ b/pkg/cleanup/cni.go
@@ -34,7 +34,7 @@ func (c *cni) Name() string {
 
 // Run removes found CNI leftovers
 func (c *cni) Run() error {
-	var msg []error
+	var errs []error
 
 	files := []string{
 		"/etc/cni/net.d/10-calico.conflist",
@@ -44,11 +44,11 @@ func (c *cni) Run() error {
 	for _, f := range files {
 		if err := os.Remove(f); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			logrus.Debug("failed to remove", f, err)
-			msg = append(msg, err)
+			errs = append(errs, err)
 		}
 	}
-	if len(msg) > 0 {
-		return fmt.Errorf("error occured while removing CNI leftovers: %v", msg)
+	if len(errs) > 0 {
+		return fmt.Errorf("errors occurred while removing CNI leftovers: %w", errors.Join(errs...))
 	}
 	return nil
 }

--- a/pkg/cleanup/directories.go
+++ b/pkg/cleanup/directories.go
@@ -73,9 +73,9 @@ func (d *directories) Run() error {
 		}
 	}
 
-	logrus.Debugf("deleting k0s generated run-dir (%v)", d.Config.runDir)
+	logrus.Debugf("deleting k0s generated run-dir (%s)", d.Config.runDir)
 	if err := os.RemoveAll(d.Config.runDir); err != nil {
-		return fmt.Errorf("failed to delete %v. err: %v", d.Config.runDir, err)
+		return fmt.Errorf("failed to delete %s: %w", d.Config.runDir, err)
 	}
 
 	return nil

--- a/pkg/cleanup/services.go
+++ b/pkg/cleanup/services.go
@@ -18,10 +18,8 @@ package cleanup
 
 import (
 	"errors"
-	"fmt"
 	"io/fs"
 	"os/exec"
-	"strings"
 
 	"github.com/k0sproject/k0s/pkg/install"
 )
@@ -37,17 +35,15 @@ func (s *services) Name() string {
 
 // Run uninstalls k0s services that are found on the host
 func (s *services) Run() error {
-	var msg []string
+	var errs []error
 
 	for _, role := range []string{"controller", "worker"} {
 		if err := install.UninstallService(role); err != nil && !(errors.Is(err, fs.ErrNotExist) || isExitCode(err, 1)) {
-			msg = append(msg, err.Error())
+			errs = append(errs, err)
 		}
 	}
-	if len(msg) > 0 {
-		return fmt.Errorf("%v", strings.Join(msg, "\n"))
-	}
-	return nil
+
+	return errors.Join(errs...)
 }
 
 func isExitCode(err error, exitcode int) bool {

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -90,7 +90,7 @@ func (a *APIServer) Init(_ context.Context) error {
 	var err error
 	a.uid, err = users.GetUID(constant.ApiserverUser)
 	if err != nil {
-		logrus.Warning(fmt.Errorf("running kube-apiserver as root: %w", err))
+		logrus.Warn("running kube-apiserver as root: ", err)
 	}
 	return assets.Stage(a.K0sVars.BinDir, kubeAPIComponentName, constant.BinDirMode)
 }

--- a/pkg/component/controller/calico.go
+++ b/pkg/component/controller/calico.go
@@ -139,7 +139,7 @@ func (c *Calico) dumpCRDs() error {
 func (c *Calico) processConfigChanges(newConfig calicoConfig) error {
 	manifestDirectories, err := static.AssetDir("manifests/calico")
 	if err != nil {
-		return fmt.Errorf("error retrieving calico manifests: %w. will retry", err)
+		return fmt.Errorf("error retrieving calico manifests: %w, will retry", err)
 	}
 
 	for _, dir := range manifestDirectories {
@@ -149,12 +149,12 @@ func (c *Calico) processConfigChanges(newConfig calicoConfig) error {
 		}
 		manifestPaths, err := static.AssetDir(fmt.Sprintf("manifests/calico/%s", dir))
 		if err != nil {
-			return fmt.Errorf("error retrieving calico manifests: %w. will retry", err)
+			return fmt.Errorf("error retrieving calico manifests: %w, will retry", err)
 		}
 
 		tryAndLog := func(name string, e error) {
 			if e != nil {
-				c.log.Errorf("failed to write manifest %s: %w, will re-try", name, e)
+				c.log.Errorf("failed to write manifest %s: %v, will retry", name, e)
 			}
 		}
 

--- a/pkg/component/controller/clusterConfig.go
+++ b/pkg/component/controller/clusterConfig.go
@@ -57,7 +57,7 @@ func NewClusterConfigReconciler(leaderElector leaderelector.Interface, k0sVars *
 
 	cfg, err := k0sVars.NodeConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get config: %v", err)
+		return nil, fmt.Errorf("failed to get config: %w", err)
 	}
 
 	configClient, err := kubeClientFactory.GetConfigClient()

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -71,13 +70,13 @@ func (a *Manager) Init(_ context.Context) error {
 	// controller manager running as api-server user as they both need access to same sa.key
 	a.uid, err = users.GetUID(constant.ApiserverUser)
 	if err != nil {
-		logrus.Warning(fmt.Errorf("running kube-controller-manager as root: %w", err))
+		logrus.Warn("running kube-controller-manager as root: ", err)
 	}
 
 	// controller manager should be the only component that needs access to
 	// ca.key so let it own it.
 	if err := os.Chown(path.Join(a.K0sVars.CertRootDir, "ca.key"), a.uid, -1); err != nil && os.Geteuid() == 0 {
-		logrus.Warning(fmt.Errorf("failed to change permissions for the ca.key: %w", err))
+		logrus.Warn("failed to change permissions for the ca.key: ", err)
 	}
 	return assets.Stage(a.K0sVars.BinDir, kubeControllerManagerComponent, constant.BinDirMode)
 }

--- a/pkg/component/controller/controllersleasecounter.go
+++ b/pkg/component/controller/controllersleasecounter.go
@@ -57,7 +57,7 @@ func (l *K0sControllersLeaseCounter) Start(ctx context.Context) error {
 	log := logrus.WithFields(logrus.Fields{"component": "controllerlease"})
 	client, err := l.KubeClientFactory.GetClient()
 	if err != nil {
-		return fmt.Errorf("can't create kubernetes rest client for lease pool: %v", err)
+		return fmt.Errorf("can't create kubernetes rest client for lease pool: %w", err)
 	}
 
 	// hostname used to make the lease names be clear to which controller they belong to

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -428,7 +428,7 @@ func (c *CoreDNS) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterC
 	logrus.Debug("reconcile method called for: CoreDNS")
 	cfg, err := c.getConfig(ctx, clusterConfig)
 	if err != nil {
-		return fmt.Errorf("error calculating coredns configs: %v. will retry", err)
+		return fmt.Errorf("error calculating coredns configs: %w, will retry", err)
 	}
 	if reflect.DeepEqual(c.previousConfig, cfg) {
 		c.log.Infof("current cfg matches existing, not gonna do anything")
@@ -442,7 +442,7 @@ func (c *CoreDNS) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterC
 	}
 	err = tw.Write()
 	if err != nil {
-		return fmt.Errorf("error writing coredns manifests: %v. will retry", err)
+		return fmt.Errorf("error writing coredns manifests: %w, will retry", err)
 	}
 	c.previousConfig = cfg
 	c.lastKnownClusterConfig = clusterConfig

--- a/pkg/component/controller/crd.go
+++ b/pkg/component/controller/crd.go
@@ -50,17 +50,17 @@ func (c CRD) Start(_ context.Context) error {
 	for _, bundle := range c.bundles {
 		crds, err := static.AssetDir(fmt.Sprintf("manifests/%s/CustomResourceDefinition", bundle))
 		if err != nil {
-			return fmt.Errorf("can't unbundle CRD `%s` manifests: %v", bundle, err)
+			return fmt.Errorf("can't unbundle CRD `%s` manifests: %w", bundle, err)
 		}
 
 		for _, filename := range crds {
 			manifestName := fmt.Sprintf("%s-crd-%s", bundle, filename)
 			content, err := static.Asset(fmt.Sprintf("manifests/%s/CustomResourceDefinition/%s", bundle, filename))
 			if err != nil {
-				return fmt.Errorf("failed to fetch crd `%s`: %v", filename, err)
+				return fmt.Errorf("failed to fetch crd `%s`: %w", filename, err)
 			}
 			if err := c.saver.Save(manifestName, content); err != nil {
-				return fmt.Errorf("failed to save CRD `%s` manifest `%s` to FS: %v", bundle, manifestName, err)
+				return fmt.Errorf("failed to save CRD `%s` manifest `%s` to FS: %w", bundle, manifestName, err)
 			}
 		}
 

--- a/pkg/component/controller/csrapprover.go
+++ b/pkg/component/controller/csrapprover.go
@@ -74,7 +74,7 @@ func (a *CSRApprover) Init(_ context.Context) error {
 	var err error
 	a.clientset, err = a.KubeClientFactory.GetClient()
 	if err != nil {
-		return fmt.Errorf("can't create kubernetes rest client for CSR check: %v", err)
+		return fmt.Errorf("can't create kubernetes rest client for CSR check: %w", err)
 	}
 
 	return nil

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -66,13 +66,12 @@ func (e *Etcd) Init(_ context.Context) error {
 	var err error
 
 	if err = detectUnsupportedEtcdArch(); err != nil {
-		logrus.Error(fmt.Errorf("missing environment variable: %w", err))
-		return err
+		return fmt.Errorf("missing environment variable: %w", err)
 	}
 
 	e.uid, err = users.GetUID(constant.EtcdUser)
 	if err != nil {
-		logrus.Warning(fmt.Errorf("running etcd as root: %w", err))
+		logrus.Warn("running etcd as root: ", err)
 	}
 
 	err = dir.Init(e.K0sVars.EtcdDataDir, constant.EtcdDataDirMode) // https://docs.datadoghq.com/security_monitoring/default_rules/cis-kubernetes-1.5.1-1.1.11/
@@ -310,10 +309,10 @@ func (e *Etcd) Ready() error {
 }
 
 func detectUnsupportedEtcdArch() error {
-	// https://github.com/etcd-io/etcd/blob/v3.5.2/server/etcdmain/etcd.go#L467-L472
+	// https://github.com/etcd-io/etcd/blob/v3.5.12/server/etcdmain/etcd.go#L467-L472
 	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
 		if os.Getenv("ETCD_UNSUPPORTED_ARCH") != runtime.GOARCH {
-			return fmt.Errorf("running ETCD on %s requires ETCD_UNSUPPORTED_ARCH=%s ", runtime.GOARCH, runtime.GOARCH)
+			return fmt.Errorf("running etcd on %s requires ETCD_UNSUPPORTED_ARCH=%s", runtime.GOARCH, runtime.GOARCH)
 		}
 	}
 	return nil

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -59,7 +59,7 @@ func (k *Kine) Init(_ context.Context) error {
 	var err error
 	k.uid, err = users.GetUID(constant.KineUser)
 	if err != nil {
-		logrus.Warning(fmt.Errorf("running kine as root: %w", err))
+		logrus.Warn("running kine as root: ", err)
 	}
 
 	kineSocketDir := filepath.Dir(k.K0sVars.KineSocketPath)
@@ -68,7 +68,7 @@ func (k *Kine) Init(_ context.Context) error {
 		return fmt.Errorf("failed to create %s: %w", kineSocketDir, err)
 	}
 	if err := os.Chown(kineSocketDir, k.uid, k.gid); err != nil && os.Geteuid() == 0 {
-		logrus.Warningf("failed to chown %s", kineSocketDir)
+		logrus.Warn("failed to chown ", kineSocketDir)
 	}
 
 	dsURL, err := url.Parse(k.Config.DataSource)

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -69,27 +69,27 @@ func (k *Konnectivity) Init(ctx context.Context) error {
 	k.uid, err = users.GetUID(constant.KonnectivityServerUser)
 	if err != nil {
 		k.EmitWithPayload("error getting UID for", err)
-		logrus.Warning(fmt.Errorf("running konnectivity as root: %w", err))
+		logrus.Warn("running konnectivity as root: ", err)
 	}
 	err = dir.Init(k.K0sVars.KonnectivitySocketDir, 0755)
 	if err != nil {
 		k.EmitWithPayload("failed to initialize socket directory", err)
-		return fmt.Errorf("failed to initialize directory %s: %v", k.K0sVars.KonnectivitySocketDir, err)
+		return fmt.Errorf("failed to initialize directory %s: %w", k.K0sVars.KonnectivitySocketDir, err)
 	}
 
 	err = os.Chown(k.K0sVars.KonnectivitySocketDir, k.uid, -1)
 	if err != nil && os.Geteuid() == 0 {
 		k.EmitWithPayload("failed to chown socket directory", err)
-		return fmt.Errorf("failed to chown %s: %v", k.K0sVars.KonnectivitySocketDir, err)
+		return fmt.Errorf("failed to chown %s: %w", k.K0sVars.KonnectivitySocketDir, err)
 	}
 
 	k.log = logrus.WithFields(logrus.Fields{"component": "konnectivity"})
 	if err := assets.Stage(k.K0sVars.BinDir, "konnectivity-server", constant.BinDirMode); err != nil {
 		k.EmitWithPayload("failed to stage konnectivity-server", err)
-		return fmt.Errorf("failed to stage konnectivity-server binary %v", err)
+		return fmt.Errorf("failed to stage konnectivity-server binary %w", err)
 
 	}
-	defer k.Emit("succesfully initialized konnectivity component")
+	defer k.Emit("successfully initialized konnectivity component")
 
 	k.clusterConfig = k0scontext.GetNodeConfig(ctx)
 

--- a/pkg/component/controller/konnectivityagent.go
+++ b/pkg/component/controller/konnectivityagent.go
@@ -176,7 +176,7 @@ func (k *KonnectivityAgent) writeKonnectivityAgent() error {
 	err = tw.Write()
 	if err != nil {
 		k.EmitWithPayload("failed to write konnectivity agent manifest", err)
-		return fmt.Errorf("failed to write konnectivity agent manifest: %v", err)
+		return fmt.Errorf("failed to write konnectivity agent manifest: %w", err)
 	}
 	k.previousConfig = cfg
 	k.Emit("wrote konnectivity agent new manifest")

--- a/pkg/component/controller/leaderelector/leasepool.go
+++ b/pkg/component/controller/leaderelector/leasepool.go
@@ -61,7 +61,7 @@ func (l *LeasePool) Init(_ context.Context) error {
 func (l *LeasePool) Start(ctx context.Context) error {
 	client, err := l.kubeClientFactory.GetClient()
 	if err != nil {
-		return fmt.Errorf("can't create kubernetes rest client for lease pool: %v", err)
+		return fmt.Errorf("can't create kubernetes rest client for lease pool: %w", err)
 	}
 	leasePool, err := leaderelection.NewLeasePool(ctx, client, "k0s-endpoint-reconciler",
 		leaderelection.WithLogger(l.log),

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
@@ -54,7 +53,7 @@ func (a *Scheduler) Init(_ context.Context) error {
 	var err error
 	a.uid, err = users.GetUID(constant.SchedulerUser)
 	if err != nil {
-		logrus.Warning(fmt.Errorf("running kube-scheduler as root: %w", err))
+		logrus.Warn("running kube-scheduler as root: ", err)
 	}
 	return assets.Stage(a.K0sVars.BinDir, kubeSchedulerComponentName, constant.BinDirMode)
 }

--- a/pkg/component/status/status.go
+++ b/pkg/component/status/status.go
@@ -152,7 +152,7 @@ func (sh *statusHandler) getCurrentStatus(ctx context.Context) K0sStatus {
 	if sh.client == nil {
 		kubeClient, err := sh.buildWorkerSideKubeAPIClient(ctx)
 		if err != nil {
-			status.WorkerToAPIConnectionStatus.Message = fmt.Errorf("failed to create kube-api client required for kube-api status reports, probably kubelet failed to init: %v", err).Error()
+			status.WorkerToAPIConnectionStatus.Message = fmt.Sprintf("failed to create kube-api client required for kube-api status reports, probably kubelet failed to init: %s", err.Error())
 			return status
 		}
 		sh.client = kubeClient

--- a/pkg/component/worker/autopilot.go
+++ b/pkg/component/worker/autopilot.go
@@ -69,7 +69,7 @@ func (a *Autopilot) Start(ctx context.Context) error {
 
 		return true, nil
 	}); err != nil {
-		return fmt.Errorf("unable to create autopilot client: %v", err)
+		return fmt.Errorf("unable to create autopilot client: %w", err)
 	}
 
 	// Without the config, there is nothing that we can do.

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -173,7 +173,7 @@ func (k *Kubelet) Start(ctx context.Context) error {
 	if runtime.GOOS == "windows" {
 		node, err := node.GetNodename("")
 		if err != nil {
-			return fmt.Errorf("can't get hostname: %v", err)
+			return fmt.Errorf("can't get hostname: %w", err)
 		}
 		kubeletConfigData.CgroupsPerQOS = false
 		kubeletConfigData.ResolvConf = ""
@@ -258,7 +258,7 @@ func (k *Kubelet) prepareLocalKubeletConfig(kubeletConfigData kubeletConfig) (st
 		for _, taint := range k.Taints {
 			parsedTaint, err := parseTaint(taint)
 			if err != nil {
-				return "", fmt.Errorf("can't parse taints for profile config map: %v", err)
+				return "", fmt.Errorf("can't parse taints for profile config map: %w", err)
 			}
 			taints = append(taints, parsedTaint)
 		}
@@ -267,7 +267,7 @@ func (k *Kubelet) prepareLocalKubeletConfig(kubeletConfigData kubeletConfig) (st
 
 	preparedConfigBytes, err := yaml.Marshal(preparedConfig)
 	if err != nil {
-		return "", fmt.Errorf("can't marshal kubelet config: %v", err)
+		return "", fmt.Errorf("can't marshal kubelet config: %w", err)
 	}
 	return string(preparedConfigBytes), nil
 }
@@ -291,21 +291,21 @@ func parseTaint(st string) (corev1.Taint, error) {
 
 		partsKV := strings.Split(parts[0], "=")
 		if len(partsKV) > 2 {
-			return taint, fmt.Errorf("invalid taint spec: %v", st)
+			return taint, fmt.Errorf("invalid taint spec: %s", st)
 		}
 		key = partsKV[0]
 		if len(partsKV) == 2 {
 			value = partsKV[1]
 			if errs := validation.IsValidLabelValue(value); len(errs) > 0 {
-				return taint, fmt.Errorf("invalid taint spec: %v, %s", st, strings.Join(errs, "; "))
+				return taint, fmt.Errorf("invalid taint spec: %s, %s", st, strings.Join(errs, "; "))
 			}
 		}
 	default:
-		return taint, fmt.Errorf("invalid taint spec: %v", st)
+		return taint, fmt.Errorf("invalid taint spec: %s", st)
 	}
 
 	if errs := validation.IsQualifiedName(key); len(errs) > 0 {
-		return taint, fmt.Errorf("invalid taint spec: %v, %s", st, strings.Join(errs, "; "))
+		return taint, fmt.Errorf("invalid taint spec: %s, %s", st, strings.Join(errs, "; "))
 	}
 
 	taint.Key = key
@@ -317,7 +317,7 @@ func parseTaint(st string) (corev1.Taint, error) {
 
 func validateTaintEffect(effect corev1.TaintEffect) error {
 	if effect != corev1.TaintEffectNoSchedule && effect != corev1.TaintEffectPreferNoSchedule && effect != corev1.TaintEffectNoExecute {
-		return fmt.Errorf("invalid taint effect: %v, unsupported taint effect", effect)
+		return fmt.Errorf("invalid taint effect: %s, unsupported taint effect", effect)
 	}
 
 	return nil

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -83,7 +83,7 @@ func (a *OCIBundleReconciler) Start(ctx context.Context) error {
 	}, retry.Context(ctx), retry.Delay(time.Second*5))
 	if err != nil {
 		a.EmitWithPayload("can't connect to containerd socket", map[string]interface{}{"socket": sock, "error": err})
-		return fmt.Errorf("can't connect to containerd socket %s: %v", sock, err)
+		return fmt.Errorf("can't connect to containerd socket %s: %w", sock, err)
 	}
 	defer client.Close()
 
@@ -102,12 +102,12 @@ func (a *OCIBundleReconciler) Start(ctx context.Context) error {
 func (a OCIBundleReconciler) unpackBundle(ctx context.Context, client *containerd.Client, bundlePath string) error {
 	r, err := os.Open(bundlePath)
 	if err != nil {
-		return fmt.Errorf("can't open bundle file %s: %v", bundlePath, err)
+		return fmt.Errorf("can't open bundle file %s: %w", bundlePath, err)
 	}
 	defer r.Close()
 	images, err := client.Import(ctx, r)
 	if err != nil {
-		return fmt.Errorf("can't import bundle: %v", err)
+		return fmt.Errorf("can't import bundle: %w", err)
 	}
 	is := client.ImageService()
 	for _, i := range images {

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -95,17 +95,17 @@ func (hc *Commands) getActionCfg(namespace string) (*action.Configuration, error
 func (hc *Commands) AddRepository(repoCfg v1beta1.Repository) error {
 	err := dir.Init(filepath.Dir(hc.repoFile), constant.DataDirMode)
 	if err != nil && !os.IsExist(err) {
-		return fmt.Errorf("can't add repository to %s: %v", hc.repoFile, err)
+		return fmt.Errorf("can't add repository to %s: %w", hc.repoFile, err)
 	}
 
 	b, err := os.ReadFile(hc.repoFile)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("can't add repository to %s: %v", hc.repoFile, err)
+		return fmt.Errorf("can't add repository to %s: %w", hc.repoFile, err)
 	}
 
 	var f repo.File
 	if err := yaml.Unmarshal(b, &f); err != nil {
-		return fmt.Errorf("can't add repository to %s: %v", hc.repoFile, err)
+		return fmt.Errorf("can't add repository to %s: %w", hc.repoFile, err)
 	}
 
 	c := repo.Entry{
@@ -121,16 +121,16 @@ func (hc *Commands) AddRepository(repoCfg v1beta1.Repository) error {
 
 	r, err := repo.NewChartRepository(&c, getters)
 	if err != nil {
-		return fmt.Errorf("can't add repository to %s: %v", hc.repoFile, err)
+		return fmt.Errorf("can't add repository to %s: %w", hc.repoFile, err)
 	}
 	r.CachePath = hc.helmCacheDir
 
 	if _, err := r.DownloadIndexFile(); err != nil {
-		return fmt.Errorf("can't add repository: %q is not a valid chart repository or cannot be reached: %v", "repo", err)
+		return fmt.Errorf("can't add repository: %q is not a valid chart repository or cannot be reached: %w", "repo", err)
 	}
 	f.Update(&c)
 	if err := f.WriteFile(hc.repoFile, 0644); err != nil {
-		return fmt.Errorf("can't add repository to %s: %v", hc.repoFile, err)
+		return fmt.Errorf("can't add repository to %s: %w", hc.repoFile, err)
 	}
 
 	return nil
@@ -163,7 +163,7 @@ func (hc *Commands) locateChart(name string, version string) (string, error) {
 	if _, err := os.Stat(name); err == nil {
 		abs, err := filepath.Abs(name)
 		if err != nil {
-			return abs, fmt.Errorf("can't locate chart `%s-%s`: %v", name, version, err)
+			return abs, fmt.Errorf("can't locate chart `%s-%s`: %w", name, version, err)
 		}
 		return abs, nil
 	}
@@ -180,7 +180,7 @@ func (hc *Commands) locateChart(name string, version string) (string, error) {
 	}
 
 	if err := dir.Init(hc.helmCacheDir, constant.DataDirMode); err != nil {
-		return "", fmt.Errorf("can't locate chart `%s-%s`: %v", name, version, err)
+		return "", fmt.Errorf("can't locate chart `%s-%s`: %w", name, version, err)
 	}
 
 	filename, _, err := dl.DownloadTo(name, version, hc.helmCacheDir)
@@ -206,7 +206,7 @@ func (hc *Commands) isInstallable(chart *chart.Chart) bool {
 func (hc *Commands) InstallChart(ctx context.Context, chartName string, version string, releaseName string, namespace string, values map[string]interface{}, timeout time.Duration) (*release.Release, error) {
 	cfg, err := hc.getActionCfg(namespace)
 	if err != nil {
-		return nil, fmt.Errorf("can't create action configuration: %v", err)
+		return nil, fmt.Errorf("can't create action configuration: %w", err)
 	}
 	install := action.NewInstall(cfg)
 	install.CreateNamespace = true
@@ -229,7 +229,7 @@ func (hc *Commands) InstallChart(ctx context.Context, chartName string, version 
 
 	loadedChart, err := loader.Load(chartDir)
 	if err != nil {
-		return nil, fmt.Errorf("can't load loadedChart `%s`: %v", chartDir, err)
+		return nil, fmt.Errorf("can't load loadedChart `%s`: %w", chartDir, err)
 	}
 	if !hc.isInstallable(loadedChart) {
 		return nil, fmt.Errorf("loadedChart with type `%s` is not installable", loadedChart.Metadata.Type)
@@ -241,11 +241,11 @@ func (hc *Commands) InstallChart(ctx context.Context, chartName string, version 
 
 	loadedChart, err = loader.Load(chartDir)
 	if err != nil {
-		return nil, fmt.Errorf("can't reload loadedChart `%s`: %v", chartDir, err)
+		return nil, fmt.Errorf("can't reload loadedChart `%s`: %w", chartDir, err)
 	}
 	chartRelease, err := install.RunWithContext(ctx, loadedChart, values)
 	if err != nil {
-		return nil, fmt.Errorf("can't install loadedChart `%s`: %v", loadedChart.Name(), err)
+		return nil, fmt.Errorf("can't install loadedChart `%s`: %w", loadedChart.Name(), err)
 	}
 	return chartRelease, nil
 }
@@ -255,7 +255,7 @@ func (hc *Commands) InstallChart(ctx context.Context, chartName string, version 
 func (hc *Commands) UpgradeChart(ctx context.Context, chartName string, version string, releaseName string, namespace string, values map[string]interface{}, timeout time.Duration) (*release.Release, error) {
 	cfg, err := hc.getActionCfg(namespace)
 	if err != nil {
-		return nil, fmt.Errorf("can't create action configuration: %v", err)
+		return nil, fmt.Errorf("can't create action configuration: %w", err)
 	}
 	upgrade := action.NewUpgrade(cfg)
 	upgrade.Namespace = namespace
@@ -271,7 +271,7 @@ func (hc *Commands) UpgradeChart(ctx context.Context, chartName string, version 
 	}
 	loadedChart, err := loader.Load(chartDir)
 	if err != nil {
-		return nil, fmt.Errorf("can't load loadedChart `%s`: %v", chartDir, err)
+		return nil, fmt.Errorf("can't load loadedChart `%s`: %w", chartDir, err)
 	}
 	if !hc.isInstallable(loadedChart) {
 		return nil, fmt.Errorf("loadedChart with type `%s` is not installable", loadedChart.Metadata.Type)
@@ -283,12 +283,12 @@ func (hc *Commands) UpgradeChart(ctx context.Context, chartName string, version 
 
 	loadedChart, err = loader.Load(chartDir)
 	if err != nil {
-		return nil, fmt.Errorf("can't reload loadedChart `%s`: %v", chartDir, err)
+		return nil, fmt.Errorf("can't reload loadedChart `%s`: %w", chartDir, err)
 	}
 
 	chartRelease, err := upgrade.RunWithContext(ctx, releaseName, loadedChart, values)
 	if err != nil {
-		return nil, fmt.Errorf("can't upgrade loadedChart `%s`: %v", loadedChart.Metadata.Name, err)
+		return nil, fmt.Errorf("can't upgrade loadedChart `%s`: %w", loadedChart.Metadata.Name, err)
 	}
 
 	return chartRelease, nil
@@ -301,7 +301,7 @@ func stringptr(s string) *string {
 func (hc *Commands) ListReleases(namespace string) ([]*release.Release, error) {
 	cfg, err := hc.getActionCfg(namespace)
 	if err != nil {
-		return nil, fmt.Errorf("can't create helmAction configuration: %v", err)
+		return nil, fmt.Errorf("can't create helmAction configuration: %w", err)
 	}
 	helmAction := action.NewList(cfg)
 	return helmAction.Run()

--- a/pkg/install/service.go
+++ b/pkg/install/service.go
@@ -130,7 +130,7 @@ func EnsureService(args []string, envVars []string, force bool) error {
 	logrus.Infof("Installing %s service", svcConfig.Name)
 	err = s.Install()
 	if err != nil {
-		return fmt.Errorf("failed to install service: %v", err)
+		return fmt.Errorf("failed to install service: %w", err)
 	}
 	return nil
 }

--- a/pkg/supervisor/supervisor_unix.go
+++ b/pkg/supervisor/supervisor_unix.go
@@ -106,12 +106,12 @@ func (s *Supervisor) maybeKillPidFile(check <-chan time.Time, deadline <-chan ti
 	if os.IsNotExist(err) {
 		return nil
 	} else if err != nil {
-		return fmt.Errorf("failed to read pid file %s: %v", s.PidFile, err)
+		return fmt.Errorf("failed to read pid file %s: %w", s.PidFile, err)
 	}
 
 	p, err := strconv.Atoi(strings.TrimSuffix(string(pid), "\n"))
 	if err != nil {
-		return fmt.Errorf("failed to parse pid file %s: %v", s.PidFile, err)
+		return fmt.Errorf("failed to parse pid file %s: %w", s.PidFile, err)
 	}
 
 	return s.killPid(p, check, deadline)
@@ -122,7 +122,7 @@ func (s *Supervisor) shouldKillProcess(pid int) (bool, error) {
 	if os.IsNotExist(err) {
 		return false, nil
 	} else if err != nil {
-		return false, fmt.Errorf("failed to read process %d cmdline: %v", pid, err)
+		return false, fmt.Errorf("failed to read process %d cmdline: %w", pid, err)
 	}
 
 	// only kill process if it has the expected cmd
@@ -136,7 +136,7 @@ func (s *Supervisor) shouldKillProcess(pid int) (bool, error) {
 	if os.IsNotExist(err) {
 		return false, nil
 	} else if err != nil {
-		return false, fmt.Errorf("failed to read process %d environ: %v", pid, err)
+		return false, fmt.Errorf("failed to read process %d environ: %w", pid, err)
 	}
 
 	for _, e := range strings.Split(string(env), "\x00") {

--- a/pkg/supervisor/supervisor_unix_test.go
+++ b/pkg/supervisor/supervisor_unix_test.go
@@ -33,10 +33,10 @@ import (
 
 func createMockProcess(procFSPath string, pid string, cmdline []byte, k0smanaged bool) error {
 	if err := os.Mkdir(filepath.Join(procFSPath, pid), 0700); err != nil {
-		return fmt.Errorf("Failed to create fake proc dir: %v", err)
+		return fmt.Errorf("Failed to create fake proc dir: %w", err)
 	}
 	if err := ioutil.WriteFile(filepath.Join(procFSPath, pid, "cmdline"), cmdline, 0700); err != nil {
-		return fmt.Errorf("Failed to write cmdline: %v", err)
+		return fmt.Errorf("Failed to write cmdline: %w", err)
 	}
 
 	var env []byte
@@ -46,7 +46,7 @@ func createMockProcess(procFSPath string, pid string, cmdline []byte, k0smanaged
 		env = []byte("ENV1=A\x00ENV3=B\x00")
 	}
 	if err := ioutil.WriteFile(filepath.Join(procFSPath, pid, "environ"), env, 0700); err != nil {
-		return fmt.Errorf("Failed to write environ: %v", err)
+		return fmt.Errorf("Failed to write environ: %w", err)
 	}
 	return nil
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -68,11 +68,11 @@ func (c Component) collectTelemetry(ctx context.Context) (telemetryData, error) 
 	data.ClusterID, err = c.getClusterID(ctx)
 
 	if err != nil {
-		return data, fmt.Errorf("can't collect cluster ID: %v", err)
+		return data, fmt.Errorf("can't collect cluster ID: %w", err)
 	}
 	wds, sums, err := c.getWorkerData(ctx)
 	if err != nil {
-		return data, fmt.Errorf("can't collect workers count: %v", err)
+		return data, fmt.Errorf("can't collect workers count: %w", err)
 	}
 
 	data.WorkerNodesCount = len(wds)
@@ -81,7 +81,7 @@ func (c Component) collectTelemetry(ctx context.Context) (telemetryData, error) 
 	data.CPUTotal = sums.cpuTotal
 	data.ControlPlaneNodesCount, err = kubeutil.GetControlPlaneNodeCount(ctx, c.kubernetesClient)
 	if err != nil {
-		return data, fmt.Errorf("can't collect control plane nodes count: %v", err)
+		return data, fmt.Errorf("can't collect control plane nodes count: %w", err)
 	}
 	return data, nil
 }
@@ -99,7 +99,7 @@ func (c Component) getClusterID(ctx context.Context) (string, error) {
 		"kube-system",
 		metav1.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("can't find kube-system namespace: %v", err)
+		return "", fmt.Errorf("can't find kube-system namespace: %w", err)
 	}
 
 	return fmt.Sprintf("kube-system:%s", ns.UID), nil


### PR DESCRIPTION
## Description

Replace the %v format specifier in calls to fmt.Errorf() with %w whenever an error argument is used. Use errors.Join() in some cases where multiple errors were collected by their error messages. Replace %v with %s in error format strings whenever it's used for string-like arguments. Remove unnecessary fmt.Errorf() calls when logging errors.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings