### PR TITLE
Remove unused bootstrap-api-auth token usage

### DIFF
--- a/pkg/token/manager.go
+++ b/pkg/token/manager.go
@@ -79,12 +79,6 @@ func RandomBootstrapSecret(role string, valid time.Duration) (*corev1.Secret, st
 		StringData: map[string]string{
 			"token-id":     tokenID,
 			"token-secret": tokenSecret,
-
-			// This "usage-" is shared for all roles of the token which allows
-			// them to execute calls to the k0s API. This is done because we
-			// need to call the k0s API from windows workers during the join
-			// step.
-			"usage-bootstrap-api-auth": "true",
 		},
 	}
 


### PR DESCRIPTION
## Description

It has been added as part of the initial Windows support, but it seems it has never been in use. Supposedly this is a remnant of an intermediary variant, and has been renamed to bootstrap-api-worker-calls.

See:
* #508

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings