### PR TITLE
Replace x/exp/slices with standard slices

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"syscall"
 	"time"
 
@@ -57,7 +58,6 @@ import (
 	"github.com/k0sproject/k0s/pkg/token"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 )
 
 type command config.CLIOptions

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/k0sproject/k0s/pkg/config"
@@ -34,7 +35,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 )
 
 func checkKubectlInPath() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -19,12 +19,12 @@ package cmd_test
 import (
 	"bytes"
 	"io"
+	"slices"
 	"testing"
 
 	"github.com/k0sproject/k0s/cmd"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/slices"
 )
 
 // TestRootCmd_Flags ensures that no unwanted global flags have been registered

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.18.0
-	golang.org/x/exp v0.0.0-20230711153332-06a737ee72cb
 	golang.org/x/mod v0.14.0
 	golang.org/x/sync v0.6.0
 	golang.org/x/sys v0.16.0
@@ -259,6 +258,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.20.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
+	golang.org/x/exp v0.0.0-20230711153332-06a737ee72cb // indirect
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/oauth2 v0.14.0 // indirect
 	golang.org/x/term v0.16.0 // indirect

--- a/inttest/ap-ha3x3/ha3x3_test.go
+++ b/inttest/ap-ha3x3/ha3x3_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -32,7 +33,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/exp/slices"
 )
 
 type ha3x3Suite struct {

--- a/inttest/nllb/nllb_test.go
+++ b/inttest/nllb/nllb_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -39,7 +40,6 @@ import (
 
 	testifysuite "github.com/stretchr/testify/suite"
 	"go.uber.org/multierr"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"sigs.k8s.io/yaml"
 )

--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -21,12 +21,12 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -37,7 +38,6 @@ import (
 	"github.com/k0sproject/k0s/pkg/helm"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -24,6 +24,7 @@ import (
 	"math"
 	"net"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -52,7 +53,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"go.uber.org/multierr"
-	"golang.org/x/exp/slices"
 	"sigs.k8s.io/yaml"
 )
 
@@ -492,10 +492,10 @@ func (r *Reconciler) generateResources(snapshot *snapshot) (resources, error) {
 	}
 
 	// Ensure a stable order, so that reflect.DeepEqual on slices will work.
-	slices.SortFunc(objects, func(l, r resource) bool {
+	slices.SortFunc(objects, func(l, r resource) int {
 		x := strings.Join([]string{l.GetObjectKind().GroupVersionKind().Kind, l.GetNamespace(), l.GetName()}, "/")
 		y := strings.Join([]string{r.GetObjectKind().GroupVersionKind().Kind, r.GetNamespace(), r.GetName()}, "/")
-		return x < y
+		return strings.Compare(x, y)
 	})
 
 	resources, err := applier.ToUnstructuredSlice(nil, objects...)

--- a/pkg/component/controller/workerconfig/snapshot.go
+++ b/pkg/component/controller/workerconfig/snapshot.go
@@ -17,12 +17,12 @@ limitations under the License.
 package workerconfig
 
 import (
+	"slices"
+
 	"github.com/k0sproject/k0s/internal/pkg/net"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
-
-	"golang.org/x/exp/slices"
 )
 
 // snapshot holds a snapshot of the parts that influence worker configurations.

--- a/pkg/component/worker/config/config.go
+++ b/pkg/component/worker/config/config.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 
 	"github.com/k0sproject/k0s/internal/pkg/net"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
@@ -30,7 +31,6 @@ import (
 	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	"go.uber.org/multierr"
-	"golang.org/x/exp/slices"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/component/worker/nllb/reconciler.go
+++ b/pkg/component/worker/nllb/reconciler.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -38,7 +40,6 @@ import (
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
-	"golang.org/x/exp/slices"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -320,8 +321,8 @@ func (r *Reconciler) runReconcileLoop(ctx context.Context) {
 			}
 
 			desiredAPIServers = slices.Clone(profile.APIServerAddresses)
-			slices.SortFunc(desiredAPIServers, func(l, r k0snet.HostPort) bool {
-				return l.String() < r.String()
+			slices.SortFunc(desiredAPIServers, func(l, r k0snet.HostPort) int {
+				return strings.Compare(l.String(), r.String())
 			})
 
 		case <-ticker.C:

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -19,6 +19,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -29,7 +30,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/exp/slices"
 )
 
 var (

--- a/pkg/config/cli_test.go
+++ b/pkg/config/cli_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package config
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func TestAvailableComponents_SortedAndUnique(t *testing.T) {

--- a/pkg/constant/constant_shared_test.go
+++ b/pkg/constant/constant_shared_test.go
@@ -21,13 +21,13 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"golang.org/x/exp/slices"
 	"golang.org/x/tools/go/packages"
 )
 


### PR DESCRIPTION
## Description

The slices package in the standard library is sufficient for k0s's requirements nowadays. So let's use it.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings