### PR TITLE
Synchronize Windows and POSIX constants

### DIFF
--- a/pkg/constant/constant_posix.go
+++ b/pkg/constant/constant_posix.go
@@ -19,12 +19,12 @@ limitations under the License.
 package constant
 
 const (
-	// DataDirDefault is the default data directory containing k0s state
-	DataDirDefault                 = "/var/lib/k0s"
-	KubeletVolumePluginDir         = "/usr/libexec/k0s/kubelet-plugins/volume/exec"
-	KineSocket                     = "kine/kine.sock:2379"
-	KubePauseContainerImage        = "registry.k8s.io/pause"
-	KubePauseContainerImageVersion = "3.9"
-	K0sConfigPathDefault           = "/etc/k0s/k0s.yaml"
-	RuntimeConfigPathDefault       = "/run/k0s/k0s.yaml"
+	// DataDirDefault is the default directory containing k0s state.
+	DataDirDefault = "/var/lib/k0s"
+
+	// KubeletVolumePluginDir defines the location for kubelet volume plugin executables.
+	KubeletVolumePluginDir = "/usr/libexec/k0s/kubelet-plugins/volume/exec"
+
+	KineSocket           = "kine/kine.sock:2379"
+	K0sConfigPathDefault = "/etc/k0s/k0s.yaml"
 )

--- a/pkg/constant/constant_shared.go
+++ b/pkg/constant/constant_shared.go
@@ -77,6 +77,8 @@ const (
 	PushGatewayImageVersion            = "1.4.0-k0s.0"
 	MetricsImage                       = "registry.k8s.io/metrics-server/metrics-server"
 	MetricsImageVersion                = "v0.6.4"
+	KubePauseContainerImage            = "registry.k8s.io/pause"
+	KubePauseContainerImageVersion     = "3.9"
 	KubeProxyImage                     = "quay.io/k0sproject/kube-proxy"
 	KubeProxyImageVersion              = "v1.29.1"
 	CoreDNSImage                       = "quay.io/k0sproject/coredns"

--- a/pkg/constant/constant_windows.go
+++ b/pkg/constant/constant_windows.go
@@ -17,22 +17,12 @@ limitations under the License.
 package constant
 
 const (
-	// DataDirDefault folder contains all k0s state
+	// DataDirDefault is the default directory containing k0s state.
 	DataDirDefault = "C:\\var\\lib\\k0s"
-	// CertRootDir defines the root location for all pki related artifacts
-	CertRootDir = "C:\\var\\lib\\k0s\\pki"
-	// BinDir defines the location for all pki related binaries
-	BinDir = "C:\\var\\lib\\k0s\\bin"
-	// RunDir run directory
-	RunDir = "C:\\run\\k0s"
-	// ManifestsDir stack applier directory
-	ManifestsDir = "C:\\var\\lib\\k0s\\manifests"
+
 	// KubeletVolumePluginDir defines the location for kubelet plugins volume executables
 	KubeletVolumePluginDir = "C:\\usr\\libexec\\k0s\\kubelet-plugins\\volume\\exec"
 
-	KineSocket                     = "kine\\kine.sock:2379"
-	KubePauseContainerImage        = "registry.k8s.io/pause"
-	KubePauseContainerImageVersion = "3.9"
-	K0sConfigPathDefault           = "C:\\etc\\k0s\\k0s.yaml"
-	RuntimeConfigPathDefault       = RunDir + "\\k0s.yaml"
+	KineSocket           = "kine\\kine.sock:2379"
+	K0sConfigPathDefault = "C:\\etc\\k0s\\k0s.yaml"
 )


### PR DESCRIPTION
## Description

Deduplicate identical pause image constants. Remove constants that are no longer used. Synchronize doc strings between the Windows and POSIX constants.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings