### PR TITLE
Make Plan id and timestamp fields optional

### DIFF
--- a/pkg/apis/autopilot/v1beta2/types.go
+++ b/pkg/apis/autopilot/v1beta2/types.go
@@ -106,10 +106,10 @@ type PlanList struct {
 // PlanSpec describes the behavior of the `Plan`
 type PlanSpec struct {
 	// ID is a user-provided identifier for this plan.
-	ID string `json:"id"`
+	ID string `json:"id,omitempty"`
 
 	// Timestamp is a user-provided time that the plan was created.
-	Timestamp string `json:"timestamp"`
+	Timestamp string `json:"timestamp,omitempty"`
 
 	// Commands are a collection of all of the commands that need to be executed
 	// in order for this plan to transition to Completed.

--- a/static/manifests/autopilot/CustomResourceDefinition/autopilot.k0sproject.io_plans.yaml
+++ b/static/manifests/autopilot/CustomResourceDefinition/autopilot.k0sproject.io_plans.yaml
@@ -285,8 +285,6 @@ spec:
                 type: string
             required:
             - commands
-            - id
-            - timestamp
             type: object
           status:
             description: Status is the most recently observed status of the plan.


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/k0sproject/k0s/issues/4058

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

k0s cluster was created with newly built binary, `Plan` without `spec.id` and `spec.timestamp` was created:
```yaml
kind: Plan
metadata:
  name: autopilot
spec:
  commands:
    - k0supdate:
        version: v1.29.1+k0s.1
        platforms:
          linux-amd64:
            url: https://github.com/k0sproject/k0s/releases/download/v1.29.1+k0s.1/k0s-v1.29.1+k0s.1-amd64
        targets:
          controllers:
            discovery:
              selector:
                labels: app=123
```

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings