### PR TITLE
Remove some outdated bullet points from kube-router docs

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -23,11 +23,9 @@ You can opt-out of having k0s manage the network setup and choose instead to use
 
 Kube-router is built into k0s, and so by default the distribution uses it for network provision. Kube-router uses the standard Linux networking stack and toolset, and you can set up CNI networking without any overlays by using BGP as the main mechanism for in-cluster networking.
 
-- Supports armv7 (among many other archs)
 - Uses bit less resources (~15%)
 - Does NOT support dual-stack (IPv4/IPv6) networking
 - Does NOT support Windows nodes
-- Does NOT activate hairpin mode by default
 
 ### Calico
 


### PR DESCRIPTION
## Description

ARMv7 support is also present in Calico nowadays, so this is not something to highlight anymore. Hairpinning is enabled by default since quite some time, too.

See:
* #2417

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings