### PR TITLE
Error out when NLLB is enabled for a single-node cluster

### DIFF
--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -18,6 +18,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -129,7 +130,11 @@ func (c *Command) Start(ctx context.Context) error {
 
 	var staticPods worker.StaticPods
 
-	if !c.SingleNode && workerConfig.NodeLocalLoadBalancing.IsEnabled() {
+	if workerConfig.NodeLocalLoadBalancing.IsEnabled() {
+		if c.SingleNode {
+			return errors.New("node-local load balancing cannot be used in a single-node cluster")
+		}
+
 		sp := worker.NewStaticPods()
 		reconciler, err := nllb.NewReconciler(c.K0sVars, sp, c.WorkerProfile, *workerConfig.DeepCopy())
 		if err != nil {


### PR DESCRIPTION
## Description

Using NLLB in a single-node cluster was never supported and documented as such since the inception of NLLB. K0s didn't error out early in this case, though. Weird things happened instead.

Fixes:
* #4056

Alternatively, we could try to remove the single-node check and simply enable NLLB even for single-node clusters and see how far we get. This would require more testing just to support an unnecessary feature for a simple use case. So I'd vote for actually enforcing the documented limitations instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings