### PR TITLE
left-pad helm chart filenames with 0s to fix sorting

### DIFF
--- a/pkg/apis/k0s/v1beta1/extensions.go
+++ b/pkg/apis/k0s/v1beta1/extensions.go
@@ -102,7 +102,7 @@ type Chart struct {
 
 // ManifestFileName returns filename to use for the crd manifest
 func (c Chart) ManifestFileName() string {
-	return fmt.Sprintf("%d_helm_extension_%s.yaml", c.Order, c.Name)
+	return fmt.Sprintf("%09d_helm_extension_%s.yaml", c.Order, c.Name)
 }
 
 // Validate performs validation

--- a/pkg/apis/k0s/v1beta1/extenstions_test.go
+++ b/pkg/apis/k0s/v1beta1/extenstions_test.go
@@ -102,9 +102,17 @@ func TestValidation(t *testing.T) {
 			TargetNS:  "default",
 			Order:     2,
 		}
-		assert.Equal(t, chart.ManifestFileName(), "0_helm_extension_release.yaml")
-		assert.Equal(t, chart1.ManifestFileName(), "1_helm_extension_release.yaml")
-		assert.Equal(t, chart2.ManifestFileName(), "2_helm_extension_release.yaml")
+
+		chart20 := Chart{
+			Name:      "release",
+			ChartName: "k0s/chart",
+			TargetNS:  "default",
+			Order:     20,
+		}
+		assert.Equal(t, "000000000_helm_extension_release.yaml", chart.ManifestFileName())
+		assert.Equal(t, "000000001_helm_extension_release.yaml", chart1.ManifestFileName())
+		assert.Equal(t, "000000002_helm_extension_release.yaml", chart2.ManifestFileName())
+		assert.Equal(t, "000000020_helm_extension_release.yaml", chart20.ManifestFileName())
 	})
 
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

Currently, helm chart apply order is determined by sorting the helm chart manifest filenames. The order is included as the first element in the filename, resulting in names like `1_helm_extension_chartname.yaml`.

Manifests are fetched [here](https://github.com/k0sproject/k0s/blob/v1.29.1%2Bk0s.1/pkg/applier/applier.go#L37-L39), which uses [filepath.Glob](https://github.com/golang/go/blob/go1.22.0/src/path/filepath/match.go#L347), which calls sort on the results.

Unfortunately, this breaks at 10 - `10_helm_extension_anothername.yaml` is alphabetically before `1_helm_extension_chartname.yaml`.

This PR adds a fmt directive to left-pad these integers to 9 digits, which allows sorting to work properly - see https://go.dev/play/p/THZg3TD6eHI.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings