### PR TITLE
Remove the info about runtime dependencies of old k0s versions

### DIFF
--- a/docs/external-runtime-deps.md
+++ b/docs/external-runtime-deps.md
@@ -224,22 +224,6 @@ are not detected.
 External `/usr/bin/id` will be executed as a fallback if local user lookup
 fails, in case NSS is used.
 
-### Other dependencies in previous versions of k0s
-
-- up until k0s v1.21.9+k0s.0: `iptables`  
-  Required for worker nodes. Resolved by @ncopa in [#1046] by adding `iptables`
-  and friends to k0s's embedded binaries.
-
-- up until k0s v1.21.7+k0s.0: `find`, `du` and `nice`  
-  Required for worker nodes. Resolved upstream by @ncopa in
-  [kubernetes/kubernetes#96115], contained in Kubernetes 1.21.8 ([5b13c8f68d4])
-  and 1.22.0 ([d45ba645a8f]).
-
-[#1046]: https://github.com/k0sproject/k0s/pull/1046
-[kubernetes/kubernetes#96115]: https://github.com/kubernetes/kubernetes/pull/96115
-[5b13c8f68d4]: https://github.com/kubernetes/kubernetes/commit/5b13c8f68d48740261fa4c96ecb0a504982088a8
-[d45ba645a8f]: https://github.com/kubernetes/kubernetes/commit/d45ba645a8f7b288284890a051c73bbae717da4b
-
 ## Windows specific
 <!--
 The kubernetes/system-validators require certain Windows versions starting with


### PR DESCRIPTION
## Description

These versions are quite old. This historical information does not add much value to understanding the current state of affairs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings