### PR TITLE
Improve k0s-managed containerd config detection

### DIFF
--- a/pkg/component/worker/containerd/component_test.go
+++ b/pkg/component/worker/containerd/component_test.go
@@ -21,13 +21,67 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	workerconfig "github.com/k0sproject/k0s/pkg/component/worker/config"
+	"github.com/k0sproject/k0s/pkg/config"
+
 	"github.com/stretchr/testify/require"
 )
 
 func Test_isK0sManagedConfig(t *testing.T) {
 
 	t.Run("should return true if file does not exist", func(t *testing.T) {
-		isManaged, err := isK0sManagedConfig("non-existent.toml")
+		isManaged, err := isK0sManagedConfig(filepath.Join(t.TempDir(), "non-existent.toml"))
+		require.NoError(t, err)
+		require.True(t, isManaged)
+	})
+
+	t.Run("should return true for generated default config", func(t *testing.T) {
+		defaultConfigPath := filepath.Join(t.TempDir(), "default.toml")
+
+		underTest := Component{
+			K0sVars: &config.CfgVars{
+				RunDir: /* The merged config file will be written here: */ t.TempDir(),
+			},
+			confPath:/* The main config file will be written here: */ defaultConfigPath,
+			importsPath:/* some empty dir: */ t.TempDir(),
+			Profile:/* Some non-nil pause image: */ &workerconfig.Profile{PauseImage: &v1beta1.ImageSpec{}},
+		}
+		err := underTest.setupConfig()
+
+		require.NoError(t, err)
+		require.FileExists(t, defaultConfigPath, "The generated config file is missing.")
+
+		isManaged, err := isK0sManagedConfig(defaultConfigPath)
+		require.NoError(t, err)
+		require.True(t, isManaged, "The generated config file should qualify as k0s-managed, but doesn't.")
+	})
+
+	t.Run("should return false if file has no marker", func(t *testing.T) {
+		unmanagedPath := filepath.Join(t.TempDir(), "unmanaged.toml")
+		require.NoError(t, os.WriteFile(unmanagedPath, []byte(" # k0s_managed=true"), 0644))
+
+		isManaged, err := isK0sManagedConfig(unmanagedPath)
+		require.NoError(t, err)
+		require.False(t, isManaged)
+	})
+
+	t.Run("should return true for pre-1.30 generated config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "containerd.toml")
+		cfg := `
+# k0s_managed=true
+# This is a placeholder configuration for k0s managed containerD. 
+# If you wish to override the config, remove the first line and replace this file with your custom configuration.
+# For reference see https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md
+version = 2
+imports = [
+	"/run/k0s/containerd-cri.toml",
+]
+`
+		err := os.WriteFile(configPath, []byte(cfg), 0644)
+		require.NoError(t, err)
+		isManaged, err := isK0sManagedConfig(configPath)
 		require.NoError(t, err)
 		require.True(t, isManaged)
 	})


### PR DESCRIPTION
## Description

The previous detection method was to read the whole file and search each line for the magic string "# k0s_managed=true". This seems excessive and unexpected, as it will catch any substring, even if it is not at the beginning of the file, the start of a line, or even inside a comment. It would even have caught this as part of a TOML string value.

Change this behavior by expecting the first line of the file to be exactly this magic string. All files generated by k0s will have exactly that first line. Also return any previously swallowed errors back to the caller.

Add more test cases to ensure that the generated default config is recognized as being managed by k0s, and that a file not starting with the magic line is recognized as not being managed by k0s.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings