### PR TITLE
Pass along containerd config as return value

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -54,9 +54,22 @@ state = "/run/k0s/containerd"
 
 ## k0s managed dynamic runtime configuration
 
-From 1.27.1 onwards k0s enables dynamic configuration on containerd CRI runtimes. This works by k0s creating a special directory in `/etc/k0s/containerd.d/` where user can drop-in partial containerd configuration snippets.
+As of 1.27.1, k0s allows dynamic configuration of containerd CRI runtimes. This
+works by k0s creating a special directory in `/etc/k0s/containerd.d/` where
+users can place partial containerd configuration files.
 
-k0s will automatically pick up these files and adds these in containerd configuration `imports` list. If k0s sees the configuration drop-ins are CRI related configurations k0s will automatically collect all these into a single file and adds that as a single import file. This is to overcome some hard limitation on containerd 1.X versions. Read more at [containerd#8056](https://github.com/containerd/containerd/pull/8056)
+K0s will automatically pick up these files and add them as containerd
+configuration `imports`. If a partial configuration file contains a CRI plugin
+configuration section, k0s will instead treat such a file as a [merge patch] to
+k0s's default containerd configuration. This is to mitigate [containerd's
+decision] to replace rather than merge individual plugin configuration sections
+from imported configuration files. However, this behavior [may][containerd#7347]
+[change][containerd#9982] in future releases of containerd.
+
+[merge patch]: https://datatracker.ietf.org/doc/html/rfc7396
+[containerd's decision]: https://github.com/containerd/containerd/pull/3574/commits/24b9e2c1a0a72a7ad302cdce7da3abbc4e6295cb
+[containerd#7347]: https://github.com/containerd/containerd/pull/7347
+[containerd#9982]: https://github.com/containerd/containerd/pull/9982
 
 ### Examples
 
@@ -146,7 +159,7 @@ distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
 sudo apt-get update && sudo apt-get install -y nvidia-container-runtime
 ```
 
-Next, drop in the containerd runtime configuration snippet into `/etc/k0s/containerd.d/nvidia.toml`
+Next, drop in the NVIDIA runtime's configuration into into `/etc/k0s/containerd.d/nvidia.toml`:
 
 ```toml
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]

--- a/pkg/component/worker/containerd/configurer_test.go
+++ b/pkg/component/worker/containerd/configurer_test.go
@@ -26,42 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testImportsPath = "/etc/k0s/containerd.d/"
-
-func TestConfigurer_hasCRIPluginConfig(t *testing.T) {
-	t.Run("should return true if config has cri plugin configs", func(t *testing.T) {
-		cfg := `
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-    endpoint = ["https://registry-1.docker.io"]
-`
-
-		c := configurer{
-			loadPath: testImportsPath,
-			log:      logrus.New().WithField("test", t.Name()),
-		}
-		hasCRIPluginConfig, err := c.hasCRIPluginConfig([]byte(cfg))
-		require.NoError(t, err)
-		require.True(t, hasCRIPluginConfig)
-	})
-
-	t.Run("should return false if config has no cri plugin configs", func(t *testing.T) {
-		cfg := `
-timeout = 3
-version = 2
-`
-
-		c := configurer{
-			loadPath: testImportsPath,
-			log:      logrus.New().WithField("test", t.Name()),
-		}
-		hasCRIPluginConfig, err := c.hasCRIPluginConfig([]byte(cfg))
-		require.NoError(t, err)
-		require.False(t, hasCRIPluginConfig)
-	})
-
-}
-
 func TestConfigurer_HandleImports(t *testing.T) {
 	t.Run("should merge CRI configs", func(t *testing.T) {
 		tmp := t.TempDir()


### PR DESCRIPTION
## Description

* Pass along containerd config as return value
  Return the containerd config as a string instead of having the configurer write it to disk. This reduces the number of struct fields required by the configurer, and makes testing less dependent on the file system.

  Let the containerd component write the file instead.

  Remove the hard-coded string literal for the paths to containerd-cri.toml and use k0s' RunDir instead. This already takes into account the differences between Windows and UNIX-like operating systems, and also takes into account the different defaults when running as non-root user.

  Remove the escapedPath function and inline it directly before the containerd component generates the template.

* Use toml.Marshal to generate default CRI config
  This is more convenient and removes the necessity to declare some one-shot writer variable to get the marshalled data. Moreover, make this a free-standing function, so it's more obvious that the default config is solely dependent on the pause image.

* Simplify hasCRIPluginConfig
  * Use toml.Tree's HasPath function to simplify the check for the CRI plugin config section
  * Make it a free-standing function. The only reason why it had the receiver was to use the usage of the logger.
  * Remove unit tests for it, as all the interesting cases are already covered by the unit tests for handleImports and don't add anything of interest.
  * Add some more comments, refine log statements and error messages.

* Refactor CRI config tests
  * Merge two nearly identical configurer tests
    The two tests "should merge CRI configs" and "should have single import for all CRI configs" were nearly doing the same. One of them was missing two assertions. Combine them into one test.
  * Rename `srvconfig` import alias to the more idiomatic `serverconfig`
  * Adjust variable names to more accurately reflect their purpose
  * Transition from `require` to `assert` in certain test assertions to continue execution after a failure, allowing for more comprehensive test feedback.
  * Use upper-case CRI instead lower-case cri in descriptive strings

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings