### PR TITLE
remove --enable-hostpath-provisioner flag from kube-controller-manager

### DIFF
--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -55,7 +55,6 @@ var cmDefaultArgs = stringmap.StringMap{
 	"bind-address":                    "127.0.0.1",
 	"cluster-name":                    "k0s",
 	"controllers":                     "*,bootstrapsigner,tokencleaner",
-	"enable-hostpath-provisioner":     "true",
 	"leader-elect":                    "true",
 	"use-service-account-credentials": "true",
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

See https://github.com/kubernetes/kubernetes/issues/123804

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings