### PR TITLE
Wrap errors correctly, part 2

### DIFF
--- a/cmd/backup/backup_unix.go
+++ b/cmd/backup/backup_unix.go
@@ -81,7 +81,7 @@ func (c *command) backup(savePath string, out io.Writer) error {
 
 	status, err := status.GetStatusInfo(c.K0sVars.StatusSocketPath)
 	if err != nil {
-		return fmt.Errorf("unable to detect cluster status %s", err)
+		return fmt.Errorf("unable to detect cluster status %w", err)
 	}
 	logrus.Debugf("detected role for backup operations: %v", status.Role)
 

--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -72,7 +72,7 @@ func (s *Stack) Apply(ctx context.Context, prune bool) error {
 		s.prepareResource(resource)
 		mapping, err := mapper.RESTMapping(resource.GroupVersionKind().GroupKind(), resource.GroupVersionKind().Version)
 		if err != nil {
-			return fmt.Errorf("mapping error: %s", err)
+			return fmt.Errorf("mapping error: %w", err)
 		}
 		var drClient dynamic.ResourceInterface
 		if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
@@ -84,10 +84,10 @@ func (s *Stack) Apply(ctx context.Context, prune bool) error {
 		if apiErrors.IsNotFound(err) {
 			_, err := drClient.Create(ctx, resource, metav1.CreateOptions{})
 			if err != nil {
-				return fmt.Errorf("cannot create resource %s: %s", resource.GetName(), err)
+				return fmt.Errorf("cannot create resource %s: %w", resource.GetName(), err)
 			}
 		} else if err != nil {
-			return fmt.Errorf("unknown api error: %s", err)
+			return fmt.Errorf("unknown api error: %w", err)
 		} else { // The resource already exists, we need to update/patch it
 			localChecksum := resource.GetAnnotations()[ChecksumAnnotation]
 			if serverResource.GetAnnotations()[ChecksumAnnotation] == localChecksum {
@@ -247,7 +247,7 @@ func (s *Stack) deleteResource(ctx context.Context, mapper *restmapper.DeferredD
 		PropagationPolicy: &propagationPolicy,
 	})
 	if err != nil && !apiErrors.IsNotFound(err) && !apiErrors.IsGone(err) {
-		return fmt.Errorf("deleting resource failed: %s", err)
+		return fmt.Errorf("deleting resource failed: %w", err)
 	}
 	return nil
 }
@@ -255,7 +255,7 @@ func (s *Stack) deleteResource(ctx context.Context, mapper *restmapper.DeferredD
 func (s *Stack) clientForResource(mapper *restmapper.DeferredDiscoveryRESTMapper, resource unstructured.Unstructured) (dynamic.ResourceInterface, error) {
 	mapping, err := mapper.RESTMapping(resource.GroupVersionKind().GroupKind(), resource.GroupVersionKind().Version)
 	if err != nil {
-		return nil, fmt.Errorf("mapping error: %s", err)
+		return nil, fmt.Errorf("mapping error: %w", err)
 	}
 
 	var drClient dynamic.ResourceInterface

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -104,7 +104,7 @@ func (k *Konnectivity) Start(ctx context.Context) error {
 	// To make the server start, add "dummy" 0 into the channel
 	if err := k.runServer(ctx, 0); err != nil {
 		k.EmitWithPayload("failed to run konnectivity server", err)
-		return fmt.Errorf("failed to run konnectivity server: %s", err)
+		return fmt.Errorf("failed to run konnectivity server: %w", err)
 	}
 
 	go k.watchControllerCountChanges(ctx)

--- a/pkg/supervisor/supervisor_unix.go
+++ b/pkg/supervisor/supervisor_unix.go
@@ -68,7 +68,7 @@ Loop:
 			if err == syscall.ESRCH {
 				return nil
 			} else if err != nil {
-				return fmt.Errorf("failed to send SIGTERM to pid %d: %s", s.cmd.Process.Pid, err)
+				return fmt.Errorf("failed to send SIGTERM to pid %d: %w", s.cmd.Process.Pid, err)
 			}
 		case <-deadline:
 			break Loop
@@ -87,7 +87,7 @@ Loop:
 	if err == syscall.ESRCH {
 		return nil
 	} else if err != nil {
-		return fmt.Errorf("failed to send SIGKILL to pid %d: %s", s.cmd.Process.Pid, err)
+		return fmt.Errorf("failed to send SIGKILL to pid %d: %w", s.cmd.Process.Pid, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

Replace the `%s` format specifier in calls to `fmt.Errorf()` with `%w` whenever an `error` argument is used.

See:
* #4029

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings