### PR TITLE
[Backport release-1.27] Fix copyright script

### DIFF
--- a/cmd/airgap/airgap.go
+++ b/cmd/airgap/airgap.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/airgap/listimages.go
+++ b/cmd/airgap/listimages.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/api/util.go
+++ b/cmd/api/util.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/backup/backup_windows.go
+++ b/cmd/backup/backup_windows.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/config/create.go
+++ b/cmd/config/create.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/config/edit.go
+++ b/cmd/config/edit.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/config/status.go
+++ b/cmd/config/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/config/validate.go
+++ b/cmd/config/validate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/etcd/list.go
+++ b/cmd/etcd/list.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/kubeconfig/kubeconfig.go
+++ b/cmd/kubeconfig/kubeconfig.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/restore/restore_windows.go
+++ b/cmd/restore/restore_windows.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/token/invalidate.go
+++ b/cmd/token/invalidate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/copyright.sh
+++ b/hack/copyright.sh
@@ -22,12 +22,12 @@ FIX=${FIX:=n}
 get_year(){
     # The -1 has to be added because if a file has been added, removed and added
     # again we'll get two lines with both dates. We only pick the newest one.
-    YEAR=$(TZ=UTC git log --follow -1 --diff-filter=A --pretty=format:%ad --date=format:%Y -- "$1")
+    YEAR=$(TZ=UTC git log --follow --find-copies=90% -1 --diff-filter=A --pretty=format:%ad --date=format:%Y -- "$1")
     if [ -z "$YEAR" ]; then
         YEAR=$(TZ=UTC date +%Y)
 	    echo "WARN: $1 doesn't seem to be commited in the repo, assuming $YEAR" 1>&2
     fi
-    echo $YEAR
+    echo "$YEAR"
 }
 
 has_basic_copyright(){
@@ -63,7 +63,7 @@ for i in $(find cmd hack internal inttest pkg static -type f -name '*.go' -not -
         fi
 
         if ! has_date_copyright "$DATE" "$i"; then
-          echo "ERROR: $i doesn't have a proper copyright notice" 1>&2
+          echo "ERROR: $i doesn't have a proper copyright notice. Expected $DATE" 1>&2
           RESULT=1
         fi
         ;;

--- a/hack/copyright.sh
+++ b/hack/copyright.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright 2023 k0s authors
 #
@@ -58,8 +58,8 @@ for i in $(find cmd hack internal inttest pkg static -type f -name '*.go' -not -
 
         # codegen gets the header from a static file, so instead we'll replace it every time.
         # Also fix every file if FIX=y
-        if [[ "$FIX" == 'y' ]]; then
-          sed -i "s/Copyright 20../Copyright $DATE/" "$i"
+        if [ "$FIX" = 'y' ]; then
+          sed -i.tmp -e "s/Copyright 20../Copyright $DATE/" -- "$i" && rm -f "$i".tmp
         fi
 
         if ! has_date_copyright "$DATE" "$i"; then
@@ -70,8 +70,8 @@ for i in $(find cmd hack internal inttest pkg static -type f -name '*.go' -not -
     esac
 done
 
-if [[ "$RESULT" != 0 ]]; then
-    if [[ "$FIX" == 'y' ]]; then
+if [ "$RESULT" != "0" ]; then
+    if [ "$FIX" = 'y' ]; then
         echo "hack/copyright.sh can't fix the problem automatically. Manual intervention is required"
     else
         echo "Retry running the script with FIX=y hack/copyright.sh to see if can be fixed automatically"

--- a/hack/gen-bindata/cmd/main.go
+++ b/hack/gen-bindata/cmd/main.go
@@ -2,7 +2,7 @@
 // +build hack
 
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/gen-bindata/gen_bindata.go
+++ b/hack/gen-bindata/gen_bindata.go
@@ -2,7 +2,7 @@
 // +build hack
 
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/tool/cmd/aws/aws.go
+++ b/hack/tool/cmd/aws/aws.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/tool/cmd/root.go
+++ b/hack/tool/cmd/root.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/tool/main.go
+++ b/hack/tool/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/tool/pkg/constant/constant.go
+++ b/hack/tool/pkg/constant/constant.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/tool/pkg/k0s/version.go
+++ b/hack/tool/pkg/k0s/version.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/dir/dir.go
+++ b/internal/pkg/dir/dir.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/file/file.go
+++ b/internal/pkg/file/file.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/flags/flags_test.go
+++ b/internal/pkg/flags/flags_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/iface/iface.go
+++ b/internal/pkg/iface/iface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/log/k0s.go
+++ b/internal/pkg/log/k0s.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2023 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/middleware/allow_methods.go
+++ b/internal/pkg/middleware/allow_methods.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2023 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/random/random.go
+++ b/internal/pkg/random/random.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/stringslice/stringslice.go
+++ b/internal/pkg/stringslice/stringslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/sysinfo/host_other.go
+++ b/internal/pkg/sysinfo/host_other.go
@@ -2,7 +2,7 @@
 // +build !linux
 
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/sysinfo/machineid/machineid.go
+++ b/internal/pkg/sysinfo/machineid/machineid.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/sysinfo/machineid/machineid_test.go
+++ b/internal/pkg/sysinfo/machineid/machineid_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/sysinfo/probes/disk.go
+++ b/internal/pkg/sysinfo/probes/disk.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/sysinfo/probes/disk_other.go
+++ b/internal/pkg/sysinfo/probes/disk_other.go
@@ -2,7 +2,7 @@
 // +build !linux
 
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/sysinfo/probes/executables.go
+++ b/internal/pkg/sysinfo/probes/executables.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/sysinfo/probes/linux/types.go
+++ b/internal/pkg/sysinfo/probes/linux/types.go
@@ -2,7 +2,7 @@
 // +build linux,!arm
 
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/sysinfo/probes/linux/types_arm.go
+++ b/internal/pkg/sysinfo/probes/linux/types_arm.go
@@ -2,7 +2,7 @@
 // +build linux,arm
 
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/sysinfo/probes/memory_linux.go
+++ b/internal/pkg/sysinfo/probes/memory_linux.go
@@ -2,7 +2,7 @@
 // +build linux
 
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/sysinfo/probes/memory_other.go
+++ b/internal/pkg/sysinfo/probes/memory_other.go
@@ -2,7 +2,7 @@
 // +build !linux
 
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/sysinfo/probes/util.go
+++ b/internal/pkg/sysinfo/probes/util.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/testutil/os.go
+++ b/internal/testutil/os.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2023 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/ap-airgap/airgap_test.go
+++ b/inttest/ap-airgap/airgap_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/inttest/ap-ha3x3/ha3x3_test.go
+++ b/inttest/ap-ha3x3/ha3x3_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/inttest/ap-platformselect/platformselect_test.go
+++ b/inttest/ap-platformselect/platformselect_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/inttest/ap-quorum/quorum_test.go
+++ b/inttest/ap-quorum/quorum_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/inttest/ap-quorumsafety/quorumsafety_test.go
+++ b/inttest/ap-quorumsafety/quorumsafety_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/inttest/ap-removedapis/removedapis_test.go
+++ b/inttest/ap-removedapis/removedapis_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/inttest/ap-selector/selector_test.go
+++ b/inttest/ap-selector/selector_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/inttest/ap-single/single_test.go
+++ b/inttest/ap-single/single_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/inttest/ap-updater/updater_test.go
+++ b/inttest/ap-updater/updater_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/inttest/calico/calico_test.go
+++ b/inttest/calico/calico_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/clusterreboot/clusterreboot_test.go
+++ b/inttest/clusterreboot/clusterreboot_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/cnichange/cnichange_test.go
+++ b/inttest/cnichange/cnichange_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/ctr/ctr_test.go
+++ b/inttest/ctr/ctr_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/custom-cidrs/customcidrs_test.go
+++ b/inttest/custom-cidrs/customcidrs_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2023 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/customdomain/customdomain_test.go
+++ b/inttest/customdomain/customdomain_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/disabledcomponents/disabled_components_test.go
+++ b/inttest/disabledcomponents/disabled_components_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/extraargs/extraargs_test.go
+++ b/inttest/extraargs/extraargs_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/hostnameoverride/hostnameoverride_test.go
+++ b/inttest/hostnameoverride/hostnameoverride_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/kubeletcertrotate/kubeletcertrotate_test.go
+++ b/inttest/kubeletcertrotate/kubeletcertrotate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/inttest/metrics/metrics_test.go
+++ b/inttest/metrics/metrics_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/metricsscraper/metricsscraper_test.go
+++ b/inttest/metricsscraper/metricsscraper_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 k0s authors
+Copyright 2023 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/multicontroller/multicontroller_test.go
+++ b/inttest/multicontroller/multicontroller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/noderole-no-taints/noderole_no_taints_test.go
+++ b/inttest/noderole-no-taints/noderole_no_taints_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/noderole-single/noderole_single_test.go
+++ b/inttest/noderole-single/noderole_single_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/noderole/noderole_test.go
+++ b/inttest/noderole/noderole_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/inttest/statussocket/statussocket_test.go
+++ b/inttest/statussocket/statussocket_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/clusterconfig_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/groupversion_info.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/groupversion_info.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/konnectivity.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/konnectivity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/kuberouter.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/kuberouter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/autopilot/build/version.go
+++ b/pkg/autopilot/build/version.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/autopilot/common/telemetry.go
+++ b/pkg/autopilot/common/telemetry.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/newplan.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/newplan.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/autopilot/controller/root_worker.go
+++ b/pkg/autopilot/controller/root_worker.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/autopilot/controller/setup.go
+++ b/pkg/autopilot/controller/setup.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/autopilot/controller/signal/airgap/download.go
+++ b/pkg/autopilot/controller/signal/airgap/download.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/autopilot/controller/signal/airgap/init.go
+++ b/pkg/autopilot/controller/signal/airgap/init.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/autopilot/controller/signal/init.go
+++ b/pkg/autopilot/controller/signal/init.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/autopilot/controller/signal/k0s/download.go
+++ b/pkg/autopilot/controller/signal/k0s/download.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/autopilot/controller/signal/k0s/restart_windows.go
+++ b/pkg/autopilot/controller/signal/k0s/restart_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/autopilot/controller/signal/k0s/restarted.go
+++ b/pkg/autopilot/controller/signal/k0s/restarted.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/autopilot/controller/signal/k0s/restarted_windows.go
+++ b/pkg/autopilot/controller/signal/k0s/restarted_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2021 k0s authors
+// Copyright 2022 k0s authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/component/controller/clusterconfig/configsource.go
+++ b/pkg/component/controller/clusterconfig/configsource.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/component/controller/controllersleasecounter.go
+++ b/pkg/component/controller/controllersleasecounter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/component/controller/leaderelector/dummy.go
+++ b/pkg/component/controller/leaderelector/dummy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/component/controller/leaderelector/leasepool.go
+++ b/pkg/component/controller/leaderelector/leasepool.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/component/controller/leaderelector/types.go
+++ b/pkg/component/controller/leaderelector/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/component/manager/manager.go
+++ b/pkg/component/manager/manager.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/component/prober/events.go
+++ b/pkg/component/prober/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/component/status/client.go
+++ b/pkg/component/status/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/component/worker/nllb/doc.go
+++ b/pkg/component/worker/nllb/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kubernetes/watch/apps.go
+++ b/pkg/kubernetes/watch/apps.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kubernetes/watch/core.go
+++ b/pkg/kubernetes/watch/core.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kubernetes/watch/k0s.go
+++ b/pkg/kubernetes/watch/k0s.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/supervisor/supervisor_windows.go
+++ b/pkg/supervisor/supervisor_windows.go
@@ -2,7 +2,7 @@
 // +build windows
 
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/token/joinclient.go
+++ b/pkg/token/joinclient.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2021 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/token/kubeconfig_test.go
+++ b/pkg/token/kubeconfig_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/static/doc.go
+++ b/static/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 k0s authors
+Copyright 2022 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Backport to `release-1.27`:
* #3087

This will allow CI to pass on other backports that add new files without the copyright check complaining.