### PR TITLE
Let k0s cloud provider assign a node's provider ID

### DIFF
--- a/inttest/k0scloudprovider/k0scloudprovider_test.go
+++ b/inttest/k0scloudprovider/k0scloudprovider_test.go
@@ -48,12 +48,17 @@ func (s *K0sCloudProviderSuite) TestK0sGetsUp() {
 	s.Require().NoError(err)
 	s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(0)))
 
-	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
+	nodeName := s.WorkerNode(0)
+	err = s.WaitForNodeReady(nodeName, kc)
 	s.Require().NoError(err)
 
-	s.testAddAddress(ctx, kc, s.WorkerNode(0), "1.2.3.4")
-	s.testAddAddress(ctx, kc, s.WorkerNode(0), "2041:0000:140F::875B:131B")
-	s.testAddAddress(ctx, kc, s.WorkerNode(0), "GIGO")
+	node, err := kc.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	s.Require().NoError(err)
+	s.Equal("k0s-cloud-provider://"+nodeName, node.Spec.ProviderID)
+
+	s.testAddAddress(ctx, kc, nodeName, "1.2.3.4")
+	s.testAddAddress(ctx, kc, nodeName, "2041:0000:140F::875B:131B")
+	s.testAddAddress(ctx, kc, nodeName, "GIGO")
 }
 
 // testAddAddress adds the provided address to a node and ensures that the

--- a/pkg/k0scloudprovider/instances.go
+++ b/pkg/k0scloudprovider/instances.go
@@ -56,7 +56,7 @@ func (i *instancesV2) InstanceShutdown(ctx context.Context, node *v1.Node) (bool
 // properties of the node like its name, labels and annotations.
 func (i *instancesV2) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error) {
 	return &cloudprovider.InstanceMetadata{
-		ProviderID:    node.Spec.ProviderID,
+		ProviderID:    Name + "://" + node.Name,
 		InstanceType:  Name,
 		NodeAddresses: i.addressCollector(node),
 	}, nil


### PR DESCRIPTION
## Description

Since kubernetes/kubernetes#123713, it is required for cloud providers to assign a provider ID to each node. Let k0s comply with that requirement.

See:
* #4111

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings