### PR TITLE
Have a constant to indicate Kubernetes pre-releases

### DIFF
--- a/inttest/kubectl/kubectl_test.go
+++ b/inttest/kubectl/kubectl_test.go
@@ -211,8 +211,12 @@ func checkClientVersion(t *testing.T, v map[string]any) {
 }
 
 func checkServerVersion(t *testing.T, v map[string]any) {
+	expectedVersion := constant.KubernetesMajorMinorVersion
+	if constant.KubernetesPreRelease {
+		expectedVersion += "+"
+	}
 	assert.Equal(t,
-		constant.KubernetesMajorMinorVersion,
+		expectedVersion,
 		fmt.Sprintf("%v.%v", requiredValue[string](t, v, "major"), requiredValue[string](t, v, "minor")),
 	)
 	assert.Contains(t,

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -72,6 +72,8 @@ const (
 
 	// KubernetesMajorMinorVersion defines the current embedded major.minor version info
 	KubernetesMajorMinorVersion = "1.29"
+	// Indicates if k0s is using a Kubernetes pre-release or a GA version.
+	KubernetesPreRelease = false
 
 	/* Image Constants */
 


### PR DESCRIPTION
## Description

The pre-releases of Kubernetes have slightly different version strings than the GA versions. Add a simple boolean constant to allow CI to pass on pre-releases.

This constant might also get used in other integration tests to modify certain test assumptions.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings