### PR TITLE
Add integration tests around k0s reset

### DIFF
--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -54,6 +54,7 @@ smoketests := \
 	check-noderole-single \
 	check-openebs\
 	check-psp \
+	check-reset \
 	check-singlenode \
 	check-statussocket \
 	check-upgrade \

--- a/inttest/backup/backup_test.go
+++ b/inttest/backup/backup_test.go
@@ -96,8 +96,8 @@ func (s *BackupSuite) TestK0sGetsUp() {
 	s.Require().NoError(s.StopController(s.ControllerNode(0)))
 	_ = s.StopController(s.ControllerNode(1)) // No error check as k0s might have actually exited since etcd is not really happy
 
-	s.Require().NoError(s.Reset(s.ControllerNode(0)))
-	s.Require().NoError(s.Reset(s.ControllerNode(1)))
+	s.reset(s.ControllerNode(0))
+	s.reset(s.ControllerNode(1))
 
 	s.Require().NoError(s.restoreFunc())
 	s.Require().NoError(s.InitController(0, "--enable-worker"))
@@ -120,6 +120,13 @@ func (s *BackupSuite) TestK0sGetsUp() {
 	s.Require().Equal(snapshot, snapshotAfterBackup)
 
 	s.Require().NoError(s.VerifyFileSystemRestore())
+}
+
+func (s *BackupSuite) reset(name string) {
+	ssh, err := s.SSH(s.Context(), name)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+	s.Require().NoError(ssh.Exec(s.Context(), "k0s reset --debug", common.SSHStreams{}))
 }
 
 type snapshot struct {

--- a/inttest/common/bootloosesuite.go
+++ b/inttest/common/bootloosesuite.go
@@ -795,15 +795,6 @@ func (s *BootlooseSuite) StopWorker(name string) error {
 	return s.launchDelegate.StopWorker(s.Context(), ssh)
 }
 
-func (s *BootlooseSuite) Reset(name string) error {
-	ssh, err := s.SSH(s.Context(), name)
-	s.Require().NoError(err)
-	defer ssh.Disconnect()
-	resetCommand := fmt.Sprintf("%s reset --debug", s.K0sFullPath)
-	_, err = ssh.ExecWithOutput(s.Context(), resetCommand)
-	return err
-}
-
 // KubeClient return kube client by loading the admin access config from given node
 func (s *BootlooseSuite) GetKubeConfig(node string, k0sKubeconfigArgs ...string) (*rest.Config, error) {
 	machine, err := s.MachineForName(node)

--- a/inttest/common/ssh.go
+++ b/inttest/common/ssh.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"testing"
 
 	"github.com/mitchellh/go-homedir"
 	"golang.org/x/crypto/ssh"
@@ -190,6 +191,16 @@ func (c *SSHConnection) Exec(ctx context.Context, cmd string, streams SSHStreams
 
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+// Returns SSH streams that log lines to the test log.
+func TestLogStreams(t *testing.T, prefix string) (_ SSHStreams, flush func()) {
+	out := LineWriter{WriteLine: func(line []byte) { t.Logf("%s stdout: %s", prefix, string(line)) }}
+	err := LineWriter{WriteLine: func(line []byte) { t.Logf("%s stderr: %s", prefix, string(line)) }}
+	return SSHStreams{Out: &out, Err: &err}, func() {
+		out.Flush()
+		err.Flush()
 	}
 }
 

--- a/inttest/reset/reset_test.go
+++ b/inttest/reset/reset_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reset
+
+import (
+	"testing"
+
+	testifysuite "github.com/stretchr/testify/suite"
+
+	"github.com/k0sproject/k0s/inttest/common"
+)
+
+type suite struct {
+	common.BootlooseSuite
+}
+
+func (s *suite) TestReset() {
+	ctx := s.Context()
+	workerNode := s.WorkerNode(0)
+
+	if ok := s.Run("k0s gets up", func() {
+		s.Require().NoError(s.InitController(0, "--disable-components=konnectivity-server,metrics-server"))
+		s.Require().NoError(s.RunWorkers())
+
+		kc, err := s.KubeClient(s.ControllerNode(0))
+		s.Require().NoError(err)
+
+		err = s.WaitForNodeReady(workerNode, kc)
+		s.NoError(err)
+
+		s.T().Log("waiting to see CNI pods ready")
+		s.NoError(common.WaitForKubeRouterReady(ctx, kc), "CNI did not start")
+	}); !ok {
+		return
+	}
+
+	s.Run("k0s reset", func() {
+		ssh, err := s.SSH(ctx, workerNode)
+		s.Require().NoError(err)
+		defer ssh.Disconnect()
+
+		s.NoError(ssh.Exec(ctx, "test -d /var/lib/k0s", common.SSHStreams{}), "/var/lib/k0s is not a directory")
+		s.NoError(ssh.Exec(ctx, "test -d /run/k0s", common.SSHStreams{}), "/run/k0s is not a directory")
+
+		s.NoError(ssh.Exec(ctx, "pidof containerd-shim-runc-v2 >&2", common.SSHStreams{}), "Expected some running containerd shims")
+
+		s.NoError(s.StopWorker(workerNode), "Failed to stop k0s")
+
+		streams, flushStreams := common.TestLogStreams(s.T(), "reset")
+		err = ssh.Exec(ctx, "k0s reset --debug", streams)
+		flushStreams()
+		s.NoError(err, "k0s reset didn't exit cleanly")
+
+		// /var/lib/k0s is a mount point in the Docker container and can't be deleted, so it must be empty
+		s.NoError(ssh.Exec(ctx, `x="$(ls -A /var/lib/k0s)" && echo "$x" >&2 && [ -z "$x" ]`, common.SSHStreams{}), "/var/lib/k0s is not empty")
+		s.NoError(ssh.Exec(ctx, "! test -e /run/k0s", common.SSHStreams{}), "/run/k0s still exists")
+		s.NoError(ssh.Exec(ctx, "! pidof containerd-shim-runc-v2 >&2", common.SSHStreams{}), "Expected no running containerd shims")
+	})
+}
+
+func TestResetSuite(t *testing.T) {
+	testifysuite.Run(t, &suite{
+		common.BootlooseSuite{
+			ControllerCount: 1,
+			WorkerCount:     1,
+		},
+	})
+}


### PR DESCRIPTION
## Description

Have a "full-fledged" integration test called reset which should cover all aspects of k0s reset for the default CRI. Also add a check to byocri to verify that k0s reset terminates the Docker containers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings