### PR TITLE
Rework users.GetUID

### DIFF
--- a/cmd/controller/certificates.go
+++ b/cmd/controller/certificates.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 
 	"github.com/k0sproject/k0s/internal/pkg/file"
+	"github.com/k0sproject/k0s/internal/pkg/users"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/certificate"
 	"github.com/k0sproject/k0s/pkg/config"
@@ -65,6 +66,13 @@ func (c *Certificates) Init(ctx context.Context) error {
 	c.CACert = string(cert)
 	// Changing the URL here also requires changes in the "k0s kubeconfig admin" subcommand.
 	kubeConfigAPIUrl := fmt.Sprintf("https://localhost:%d", c.ClusterSpec.API.Port)
+
+	apiServerUID, err := users.GetUID(constant.ApiserverUser)
+	if err != nil {
+		apiServerUID = users.RootUID
+		logrus.WithError(err).Warn("Files with key material for kube-apiserver user will be owned by root")
+	}
+
 	eg.Go(func() error {
 		// Front proxy CA
 		if err := c.CertManager.EnsureCA("front-proxy-ca", "kubernetes-front-proxy-ca"); err != nil {
@@ -80,7 +88,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 			CACert: proxyCertPath,
 			CAKey:  proxyCertKey,
 		}
-		_, err := c.CertManager.EnsureCertificate(proxyClientReq, constant.ApiserverUser)
+		_, err := c.CertManager.EnsureCertificate(proxyClientReq, apiServerUID)
 
 		return err
 	})
@@ -94,16 +102,16 @@ func (c *Certificates) Init(ctx context.Context) error {
 			CACert: caCertPath,
 			CAKey:  caCertKey,
 		}
-		adminCert, err := c.CertManager.EnsureCertificate(adminReq, "root")
+		adminCert, err := c.CertManager.EnsureCertificate(adminReq, users.RootUID)
 		if err != nil {
 			return err
 		}
 
-		if err := kubeConfig(c.K0sVars.AdminKubeConfigPath, kubeConfigAPIUrl, c.CACert, adminCert.Cert, adminCert.Key, "root"); err != nil {
+		if err := kubeConfig(c.K0sVars.AdminKubeConfigPath, kubeConfigAPIUrl, c.CACert, adminCert.Cert, adminCert.Key, users.RootUID); err != nil {
 			return err
 		}
 
-		return c.CertManager.CreateKeyPair("sa", c.K0sVars, constant.ApiserverUser)
+		return c.CertManager.CreateKeyPair("sa", c.K0sVars, apiServerUID)
 	})
 
 	eg.Go(func() error {
@@ -115,11 +123,19 @@ func (c *Certificates) Init(ctx context.Context) error {
 			CACert: caCertPath,
 			CAKey:  caCertKey,
 		}
-		konnectivityCert, err := c.CertManager.EnsureCertificate(konnectivityReq, constant.KonnectivityServerUser)
+
+		uid, err := users.GetUID(constant.KonnectivityServerUser)
+		if err != nil {
+			uid = users.RootUID
+			logrus.WithError(err).Warn("Files with key material for konnectivity-server user will be owned by root")
+		}
+
+		konnectivityCert, err := c.CertManager.EnsureCertificate(konnectivityReq, uid)
 		if err != nil {
 			return err
 		}
-		return kubeConfig(c.K0sVars.KonnectivityKubeConfigPath, kubeConfigAPIUrl, c.CACert, konnectivityCert.Cert, konnectivityCert.Key, constant.KonnectivityServerUser)
+
+		return kubeConfig(c.K0sVars.KonnectivityKubeConfigPath, kubeConfigAPIUrl, c.CACert, konnectivityCert.Cert, konnectivityCert.Key, uid)
 	})
 
 	eg.Go(func() error {
@@ -130,12 +146,12 @@ func (c *Certificates) Init(ctx context.Context) error {
 			CACert: caCertPath,
 			CAKey:  caCertKey,
 		}
-		ccmCert, err := c.CertManager.EnsureCertificate(ccmReq, constant.ApiserverUser)
+		ccmCert, err := c.CertManager.EnsureCertificate(ccmReq, apiServerUID)
 		if err != nil {
 			return err
 		}
 
-		return kubeConfig(filepath.Join(c.K0sVars.CertRootDir, "ccm.conf"), kubeConfigAPIUrl, c.CACert, ccmCert.Cert, ccmCert.Key, constant.ApiserverUser)
+		return kubeConfig(filepath.Join(c.K0sVars.CertRootDir, "ccm.conf"), kubeConfigAPIUrl, c.CACert, ccmCert.Cert, ccmCert.Key, apiServerUID)
 	})
 
 	eg.Go(func() error {
@@ -146,12 +162,19 @@ func (c *Certificates) Init(ctx context.Context) error {
 			CACert: caCertPath,
 			CAKey:  caCertKey,
 		}
-		schedulerCert, err := c.CertManager.EnsureCertificate(schedulerReq, constant.SchedulerUser)
+
+		uid, err := users.GetUID(constant.SchedulerUser)
+		if err != nil {
+			uid = users.RootUID
+			logrus.WithError(err).Warn("Files with key material for kube-scheduler user will be owned by root")
+		}
+
+		schedulerCert, err := c.CertManager.EnsureCertificate(schedulerReq, uid)
 		if err != nil {
 			return err
 		}
 
-		return kubeConfig(filepath.Join(c.K0sVars.CertRootDir, "scheduler.conf"), kubeConfigAPIUrl, c.CACert, schedulerCert.Cert, schedulerCert.Key, constant.SchedulerUser)
+		return kubeConfig(filepath.Join(c.K0sVars.CertRootDir, "scheduler.conf"), kubeConfigAPIUrl, c.CACert, schedulerCert.Cert, schedulerCert.Key, uid)
 	})
 
 	eg.Go(func() error {
@@ -162,7 +185,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 			CACert: caCertPath,
 			CAKey:  caCertKey,
 		}
-		_, err := c.CertManager.EnsureCertificate(kubeletClientReq, constant.ApiserverUser)
+		_, err := c.CertManager.EnsureCertificate(kubeletClientReq, apiServerUID)
 		return err
 	})
 
@@ -212,8 +235,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 			CAKey:     caCertKey,
 			Hostnames: hostnames,
 		}
-		_, err = c.CertManager.EnsureCertificate(serverReq, constant.ApiserverUser)
-
+		_, err = c.CertManager.EnsureCertificate(serverReq, apiServerUID)
 		return err
 	})
 
@@ -227,7 +249,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 			Hostnames: hostnames,
 		}
 		// TODO Not sure about the user...
-		_, err := c.CertManager.EnsureCertificate(apiReq, constant.ApiserverUser)
+		_, err := c.CertManager.EnsureCertificate(apiReq, apiServerUID)
 		return err
 	})
 
@@ -262,7 +284,7 @@ func detectLocalIPs(ctx context.Context) ([]string, error) {
 	return localIPs, nil
 }
 
-func kubeConfig(dest, url, caCert, clientCert, clientKey, owner string) error {
+func kubeConfig(dest, url, caCert, clientCert, clientKey string, ownerID int) error {
 	// We always overwrite the kubeconfigs as the certs might be regenerated at startup
 	const (
 		clusterName = "local"
@@ -295,5 +317,5 @@ func kubeConfig(dest, url, caCert, clientCert, clientKey, owner string) error {
 		return err
 	}
 
-	return file.Chown(dest, owner, constant.CertSecureMode)
+	return file.Chown(dest, ownerID, constant.CertSecureMode)
 }

--- a/cmd/controller/certificates.go
+++ b/cmd/controller/certificates.go
@@ -67,7 +67,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 	// Changing the URL here also requires changes in the "k0s kubeconfig admin" subcommand.
 	kubeConfigAPIUrl := fmt.Sprintf("https://localhost:%d", c.ClusterSpec.API.Port)
 
-	apiServerUID, err := users.GetUID(constant.ApiserverUser)
+	apiServerUID, err := users.LookupUID(constant.ApiserverUser)
 	if err != nil {
 		apiServerUID = users.RootUID
 		logrus.WithError(err).Warn("Files with key material for kube-apiserver user will be owned by root")
@@ -124,7 +124,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 			CAKey:  caCertKey,
 		}
 
-		uid, err := users.GetUID(constant.KonnectivityServerUser)
+		uid, err := users.LookupUID(constant.KonnectivityServerUser)
 		if err != nil {
 			uid = users.RootUID
 			logrus.WithError(err).Warn("Files with key material for konnectivity-server user will be owned by root")
@@ -163,7 +163,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 			CAKey:  caCertKey,
 		}
 
-		uid, err := users.GetUID(constant.SchedulerUser)
+		uid, err := users.LookupUID(constant.SchedulerUser)
 		if err != nil {
 			uid = users.RootUID
 			logrus.WithError(err).Warn("Files with key material for kube-scheduler user will be owned by root")

--- a/cmd/controller/certificates.go
+++ b/cmd/controller/certificates.go
@@ -69,6 +69,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 
 	apiServerUID, err := users.LookupUID(constant.ApiserverUser)
 	if err != nil {
+		err = fmt.Errorf("failed to lookup UID for %q: %w", constant.ApiserverUser, err)
 		apiServerUID = users.RootUID
 		logrus.WithError(err).Warn("Files with key material for kube-apiserver user will be owned by root")
 	}
@@ -126,6 +127,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 
 		uid, err := users.LookupUID(constant.KonnectivityServerUser)
 		if err != nil {
+			err = fmt.Errorf("failed to lookup UID for %q: %w", constant.KonnectivityServerUser, err)
 			uid = users.RootUID
 			logrus.WithError(err).Warn("Files with key material for konnectivity-server user will be owned by root")
 		}
@@ -165,6 +167,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 
 		uid, err := users.LookupUID(constant.SchedulerUser)
 		if err != nil {
+			err = fmt.Errorf("failed to lookup UID for %q: %w", constant.SchedulerUser, err)
 			uid = users.RootUID
 			logrus.WithError(err).Warn("Files with key material for kube-scheduler user will be owned by root")
 		}

--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/k0sproject/k0s/internal/pkg/users"
 	"github.com/k0sproject/k0s/pkg/certificate"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/sirupsen/logrus"
@@ -104,7 +105,7 @@ Note: A certificate once signed cannot be revoked for a particular user`,
 			certManager := certificate.Manager{
 				K0sVars: opts.K0sVars,
 			}
-			userCert, err := certManager.EnsureCertificate(userReq, "root")
+			userCert, err := certManager.EnsureCertificate(userReq, users.RootUID)
 			if err != nil {
 				return err
 			}

--- a/cmd/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeconfig/kubeconfig_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/k0sproject/k0s/internal/pkg/users"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/certificate"
 	"github.com/k0sproject/k0s/pkg/config"
@@ -118,7 +119,7 @@ yJm2KSue0toWmkBFK8WMTjAvmAw3Z/qUhJRKoqCu3k6Mf8DNl6t+Uw==
 
 	s.Require().NoError(os.MkdirAll(k0sVars.CertRootDir, 0755))
 
-	userCert, err := certManager.EnsureCertificate(userReq, "root")
+	userCert, err := certManager.EnsureCertificate(userReq, users.RootUID)
 	s.Require().NoError(err)
 	clusterAPIURL := cfg.Spec.API.APIAddressURL()
 

--- a/docs/external-runtime-deps.md
+++ b/docs/external-runtime-deps.md
@@ -204,8 +204,8 @@ are not detected.
 
 #### id
 
-External `/usr/bin/id` will be executed as a fallback if local user lookup
-fails, in case NSS is used.
+External `id` will be executed as a fallback if local user lookup fails, in case
+NSS is used.
 
 ## Windows specific
 <!--

--- a/internal/pkg/file/file.go
+++ b/internal/pkg/file/file.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-
-	"github.com/k0sproject/k0s/internal/pkg/users"
 )
 
 // Exists checks if a file exists and is not a directory before we
@@ -36,9 +34,8 @@ func Exists(fileName string) bool {
 }
 
 // Chown changes file/dir mode
-func Chown(file, owner string, permissions os.FileMode) error {
+func Chown(file string, uid int, permissions os.FileMode) error {
 	// Chown the file properly for the owner
-	uid, _ := users.GetUID(owner)
 	err := os.Chown(file, uid, -1)
 	if err != nil && os.Geteuid() == 0 {
 		return err

--- a/internal/pkg/users/users.go
+++ b/internal/pkg/users/users.go
@@ -38,9 +38,11 @@ const (
 	RootUID = 0 // User ID of the root user
 )
 
+var ErrNotExist = errors.New("user does not exist")
+
 // Lookup looks up a user's UID by username. If the user cannot be found, the
-// returned error is of type [user.UnknownUserError]. If an error is returned,
-// the returned UID will be [UnknownUID].
+// returned error is [ErrNotExist]. If an error is returned, the returned UID
+// will be [UnknownUID].
 func LookupUID(name string) (int, error) {
 	var uid string
 
@@ -48,6 +50,8 @@ func LookupUID(name string) (int, error) {
 		if !errors.Is(err, user.UnknownUserError(name)) {
 			return UnknownUID, err
 		}
+
+		err = ErrNotExist
 
 		// fallback to call external `id` in case NSS is used
 		out, idErr := exec.Command("id", "-u", name).Output()

--- a/internal/pkg/users/users.go
+++ b/internal/pkg/users/users.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 )
 
+const RootUID = 0 // User ID of the root user
+
 // GetUID returns uid of given username and logs a warning if its missing
 func GetUID(name string) (int, error) {
 	entry, err := user.Lookup(name)

--- a/internal/pkg/users/users.go
+++ b/internal/pkg/users/users.go
@@ -27,8 +27,8 @@ import (
 
 const RootUID = 0 // User ID of the root user
 
-// GetUID returns uid of given username and logs a warning if its missing
-func GetUID(name string) (int, error) {
+// LookupUID returns uid of given username and logs a warning if its missing
+func LookupUID(name string) (int, error) {
 	var uid string
 
 	if entry, err := user.Lookup(name); err != nil {

--- a/internal/pkg/users/users.go
+++ b/internal/pkg/users/users.go
@@ -37,7 +37,7 @@ func GetUID(name string) (int, error) {
 		}
 
 		// fallback to call external `id` in case NSS is used
-		out, idErr := exec.Command("/usr/bin/id", "-u", name).Output()
+		out, idErr := exec.Command("id", "-u", name).Output()
 		if idErr != nil {
 			var exitErr *exec.ExitError
 			if errors.As(idErr, &exitErr) {

--- a/internal/pkg/users/users_test.go
+++ b/internal/pkg/users/users_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package users
 
 import (
+	"os/user"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetUID(t *testing.T) {
@@ -27,15 +30,13 @@ func TestGetUID(t *testing.T) {
 	}
 
 	uid, err := GetUID("root")
-	if err != nil {
-		t.Errorf("failed to find uid for root: %v", err)
-	}
-	if uid != 0 {
-		t.Errorf("root uid is not 0. It is %d", uid)
+	if assert.NoError(t, err, "Failed to get UID for root user") {
+		assert.Equal(t, 0, uid, "root's UID is not 0?")
 	}
 
 	uid, err = GetUID("some-non-existing-user")
-	if err == nil {
-		t.Errorf("unexpectedly got uid for some-non-existing-user: %d", uid)
+	if assert.Error(t, err, "Got a UID for some-non-existing-user?") {
+		assert.ErrorIs(t, err, user.UnknownUserError("some-non-existing-user"))
+		assert.Zero(t, uid)
 	}
 }

--- a/internal/pkg/users/users_test.go
+++ b/internal/pkg/users/users_test.go
@@ -18,7 +18,6 @@ package users
 
 import (
 	"os/exec"
-	"os/user"
 	"runtime"
 	"testing"
 
@@ -37,7 +36,7 @@ func TestGetUID(t *testing.T) {
 
 	uid, err = LookupUID("some-non-existing-user")
 	if assert.Error(t, err, "Got a UID for some-non-existing-user?") {
-		assert.ErrorIs(t, err, user.UnknownUserError("some-non-existing-user"))
+		assert.ErrorIs(t, err, ErrNotExist)
 		var exitErr *exec.ExitError
 		assert.ErrorAs(t, err, &exitErr, "expected external `id` to return an error")
 		assert.Equal(t, UnknownUID, uid)

--- a/internal/pkg/users/users_test.go
+++ b/internal/pkg/users/users_test.go
@@ -40,6 +40,6 @@ func TestGetUID(t *testing.T) {
 		assert.ErrorIs(t, err, user.UnknownUserError("some-non-existing-user"))
 		var exitErr *exec.ExitError
 		assert.ErrorAs(t, err, &exitErr, "expected external `id` to return an error")
-		assert.Zero(t, uid)
+		assert.Equal(t, UnknownUID, uid)
 	}
 }

--- a/internal/pkg/users/users_test.go
+++ b/internal/pkg/users/users_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package users
 
 import (
+	"os/exec"
 	"os/user"
 	"runtime"
 	"testing"
@@ -37,6 +38,8 @@ func TestGetUID(t *testing.T) {
 	uid, err = GetUID("some-non-existing-user")
 	if assert.Error(t, err, "Got a UID for some-non-existing-user?") {
 		assert.ErrorIs(t, err, user.UnknownUserError("some-non-existing-user"))
+		var exitErr *exec.ExitError
+		assert.ErrorAs(t, err, &exitErr, "expected external `id` to return an error")
 		assert.Zero(t, uid)
 	}
 }

--- a/internal/pkg/users/users_test.go
+++ b/internal/pkg/users/users_test.go
@@ -30,12 +30,12 @@ func TestGetUID(t *testing.T) {
 		t.Skip("No numeric user IDs on Windows")
 	}
 
-	uid, err := GetUID("root")
+	uid, err := LookupUID("root")
 	if assert.NoError(t, err, "Failed to get UID for root user") {
 		assert.Equal(t, 0, uid, "root's UID is not 0?")
 	}
 
-	uid, err = GetUID("some-non-existing-user")
+	uid, err = LookupUID("some-non-existing-user")
 	if assert.Error(t, err, "Got a UID for some-non-existing-user?") {
 		assert.ErrorIs(t, err, user.UnknownUserError("some-non-existing-user"))
 		var exitErr *exec.ExitError

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -90,7 +90,8 @@ func (a *APIServer) Init(_ context.Context) error {
 	var err error
 	a.uid, err = users.GetUID(constant.ApiserverUser)
 	if err != nil {
-		logrus.Warn("running kube-apiserver as root: ", err)
+		a.uid = users.RootUID
+		logrus.WithError(err).Warn("Running Kubernetes API server as root")
 	}
 	return assets.Stage(a.K0sVars.BinDir, kubeAPIComponentName, constant.BinDirMode)
 }

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -88,7 +88,7 @@ type egressSelectorConfig struct {
 // Init extracts needed binaries
 func (a *APIServer) Init(_ context.Context) error {
 	var err error
-	a.uid, err = users.GetUID(constant.ApiserverUser)
+	a.uid, err = users.LookupUID(constant.ApiserverUser)
 	if err != nil {
 		a.uid = users.RootUID
 		logrus.WithError(err).Warn("Running Kubernetes API server as root")

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -90,6 +90,7 @@ func (a *APIServer) Init(_ context.Context) error {
 	var err error
 	a.uid, err = users.LookupUID(constant.ApiserverUser)
 	if err != nil {
+		err = fmt.Errorf("failed to lookup UID for %q: %w", constant.ApiserverUser, err)
 		a.uid = users.RootUID
 		logrus.WithError(err).Warn("Running Kubernetes API server as root")
 	}

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -67,7 +67,7 @@ var _ manager.Reconciler = (*Manager)(nil)
 func (a *Manager) Init(_ context.Context) error {
 	var err error
 	// controller manager running as api-server user as they both need access to same sa.key
-	a.uid, err = users.GetUID(constant.ApiserverUser)
+	a.uid, err = users.LookupUID(constant.ApiserverUser)
 	if err != nil {
 		a.uid = users.RootUID
 		logrus.WithError(err).Warn("Running Kubernetes controller manager as root")

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -69,7 +69,8 @@ func (a *Manager) Init(_ context.Context) error {
 	// controller manager running as api-server user as they both need access to same sa.key
 	a.uid, err = users.GetUID(constant.ApiserverUser)
 	if err != nil {
-		logrus.Warn("running kube-controller-manager as root: ", err)
+		a.uid = users.RootUID
+		logrus.WithError(err).Warn("Running Kubernetes controller manager as root")
 	}
 
 	// controller manager should be the only component that needs access to

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -69,6 +70,7 @@ func (a *Manager) Init(_ context.Context) error {
 	// controller manager running as api-server user as they both need access to same sa.key
 	a.uid, err = users.LookupUID(constant.ApiserverUser)
 	if err != nil {
+		err = fmt.Errorf("failed to lookup UID for %q: %w", constant.ApiserverUser, err)
 		a.uid = users.RootUID
 		logrus.WithError(err).Warn("Running Kubernetes controller manager as root")
 	}

--- a/pkg/component/controller/cplb_unix.go
+++ b/pkg/component/controller/cplb_unix.go
@@ -69,6 +69,7 @@ func (k *Keepalived) Init(_ context.Context) error {
 	var err error
 	k.uid, err = users.LookupUID(constant.KeepalivedUser)
 	if err != nil {
+		err = fmt.Errorf("failed to lookup UID for %q: %w", constant.KeepalivedUser, err)
 		k.uid = users.RootUID
 		k.log.WithError(err).Warn("Running keepalived as root")
 	}

--- a/pkg/component/controller/cplb_unix.go
+++ b/pkg/component/controller/cplb_unix.go
@@ -69,7 +69,8 @@ func (k *Keepalived) Init(_ context.Context) error {
 	var err error
 	k.uid, err = users.GetUID(constant.KeepalivedUser)
 	if err != nil {
-		k.log.Warnf("Unable to get %s UID running keepalived as root: %v", constant.KeepalivedUser, err)
+		k.uid = users.RootUID
+		k.log.WithError(err).Warn("Running keepalived as root")
 	}
 
 	k.configFilePath = filepath.Join(k.K0sVars.RunDir, "keepalived.conf")

--- a/pkg/component/controller/cplb_unix.go
+++ b/pkg/component/controller/cplb_unix.go
@@ -67,7 +67,7 @@ func (k *Keepalived) Init(_ context.Context) error {
 	k.log = logrus.WithField("component", "CPLB")
 
 	var err error
-	k.uid, err = users.GetUID(constant.KeepalivedUser)
+	k.uid, err = users.LookupUID(constant.KeepalivedUser)
 	if err != nil {
 		k.uid = users.RootUID
 		k.log.WithError(err).Warn("Running keepalived as root")

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -69,7 +69,7 @@ func (e *Etcd) Init(_ context.Context) error {
 		return fmt.Errorf("missing environment variable: %w", err)
 	}
 
-	e.uid, err = users.GetUID(constant.EtcdUser)
+	e.uid, err = users.LookupUID(constant.EtcdUser)
 	if err != nil {
 		e.uid = users.RootUID
 		logrus.WithError(err).Warn("Running etcd as root")
@@ -264,7 +264,7 @@ func (e *Etcd) setupCerts(ctx context.Context) error {
 		return fmt.Errorf("failed to create etcd ca: %w", err)
 	}
 
-	etcdUID, err := users.GetUID(constant.EtcdUser)
+	etcdUID, err := users.LookupUID(constant.EtcdUser)
 	if err != nil {
 		etcdUID = users.RootUID
 		logrus.WithError(err).Warn("Files with key material for etcd user will be owned by root")
@@ -286,7 +286,7 @@ func (e *Etcd) setupCerts(ctx context.Context) error {
 			},
 		}
 
-		uid, err := users.GetUID(constant.ApiserverUser)
+		uid, err := users.LookupUID(constant.ApiserverUser)
 		if err != nil {
 			uid = users.RootUID
 			logrus.WithError(err).Warn("Files with key material for kube-apiserver user will be owned by root")

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -71,6 +71,7 @@ func (e *Etcd) Init(_ context.Context) error {
 
 	e.uid, err = users.LookupUID(constant.EtcdUser)
 	if err != nil {
+		err = fmt.Errorf("failed to lookup UID for %q: %w", constant.EtcdUser, err)
 		e.uid = users.RootUID
 		logrus.WithError(err).Warn("Running etcd as root, files with key material for etcd user will be owned by root")
 	}
@@ -282,6 +283,7 @@ func (e *Etcd) setupCerts(ctx context.Context) error {
 
 		uid, err := users.LookupUID(constant.ApiserverUser)
 		if err != nil {
+			err = fmt.Errorf("failed to lookup UID for %q: %w", constant.ApiserverUser, err)
 			uid = users.RootUID
 			logrus.WithError(err).Warn("Files with key material for kube-apiserver user will be owned by root")
 		}

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -60,7 +60,8 @@ func (k *Kine) Init(_ context.Context) error {
 	var err error
 	k.uid, err = users.GetUID(constant.KineUser)
 	if err != nil {
-		logrus.Warn("running kine as root: ", err)
+		k.uid = users.RootUID
+		logrus.WithError(err).Warn("Running kine as root")
 	}
 
 	kineSocketDir := filepath.Dir(k.K0sVars.KineSocketPath)

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -60,6 +60,7 @@ func (k *Kine) Init(_ context.Context) error {
 	var err error
 	k.uid, err = users.LookupUID(constant.KineUser)
 	if err != nil {
+		err = fmt.Errorf("failed to lookup UID for %q: %w", constant.KineUser, err)
 		k.uid = users.RootUID
 		logrus.WithError(err).Warn("Running kine as root")
 	}

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -58,7 +58,7 @@ var _ manager.Ready = (*Kine)(nil)
 func (k *Kine) Init(_ context.Context) error {
 	logrus.Infof("initializing kine")
 	var err error
-	k.uid, err = users.GetUID(constant.KineUser)
+	k.uid, err = users.LookupUID(constant.KineUser)
 	if err != nil {
 		k.uid = users.RootUID
 		logrus.WithError(err).Warn("Running kine as root")

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -66,8 +66,9 @@ func (k *Konnectivity) Init(ctx context.Context) error {
 	var err error
 	k.uid, err = users.GetUID(constant.KonnectivityServerUser)
 	if err != nil {
+		k.uid = users.RootUID
 		k.EmitWithPayload("error getting UID for", err)
-		logrus.Warn("running konnectivity as root: ", err)
+		logrus.WithError(err).Warn("Running konnectivity as root")
 	}
 	err = dir.Init(k.K0sVars.KonnectivitySocketDir, 0755)
 	if err != nil {

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -64,7 +64,7 @@ var _ prober.Healthz = (*Konnectivity)(nil)
 // Init ...
 func (k *Konnectivity) Init(ctx context.Context) error {
 	var err error
-	k.uid, err = users.GetUID(constant.KonnectivityServerUser)
+	k.uid, err = users.LookupUID(constant.KonnectivityServerUser)
 	if err != nil {
 		k.uid = users.RootUID
 		k.EmitWithPayload("error getting UID for", err)

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -66,6 +66,7 @@ func (k *Konnectivity) Init(ctx context.Context) error {
 	var err error
 	k.uid, err = users.LookupUID(constant.KonnectivityServerUser)
 	if err != nil {
+		err = fmt.Errorf("failed to lookup UID for %q: %w", constant.KonnectivityServerUser, err)
 		k.uid = users.RootUID
 		k.EmitWithPayload("error getting UID for", err)
 		logrus.WithError(err).Warn("Running konnectivity as root")

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -51,7 +51,7 @@ const kubeSchedulerComponentName = "kube-scheduler"
 // Init extracts the needed binaries
 func (a *Scheduler) Init(_ context.Context) error {
 	var err error
-	a.uid, err = users.GetUID(constant.SchedulerUser)
+	a.uid, err = users.LookupUID(constant.SchedulerUser)
 	if err != nil {
 		a.uid = users.RootUID
 		logrus.WithError(err).Warn("Running kube-scheduler as root")

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
@@ -53,6 +54,7 @@ func (a *Scheduler) Init(_ context.Context) error {
 	var err error
 	a.uid, err = users.LookupUID(constant.SchedulerUser)
 	if err != nil {
+		err = fmt.Errorf("failed to lookup UID for %q: %w", constant.SchedulerUser, err)
 		a.uid = users.RootUID
 		logrus.WithError(err).Warn("Running kube-scheduler as root")
 	}

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -53,7 +53,8 @@ func (a *Scheduler) Init(_ context.Context) error {
 	var err error
 	a.uid, err = users.GetUID(constant.SchedulerUser)
 	if err != nil {
-		logrus.Warn("running kube-scheduler as root: ", err)
+		a.uid = users.RootUID
+		logrus.WithError(err).Warn("Running kube-scheduler as root")
 	}
 	return assets.Stage(a.K0sVars.BinDir, kubeSchedulerComponentName, constant.BinDirMode)
 }

--- a/pkg/install/users.go
+++ b/pkg/install/users.go
@@ -19,7 +19,6 @@ package install
 import (
 	"errors"
 	"os/exec"
-	"os/user"
 	"slices"
 
 	"github.com/sirupsen/logrus"
@@ -35,7 +34,7 @@ func EnsureControllerUsers(systemUsers *v1beta1.SystemUser, homeDir string) erro
 	var errs []error
 	for _, userName := range getControllerUserNames(systemUsers) {
 		_, err := users.LookupUID(userName)
-		if errors.Is(err, user.UnknownUserError(userName)) {
+		if errors.Is(err, users.ErrNotExist) {
 			if shell == "" {
 				shell, err = nologinShell()
 				if err != nil {

--- a/pkg/install/users.go
+++ b/pkg/install/users.go
@@ -34,7 +34,7 @@ func EnsureControllerUsers(systemUsers *v1beta1.SystemUser, homeDir string) erro
 	var shell string
 	var errs []error
 	for _, userName := range getControllerUserNames(systemUsers) {
-		_, err := users.GetUID(userName)
+		_, err := users.LookupUID(userName)
 		if errors.Is(err, user.UnknownUserError(userName)) {
 			if shell == "" {
 				shell, err = nologinShell()
@@ -60,7 +60,7 @@ func EnsureControllerUsers(systemUsers *v1beta1.SystemUser, homeDir string) erro
 func DeleteControllerUsers(systemUsers *v1beta1.SystemUser) error {
 	var errs []error
 	for _, userName := range getControllerUserNames(systemUsers) {
-		if _, err := users.GetUID(userName); err == nil {
+		if _, err := users.LookupUID(userName); err == nil {
 			logrus.Debugf("Deleting user %q", userName)
 
 			if err := deleteUser(userName); err != nil {


### PR DESCRIPTION
## Description

**Rename to LookupUID**
The new name more closely matches the standard library function name. Also, "lookup" sounds less lightweight than "get", which gives a better sense of the actual runtime cost.

**Explicit usage and fallback handling**
Prefer to call utility functions directly with a UID, rather than having them accept a username and call `LookupUID` internally. This allows for a more obvious fallback handling in case certain users don't exist. Add a special `RootUID` constant that can be used to explicitly fallback to the root user. Also add log statements to every fallback assignment. Use -1 as UID return value in case of errors. The zero value for a UID happens to be root's UID. Assuming root may or may not be a good default, depending on the use case. Setting file ownership to root is a restrictive and safe default, running programs as root is not. By returning `UnknownUID` as a constant to -1, callers must explicitly decide on the fallback instead of accidentally assuming root.

**Use id program from PATH**
The `id` program is not always installed to `/usr/bin`. Rely on k0s's `PATH` to find the right executable.

**More context for errors**
There are quite some failure modes. Sort them out by providing hopefully helpful error messages. This might help when debugging things. Introduce `users.ErrNotFound`, which makes the `errors.Is()` checks nicer. On the contrary, the error message won't contain the user name anymore. Wrap the error accordingly on the caller side instead.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings