### PR TITLE
Rework user installation functions

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -65,7 +65,9 @@ func (c *command) setup(role string, args []string, installFlags *installFlags) 
 	}
 
 	if role == "controller" {
-		if err := install.EnsureControllerUsers(nodeConfig, c.K0sVars); err != nil {
+		systemUsers := nodeConfig.Spec.Install.SystemUsers
+		homeDir := c.K0sVars.DataDir
+		if err := install.EnsureControllerUsers(systemUsers, homeDir); err != nil {
 			return fmt.Errorf("failed to create controller users: %w", err)
 		}
 	}

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -65,7 +65,7 @@ func (c *command) setup(role string, args []string, installFlags *installFlags) 
 	}
 
 	if role == "controller" {
-		if err := install.CreateControllerUsers(nodeConfig, c.K0sVars); err != nil {
+		if err := install.EnsureControllerUsers(nodeConfig, c.K0sVars); err != nil {
 			return fmt.Errorf("failed to create controller users: %w", err)
 		}
 	}

--- a/pkg/cleanup/users.go
+++ b/pkg/cleanup/users.go
@@ -36,7 +36,7 @@ func (u *users) Run() error {
 	if err != nil {
 		logrus.Errorf("failed to get cluster setup: %v", err)
 	}
-	if err := install.DeleteControllerUsers(cfg); err != nil {
+	if err := install.DeleteControllerUsers(cfg.Spec.Install.SystemUsers); err != nil {
 		// don't fail, just notify on delete error
 		logrus.Warnf("failed to delete controller users: %v", err)
 	}

--- a/pkg/install/users.go
+++ b/pkg/install/users.go
@@ -26,16 +26,14 @@ import (
 
 	"github.com/k0sproject/k0s/internal/pkg/users"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
-	"github.com/k0sproject/k0s/pkg/config"
 )
 
-// EnsureControllerUsers accepts a cluster config, and cfgVars and creates controller users accordingly
-func EnsureControllerUsers(clusterConfig *v1beta1.ClusterConfig, k0sVars *config.CfgVars) error {
-	homeDir := k0sVars.DataDir
-
+// Ensures that all controller users exist and creates any missing users with
+// the given home directory.
+func EnsureControllerUsers(systemUsers *v1beta1.SystemUser, homeDir string) error {
 	var shell string
 	var errs []error
-	for _, userName := range getControllerUserNames(clusterConfig.Spec.Install.SystemUsers) {
+	for _, userName := range getControllerUserNames(systemUsers) {
 		_, err := users.GetUID(userName)
 		if errors.Is(err, user.UnknownUserError(userName)) {
 			if shell == "" {
@@ -58,10 +56,10 @@ func EnsureControllerUsers(clusterConfig *v1beta1.ClusterConfig, k0sVars *config
 	return errors.Join(errs...)
 }
 
-// CreateControllerUsers accepts a cluster config, and cfgVars and creates controller users accordingly
-func DeleteControllerUsers(clusterConfig *v1beta1.ClusterConfig) error {
+// Deletes existing controller users.
+func DeleteControllerUsers(systemUsers *v1beta1.SystemUser) error {
 	var errs []error
-	for _, userName := range getControllerUserNames(clusterConfig.Spec.Install.SystemUsers) {
+	for _, userName := range getControllerUserNames(systemUsers) {
 		if _, err := users.GetUID(userName); err == nil {
 			logrus.Debugf("Deleting user %q", userName)
 

--- a/pkg/install/users.go
+++ b/pkg/install/users.go
@@ -29,8 +29,8 @@ import (
 	"github.com/k0sproject/k0s/pkg/config"
 )
 
-// CreateControllerUsers accepts a cluster config, and cfgVars and creates controller users accordingly
-func CreateControllerUsers(clusterConfig *v1beta1.ClusterConfig, k0sVars *config.CfgVars) error {
+// EnsureControllerUsers accepts a cluster config, and cfgVars and creates controller users accordingly
+func EnsureControllerUsers(clusterConfig *v1beta1.ClusterConfig, k0sVars *config.CfgVars) error {
 	var errs []error
 	for _, userName := range getControllerUserNames(clusterConfig.Spec.Install.SystemUsers) {
 		if err := EnsureUser(userName, k0sVars.DataDir); err != nil {

--- a/pkg/install/users.go
+++ b/pkg/install/users.go
@@ -32,10 +32,6 @@ import (
 	"github.com/k0sproject/k0s/pkg/config"
 )
 
-func GetControllerUsers(clusterConfig *v1beta1.ClusterConfig) []string {
-	return getUserList(*clusterConfig.Spec.Install.SystemUsers)
-}
-
 // CreateControllerUsers accepts a cluster config, and cfgVars and creates controller users accordingly
 func CreateControllerUsers(clusterConfig *v1beta1.ClusterConfig, k0sVars *config.CfgVars) error {
 	users := getUserList(*clusterConfig.Spec.Install.SystemUsers)

--- a/pkg/install/users.go
+++ b/pkg/install/users.go
@@ -33,10 +33,9 @@ import (
 
 // CreateControllerUsers accepts a cluster config, and cfgVars and creates controller users accordingly
 func CreateControllerUsers(clusterConfig *v1beta1.ClusterConfig, k0sVars *config.CfgVars) error {
-	users := getUserNames(clusterConfig.Spec.Install.SystemUsers)
 	var messages []string
-	for _, v := range users {
-		if err := EnsureUser(v, k0sVars.DataDir); err != nil {
+	for _, userName := range getControllerUserNames(clusterConfig.Spec.Install.SystemUsers) {
+		if err := EnsureUser(userName, k0sVars.DataDir); err != nil {
 			messages = append(messages, err.Error())
 		}
 	}
@@ -48,13 +47,12 @@ func CreateControllerUsers(clusterConfig *v1beta1.ClusterConfig, k0sVars *config
 
 // CreateControllerUsers accepts a cluster config, and cfgVars and creates controller users accordingly
 func DeleteControllerUsers(clusterConfig *v1beta1.ClusterConfig) error {
-	cfgUsers := getUserNames(clusterConfig.Spec.Install.SystemUsers)
 	var messages []string
-	for _, v := range cfgUsers {
-		if _, err := users.GetUID(v); err == nil {
-			logrus.Debugf("deleting user: %s", v)
+	for _, userName := range getControllerUserNames(clusterConfig.Spec.Install.SystemUsers) {
+		if _, err := users.GetUID(userName); err == nil {
+			logrus.Debugf("deleting user: %s", userName)
 
-			if err := deleteUser(v); err != nil {
+			if err := deleteUser(userName); err != nil {
 				messages = append(messages, err.Error())
 			}
 		}
@@ -110,8 +108,8 @@ func deleteUser(userName string) error {
 	return err
 }
 
-// get user list
-func getUserNames(users *v1beta1.SystemUser) []string {
+// Returns the controller user names.
+func getControllerUserNames(users *v1beta1.SystemUser) []string {
 	userNames := []string{
 		users.Etcd,
 		users.Kine,


### PR DESCRIPTION
## Description

* Rename `CreateControllerUsers` to `EnsureControllerUsers`
  This better reflects what it's actually doing.

* Narrow down parameters to `Ensure`/`DeleteControllerUsers`
  Both functions took the full k0s config as parameters, but only needed some usernames. Make this more obvious by passing only the required parts as parameters.

* Inline `EnsureUsers` and cache the shell in the create users loop
  It was only used once and so simple that it is easier to read inside the loop body. This also enables the caching of the login shell, so that k0s can exit early instead of trying to create more users, which will all fail for the same reason.

* Rename `getUserNames` to `getControllerUserNames`
  This makes more sense in the context in which it is used. Don't use reflection to build the username slice, which is more straight forward and makes the code a bit simpler. Also, inline the calls to the function in the loops and give the loop variables a better name.

* Remove unused `GetControllerUsers` function

* Use joined errors instead of joined error messages

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings