### PR TITLE
Remove worker related flags from GetControllerFlags()

### DIFF
--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -17,65 +17,71 @@ limitations under the License.
 package controller_test
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/k0sproject/k0s/cmd"
+	"github.com/k0sproject/k0s/pkg/constant"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestControllerCmd_Help(t *testing.T) {
+	defaultConfigPath := strconv.Quote(constant.K0sConfigPathDefault)
+	defaultDataDir := strconv.Quote(constant.DataDirDefault)
+
 	var out strings.Builder
 	underTest := cmd.NewRootCmd()
 	underTest.SetArgs([]string{"controller", "--help"})
 	underTest.SetOut(&out)
 	assert.NoError(t, underTest.Execute())
 
-	assert.Regexp(t, `^Run controller
+	assert.Equal(t, `Run controller
 
 Usage:
-  k0s controller \[join-token\] \[flags\]
+  k0s controller [join-token] [flags]
 
 Aliases:
   controller, server
 
 Examples:
-\tCommand to associate master nodes:
-\tCLI argument:
-\t\$ k0s controller \[join-token\]
+	Command to associate master nodes:
+	CLI argument:
+	$ k0s controller [join-token]
 
-\tor CLI flag:
-\t\$ k0s controller --token-file \[path_to_file\]
-\tNote: Token can be passed either as a CLI argument or as a flag
+	or CLI flag:
+	$ k0s controller --token-file [path_to_file]
+	Note: Token can be passed either as a CLI argument or as a flag
 
 Flags:
-      --cidr-range string                              HACK: cidr range for the windows worker node \(default "10\.96\.0\.0/12"\)
-  -c, --config string                                  config file, use '-' to read the config from stdin \(default ".+k0s\.yaml"\)
-      --cri-socket string                              container runtime socket to use, default to internal containerd\. Format: \[remote\|docker\]:\[path-to-socket\]
-      --data-dir string                                Data Directory for k0s\. DO NOT CHANGE for an existing setup, things will break! \(default ".+k0s"\)
-  -d, --debug                                          Debug logging \(default: false\)
-      --debugListenOn string                           Http listenOn for Debug pprof handler \(default ":6060"\)
-      --disable-components strings                     disable components \(valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,windows-node,worker-config\)
+      --cidr-range string                              HACK: cidr range for the windows worker node (default "10.96.0.0/12")
+  -c, --config string                                  config file, use '-' to read the config from stdin (default `+defaultConfigPath+`)
+      --cri-socket string                              container runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]
+      --data-dir string                                Data Directory for k0s. DO NOT CHANGE for an existing setup, things will break! (default `+defaultDataDir+`)
+  -d, --debug                                          Debug logging (default: false)
+      --debugListenOn string                           Http listenOn for Debug pprof handler (default ":6060")
+      --disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,windows-node,worker-config)
       --enable-cloud-provider                          Whether or not to enable cloud provider support in kubelet
       --enable-dynamic-config                          enable cluster-wide dynamic config based on custom resource
-      --enable-k0s-cloud-provider                      enables the k0s-cloud-provider \(default false\)
-      --enable-metrics-scraper                         enable scraping metrics from the controller components \(kube-scheduler, kube-controller-manager\)
-      --enable-worker                                  enable worker \(default false\)
+      --enable-k0s-cloud-provider                      enables the k0s-cloud-provider (default false)
+      --enable-metrics-scraper                         enable scraping metrics from the controller components (kube-scheduler, kube-controller-manager)
+      --enable-worker                                  enable worker (default false)
   -h, --help                                           help for controller
       --ignore-pre-flight-checks                       continue even if pre-flight checks fail
-      --iptables-mode string                           iptables mode \(valid values: nft, legacy, auto\)\. default: auto
-      --k0s-cloud-provider-port int                    the port that k0s-cloud-provider binds on \(default 10258\)
-      --k0s-cloud-provider-update-frequency duration   the frequency of k0s-cloud-provider node updates \(default 2m0s\)
+      --iptables-mode string                           iptables mode (valid values: nft, legacy, auto). default: auto
+      --k0s-cloud-provider-port int                    the port that k0s-cloud-provider binds on (default 10258)
+      --k0s-cloud-provider-update-frequency duration   the frequency of k0s-cloud-provider node updates (default 2m0s)
       --kube-controller-manager-extra-args string      extra args for kube-controller-manager
       --kubelet-extra-args string                      extra args for kubelet
       --labels strings                                 Node labels, list of key=value pairs
-  -l, --logging stringToString                         Logging Levels for the different components \(default \[.+]\)
+  -l, --logging stringToString                         Logging Levels for the different components (default [containerd=info,etcd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1])
       --no-taints                                      disable default taints for controller node
-      --profile string                                 worker profile to use on the node \(default "default"\)
-      --single                                         enable single node \(implies --enable-worker, default false\)
-      --status-socket string                           Full file path to the socket file\. \(default: <rundir>/status\.sock\)
+      --profile string                                 worker profile to use on the node (default "default")
+      --single                                         enable single node (implies --enable-worker, default false)
+      --status-socket string                           Full file path to the socket file. (default: <rundir>/status.sock)
       --taints strings                                 Node taints, list of key=value:effect strings
-      --token-file string                              Path to the file containing join-token\.
-  -v, --verbose                                        Verbose logging \(default: false\)
-$`, out.String())
+      --token-file string                              Path to the file containing join-token.
+  -v, --verbose                                        Verbose logging (default: false)
+`, out.String())
 }

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/k0s/cmd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestControllerCmd_Help(t *testing.T) {
+	var out strings.Builder
+	underTest := cmd.NewRootCmd()
+	underTest.SetArgs([]string{"controller", "--help"})
+	underTest.SetOut(&out)
+	assert.NoError(t, underTest.Execute())
+
+	assert.Regexp(t, `^Run controller
+
+Usage:
+  k0s controller \[join-token\] \[flags\]
+
+Aliases:
+  controller, server
+
+Examples:
+\tCommand to associate master nodes:
+\tCLI argument:
+\t\$ k0s controller \[join-token\]
+
+\tor CLI flag:
+\t\$ k0s controller --token-file \[path_to_file\]
+\tNote: Token can be passed either as a CLI argument or as a flag
+
+Flags:
+      --cidr-range string                              HACK: cidr range for the windows worker node \(default "10\.96\.0\.0/12"\)
+  -c, --config string                                  config file, use '-' to read the config from stdin \(default ".+k0s\.yaml"\)
+      --cri-socket string                              container runtime socket to use, default to internal containerd\. Format: \[remote\|docker\]:\[path-to-socket\]
+      --data-dir string                                Data Directory for k0s \(default: .+k0s\)\. DO NOT CHANGE for an existing setup, things will break!
+  -d, --debug                                          Debug logging \(default: false\)
+      --debugListenOn string                           Http listenOn for Debug pprof handler \(default ":6060"\)
+      --disable-components strings                     disable components \(valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,windows-node,worker-config\)
+      --enable-cloud-provider                          Whether or not to enable cloud provider support in kubelet
+      --enable-dynamic-config                          enable cluster-wide dynamic config based on custom resource
+      --enable-k0s-cloud-provider                      enables the k0s-cloud-provider \(default false\)
+      --enable-metrics-scraper                         enable scraping metrics from the controller components \(kube-scheduler, kube-controller-manager\)
+      --enable-worker                                  enable worker \(default false\)
+  -h, --help                                           help for controller
+      --ignore-pre-flight-checks                       continue even if pre-flight checks fail
+      --iptables-mode string                           iptables mode \(valid values: nft, legacy, auto\)\. default: auto
+      --k0s-cloud-provider-port int                    the port that k0s-cloud-provider binds on \(default 10258\)
+      --k0s-cloud-provider-update-frequency duration   the frequency of k0s-cloud-provider node updates \(default 2m0s\)
+      --kube-controller-manager-extra-args string      extra args for kube-controller-manager
+      --kubelet-extra-args string                      extra args for kubelet
+      --labels strings                                 Node labels, list of key=value pairs
+  -l, --logging stringToString                         Logging Levels for the different components \(default \[.+]\)
+      --no-taints                                      disable default taints for controller node
+      --profile string                                 worker profile to use on the node \(default "default"\)
+      --single                                         enable single node \(implies --enable-worker, default false\)
+      --status-socket string                           Full file path to the socket file\. \(default: <rundir>/status\.sock\)
+      --taints strings                                 Node taints, list of key=value:effect strings
+      --token-file string                              Path to the file containing join-token\.
+  -v, --verbose                                        Verbose logging \(default: false\)
+$`, out.String())
+}

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -52,7 +52,7 @@ Flags:
       --cidr-range string                              HACK: cidr range for the windows worker node \(default "10\.96\.0\.0/12"\)
   -c, --config string                                  config file, use '-' to read the config from stdin \(default ".+k0s\.yaml"\)
       --cri-socket string                              container runtime socket to use, default to internal containerd\. Format: \[remote\|docker\]:\[path-to-socket\]
-      --data-dir string                                Data Directory for k0s \(default: .+k0s\)\. DO NOT CHANGE for an existing setup, things will break!
+      --data-dir string                                Data Directory for k0s\. DO NOT CHANGE for an existing setup, things will break! \(default ".+k0s"\)
   -d, --debug                                          Debug logging \(default: false\)
       --debugListenOn string                           Http listenOn for Debug pprof handler \(default ":6060"\)
       --disable-components strings                     disable components \(valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,windows-node,worker-config\)

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -17,24 +17,30 @@ limitations under the License.
 package install_test
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/k0sproject/k0s/cmd"
+	"github.com/k0sproject/k0s/pkg/constant"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInstallCmd_Controller_Help(t *testing.T) {
+	defaultConfigPath := strconv.Quote(constant.K0sConfigPathDefault)
+	defaultDataDir := strconv.Quote(constant.DataDirDefault)
+
 	var out strings.Builder
 	underTest := cmd.NewRootCmd()
 	underTest.SetArgs([]string{"install", "controller", "--help"})
 	underTest.SetOut(&out)
 	assert.NoError(t, underTest.Execute())
 
-	assert.Regexp(t, `^Install k0s controller on a brand-new system\. Must be run as root \(or with sudo\)
+	assert.Equal(t, `Install k0s controller on a brand-new system. Must be run as root (or with sudo)
 
 Usage:
-  k0s install controller \[flags\]
+  k0s install controller [flags]
 
 Aliases:
   controller, server
@@ -48,36 +54,36 @@ With the controller subcommand you can setup a single node cluster by running:
 	
 
 Flags:
-      --cidr-range string                              HACK: cidr range for the windows worker node \(default "10\.96\.0\.0/12"\)
-  -c, --config string                                  config file, use '-' to read the config from stdin \(default ".+k0s\.yaml"\)
-      --cri-socket string                              container runtime socket to use, default to internal containerd\. Format: \[remote\|docker\]:\[path-to-socket\]
-      --data-dir string                                Data Directory for k0s\. DO NOT CHANGE for an existing setup, things will break! \(default ".+k0s"\)
-  -d, --debug                                          Debug logging \(default: false\)
-      --debugListenOn string                           Http listenOn for Debug pprof handler \(default ":6060"\)
-      --disable-components strings                     disable components \(valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,windows-node,worker-config\)
+      --cidr-range string                              HACK: cidr range for the windows worker node (default "10.96.0.0/12")
+  -c, --config string                                  config file, use '-' to read the config from stdin (default `+defaultConfigPath+`)
+      --cri-socket string                              container runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]
+      --data-dir string                                Data Directory for k0s. DO NOT CHANGE for an existing setup, things will break! (default `+defaultDataDir+`)
+  -d, --debug                                          Debug logging (default: false)
+      --debugListenOn string                           Http listenOn for Debug pprof handler (default ":6060")
+      --disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,windows-node,worker-config)
       --enable-cloud-provider                          Whether or not to enable cloud provider support in kubelet
       --enable-dynamic-config                          enable cluster-wide dynamic config based on custom resource
-      --enable-k0s-cloud-provider                      enables the k0s-cloud-provider \(default false\)
-      --enable-metrics-scraper                         enable scraping metrics from the controller components \(kube-scheduler, kube-controller-manager\)
-      --enable-worker                                  enable worker \(default false\)
+      --enable-k0s-cloud-provider                      enables the k0s-cloud-provider (default false)
+      --enable-metrics-scraper                         enable scraping metrics from the controller components (kube-scheduler, kube-controller-manager)
+      --enable-worker                                  enable worker (default false)
   -h, --help                                           help for controller
-      --iptables-mode string                           iptables mode \(valid values: nft, legacy, auto\)\. default: auto
-      --k0s-cloud-provider-port int                    the port that k0s-cloud-provider binds on \(default 10258\)
-      --k0s-cloud-provider-update-frequency duration   the frequency of k0s-cloud-provider node updates \(default 2m0s\)
+      --iptables-mode string                           iptables mode (valid values: nft, legacy, auto). default: auto
+      --k0s-cloud-provider-port int                    the port that k0s-cloud-provider binds on (default 10258)
+      --k0s-cloud-provider-update-frequency duration   the frequency of k0s-cloud-provider node updates (default 2m0s)
       --kube-controller-manager-extra-args string      extra args for kube-controller-manager
       --kubelet-extra-args string                      extra args for kubelet
       --labels strings                                 Node labels, list of key=value pairs
-  -l, --logging stringToString                         Logging Levels for the different components \(default \[.+]\)
+  -l, --logging stringToString                         Logging Levels for the different components (default [containerd=info,etcd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1])
       --no-taints                                      disable default taints for controller node
-      --profile string                                 worker profile to use on the node \(default "default"\)
-      --single                                         enable single node \(implies --enable-worker, default false\)
-      --status-socket string                           Full file path to the socket file\. \(default: <rundir>/status\.sock\)
+      --profile string                                 worker profile to use on the node (default "default")
+      --single                                         enable single node (implies --enable-worker, default false)
+      --status-socket string                           Full file path to the socket file. (default: <rundir>/status.sock)
       --taints strings                                 Node taints, list of key=value:effect strings
-      --token-file string                              Path to the file containing join-token\.
-  -v, --verbose                                        Verbose logging \(default: false\)
+      --token-file string                              Path to the file containing join-token.
+  -v, --verbose                                        Verbose logging (default: false)
 
 Global Flags:
   -e, --env stringArray   set environment variable
       --force             force init script creation
-$`, out.String())
+`, out.String())
 }

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package install_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/k0s/cmd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInstallCmd_Controller_Help(t *testing.T) {
+	var out strings.Builder
+	underTest := cmd.NewRootCmd()
+	underTest.SetArgs([]string{"install", "controller", "--help"})
+	underTest.SetOut(&out)
+	assert.NoError(t, underTest.Execute())
+
+	assert.Regexp(t, `^Install k0s controller on a brand-new system\. Must be run as root \(or with sudo\)
+
+Usage:
+  k0s install controller \[flags\]
+
+Aliases:
+  controller, server
+
+Examples:
+All default values of controller command will be passed to the service stub unless overridden.
+
+With the controller subcommand you can setup a single node cluster by running:
+
+	k0s install controller --single
+	
+
+Flags:
+      --cidr-range string                              HACK: cidr range for the windows worker node \(default "10\.96\.0\.0/12"\)
+  -c, --config string                                  config file, use '-' to read the config from stdin \(default ".+k0s\.yaml"\)
+      --cri-socket string                              container runtime socket to use, default to internal containerd\. Format: \[remote\|docker\]:\[path-to-socket\]
+      --data-dir string                                Data Directory for k0s \(default: .+k0s\)\. DO NOT CHANGE for an existing setup, things will break!
+  -d, --debug                                          Debug logging \(default: false\)
+      --debugListenOn string                           Http listenOn for Debug pprof handler \(default ":6060"\)
+      --disable-components strings                     disable components \(valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,windows-node,worker-config\)
+      --enable-cloud-provider                          Whether or not to enable cloud provider support in kubelet
+      --enable-dynamic-config                          enable cluster-wide dynamic config based on custom resource
+      --enable-k0s-cloud-provider                      enables the k0s-cloud-provider \(default false\)
+      --enable-metrics-scraper                         enable scraping metrics from the controller components \(kube-scheduler, kube-controller-manager\)
+      --enable-worker                                  enable worker \(default false\)
+  -h, --help                                           help for controller
+      --iptables-mode string                           iptables mode \(valid values: nft, legacy, auto\)\. default: auto
+      --k0s-cloud-provider-port int                    the port that k0s-cloud-provider binds on \(default 10258\)
+      --k0s-cloud-provider-update-frequency duration   the frequency of k0s-cloud-provider node updates \(default 2m0s\)
+      --kube-controller-manager-extra-args string      extra args for kube-controller-manager
+      --kubelet-extra-args string                      extra args for kubelet
+      --labels strings                                 Node labels, list of key=value pairs
+  -l, --logging stringToString                         Logging Levels for the different components \(default \[.+]\)
+      --no-taints                                      disable default taints for controller node
+      --profile string                                 worker profile to use on the node \(default "default"\)
+      --single                                         enable single node \(implies --enable-worker, default false\)
+      --status-socket string                           Full file path to the socket file\. \(default: <rundir>/status\.sock\)
+      --taints strings                                 Node taints, list of key=value:effect strings
+      --token-file string                              Path to the file containing join-token\.
+  -v, --verbose                                        Verbose logging \(default: false\)
+
+Global Flags:
+  -e, --env stringArray   set environment variable
+      --force             force init script creation
+$`, out.String())
+}

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -51,7 +51,7 @@ Flags:
       --cidr-range string                              HACK: cidr range for the windows worker node \(default "10\.96\.0\.0/12"\)
   -c, --config string                                  config file, use '-' to read the config from stdin \(default ".+k0s\.yaml"\)
       --cri-socket string                              container runtime socket to use, default to internal containerd\. Format: \[remote\|docker\]:\[path-to-socket\]
-      --data-dir string                                Data Directory for k0s \(default: .+k0s\)\. DO NOT CHANGE for an existing setup, things will break!
+      --data-dir string                                Data Directory for k0s\. DO NOT CHANGE for an existing setup, things will break! \(default ".+k0s"\)
   -d, --debug                                          Debug logging \(default: false\)
       --debugListenOn string                           Http listenOn for Debug pprof handler \(default ":6060"\)
       --disable-components strings                     disable components \(valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,windows-node,worker-config\)

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -26,7 +26,6 @@ import (
 	"syscall"
 
 	k0slog "github.com/k0sproject/k0s/internal/pkg/log"
-	"github.com/k0sproject/k0s/internal/pkg/stringmap"
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo"
 	"github.com/k0sproject/k0s/pkg/build"
 	"github.com/k0sproject/k0s/pkg/component/manager"
@@ -74,7 +73,6 @@ func NewWorkerCmd() *cobra.Command {
 				c.TokenArg = args[0]
 			}
 
-			c.Logging = stringmap.Merge(c.CmdLogLevels, c.DefaultLogLevels)
 			if c.TokenArg != "" && c.TokenFile != "" {
 				return fmt.Errorf("you can only pass one token argument either as a CLI argument 'k0s worker [token]' or as a flag 'k0s worker --token-file [path]'")
 			}
@@ -141,7 +139,7 @@ func (c *Command) Start(ctx context.Context) error {
 	}
 
 	if c.CriSocket == "" {
-		componentManager.Add(ctx, containerd.NewComponent(c.Logging["containerd"], c.K0sVars, workerConfig))
+		componentManager.Add(ctx, containerd.NewComponent(c.LogLevels.Containerd, c.K0sVars, workerConfig))
 	}
 
 	componentManager.Add(ctx, worker.NewOCIBundleReconciler(c.K0sVars))
@@ -156,7 +154,7 @@ func (c *Command) Start(ctx context.Context) error {
 		StaticPods:          staticPods,
 		Kubeconfig:          kubeletKubeconfigPath,
 		Configuration:       *workerConfig.KubeletConfiguration.DeepCopy(),
-		LogLevel:            c.Logging["kubelet"],
+		LogLevel:            c.LogLevels.Kubelet,
 		Labels:              c.Labels,
 		Taints:              c.Taints,
 		ExtraArgs:           c.KubeletExtraArgs,

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -34,7 +34,6 @@ import (
 
 var (
 	CfgFile        string
-	DataDir        string
 	Debug          bool
 	DebugListenOn  string
 	StatusSocket   string
@@ -124,7 +123,7 @@ func GetPersistentFlagSet() *pflag.FlagSet {
 	flagset := &pflag.FlagSet{}
 	flagset.BoolVarP(&Debug, "debug", "d", false, "Debug logging (default: false)")
 	flagset.BoolVarP(&Verbose, "verbose", "v", false, "Verbose logging (default: false)")
-	flagset.StringVar(&DataDir, "data-dir", "", "Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!")
+	flagset.String("data-dir", constant.DataDirDefault, "Data Directory for k0s. DO NOT CHANGE for an existing setup, things will break!")
 	flagset.StringVar(&StatusSocket, "status-socket", "", "Full file path to the socket file. (default: <rundir>/status.sock)")
 	flagset.StringVar(&DebugListenOn, "debugListenOn", ":6060", "Http listenOn for Debug pprof handler")
 	return flagset
@@ -139,7 +138,7 @@ func GetKubeCtlFlagSet() *pflag.FlagSet {
 	}
 
 	flagset := &pflag.FlagSet{}
-	flagset.StringVar(&DataDir, "data-dir", "", "Data Directory for k0s (default: /var/lib/k0s). DO NOT CHANGE for an existing setup, things will break!")
+	flagset.String("data-dir", constant.DataDirDefault, "Data Directory for k0s. DO NOT CHANGE for an existing setup, things will break!")
 	flagset.BoolVar(&Debug, "debug", debugDefault, "Debug logging [$DEBUG]")
 	return flagset
 }

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -155,7 +155,7 @@ func GetWorkerFlags() *pflag.FlagSet {
 	flagset.StringVar(&workerOpts.WorkerProfile, "profile", "default", "worker profile to use on the node")
 	flagset.StringVar(&workerOpts.CIDRRange, "cidr-range", "10.96.0.0/12", "HACK: cidr range for the windows worker node")
 	flagset.BoolVar(&workerOpts.CloudProvider, "enable-cloud-provider", false, "Whether or not to enable cloud provider support in kubelet")
-	flagset.StringVar(&workerOpts.TokenFile, "token-file", "", "Path to the file containing token.")
+	flagset.StringVar(&workerOpts.TokenFile, "token-file", "", "Path to the file containing join-token.")
 	flagset.StringToStringVarP(&workerOpts.CmdLogLevels, "logging", "l", DefaultLogLevels(), "Logging Levels for the different components")
 	flagset.StringSliceVarP(&workerOpts.Labels, "labels", "", []string{}, "Node labels, list of key=value pairs")
 	flagset.StringSliceVarP(&workerOpts.Taints, "taints", "", []string{}, "Node taints, list of key=value:effect strings")
@@ -189,17 +189,13 @@ var availableComponents = []string{
 func GetControllerFlags() *pflag.FlagSet {
 	flagset := &pflag.FlagSet{}
 
-	flagset.StringVar(&workerOpts.WorkerProfile, "profile", "default", "worker profile to use on the node")
 	flagset.BoolVar(&controllerOpts.EnableWorker, "enable-worker", false, "enable worker (default false)")
 	flagset.StringSliceVar(&controllerOpts.DisableComponents, "disable-components", []string{}, "disable components (valid items: "+strings.Join(availableComponents, ",")+")")
-	flagset.StringVar(&workerOpts.TokenFile, "token-file", "", "Path to the file containing join-token.")
-	flagset.StringToStringVarP(&workerOpts.CmdLogLevels, "logging", "l", DefaultLogLevels(), "Logging Levels for the different components")
 	flagset.BoolVar(&controllerOpts.SingleNode, "single", false, "enable single node (implies --enable-worker, default false)")
 	flagset.BoolVar(&controllerOpts.NoTaints, "no-taints", false, "disable default taints for controller node")
 	flagset.BoolVar(&controllerOpts.EnableK0sCloudProvider, "enable-k0s-cloud-provider", false, "enables the k0s-cloud-provider (default false)")
 	flagset.DurationVar(&controllerOpts.K0sCloudProviderUpdateFrequency, "k0s-cloud-provider-update-frequency", 2*time.Minute, "the frequency of k0s-cloud-provider node updates")
 	flagset.IntVar(&controllerOpts.K0sCloudProviderPort, "k0s-cloud-provider-port", k0scloudprovider.DefaultBindPort, "the port that k0s-cloud-provider binds on")
-	flagset.AddFlagSet(GetCriSocketFlag())
 	flagset.BoolVar(&controllerOpts.EnableDynamicConfig, "enable-dynamic-config", false, "enable cluster-wide dynamic config based on custom resource")
 	flagset.BoolVar(&controllerOpts.EnableMetricsScraper, "enable-metrics-scraper", false, "enable scraping metrics from the controller components (kube-scheduler, kube-controller-manager)")
 	flagset.StringVar(&controllerOpts.KubeControllerManagerExtraArgs, "kube-controller-manager-extra-args", "", "extra args for kube-controller-manager")

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -48,13 +48,11 @@ var (
 type CLIOptions struct {
 	WorkerOptions
 	ControllerOptions
-	CfgFile          string
-	Debug            bool
-	DebugListenOn    string
-	DefaultLogLevels map[string]string
-	K0sVars          *CfgVars
-	Logging          map[string]string // merged outcome of default log levels and cmdLoglevels
-	Verbose          bool
+	CfgFile       string
+	Debug         bool
+	DebugListenOn string
+	K0sVars       *CfgVars
+	Verbose       bool
 }
 
 // Shared controller cli flags
@@ -78,7 +76,7 @@ type ControllerOptions struct {
 type WorkerOptions struct {
 	CIDRRange        string
 	CloudProvider    bool
-	CmdLogLevels     map[string]string
+	LogLevels        LogLevels
 	CriSocket        string
 	KubeletExtraArgs string
 	Labels           []string
@@ -106,17 +104,94 @@ func (o *ControllerOptions) Normalize() error {
 	return nil
 }
 
-func DefaultLogLevels() map[string]string {
-	return map[string]string{
-		"etcd":                    "info",
-		"containerd":              "info",
-		"konnectivity-server":     "1",
-		"kube-apiserver":          "1",
-		"kube-controller-manager": "1",
-		"kube-scheduler":          "1",
-		"kubelet":                 "1",
-		"kube-proxy":              "1",
+type LogLevels = struct {
+	Containerd            string
+	Etcd                  string
+	Konnectivity          string
+	KubeAPIServer         string
+	KubeControllerManager string
+	KubeScheduler         string
+	Kubelet               string
+}
+
+func DefaultLogLevels() LogLevels {
+	return LogLevels{
+		Containerd:            "info",
+		Etcd:                  "info",
+		Konnectivity:          "1",
+		KubeAPIServer:         "1",
+		KubeControllerManager: "1",
+		KubeScheduler:         "1",
+		Kubelet:               "1",
 	}
+}
+
+type logLevelsFlag LogLevels
+
+func (f *logLevelsFlag) Type() string {
+	return "stringToString"
+}
+
+func (f *logLevelsFlag) Set(val string) error {
+	val = strings.TrimPrefix(val, "[")
+	val = strings.TrimSuffix(val, "]")
+
+	parsed := DefaultLogLevels()
+
+	for val != "" {
+		pair, rest, _ := strings.Cut(val, ",")
+		val = rest
+		k, v, ok := strings.Cut(pair, "=")
+
+		if k == "" {
+			return fmt.Errorf("component name cannot be empty: %q", pair)
+		}
+		if !ok {
+			return fmt.Errorf("must be of format component=level: %q", pair)
+		}
+
+		switch k {
+		case "containerd":
+			parsed.Containerd = v
+		case "etcd":
+			parsed.Etcd = v
+		case "konnectivity-server":
+			parsed.Konnectivity = v
+		case "kube-apiserver":
+			parsed.KubeAPIServer = v
+		case "kube-controller-manager":
+			parsed.KubeControllerManager = v
+		case "kube-scheduler":
+			parsed.KubeScheduler = v
+		case "kubelet":
+			parsed.Kubelet = v
+		default:
+			return fmt.Errorf("unknown component name: %q", k)
+		}
+	}
+
+	*f = parsed
+	return nil
+}
+
+func (f *logLevelsFlag) String() string {
+	var buf strings.Builder
+	buf.WriteString("[containerd=")
+	buf.WriteString(f.Containerd)
+	buf.WriteString(",etcd=")
+	buf.WriteString(f.Etcd)
+	buf.WriteString(",konnectivity-server=")
+	buf.WriteString(f.Konnectivity)
+	buf.WriteString(",kube-apiserver=")
+	buf.WriteString(f.KubeAPIServer)
+	buf.WriteString(",kube-controller-manager=")
+	buf.WriteString(f.KubeControllerManager)
+	buf.WriteString(",kube-scheduler=")
+	buf.WriteString(f.KubeScheduler)
+	buf.WriteString(",kubelet=")
+	buf.WriteString(f.Kubelet)
+	buf.WriteString("]")
+	return buf.String()
 }
 
 func GetPersistentFlagSet() *pflag.FlagSet {
@@ -152,11 +227,16 @@ func GetCriSocketFlag() *pflag.FlagSet {
 func GetWorkerFlags() *pflag.FlagSet {
 	flagset := &pflag.FlagSet{}
 
+	if workerOpts.LogLevels == (LogLevels{}) {
+		// initialize zero value with defaults
+		workerOpts.LogLevels = DefaultLogLevels()
+	}
+
 	flagset.StringVar(&workerOpts.WorkerProfile, "profile", "default", "worker profile to use on the node")
 	flagset.StringVar(&workerOpts.CIDRRange, "cidr-range", "10.96.0.0/12", "HACK: cidr range for the windows worker node")
 	flagset.BoolVar(&workerOpts.CloudProvider, "enable-cloud-provider", false, "Whether or not to enable cloud provider support in kubelet")
 	flagset.StringVar(&workerOpts.TokenFile, "token-file", "", "Path to the file containing join-token.")
-	flagset.StringToStringVarP(&workerOpts.CmdLogLevels, "logging", "l", DefaultLogLevels(), "Logging Levels for the different components")
+	flagset.VarP((*logLevelsFlag)(&workerOpts.LogLevels), "logging", "l", "Logging Levels for the different components")
 	flagset.StringSliceVarP(&workerOpts.Labels, "labels", "", []string{}, "Node labels, list of key=value pairs")
 	flagset.StringSliceVarP(&workerOpts.Taints, "taints", "", []string{}, "Node taints, list of key=value:effect strings")
 	flagset.StringVar(&workerOpts.KubeletExtraArgs, "kubelet-extra-args", "", "extra args for kubelet")
@@ -208,7 +288,7 @@ func GetControllerFlags() *pflag.FlagSet {
 // it in multiple places
 func FileInputFlag() *pflag.FlagSet {
 	flagset := &pflag.FlagSet{}
-	descString := fmt.Sprintf("config file, use '-' to read the config from stdin (default \"%s\")", constant.K0sConfigPathDefault)
+	descString := fmt.Sprintf("config file, use '-' to read the config from stdin (default %q)", constant.K0sConfigPathDefault)
 	flagset.StringVarP(&CfgFile, "config", "c", "", descString)
 
 	return flagset
@@ -233,12 +313,11 @@ func GetCmdOpts(cobraCmd command) (*CLIOptions, error) {
 		ControllerOptions: controllerOpts,
 		WorkerOptions:     workerOpts,
 
-		CfgFile:          CfgFile,
-		Debug:            Debug,
-		Verbose:          Verbose,
-		DefaultLogLevels: DefaultLogLevels(),
-		K0sVars:          k0sVars,
-		DebugListenOn:    DebugListenOn,
+		CfgFile:       CfgFile,
+		Debug:         Debug,
+		Verbose:       Verbose,
+		K0sVars:       k0sVars,
+		DebugListenOn: DebugListenOn,
 	}, nil
 }
 


### PR DESCRIPTION
## Description

Those are also part of `GetWorkerFlags()`. In fact, the two commands that use `GetControllerFlags()` ("controller" and "install"), both also add `GetWorkerFlags()`, defining them effectively twice. Add tests for the `--help` output to prove that nothing changed. Make logging CLI option statically typed, which will reject logging settings for unknown component names and introduces a deterministic output in the Cobra command's help texts. Remove the unused kube-proxy component from logging.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings