### PR TITLE
Fix inttests on darwin

### DIFF
--- a/pkg/apis/k0s/v1beta1/cplb_linux.go
+++ b/pkg/apis/k0s/v1beta1/cplb_linux.go
@@ -1,4 +1,4 @@
-//go:build unix
+//go:build linux
 
 /*
 Copyright 2024 k0s authors

--- a/pkg/apis/k0s/v1beta1/cplb_notlinux.go
+++ b/pkg/apis/k0s/v1beta1/cplb_notlinux.go
@@ -1,3 +1,5 @@
+//go:build !linux
+
 /*
 Copyright 2024 k0s authors
 


### PR DESCRIPTION
## Description

Inttests started failing after merging CPLB because cplb_unix.go uses netlink.FAMILY_ALL which isn't standard unix but just linux. This fixes it by using for every other unix the windows code.
## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings