### PR TITLE
Remove implicit build tag

### DIFF
--- a/pkg/apis/k0s/v1beta1/cplb_linux.go
+++ b/pkg/apis/k0s/v1beta1/cplb_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 /*
 Copyright 2024 k0s authors
 

--- a/pkg/apis/k0s/v1beta1/cplb_other.go
+++ b/pkg/apis/k0s/v1beta1/cplb_other.go
@@ -19,9 +19,10 @@ limitations under the License.
 package v1beta1
 
 import (
-	"errors"
+	"fmt"
+	"runtime"
 )
 
 func getDefaultNIC() (string, error) {
-	return "", errors.New("getDefaultNIC on Windows is not supported")
+	return "", fmt.Errorf("getDefaultNIC on %s is not supported", runtime.GOOS)
 }


### PR DESCRIPTION
## Description

Files ending with  _linux.go are implicitly guarded with the linux build tag, so no need to add it explicitly. Also, rename _notlinux.go to _other.go, as files containing generic implementations for other platfforms are called in other places across the codebase.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings