### PR TITLE
Remove convertFileParamsToAbsolute

### DIFF
--- a/cmd/install/controller.go
+++ b/cmd/install/controller.go
@@ -53,9 +53,6 @@ With the controller subcommand you can setup a single node cluster by running:
 				return fmt.Errorf("invalid node config: %w", errors.Join(errs...))
 			}
 
-			if err := c.convertFileParamsToAbsolute(); err != nil {
-				return err
-			}
 			flagsAndVals := []string{"controller"}
 			flagsAndVals = append(flagsAndVals, cmdFlagsToArgs(cmd)...)
 			if err := c.setup("controller", flagsAndVals, installFlags); err != nil {

--- a/cmd/install/controller.go
+++ b/cmd/install/controller.go
@@ -53,8 +53,12 @@ With the controller subcommand you can setup a single node cluster by running:
 				return fmt.Errorf("invalid node config: %w", errors.Join(errs...))
 			}
 
-			flagsAndVals := []string{"controller"}
-			flagsAndVals = append(flagsAndVals, cmdFlagsToArgs(cmd)...)
+			flagsAndVals, err := cmdFlagsToArgs(cmd)
+			if err != nil {
+				return err
+			}
+
+			flagsAndVals = append([]string{"controller"}, flagsAndVals...)
 			if err := c.setup("controller", flagsAndVals, installFlags); err != nil {
 				return err
 			}

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -19,9 +19,7 @@ package install
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
-	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/install"
 
@@ -72,35 +70,6 @@ func (c *command) setup(role string, args []string, installFlags *installFlags) 
 	err = install.EnsureService(args, installFlags.envVars, installFlags.force)
 	if err != nil {
 		return fmt.Errorf("failed to install k0s service: %w", err)
-	}
-	return nil
-}
-
-// This command converts the file paths in the command struct to absolute paths.
-// For flags passed to service init file, see the [cmdFlagsToArgs] func.
-func (c *command) convertFileParamsToAbsolute() (err error) {
-	// don't convert if cfgFile is empty
-
-	if c.K0sVars.StartupConfigPath != "" {
-		c.K0sVars.StartupConfigPath, err = filepath.Abs(c.K0sVars.StartupConfigPath)
-		if err != nil {
-			return err
-		}
-	}
-	if c.K0sVars.DataDir != "" {
-		c.K0sVars.DataDir, err = filepath.Abs(c.K0sVars.DataDir)
-		if err != nil {
-			return err
-		}
-	}
-	if c.TokenFile != "" {
-		c.TokenFile, err = filepath.Abs(c.TokenFile)
-		if err != nil {
-			return err
-		}
-		if !file.Exists(c.TokenFile) {
-			return fmt.Errorf("%s does not exist", c.TokenFile)
-		}
 	}
 	return nil
 }

--- a/cmd/install/worker.go
+++ b/cmd/install/worker.go
@@ -36,9 +36,6 @@ Windows flags like "--api-server", "--cidr-range" and "--cluster-dns" will be ig
 				return err
 			}
 			c := (*command)(opts)
-			if err := c.convertFileParamsToAbsolute(); err != nil {
-				return err
-			}
 
 			flagsAndVals := []string{"worker"}
 			flagsAndVals = append(flagsAndVals, cmdFlagsToArgs(cmd)...)

--- a/cmd/install/worker.go
+++ b/cmd/install/worker.go
@@ -37,8 +37,12 @@ Windows flags like "--api-server", "--cidr-range" and "--cluster-dns" will be ig
 			}
 			c := (*command)(opts)
 
-			flagsAndVals := []string{"worker"}
-			flagsAndVals = append(flagsAndVals, cmdFlagsToArgs(cmd)...)
+			flagsAndVals, err := cmdFlagsToArgs(cmd)
+			if err != nil {
+				return err
+			}
+
+			flagsAndVals = append([]string{"worker"}, flagsAndVals...)
 			if err := c.setup("worker", flagsAndVals, installFlags); err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description

Making those paths absolute seems unnecessary. The dataDir is made absoulte anyways, and if the StartupConfigFilePath or TokenFile are absoulte or not is not important. The args for the install command are handled by a different function anyways.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings