### PR TITLE
feat: implement watcher for oci bundles

### DIFF
--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -89,7 +89,7 @@ func (a *OCIBundleReconciler) loadOne(ctx context.Context, fpath string) error {
 	return nil
 }
 
-// loadAll loads all OCI bundle files into containerd. Read all files from the oci bundle
+// loadAll loads all OCI bundle files into containerd. Read all files from the OCI bundle
 // directory and loads them one by one. Errors are logged but not returned, upon failure
 // in one file this function logs the error and moves to the next file.
 func (a *OCIBundleReconciler) loadAll(ctx context.Context) {

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -26,18 +26,22 @@ import (
 	"github.com/avast/retry-go"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/platforms"
+	"github.com/fsnotify/fsnotify"
+	"github.com/sirupsen/logrus"
+
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/component/prober"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
-	"github.com/sirupsen/logrus"
+	"github.com/k0sproject/k0s/pkg/debounce"
 )
 
 // OCIBundleReconciler tries to import OCI bundle into the running containerd instance
 type OCIBundleReconciler struct {
 	k0sVars *config.CfgVars
 	log     *logrus.Entry
+	loaded  map[string]time.Time
 	*prober.EventEmitter
 }
 
@@ -49,6 +53,7 @@ func NewOCIBundleReconciler(vars *config.CfgVars) *OCIBundleReconciler {
 		k0sVars:      vars,
 		log:          logrus.WithField("component", "OCIBundleReconciler"),
 		EventEmitter: prober.NewEventEmitter(),
+		loaded:       make(map[string]time.Time),
 	}
 }
 
@@ -56,46 +61,129 @@ func (a *OCIBundleReconciler) Init(_ context.Context) error {
 	return dir.Init(a.k0sVars.OCIBundleDir, constant.ManifestsDirMode)
 }
 
-func (a *OCIBundleReconciler) Start(ctx context.Context) error {
+// load loads all OCI bundle files into containerd. Read all files from the oci bundle
+// directory and loads them only once. If the file is already loaded and hasn't changed
+// it will skip it. Errors are logged but not returned, upon failure in one file this
+// function logs the error and moves to the next file.
+func (a *OCIBundleReconciler) load(ctx context.Context) {
 	files, err := os.ReadDir(a.k0sVars.OCIBundleDir)
 	if err != nil {
+		a.log.WithError(err).Errorf("can't read bundles directory")
 		a.Emit("can't read bundles directory")
-		return fmt.Errorf("can't read bundles directory")
+		return
 	}
+
 	a.EmitWithPayload("importing OCI bundles", files)
 	if len(files) == 0 {
-		return nil
+		return
 	}
+
 	var client *containerd.Client
 	sock := filepath.Join(a.k0sVars.RunDir, "containerd.sock")
-	err = retry.Do(func() error {
-		client, err = containerd.New(sock, containerd.WithDefaultNamespace("k8s.io"), containerd.WithDefaultPlatform(platforms.OnlyStrict(platforms.DefaultSpec())))
+	if err := retry.Do(func() error {
+		client, err = containerd.New(
+			sock,
+			containerd.WithDefaultNamespace("k8s.io"),
+			containerd.WithDefaultPlatform(platforms.OnlyStrict(platforms.DefaultSpec())),
+		)
 		if err != nil {
 			a.log.WithError(err).Errorf("can't connect to containerd socket %s", sock)
 			return err
 		}
-		_, err := client.ListImages(ctx)
-		if err != nil {
+
+		if _, err := client.ListImages(ctx); err != nil {
 			a.log.WithError(err).Errorf("can't use containerd client")
 			return err
 		}
 		return nil
-	}, retry.Context(ctx), retry.Delay(time.Second*5))
-	if err != nil {
-		a.EmitWithPayload("can't connect to containerd socket", map[string]interface{}{"socket": sock, "error": err})
-		return fmt.Errorf("can't connect to containerd socket %s: %w", sock, err)
+	}, retry.Context(ctx), retry.Delay(time.Second*5)); err != nil {
+		payload := map[string]interface{}{"socket": sock, "error": err}
+		a.EmitWithPayload("can't connect to containerd socket", payload)
+		return
 	}
 	defer client.Close()
 
 	for _, file := range files {
-		if err := a.unpackBundle(ctx, client, a.k0sVars.OCIBundleDir+"/"+file.Name()); err != nil {
-			a.EmitWithPayload("unpacking OCI bundle error", map[string]interface{}{"file": file.Name(), "error": err})
-			a.log.WithError(err).Errorf("can't unpack bundle %s", file.Name())
-			return fmt.Errorf("can't unpack bundle %s: %w", file.Name(), err)
+		payload := map[string]interface{}{"file": file.Name(), "error": err}
+		fpath := filepath.Join(a.k0sVars.OCIBundleDir, file.Name())
+		finfo, err := os.Stat(fpath)
+		if err != nil {
+			a.log.WithError(err).Errorf("can't stat file %s", fpath)
+			a.EmitWithPayload("can't stat file", payload)
+			continue
 		}
+
+		if when, ok := a.loaded[file.Name()]; ok && when.Equal(finfo.ModTime()) {
+			continue
+		}
+
+		if err := a.unpackBundle(ctx, client, fpath); err != nil {
+			a.EmitWithPayload("unpacking OCI bundle error", payload)
+			a.log.WithError(err).Errorf("can't unpack bundle %s", file.Name())
+			continue
+		}
+
+		// if succeed in loading the bundle, remember the time.
+		a.loaded[file.Name()] = finfo.ModTime()
 		a.EmitWithPayload("unpacked OCI bundle", file.Name())
 	}
 	a.Emit("finished importing OCI bundle")
+}
+
+// watch creates a fs watched on the oci bundle directory. This function calls load() anytime
+// a new file is created on the directory or a write operation took place . Events are debounced
+// with a timeout of 10 seconds. This function is blocking.
+func (a *OCIBundleReconciler) watch(ctx context.Context) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		a.log.WithError(err).Error("failed to create watcher for OCI bundles")
+		return
+	}
+	defer watcher.Close()
+
+	if err := watcher.Add(a.k0sVars.OCIBundleDir); err != nil {
+		a.log.WithError(err).Error("failed to watch for OCI bundles")
+		return
+	}
+
+	debouncer := debounce.Debouncer[fsnotify.Event]{
+		Input:   watcher.Events,
+		Timeout: 10 * time.Second,
+		Filter: func(item fsnotify.Event) bool {
+			switch item.Op {
+			case fsnotify.Create, fsnotify.Write:
+				return true
+			default:
+				return false
+			}
+		},
+		Callback: func(fsnotify.Event) {
+			a.log.Info("OCI bundle directory changed, reconciling")
+			a.load(ctx)
+		},
+	}
+
+	go func() {
+		for {
+			err, ok := <-watcher.Errors
+			if !ok {
+				return
+			}
+			a.log.WithError(err).Error("error while watching oci bundle directory")
+		}
+	}()
+
+	a.log.Infof("started to watch events on %s", a.k0sVars.OCIBundleDir)
+	if err := debouncer.Run(ctx); err != nil {
+		a.log.WithError(err).Warn("oci bundle watch bouncer exited with error")
+	}
+}
+
+// Starts initiate the OCI bundle loader. It does an initial load of the directory and
+// once it is done, it starts a watcher on its own goroutine.
+func (a *OCIBundleReconciler) Start(ctx context.Context) error {
+	a.load(ctx)
+	go a.watch(ctx)
 	return nil
 }
 

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -46,7 +46,6 @@ type OCIBundleReconciler struct {
 	mtx             sync.Mutex
 	cancel          context.CancelFunc
 	end             chan struct{}
-	watcher         *fsnotify.Watcher
 	*prober.EventEmitter
 }
 

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -114,7 +114,7 @@ func (a *OCIBundleReconciler) loadAll(ctx context.Context) {
 		}
 		a.log.Infof("OCI bundle %s loaded", fpath)
 	}
-	a.Emit("finished importing OCI bundle")
+	a.Emit("finished importing OCI bundles")
 }
 
 // watch creates a fs watched on the oci bundle directory. This function calls load() anytime

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -18,6 +18,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -41,7 +42,6 @@ import (
 type OCIBundleReconciler struct {
 	k0sVars *config.CfgVars
 	log     *logrus.Entry
-	loaded  map[string]time.Time
 	*prober.EventEmitter
 }
 
@@ -53,7 +53,6 @@ func NewOCIBundleReconciler(vars *config.CfgVars) *OCIBundleReconciler {
 		k0sVars:      vars,
 		log:          logrus.WithField("component", "OCIBundleReconciler"),
 		EventEmitter: prober.NewEventEmitter(),
-		loaded:       make(map[string]time.Time),
 	}
 }
 
@@ -61,71 +60,59 @@ func (a *OCIBundleReconciler) Init(_ context.Context) error {
 	return dir.Init(a.k0sVars.OCIBundleDir, constant.ManifestsDirMode)
 }
 
-// load loads all OCI bundle files into containerd. Read all files from the oci bundle
-// directory and loads them only once. If the file is already loaded and hasn't changed
-// it will skip it. Errors are logged but not returned, upon failure in one file this
-// function logs the error and moves to the next file.
-func (a *OCIBundleReconciler) load(ctx context.Context) {
+// loadOne connects to containerd and imports the provided OCI bundle.
+func (a *OCIBundleReconciler) loadOne(ctx context.Context, fpath string) error {
+	var client *containerd.Client
+	sock := filepath.Join(a.k0sVars.RunDir, "containerd.sock")
+	if err := retry.Do(func() (err error) {
+		client, err = containerd.New(
+			sock,
+			containerd.WithDefaultNamespace("k8s.io"),
+			containerd.WithDefaultPlatform(
+				platforms.OnlyStrict(platforms.DefaultSpec()),
+			),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to connect to containerd: %w", err)
+		}
+		if _, err = client.ListImages(ctx); err != nil {
+			return fmt.Errorf("failed to communicate with containerd: %w", err)
+		}
+		return nil
+	}, retry.Context(ctx), retry.Delay(time.Second*5)); err != nil {
+		return err
+	}
+	defer client.Close()
+	if err := a.unpackBundle(ctx, client, fpath); err != nil {
+		return fmt.Errorf("failed to process oci bundle: %w", err)
+	}
+	return nil
+}
+
+// loadAll loads all OCI bundle files into containerd. Read all files from the oci bundle
+// directory and loads them one by one. Errors are logged but not returned, upon failure
+// in one file this function logs the error and moves to the next file.
+func (a *OCIBundleReconciler) loadAll(ctx context.Context) {
+	a.log.Info("Loading all OCI bundles")
 	files, err := os.ReadDir(a.k0sVars.OCIBundleDir)
 	if err != nil {
-		a.log.WithError(err).Errorf("can't read bundles directory")
+		a.log.WithError(err).Errorf("Failed to read bundles directory")
 		a.Emit("can't read bundles directory")
 		return
 	}
-
 	a.EmitWithPayload("importing OCI bundles", files)
 	if len(files) == 0 {
 		return
 	}
-
-	var client *containerd.Client
-	sock := filepath.Join(a.k0sVars.RunDir, "containerd.sock")
-	if err := retry.Do(func() error {
-		client, err = containerd.New(
-			sock,
-			containerd.WithDefaultNamespace("k8s.io"),
-			containerd.WithDefaultPlatform(platforms.OnlyStrict(platforms.DefaultSpec())),
-		)
-		if err != nil {
-			a.log.WithError(err).Errorf("can't connect to containerd socket %s", sock)
-			return err
-		}
-
-		if _, err := client.ListImages(ctx); err != nil {
-			a.log.WithError(err).Errorf("can't use containerd client")
-			return err
-		}
-		return nil
-	}, retry.Context(ctx), retry.Delay(time.Second*5)); err != nil {
-		payload := map[string]interface{}{"socket": sock, "error": err}
-		a.EmitWithPayload("can't connect to containerd socket", payload)
-		return
-	}
-	defer client.Close()
-
 	for _, file := range files {
-		payload := map[string]interface{}{"file": file.Name(), "error": err}
 		fpath := filepath.Join(a.k0sVars.OCIBundleDir, file.Name())
-		finfo, err := os.Stat(fpath)
-		if err != nil {
-			a.log.WithError(err).Errorf("can't stat file %s", fpath)
-			a.EmitWithPayload("can't stat file", payload)
+		a.log.Infof("Loading OCI bundle %s", fpath)
+		if err := a.loadOne(ctx, fpath); err != nil {
+			a.log.WithError(err).Errorf("Failed to load OCI bundle %s", fpath)
+			a.EmitWithPayload("failed to load OCI bundle", fpath)
 			continue
 		}
-
-		if when, ok := a.loaded[file.Name()]; ok && when.Equal(finfo.ModTime()) {
-			continue
-		}
-
-		if err := a.unpackBundle(ctx, client, fpath); err != nil {
-			a.EmitWithPayload("unpacking OCI bundle error", payload)
-			a.log.WithError(err).Errorf("can't unpack bundle %s", file.Name())
-			continue
-		}
-
-		// if succeed in loading the bundle, remember the time.
-		a.loaded[file.Name()] = finfo.ModTime()
-		a.EmitWithPayload("unpacked OCI bundle", file.Name())
+		a.log.Infof("OCI bundle %s loaded", fpath)
 	}
 	a.Emit("finished importing OCI bundle")
 }
@@ -136,13 +123,13 @@ func (a *OCIBundleReconciler) load(ctx context.Context) {
 func (a *OCIBundleReconciler) watch(ctx context.Context) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		a.log.WithError(err).Error("failed to create watcher for OCI bundles")
+		a.log.WithError(err).Error("Failed to create watcher for OCI bundles")
 		return
 	}
 	defer watcher.Close()
 
 	if err := watcher.Add(a.k0sVars.OCIBundleDir); err != nil {
-		a.log.WithError(err).Error("failed to watch for OCI bundles")
+		a.log.WithError(err).Error("Failed to watch for OCI bundles")
 		return
 	}
 
@@ -157,9 +144,14 @@ func (a *OCIBundleReconciler) watch(ctx context.Context) {
 				return false
 			}
 		},
-		Callback: func(fsnotify.Event) {
-			a.log.Info("OCI bundle directory changed, reconciling")
-			a.load(ctx)
+		Callback: func(ev fsnotify.Event) {
+			a.log.Infof("Loading OCI bundle %s", ev.Name)
+			if err := a.loadOne(ctx, ev.Name); err != nil {
+				a.log.WithError(err).Errorf("Failed to load OCI bundle %s", ev.Name)
+				a.EmitWithPayload("failed to load OCI bundle", ev.Name)
+				return
+			}
+			a.log.Infof("OCI bundle %s loaded", ev.Name)
 		},
 	}
 
@@ -169,20 +161,24 @@ func (a *OCIBundleReconciler) watch(ctx context.Context) {
 			if !ok {
 				return
 			}
-			a.log.WithError(err).Error("error while watching oci bundle directory")
+			a.log.WithError(err).Error("Error while watching oci bundle directory")
 		}
 	}()
 
-	a.log.Infof("started to watch events on %s", a.k0sVars.OCIBundleDir)
+	a.log.Infof("Started to watch events on %s", a.k0sVars.OCIBundleDir)
 	if err := debouncer.Run(ctx); err != nil {
-		a.log.WithError(err).Warn("oci bundle watch bouncer exited with error")
+		if errors.Is(err, context.Canceled) {
+			a.log.Info("OCI bundle watch bouncer ended")
+			return
+		}
+		a.log.WithError(err).Warn("OCI bundle watch bouncer exited with error")
 	}
 }
 
 // Starts initiate the OCI bundle loader. It does an initial load of the directory and
 // once it is done, it starts a watcher on its own goroutine.
 func (a *OCIBundleReconciler) Start(ctx context.Context) error {
-	a.load(ctx)
+	a.loadAll(ctx)
 	go a.watch(ctx)
 	return nil
 }

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -18,10 +18,10 @@ package worker
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -40,8 +40,13 @@ import (
 
 // OCIBundleReconciler tries to import OCI bundle into the running containerd instance
 type OCIBundleReconciler struct {
-	k0sVars *config.CfgVars
-	log     *logrus.Entry
+	k0sVars         *config.CfgVars
+	log             *logrus.Entry
+	alreadyImported map[string]time.Time
+	mtx             sync.Mutex
+	cancel          context.CancelFunc
+	end             chan struct{}
+	watcher         *fsnotify.Watcher
 	*prober.EventEmitter
 }
 
@@ -50,9 +55,11 @@ var _ manager.Component = (*OCIBundleReconciler)(nil)
 // NewOCIBundleReconciler builds new reconciler
 func NewOCIBundleReconciler(vars *config.CfgVars) *OCIBundleReconciler {
 	return &OCIBundleReconciler{
-		k0sVars:      vars,
-		log:          logrus.WithField("component", "OCIBundleReconciler"),
-		EventEmitter: prober.NewEventEmitter(),
+		k0sVars:         vars,
+		log:             logrus.WithField("component", "OCIBundleReconciler"),
+		EventEmitter:    prober.NewEventEmitter(),
+		alreadyImported: map[string]time.Time{},
+		end:             make(chan struct{}, 1),
 	}
 }
 
@@ -91,46 +98,59 @@ func (a *OCIBundleReconciler) loadOne(ctx context.Context, fpath string) error {
 
 // loadAll loads all OCI bundle files into containerd. Read all files from the OCI bundle
 // directory and loads them one by one. Errors are logged but not returned, upon failure
-// in one file this function logs the error and moves to the next file.
+// in one file this function logs the error and moves to the next file. Files are indexed
+// by name and imported only once (if the file has not been modified).
 func (a *OCIBundleReconciler) loadAll(ctx context.Context) {
-	a.log.Info("Loading all OCI bundles")
+	// We are going to consume everything in the directory so we block. This keeps
+	// things simple and avoid the need to handle two imports of the same file at the
+	// same time without requiring locks based on file path.
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
+
+	a.log.Info("Loading OCI bundles directory")
 	files, err := os.ReadDir(a.k0sVars.OCIBundleDir)
 	if err != nil {
 		a.log.WithError(err).Errorf("Failed to read bundles directory")
-		a.Emit("can't read bundles directory")
 		return
 	}
 	a.EmitWithPayload("importing OCI bundles", files)
-	if len(files) == 0 {
-		return
-	}
 	for _, file := range files {
 		fpath := filepath.Join(a.k0sVars.OCIBundleDir, file.Name())
+		finfo, err := os.Stat(fpath)
+		if err != nil {
+			a.log.WithError(err).Errorf("failed to stat %s", fpath)
+			continue
+		}
+
+		modtime := finfo.ModTime()
+		if when, ok := a.alreadyImported[fpath]; ok && when.Equal(modtime) {
+			continue
+		}
+
 		a.log.Infof("Loading OCI bundle %s", fpath)
 		if err := a.loadOne(ctx, fpath); err != nil {
 			a.log.WithError(err).Errorf("Failed to load OCI bundle %s", fpath)
-			a.EmitWithPayload("failed to load OCI bundle", fpath)
 			continue
 		}
+
+		a.alreadyImported[fpath] = modtime
 		a.log.Infof("OCI bundle %s loaded", fpath)
 	}
 	a.Emit("finished importing OCI bundles")
 }
 
-// watch creates a fs watched on the oci bundle directory. This function calls load() anytime
-// a new file is created on the directory or a write operation took place . Events are debounced
-// with a timeout of 10 seconds. This function is blocking.
-func (a *OCIBundleReconciler) watch(ctx context.Context) {
-	watcher, err := fsnotify.NewWatcher()
+// installWatcher creates a fs watcher on the oci bundle directory. This function calls
+// loadAll every time a new file is created or updated on the oci directory. Events are
+// debounced with a timeout of 10 seconds. Watcher is started with a buffer so we don't
+// miss events.
+func (a *OCIBundleReconciler) installWatcher(ctx context.Context) error {
+	watcher, err := fsnotify.NewBufferedWatcher(10)
 	if err != nil {
-		a.log.WithError(err).Error("Failed to create watcher for OCI bundles")
-		return
+		return fmt.Errorf("failed to create watcher: %w", err)
 	}
-	defer watcher.Close()
 
 	if err := watcher.Add(a.k0sVars.OCIBundleDir); err != nil {
-		a.log.WithError(err).Error("Failed to watch for OCI bundles")
-		return
+		return fmt.Errorf("failed to add watcher: %w", err)
 	}
 
 	debouncer := debounce.Debouncer[fsnotify.Event]{
@@ -144,45 +164,44 @@ func (a *OCIBundleReconciler) watch(ctx context.Context) {
 			return true
 		},
 		Callback: func(ev fsnotify.Event) {
-			a.log.Infof("Loading OCI bundle %s", ev.Name)
-			if err := a.loadOne(ctx, ev.Name); err != nil {
-				a.log.WithError(err).Errorf("Failed to load OCI bundle %s", ev.Name)
-				a.EmitWithPayload("failed to load OCI bundle", ev.Name)
-				return
-			}
-			a.log.Infof("OCI bundle %s loaded", ev.Name)
+			a.loadAll(ctx)
 		},
 	}
 
 	go func() {
 		for {
-			err, ok := <-watcher.Errors
-			if !ok {
-				return
+			if err, ok := <-watcher.Errors; ok {
+				a.log.WithError(err).Error("Error watching OCI bundle directory")
+				continue
 			}
-			a.log.WithError(err).Error("Error while watching oci bundle directory")
+			return
 		}
 	}()
 
-	a.log.Infof("Started to watch events on %s", a.k0sVars.OCIBundleDir)
-	if err := debouncer.Run(ctx); err != nil {
-		if errors.Is(err, context.Canceled) {
-			a.log.Info("OCI bundle watch bouncer ended")
-			return
-		}
-		a.log.WithError(err).Warn("OCI bundle watch bouncer exited with error")
-	}
+	go func() {
+		a.log.Infof("Started to watch events on %s", a.k0sVars.OCIBundleDir)
+		_ = debouncer.Run(ctx)
+		watcher.Close()
+		a.log.Info("OCI bundle watch bouncer ended")
+		a.end <- struct{}{}
+	}()
+
+	return nil
 }
 
 // Starts initiate the OCI bundle loader. It does an initial load of the directory and
 // once it is done, it starts a watcher on its own goroutine.
 func (a *OCIBundleReconciler) Start(ctx context.Context) error {
-	a.loadAll(ctx)
-	go a.watch(ctx)
+	ictx, cancel := context.WithCancel(context.Background())
+	a.cancel = cancel
+	if err := a.installWatcher(ictx); err != nil {
+		return fmt.Errorf("failed to install watcher: %w", err)
+	}
+	a.loadAll(ictx)
 	return nil
 }
 
-func (a OCIBundleReconciler) unpackBundle(ctx context.Context, client *containerd.Client, bundlePath string) error {
+func (a *OCIBundleReconciler) unpackBundle(ctx context.Context, client *containerd.Client, bundlePath string) error {
 	r, err := os.Open(bundlePath)
 	if err != nil {
 		return fmt.Errorf("can't open bundle file %s: %w", bundlePath, err)
@@ -210,5 +229,9 @@ func (a OCIBundleReconciler) unpackBundle(ctx context.Context, client *container
 }
 
 func (a *OCIBundleReconciler) Stop() error {
+	a.log.Info("Stopping OCI bundle loader watcher")
+	a.cancel()
+	<-a.end
+	a.log.Info("OCI bundle loader stopped")
 	return nil
 }

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -138,11 +138,10 @@ func (a *OCIBundleReconciler) watch(ctx context.Context) {
 		Timeout: 10 * time.Second,
 		Filter: func(item fsnotify.Event) bool {
 			switch item.Op {
-			case fsnotify.Create, fsnotify.Write:
-				return true
-			default:
+			case fsnotify.Remove, fsnotify.Rename:
 				return false
 			}
+			return true
 		},
 		Callback: func(ev fsnotify.Event) {
 			a.log.Infof("Loading OCI bundle %s", ev.Name)

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -84,7 +84,7 @@ func (a *OCIBundleReconciler) loadOne(ctx context.Context, fpath string) error {
 	}
 	defer client.Close()
 	if err := a.unpackBundle(ctx, client, fpath); err != nil {
-		return fmt.Errorf("failed to process oci bundle: %w", err)
+		return fmt.Errorf("failed to process OCI bundle: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

Implements an OCI bundle watcher. This allows k0s to load new OCI bundles without requiring a restart of the process. The watcher acts upon `Create()` or `Write()` operations happening in the OCI bundles directory and events are debounced with a timeout of 10 seconds.

Fixes [# 4316](https://github.com/k0sproject/k0s/issues/4316)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

At this stage I have updated `k0s` locally and created/deleted/updated bundles manually in the OCI bundles directory. I have been checking the results by inspecting the logs (as follow) and with `k0s ctr i ls`:

```
root@ec:/usr/local/bin# journalctl -u k0scontroller.service -f | grep -i component=OCIBundleReconciler
Apr 22 10:49:44 ec k0s[2014911]: time="2024-04-22 10:49:44" level=info msg="started to watch events on /var/lib/k0s/images" component=OCIBundleReconciler
Apr 22 10:50:06 ec k0s[2014911]: time="2024-04-22 10:50:06" level=info msg="OCI bundle directory changed, reconciling" component=OCIBundleReconciler
Apr 22 10:50:08 ec k0s[2014911]: time="2024-04-22 10:50:08" level=info msg="Imported image docker.io/library/x:latest" component=OCIBundleReconciler
Apr 22 10:50:28 ec k0s[2014911]: time="2024-04-22 10:50:28" level=info msg="OCI bundle directory changed, reconciling" component=OCIBundleReconciler
Apr 22 10:50:29 ec k0s[2014911]: time="2024-04-22 10:50:29" level=info msg="Imported image docker.io/library/x:latest" component=OCIBundleReconciler
Apr 22 10:51:03 ec k0s[2014911]: time="2024-04-22 10:51:03" level=info msg="OCI bundle directory changed, reconciling" component=OCIBundleReconciler
Apr 22 10:51:04 ec k0s[2014911]: time="2024-04-22 10:51:04" level=info msg="Imported image docker.io/library/y:latest" component=OCIBundleReconciler
Apr 22 10:51:40 ec k0s[2014911]: time="2024-04-22 10:51:40" level=info msg="OCI bundle directory changed, reconciling" component=OCIBundleReconciler
Apr 22 10:51:59 ec k0s[2014911]: time="2024-04-22 10:51:59" level=info msg="Imported image docker.io/library/rhel-9-kubernetes-images-1.29.3:latest" component=OCIBundleReconciler
Apr 22 10:51:59 ec k0s[2014911]: time="2024-04-22 10:51:59" level=info msg="Imported image docker.io/kurl/rhel-7-k8s:1.29.3" component=OCIBundleReconciler
Apr 22 10:51:59 ec k0s[2014911]: time="2024-04-22 10:51:59" level=info msg="Imported image docker.io/library/dockerout-containerd-1.6.28-ubuntu-22.04:latest" component=OCIBundleReconciler
```

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings