### PR TITLE
Fixed Stop() for external etcd 

### DIFF
--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -230,6 +230,10 @@ func (e *Etcd) Start(ctx context.Context) error {
 
 // Stop stops etcd
 func (e *Etcd) Stop() error {
+	if e.Config.IsExternalClusterUsed() {
+		return nil
+	}
+
 	return e.supervisor.Stop()
 }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Don't try to stop etcd in case the external one is used.
Currently, it panics:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xa8 pc=0x23053fc]

goroutine 1 [running]:
github.com/k0sproject/k0s/pkg/supervisor.(*Supervisor).Stop(0x4001257280)
        /go/src/github.com/k0sproject/k0s/pkg/supervisor/supervisor.go:237 +0x20c
github.com/k0sproject/k0s/pkg/component/controller.(*Etcd).Stop(0x400014ac80?)
        /go/src/github.com/k0sproject/k0s/pkg/component/controller/etcd.go:233 +0x24
github.com/k0sproject/k0s/pkg/component/manager.(*Manager).Stop(0x40013e3d40)
        /go/src/github.com/k0sproject/k0s/pkg/component/manager/manager.go:118 +0xe4
github.com/k0sproject/k0s/cmd/controller.(*command).start.func1()
        /go/src/github.com/k0sproject/k0s/cmd/controller/controller.go:302 +0x24
github.com/k0sproject/k0s/cmd/controller.(*command).start(0x400160f770, {0x3b2fd80, 0x40013e3d00})
        /go/src/github.com/k0sproject/k0s/cmd/controller/controller.go:502 +0x3774
github.com/k0sproject/k0s/cmd/controller.NewControllerCmd.func2(0x4000ed2600, {0x400042b2c0, 0x0, 0x2?})
        /go/src/github.com/k0sproject/k0s/cmd/controller/controller.go:114 +0x3a0
github.com/spf13/cobra.(*Command).execute(0x4000ed2600, {0x400042b2a0, 0x2, 0x2})
        /run/k0s-build/go/mod/github.com/spf13/cobra@v1.7.0/command.go:940 +0x5c4
github.com/spf13/cobra.(*Command).ExecuteC(0x4000c37500)
        /run/k0s-build/go/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x340
github.com/spf13/cobra.(*Command).Execute(...)
        /run/k0s-build/go/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/k0sproject/k0s/cmd.Execute()
        /go/src/github.com/k0sproject/k0s/cmd/root.go:194 +0x20
main.main()
        /go/src/github.com/k0sproject/k0s/main.go:43 +0x238

```

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings