### PR TITLE
Fix metadata test

### DIFF
--- a/pkg/node/nodehostname_test.go
+++ b/pkg/node/nodehostname_test.go
@@ -61,7 +61,6 @@ func TestGetNodename(t *testing.T) {
 func startFakeMetadataServer(listenOn string) {
 	http.HandleFunc("/latest/meta-data/local-hostname", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("some-hostname-from-metadata"))
-		w.WriteHeader(http.StatusOK)
 	})
 
 	go func() {

--- a/pkg/node/nodehostname_test.go
+++ b/pkg/node/nodehostname_test.go
@@ -18,6 +18,7 @@ package node
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"testing"
 
@@ -67,11 +68,15 @@ func startFakeMetadataServer(t *testing.T, listenOn string) {
 		assert.NoError(t, err)
 	})
 	server := &http.Server{Addr: listenOn, Handler: mux}
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		require.NoError(t, err)
+	}
 
 	serverError := make(chan error)
 	go func() {
 		defer close(serverError)
-		serverError <- server.ListenAndServe()
+		serverError <- server.Serve(listener)
 	}()
 
 	t.Cleanup(func() {

--- a/pkg/node/nodehostname_test.go
+++ b/pkg/node/nodehostname_test.go
@@ -49,14 +49,6 @@ func TestGetNodename(t *testing.T) {
 		require.Equal(t, nodename, name)
 	})
 
-	t.Run("windows_metadata_service_is_broken", func(t *testing.T) {
-		name, err := getNodeNameWindows("", "http://localhost:8080/not-found")
-		nodename, err2 := nodeutil.GetHostname("")
-		require.Nil(t, err)
-		require.Nil(t, err2)
-		require.Equal(t, nodename, name)
-	})
-
 	t.Run("windows_metadata_service_is_available", func(t *testing.T) {
 		name, err := getNodeNameWindows("", "http://localhost:8080/latest/meta-data/local-hostname")
 		nodename, err2 := nodeutil.GetHostname("")
@@ -71,9 +63,6 @@ func startFakeMetadataServer(listenOn string) {
 		http.HandleFunc("/latest/meta-data/local-hostname", func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte("some-hostname-from-metadata"))
 			w.WriteHeader(http.StatusOK)
-		})
-		http.HandleFunc("/not-found", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
 		})
 		_ = http.ListenAndServe(listenOn, nil)
 	}()

--- a/pkg/node/nodehostname_test.go
+++ b/pkg/node/nodehostname_test.go
@@ -61,11 +61,12 @@ func TestGetNodename(t *testing.T) {
 }
 
 func startFakeMetadataServer(t *testing.T, listenOn string) {
-	http.HandleFunc("/latest/meta-data/local-hostname", func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/latest/meta-data/local-hostname", func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("some-hostname-from-metadata"))
 		assert.NoError(t, err)
 	})
-	server := &http.Server{Addr: listenOn}
+	server := &http.Server{Addr: listenOn, Handler: mux}
 
 	serverError := make(chan error)
 	go func() {

--- a/pkg/node/nodehostname_test.go
+++ b/pkg/node/nodehostname_test.go
@@ -59,11 +59,12 @@ func TestGetNodename(t *testing.T) {
 }
 
 func startFakeMetadataServer(listenOn string) {
+	http.HandleFunc("/latest/meta-data/local-hostname", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("some-hostname-from-metadata"))
+		w.WriteHeader(http.StatusOK)
+	})
+
 	go func() {
-		http.HandleFunc("/latest/meta-data/local-hostname", func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte("some-hostname-from-metadata"))
-			w.WriteHeader(http.StatusOK)
-		})
 		_ = http.ListenAndServe(listenOn, nil)
 	}()
 }


### PR DESCRIPTION
## Description

Start listening before starting the serving goroutine. This ensures that the socket is open before the tests are executed. Prevents test races like the following:

```text
--- FAIL: TestGetNodename (0.01s)
    --- FAIL: TestGetNodename/windows_metadata_service_is_available (0.00s)
        nodehostname_test.go:65:
            	Error Trace:	/go/src/github.com/k0sproject/k0s/pkg/node/nodehostname_test.go:65
            	Error:      	Should not be: "6471c247ef83"
            	Test:       	TestGetNodename/windows_metadata_service_is_available
FAIL
```

The unavailable and broken tests were essentially doing the same. Whenever there's no handler found, Go's HTTP server will return a 404 status response anyway. Remove one of them.


Remove superfluous call to WriteHeader, as this is done automatically once something gets written to the response writer. Silences log messages like the following:

> http: superfluous response.WriteHeader call from github.com/k0sproject/k0s/pkg/node.startFakeMetadataServer.func1 (nodehostname_test.go:64)

Register a test cleanup function that gracefully shuts down the HTTP server. Also lets the test fail if there are any HTTP server related errors. Don't use the global HTTP multiplexer to reduce side-effects. Let the operating system choose an available port instead of hard-coding a port that may already be in use.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings