### PR TITLE
Disallow test code outside of tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,13 +19,6 @@ linters:
 linters-settings:
   depguard:
     rules:
-      yaml:
-        list-mode: lax
-        deny:
-          - pkg: gopkg.in/yaml.v2
-            desc: Use sigs.k8s.io/yaml.
-          - pkg: gopkg.in/yaml.v3
-            desc: Use sigs.k8s.io/yaml.
       cloud-provider:
         list-mode: lax
         files:
@@ -36,11 +29,34 @@ linters-settings:
               Usages of the k8s cloud provider are only allowed from within the
               k0s cloud provider package. This is to ensure that it's not
               leaking global flags into k0s.
-      deprecations:
+      replacements:
         list-mode: lax
         deny:
+          - pkg: gopkg.in/yaml.v2
+            desc: Use sigs.k8s.io/yaml.
+          - pkg: gopkg.in/yaml.v3
+            desc: Use sigs.k8s.io/yaml.
           - pkg: k8s.io/utils/pointer
             desc: Use k8s.io/utils/ptr.
+      tests:
+        list-mode: lax
+        files:
+          - "!$test"
+          - "!**/internal/testutil/**"
+          - "!**/inttest/**"
+          - "!**/pkg/supervisor/pingpong*.go" # only used for testing
+        deny:
+          - pkg: github.com/k0sproject/k0s/internal/testutil
+            desc: Usage of test code outside of tests.
+          - pkg: github.com/stretchr/testify
+            desc: Usage of test code outside of tests.
+      inttests:
+        list-mode: lax
+        files:
+          - "!**/inttest/**/*"
+        deny:
+          - pkg: github.com/k0sproject/k0s/inttest
+            desc: Usage of integration test code outside of integration tests.
   goheader:
     template-path: .go-header.txt
     values:

--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/internal/testutil"
-	aptcomm "github.com/k0sproject/k0s/inttest/autopilot/common"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
@@ -29,7 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimruntime "k8s.io/apimachinery/pkg/runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,14 +53,14 @@ func TestSchedulable(t *testing.T) {
 		{
 			"WorkerCompletedNoExecute",
 			[]crcli.Object{
-				&v1.Node{
+				&corev1.Node{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Node",
 						APIVersion: "v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "worker0",
-						Annotations: aptcomm.LinuxAMD64NodeLabels(),
+						Name:   "worker0",
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
 			},
@@ -69,8 +68,8 @@ func TestSchedulable(t *testing.T) {
 				AirgapUpdate: &apv1beta2.PlanCommandAirgapUpdate{
 					Version: "v99.99.99",
 					Platforms: apv1beta2.PlanPlatformResourceURLMap{
-						"linux-amd64": {
-							URL:    "https://k0s.example.com/downloads/k0s-v99.99.99-linux-amd64",
+						"theOS-theArch": {
+							URL:    "https://k0s.example.com/downloads/k0s-v99.99.99-theOS-theArch",
 							Sha256: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 						},
 					},
@@ -104,14 +103,14 @@ func TestSchedulable(t *testing.T) {
 		{
 			"HappyMoveToSchedulableWait",
 			[]crcli.Object{
-				&v1.Node{
+				&corev1.Node{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Node",
 						APIVersion: "v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "worker0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
 			},
@@ -119,8 +118,8 @@ func TestSchedulable(t *testing.T) {
 				AirgapUpdate: &apv1beta2.PlanCommandAirgapUpdate{
 					Version: "v99.99.99",
 					Platforms: apv1beta2.PlanPlatformResourceURLMap{
-						"linux-amd64": {
-							URL:    "https://k0s.example.com/downloads/k0s-v99.99.99-linux-amd64",
+						"theOS-theArch": {
+							URL:    "https://k0s.example.com/downloads/k0s-v99.99.99-theOS-theArch",
 							Sha256: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 						},
 					},
@@ -152,7 +151,7 @@ func TestSchedulable(t *testing.T) {
 
 	scheme := apimruntime.NewScheme()
 	assert.NoError(t, apscheme.AddToScheme(scheme))
-	assert.NoError(t, v1.AddToScheme(scheme))
+	assert.NoError(t, corev1.AddToScheme(scheme))
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/newplan_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/newplan_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/internal/testutil"
-	aptcomm "github.com/k0sproject/k0s/inttest/autopilot/common"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
@@ -30,7 +29,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,24 +60,24 @@ func TestNewPlan(t *testing.T) {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "controller0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
-				&v1.Node{
+				&corev1.Node{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Node",
 						APIVersion: "v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "worker0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
 			},
 			apv1beta2.PlanCommand{
 				K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{
 					Platforms: apv1beta2.PlanPlatformResourceURLMap{
-						"linux-amd64": {},
+						"theOS-theArch": {},
 					},
 					Targets: apv1beta2.PlanCommandTargets{
 						Controllers: apv1beta2.PlanCommandTarget{
@@ -113,21 +112,21 @@ func TestNewPlan(t *testing.T) {
 		{
 			"MissingController",
 			[]crcli.Object{
-				&v1.Node{
+				&corev1.Node{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Node",
 						APIVersion: "v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "worker0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
 			},
 			apv1beta2.PlanCommand{
 				K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{
 					Platforms: apv1beta2.PlanPlatformResourceURLMap{
-						"linux-amd64": {},
+						"theOS-theArch": {},
 					},
 					Targets: apv1beta2.PlanCommandTargets{
 						Controllers: apv1beta2.PlanCommandTarget{
@@ -169,14 +168,14 @@ func TestNewPlan(t *testing.T) {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "controller0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
 			},
 			apv1beta2.PlanCommand{
 				K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{
 					Platforms: apv1beta2.PlanPlatformResourceURLMap{
-						"linux-amd64": {},
+						"theOS-theArch": {},
 					},
 					Targets: apv1beta2.PlanCommandTargets{
 						Controllers: apv1beta2.PlanCommandTarget{
@@ -217,28 +216,25 @@ func TestNewPlan(t *testing.T) {
 						APIVersion: "autopilot.k0sproject.io/v1beta2",
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "controller0",
-						Labels: map[string]string{
-							v1.LabelOSStable:   "windows",
-							v1.LabelArchStable: "amd64",
-						},
+						Name:   "controller0",
+						Labels: map[string]string{corev1.LabelOSStable: "anotherOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
-				&v1.Node{
+				&corev1.Node{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Node",
 						APIVersion: "v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "worker0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
 			},
 			apv1beta2.PlanCommand{
 				K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{
 					Platforms: apv1beta2.PlanPlatformResourceURLMap{
-						"linux-amd64": {},
+						"theOS-theArch": {},
 					},
 					Targets: apv1beta2.PlanCommandTargets{
 						Controllers: apv1beta2.PlanCommandTarget{
@@ -280,27 +276,24 @@ func TestNewPlan(t *testing.T) {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "controller0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
-				&v1.Node{
+				&corev1.Node{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Node",
 						APIVersion: "v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "worker0",
-						Labels: map[string]string{
-							v1.LabelOSStable:   "windows",
-							v1.LabelArchStable: "amd64",
-						},
+						Name:   "worker0",
+						Labels: map[string]string{corev1.LabelOSStable: "anotherOS", corev1.LabelArchStable: "amd64"},
 					},
 				},
 			},
 			apv1beta2.PlanCommand{
 				K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{
 					Platforms: apv1beta2.PlanPlatformResourceURLMap{
-						"linux-amd64": {},
+						"theOS-theArch": {},
 					},
 					Targets: apv1beta2.PlanCommandTargets{
 						Controllers: apv1beta2.PlanCommandTarget{
@@ -342,24 +335,24 @@ func TestNewPlan(t *testing.T) {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "controller0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
-				&v1.Node{
+				&corev1.Node{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Node",
 						APIVersion: "v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "worker0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
 			},
 			apv1beta2.PlanCommand{
 				K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{
 					Platforms: apv1beta2.PlanPlatformResourceURLMap{
-						"linux-amd64": {},
+						"theOS-theArch": {},
 					},
 					Targets: apv1beta2.PlanCommandTargets{
 						Controllers: apv1beta2.PlanCommandTarget{
@@ -401,24 +394,24 @@ func TestNewPlan(t *testing.T) {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "controller0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
-				&v1.Node{
+				&corev1.Node{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Node",
 						APIVersion: "v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "worker0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
 			},
 			apv1beta2.PlanCommand{
 				K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{
 					Platforms: apv1beta2.PlanPlatformResourceURLMap{
-						"linux-amd64": {},
+						"theOS-theArch": {},
 					},
 					Targets: apv1beta2.PlanCommandTargets{
 						Controllers: apv1beta2.PlanCommandTarget{
@@ -451,7 +444,7 @@ func TestNewPlan(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 	assert.NoError(t, apscheme.AddToScheme(scheme))
-	assert.NoError(t, v1.AddToScheme(scheme))
+	assert.NoError(t, corev1.AddToScheme(scheme))
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/internal/testutil"
-	aptcomm "github.com/k0sproject/k0s/inttest/autopilot/common"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
@@ -29,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimruntime "k8s.io/apimachinery/pkg/runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,8 +60,8 @@ func TestSchedulable(t *testing.T) {
 						APIVersion: "autopilot.k0sproject.io/v1beta2",
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "controller0",
-						Annotations: aptcomm.LinuxAMD64NodeLabels(),
+						Name:   "controller0",
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
 			},
@@ -69,8 +69,8 @@ func TestSchedulable(t *testing.T) {
 				K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{
 					Version: "v99.99.99",
 					Platforms: apv1beta2.PlanPlatformResourceURLMap{
-						"linux-amd64": {
-							URL:    "https://k0s.example.com/downloads/k0s-v99.99.99-linux-amd64",
+						"theOS-theArch": {
+							URL:    "https://k0s.example.com/downloads/k0s-v99.99.99-theOS-theArch",
 							Sha256: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 						},
 					},
@@ -114,7 +114,7 @@ func TestSchedulable(t *testing.T) {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "controller0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
 			},
@@ -122,8 +122,8 @@ func TestSchedulable(t *testing.T) {
 				K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{
 					Version: "v99.99.99",
 					Platforms: apv1beta2.PlanPlatformResourceURLMap{
-						"linux-amd64": {
-							URL:    "https://k0s.example.com/downloads/k0s-v99.99.99-linux-amd64",
+						"theOS-theArch": {
+							URL:    "https://k0s.example.com/downloads/k0s-v99.99.99-theOS-theArch",
 							Sha256: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 						},
 					},

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/exists_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/exists_test.go
@@ -18,13 +18,12 @@ import (
 	"context"
 	"testing"
 
-	aptcomm "github.com/k0sproject/k0s/inttest/autopilot/common"
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 	apscheme "github.com/k0sproject/k0s/pkg/client/clientset/scheme"
 
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,12 +54,12 @@ func TestObjectExistsWithPlatform(t *testing.T) {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "controller0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
 			},
 			apv1beta2.PlanPlatformResourceURLMap{
-				"linux-amd64": apv1beta2.PlanResourceURL{}, // just needs to exist
+				"theOS-theArch": apv1beta2.PlanResourceURL{}, // just needs to exist
 			},
 			true,
 			nil,
@@ -81,7 +80,7 @@ func TestObjectExistsWithPlatform(t *testing.T) {
 				},
 			},
 			apv1beta2.PlanPlatformResourceURLMap{
-				"linux-amd64": apv1beta2.PlanResourceURL{}, // just needs to exist
+				"theOS-theArch": apv1beta2.PlanResourceURL{}, // just needs to exist
 			},
 			false,
 			&appc.SignalMissingPlatform,
@@ -98,7 +97,7 @@ func TestObjectExistsWithPlatform(t *testing.T) {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "controller0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
 			},
@@ -111,21 +110,21 @@ func TestObjectExistsWithPlatform(t *testing.T) {
 		{
 			"HappyNode",
 			"worker0",
-			&v1.Node{},
+			&corev1.Node{},
 			[]crcli.Object{
-				&v1.Node{
+				&corev1.Node{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Node",
 						APIVersion: "v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "worker0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
 			},
 			apv1beta2.PlanPlatformResourceURLMap{
-				"linux-amd64": apv1beta2.PlanResourceURL{}, // just needs to exist
+				"theOS-theArch": apv1beta2.PlanResourceURL{}, // just needs to exist
 			},
 			true,
 			nil,
@@ -133,9 +132,9 @@ func TestObjectExistsWithPlatform(t *testing.T) {
 		{
 			"NodeMissingPlatformNode",
 			"worker0",
-			&v1.Node{},
+			&corev1.Node{},
 			[]crcli.Object{
-				&v1.Node{
+				&corev1.Node{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Node",
 						APIVersion: "v1",
@@ -146,7 +145,7 @@ func TestObjectExistsWithPlatform(t *testing.T) {
 				},
 			},
 			apv1beta2.PlanPlatformResourceURLMap{
-				"linux-amd64": apv1beta2.PlanResourceURL{}, // just needs to exist
+				"theOS-theArch": apv1beta2.PlanResourceURL{}, // just needs to exist
 			},
 			false,
 			&appc.SignalMissingPlatform,
@@ -154,16 +153,16 @@ func TestObjectExistsWithPlatform(t *testing.T) {
 		{
 			"NodeMissingPlatformPlan",
 			"worker0",
-			&v1.Node{},
+			&corev1.Node{},
 			[]crcli.Object{
-				&v1.Node{
+				&corev1.Node{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Node",
 						APIVersion: "v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "worker0",
-						Labels: aptcomm.LinuxAMD64NodeLabels(),
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
 					},
 				},
 			},
@@ -177,7 +176,7 @@ func TestObjectExistsWithPlatform(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 	assert.NoError(t, apscheme.AddToScheme(scheme))
-	assert.NoError(t, v1.AddToScheme(scheme))
+	assert.NoError(t, corev1.AddToScheme(scheme))
 
 	for _, test := range tests {
 		client := crfake.NewClientBuilder().WithObjects(test.objects...).WithScheme(scheme).Build()


### PR DESCRIPTION
## Description

Add some rules to the depguard linter to ensure that test code is only called from test files. This will ensure that test code is not accidentally used in production code.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings