### PR TITLE
Log keepalived config in debug mode

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -237,6 +237,7 @@ func (c *command) start(ctx context.Context) error {
 			K0sVars:         c.K0sVars,
 			Config:          cplb.Keepalived,
 			DetailedLogging: c.Debug,
+			LogConfig:       c.Debug,
 			KubeConfigPath:  c.K0sVars.AdminKubeConfigPath,
 			APIPort:         nodeConfig.Spec.API.Port,
 		})

--- a/pkg/component/controller/cplb_unix.go
+++ b/pkg/component/controller/cplb_unix.go
@@ -48,6 +48,7 @@ type Keepalived struct {
 	K0sVars          *config.CfgVars
 	Config           *k0sAPI.KeepalivedSpec
 	DetailedLogging  bool
+	LogConfig        bool
 	APIPort          int
 	KubeConfigPath   string
 	keepalivedConfig *keepalivedConfig
@@ -120,6 +121,9 @@ func (k *Keepalived) Start(_ context.Context) error {
 
 	if k.DetailedLogging {
 		args = append(args, "--log-detail")
+	}
+	if k.LogConfig {
+		args = append(args, "--dump-conf")
 	}
 
 	k.log.Infoln("Starting keepalived")

--- a/pkg/component/controller/cplb_windows.go
+++ b/pkg/component/controller/cplb_windows.go
@@ -30,6 +30,7 @@ type Keepalived struct {
 	K0sVars         *config.CfgVars
 	Config          *k0sAPI.KeepalivedSpec
 	DetailedLogging bool
+	LogConfig       bool
 	APIPort         int
 	KubeConfigPath  string
 }


### PR DESCRIPTION
## Description

Keepalived has the `--dump-conf` flag, which spits out keepalived's config when loaded. Enable this when k0s is started in debug mode.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings