### PR TITLE
Add an error callback to the CPLB reconciler watcher

### DIFF
--- a/pkg/component/controller/cplb_reconciler.go
+++ b/pkg/component/controller/cplb_reconciler.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -73,29 +72,34 @@ func (r *CPLBReconciler) Stop() {
 }
 
 func (r *CPLBReconciler) watchAPIServers(ctx context.Context, clientSet kubernetes.Interface) {
-	for {
-		select {
-		default:
-			err := watch.Endpoints(clientSet.CoreV1().Endpoints("default")).
-				WithObjectName("kubernetes").
-				Until(ctx, func(endpoints *corev1.Endpoints) (bool, error) {
-					r.maybeUpdateIPs(endpoints)
-					return false, nil
-				})
-			// Log any reconciliation errors, but only if they don't
-			// indicate that the reconciler has been stopped.
-			if err != nil && !errors.Is(err, ctx.Err()) {
-				r.log.WithError(err).Error("Failed to reconcile API server addresses")
+	var lastObservedVersion string
+	_ = watch.Endpoints(clientSet.CoreV1().Endpoints("default")).
+		WithObjectName("kubernetes").
+		WithErrorCallback(func(err error) (time.Duration, error) {
+			if retryAfter, e := watch.IsRetryable(err); e == nil {
+				r.log.WithError(err).Infof(
+					"Transient error while watching API server endpoints"+
+						", last observed version is %q, starting over in %s ...",
+					lastObservedVersion, retryAfter,
+				)
+				return retryAfter, nil
 			}
 
-			// After a watch error wait 5 seconds before retrying
-			time.Sleep(5 * time.Second)
-
-		case <-ctx.Done():
-			r.log.Info("Stopped watching kubernetes endpoints")
-			return
-		}
-	}
+			retryAfter := 10 * time.Second
+			r.log.WithError(err).Errorf(
+				"Failed to watch API server endpoints"+
+					", last observed version is %q, starting over in %s ...",
+				lastObservedVersion, retryAfter,
+			)
+			return retryAfter, nil
+		}).
+		Until(ctx, func(endpoints *corev1.Endpoints) (bool, error) {
+			if lastObservedVersion != endpoints.ResourceVersion {
+				lastObservedVersion = endpoints.ResourceVersion
+				r.maybeUpdateIPs(endpoints)
+			}
+			return false, nil
+		})
 }
 
 // maybeUpdateIPs updates the list of IP addresses if the new list has


### PR DESCRIPTION
## Description

The error callback allows for logging and retries after a backoff, eliminating the outer loop and extra select, while also responding promptly to context cancellations. Also track the last observed resource version of the API server endpoints for logging and event deduplication.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings