### PR TITLE
Close update channel when the watch loop terminates

### DIFF
--- a/pkg/component/controller/cplb_reconciler.go
+++ b/pkg/component/controller/cplb_reconciler.go
@@ -59,7 +59,10 @@ func (r *CPLBReconciler) Start() error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	r.watchCancelFunc = cancel
-	go r.watchAPIServers(ctx, clientset)
+	go func() {
+		defer close(r.updateCh)
+		r.watchAPIServers(ctx, clientset)
+	}()
 
 	return nil
 }
@@ -67,7 +70,6 @@ func (r *CPLBReconciler) Start() error {
 func (r *CPLBReconciler) Stop() {
 	r.log.Info("Stopping CPLB reconciler")
 	r.watchCancelFunc()
-	close(r.updateCh)
 }
 
 func (r *CPLBReconciler) watchAPIServers(ctx context.Context, clientSet kubernetes.Interface) {


### PR DESCRIPTION
## Description

This addresses a potential panic if the reconciler is stopped when it's processing an update. It might have tried to send an event to the update channel that was closed at the same time.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings