### PR TITLE
Default DelayLoop to 1m

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -340,7 +340,7 @@ Configuration options required for using VRRP to configure VIPs in control plane
 | Element                     | Description                                                                                                                                      |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `ipAddress`                 | The load balancer's listen address.                                                                                                              |
-| `delayLoop`                 | Delay timer for check polling. DelayLoop accepts microsecond precision. Further precision will be truncated without warnings. Example: `10s`.    |
+| `delayLoop`                 | Delay timer for check polling. DelayLoop accepts microsecond precision. Further precision will be truncated without warnings. Defaults to `1m`.  |
 | `lbAlgo`                    | Algorithm used by keepalived. Supported algorithms: `rr`, `wrr`, `lc`, `wlc`, `lblc`, `dh`, `sh`, `sed`, `nq`. Default: `rr`.                    |
 | `lbKind`                    | Kind of ipvs load balancer. Supported values: `NAT`, `DR`, `TUN`  Default: `DR`.                                                                 |
 | `persistenceTimeoutSeconds` | Timeout value for persistent connections in seconds. Must be in the range of 1-2678400 (31 days). If not specified, defaults to 360 (6 minutes). |

--- a/pkg/apis/k0s/v1beta1/cplb_test.go
+++ b/pkg/apis/k0s/v1beta1/cplb_test.go
@@ -165,14 +165,14 @@ func (s *CPLBSuite) TestValidateVirtualServers() {
 			expectedVSS: []VirtualServer{
 				{
 					IPAddress:                 "1.2.3.4",
-					DelayLoop:                 metav1.Duration{Duration: 0},
+					DelayLoop:                 metav1.Duration{Duration: time.Minute},
 					LBAlgo:                    RRAlgo,
 					LBKind:                    DRLBKind,
 					PersistenceTimeoutSeconds: 360,
 				},
 				{
 					IPAddress:                 "1.2.3.5",
-					DelayLoop:                 metav1.Duration{Duration: 0},
+					DelayLoop:                 metav1.Duration{Duration: time.Minute},
 					LBAlgo:                    RRAlgo,
 					LBKind:                    DRLBKind,
 					PersistenceTimeoutSeconds: 360,

--- a/static/manifests/v1beta1/CustomResourceDefinition/k0s.k0sproject.io_clusterconfigs.yaml
+++ b/static/manifests/v1beta1/CustomResourceDefinition/k0s.k0sproject.io_clusterconfigs.yaml
@@ -390,10 +390,11 @@ spec:
                                 options for a virtual server.
                               properties:
                                 delayLoop:
+                                  default: 1m
                                   description: |-
                                     DelayLoop is the delay timer for check polling. DelayLoop accepts
                                     microsecond precision. Further precision will be truncated without
-                                    warnings.
+                                    warnings. Defaults to 1m.
                                   type: string
                                 ipAddress:
                                   description: IPAddress is the virtual IP address


### PR DESCRIPTION
## Description

This is what keepalived does. A value of 0 is rejected by keepalived:

> (/run/k0s/keepalived.conf: Line 33) number '0' outside range [0.000001, 18446744073709.551614]
> (/run/k0s/keepalived.conf: Line 33) virtual server delay loop '0' invalid - ignoring

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings