### PR TITLE
[Backport release-1.27] Fix metadata test

### DIFF
--- a/pkg/node/nodehostname_test.go
+++ b/pkg/node/nodehostname_test.go
@@ -61,7 +61,6 @@ func TestGetNodename(t *testing.T) {
 func startFakeMetadataServer(listenOn string) {
 	http.HandleFunc("/latest/meta-data/local-hostname", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("some-hostname-from-metadata"))
-		w.WriteHeader(http.StatusOK)
 	})
 
 	go func() {

--- a/pkg/node/nodehostname_test.go
+++ b/pkg/node/nodehostname_test.go
@@ -18,6 +18,7 @@ package node
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"testing"
 
@@ -67,11 +68,15 @@ func startFakeMetadataServer(t *testing.T, listenOn string) {
 		assert.NoError(t, err)
 	})
 	server := &http.Server{Addr: listenOn, Handler: mux}
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		require.NoError(t, err)
+	}
 
 	serverError := make(chan error)
 	go func() {
 		defer close(serverError)
-		serverError <- server.ListenAndServe()
+		serverError <- server.Serve(listener)
 	}()
 
 	t.Cleanup(func() {

--- a/pkg/node/nodehostname_test.go
+++ b/pkg/node/nodehostname_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2023 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	nodeutil "k8s.io/component-helpers/node/util"
+)
+
+func TestGetNodename(t *testing.T) {
+
+	startFakeMetadataServer(":8080")
+	t.Run("should_always_return_override_if_given", func(t *testing.T) {
+		name, err := GetNodename("override")
+		require.Equal(t, "override", name)
+		require.Nil(t, err)
+	})
+
+	t.Run("should_call_kubernetes_hostname_helper_on_linux", func(t *testing.T) {
+		name, err := GetNodename("")
+		name2, err2 := nodeutil.GetHostname("")
+		require.Equal(t, name, name2)
+		require.Nil(t, err)
+		require.Nil(t, err2)
+	})
+
+	t.Run("windows_no_metadata_service_available", func(t *testing.T) {
+		name, err := getNodeNameWindows("", "http://localhost:8080")
+		nodename, err2 := nodeutil.GetHostname("")
+		require.Nil(t, err)
+		require.Nil(t, err2)
+		require.Equal(t, nodename, name)
+	})
+
+	t.Run("windows_metadata_service_is_available", func(t *testing.T) {
+		name, err := getNodeNameWindows("", "http://localhost:8080/latest/meta-data/local-hostname")
+		nodename, err2 := nodeutil.GetHostname("")
+		require.Nil(t, err)
+		require.Nil(t, err2)
+		require.NotEqual(t, nodename, name)
+	})
+}
+
+func startFakeMetadataServer(listenOn string) {
+	go func() {
+		http.HandleFunc("/latest/meta-data/local-hostname", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("some-hostname-from-metadata"))
+			w.WriteHeader(http.StatusOK)
+		})
+		_ = http.ListenAndServe(listenOn, nil)
+	}()
+}

--- a/pkg/node/nodehostname_test.go
+++ b/pkg/node/nodehostname_test.go
@@ -61,11 +61,12 @@ func TestGetNodename(t *testing.T) {
 }
 
 func startFakeMetadataServer(t *testing.T, listenOn string) {
-	http.HandleFunc("/latest/meta-data/local-hostname", func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/latest/meta-data/local-hostname", func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("some-hostname-from-metadata"))
 		assert.NoError(t, err)
 	})
-	server := &http.Server{Addr: listenOn}
+	server := &http.Server{Addr: listenOn, Handler: mux}
 
 	serverError := make(chan error)
 	go func() {

--- a/pkg/node/nodehostname_test.go
+++ b/pkg/node/nodehostname_test.go
@@ -59,11 +59,12 @@ func TestGetNodename(t *testing.T) {
 }
 
 func startFakeMetadataServer(listenOn string) {
+	http.HandleFunc("/latest/meta-data/local-hostname", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("some-hostname-from-metadata"))
+		w.WriteHeader(http.StatusOK)
+	})
+
 	go func() {
-		http.HandleFunc("/latest/meta-data/local-hostname", func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte("some-hostname-from-metadata"))
-			w.WriteHeader(http.StatusOK)
-		})
 		_ = http.ListenAndServe(listenOn, nil)
 	}()
 }


### PR DESCRIPTION
Automated backport to release-1.27, triggered by a label in https://github.com/k0sproject/k0s/pull/4368.