### PR TITLE
Stop reconciler before keepalived

### DIFF
--- a/pkg/component/controller/cplb_unix.go
+++ b/pkg/component/controller/cplb_unix.go
@@ -58,6 +58,7 @@ type Keepalived struct {
 	configFilePath   string
 	reconciler       *CPLBReconciler
 	updateCh         chan struct{}
+	reconcilerDone   chan struct{}
 }
 
 // Init extracts the needed binaries and creates the directories
@@ -137,7 +138,12 @@ func (k *Keepalived) Start(_ context.Context) error {
 	}
 
 	if k.reconciler != nil {
-		go k.watchReconcilerUpdates()
+		reconcilerDone := make(chan struct{})
+		k.reconcilerDone = reconcilerDone
+		go func() {
+			defer close(reconcilerDone)
+			k.watchReconcilerUpdates()
+		}()
 	}
 	return k.supervisor.Supervise()
 }
@@ -145,16 +151,17 @@ func (k *Keepalived) Start(_ context.Context) error {
 // Stops keepalived and cleans up the virtual IPs. This is done so that if the
 // k0s controller is stopped, it can still reach the other APIservers on the VIP
 func (k *Keepalived) Stop() error {
+	if k.reconciler != nil {
+		k.log.Infof("Stopping cplb-reconciler")
+		k.reconciler.Stop()
+		close(k.updateCh)
+		<-k.reconcilerDone
+	}
+
 	k.log.Infof("Stopping keepalived")
 	if err := k.supervisor.Stop(); err != nil {
 		// Failed to stop keepalived. Don't delete the VIP, just in case.
 		return fmt.Errorf("failed to stop keepalived: %w", err)
-	}
-
-	k.log.Infof("Stopping cplb-reconciler")
-	if k.reconciler != nil {
-		k.reconciler.Stop()
-		close(k.updateCh)
 	}
 
 	k.log.Infof("Deleting dummy interface")


### PR DESCRIPTION
## Description

So it's impossible for the reconciler to try to process updates and signal a non-existent keepalived process. Have a done channel for that which gets closed as soon as the reconciling goroutine terminates. Make the reconciler stop method blocking, so that it does not return until the watch has finished. This way, closing the update channel can be done in the component itself, where it is created. Move the reconciler stop block before the supervisor stop block.

There's still the possibility to signal the wrong PID in case keepalived is being respawned.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings