### PR TITLE
Use a versioned worker config stack

### DIFF
--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -143,7 +143,7 @@ func (r *Reconciler) Init(context.Context) error {
 			return err
 		}
 		return (&applier.Stack{
-			Name:      "k0s-" + constant.WorkerConfigComponentName,
+			Name:      fmt.Sprintf("k0s-%s-%s", constant.WorkerConfigComponentName, constant.KubernetesMajorMinorVersion),
 			Client:    dynamicClient,
 			Discovery: discoveryClient,
 			Resources: resources,
@@ -550,7 +550,7 @@ func buildRBACResources(configMaps []*corev1.ConfigMap) []resource {
 	sort.Strings(configMapNames)
 
 	meta := metav1.ObjectMeta{
-		Name:      fmt.Sprintf("system:bootstrappers:%s", constant.WorkerConfigComponentName),
+		Name:      fmt.Sprintf("system:bootstrappers:%s-%s", constant.WorkerConfigComponentName, constant.KubernetesMajorMinorVersion),
 		Namespace: "kube-system",
 		Labels:    applier.CommonLabels(constant.WorkerConfigComponentName),
 	}

--- a/pkg/component/controller/workerconfig/reconciler_test.go
+++ b/pkg/component/controller/workerconfig/reconciler_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/config"
+	"github.com/k0sproject/k0s/pkg/constant"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -405,7 +406,7 @@ func TestReconciler_ResourceGeneration(t *testing.T) {
 		})
 	}
 
-	const rbacName = "system:bootstrappers:worker-config"
+	const rbacName = "system:bootstrappers:worker-config-" + constant.KubernetesMajorMinorVersion
 
 	t.Run("Role", func(t *testing.T) {
 		role := findResource(t, "Expected to find a Role named "+rbacName,
@@ -730,6 +731,7 @@ func requireKubelet(t *testing.T, resources []*unstructured.Unstructured, name s
 }
 
 func findResource(t *testing.T, failureMessage string, resources resources, probe func(*unstructured.Unstructured) bool) *unstructured.Unstructured {
+	t.Helper()
 	for _, resource := range resources {
 		if probe(resource) {
 			return resource


### PR DESCRIPTION
## Description

The worker config ConfigMaps have the Kubernetes version in their names. This is to ensure a seamless upgrade path when upgrading minor k0s versions. However, the RBAC resources and the stack name itself didn't have the version in their names. This means that as soon as a controller with the new minor k0s version takes over, it removes all previous worker ConfigMaps from the cluster, effectively defeating the purpose of the versioned names.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings