### PR TITLE
Introduce `check-metricsscraper-singlenode`

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -99,6 +99,9 @@ check-network-conformance-calico: TIMEOUT=15m
 check-network-conformance-calico: export K0S_NETWORK_CONFORMANCE_CNI=calico
 check-network-conformance-calico: TEST_PACKAGE=network-conformance
 
+check-metricsscraper-singlenode: export K0S_SINGLENODE=1
+check-metricsscraper-singlenode: TEST_PACKAGE=metricsscraper
+
 check-nllb: TIMEOUT=15m
 
 check-openebs: TIMEOUT=7m

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -46,6 +46,7 @@ smoketests := \
 	check-kuberouter \
 	check-metrics \
 	check-metricsscraper \
+	check-metricsscraper-singlenode \
 	check-multicontroller \
 	check-network-conformance-calico \
 	check-network-conformance-kuberouter \

--- a/inttest/metricsscraper/metricsscraper_test.go
+++ b/inttest/metricsscraper/metricsscraper_test.go
@@ -18,14 +18,16 @@ package metricsscraper
 
 import (
 	"context"
-	"strings"
+	"encoding/json"
+	"slices"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/k0sproject/k0s/inttest/common"
+
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type MetricsScraperSuite struct {
@@ -45,7 +47,7 @@ func (s *MetricsScraperSuite) TestK0sGetsUp() {
 	s.Require().NoError(s.waitForPushgateway())
 
 	s.T().Logf("Waiting for metrics")
-	s.Require().NoError(s.waitForMetrics())
+	s.Require().NoError(s.waitForMetrics("kube-scheduler", "kube-controller-manager", "etcd"))
 }
 
 func (s *MetricsScraperSuite) waitForPushgateway() error {
@@ -57,22 +59,61 @@ func (s *MetricsScraperSuite) waitForPushgateway() error {
 	return common.WaitForDeployment(s.Context(), kc, "k0s-pushgateway", "k0s-system")
 }
 
-func (s *MetricsScraperSuite) waitForMetrics() error {
+func (s *MetricsScraperSuite) waitForMetrics(expectedJobs ...string) error {
 	kc, err := s.KubeClient(s.ControllerNode(0))
 	if err != nil {
 		return err
 	}
 
-	return wait.PollImmediateUntilWithContext(s.Context(), 5*time.Second, func(ctx context.Context) (done bool, err error) {
+	slices.Sort(expectedJobs)
 
-		b, err := kc.RESTClient().Get().AbsPath("/api/v1/namespaces/k0s-system/services/http:k0s-pushgateway:http/proxy/metrics").DoRaw(s.Context())
+	return wait.PollUntilContextCancel(s.Context(), 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		b, err := kc.RESTClient().Get().AbsPath("/api/v1/namespaces/k0s-system/services/http:k0s-pushgateway:http/proxy/api/v1/metrics").DoRaw(s.Context())
 		if err != nil {
 			return false, nil
 		}
 
-		// wait for kube-scheduler and kube-controller-manager metrics
-		output := string(b)
-		return strings.Contains(output, `job="kube-scheduler"`) && strings.Contains(output, `job="kube-controller-manager"`) && strings.Contains(output, `job="etcd"`), nil
+		var metrics struct {
+			Data []struct {
+				// Last Unix time when changing this group in the Pushgateway succeeded.
+				PushTimeSeconds struct {
+					Metrics []struct {
+						Labels map[string]string `json:"labels"`
+						Value  string            `json:"value"`
+					} `json:"metrics"`
+				} `json:"push_time_seconds"`
+			} `json:"data"`
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal(b, &metrics); err != nil {
+			s.T().Log(err)
+			return false, nil
+		}
+
+		if metrics.Status != "success" {
+			return false, err
+		}
+
+		// Collect all the jobs that had successful pushes.
+		var jobs []string
+		for i := range metrics.Data {
+			pts := &metrics.Data[i].PushTimeSeconds
+			for i := range pts.Metrics {
+				if job, ok := pts.Metrics[i].Labels["job"]; ok {
+					if pts.Metrics[i].Value > "0" {
+						if idx, found := slices.BinarySearch(jobs, job); !found {
+							jobs = slices.Insert(jobs, idx, job)
+						}
+						break
+					}
+				}
+			}
+		}
+
+		s.T().Log("Jobs:", jobs)
+
+		// Return if the job lists match.
+		return slices.Equal(expectedJobs, jobs), nil
 	})
 }
 


### PR DESCRIPTION
## Description

This is a variant of `check-metricsscraper` that executes the inttest on a single-node cluster. This mainly means that, in addition to etcd, kine scraping is also tested. Use the JSON API and look for the `push_time_seconds` metric. Collect all job labels that had successful pushes and compare it to the list of expected jobs.

See:
* #4411
* #4421

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings