### PR TITLE
Add readinessProbe/minReadySeconds to kube-router

### DIFF
--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -243,6 +243,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: kube-router
+      minReadySeconds: 5
       initContainers:
         - name: install-cni-bins
           image: {{ .CNIInstallerImage }}
@@ -321,12 +322,25 @@ spec:
               fieldPath: metadata.name
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
+        ports:
+        - name: healthz
+          containerPort: 20244
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 20244
-          initialDelaySeconds: 10
+            port: healthz
+          initialDelaySeconds: 300
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 6
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
           periodSeconds: 3
+          timeoutSeconds: 3
+          failureThreshold: 3
+          successThreshold: 3
         resources:
           requests:
             cpu: 250m


### PR DESCRIPTION
## Description

This allows for better feedback of kube-router health via the DaemonSet resource. Without those, it's possible to observe a "healthy" DaemonSet, even if it's not. This affects e.g. rolling updates, and, most notably k0s's own integration tests.

See:
* #4411
* #4421

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings