### PR TITLE
Change kine metrics port from 8080 to 2380

### DIFF
--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -118,6 +118,8 @@ func (k *Kine) Start(ctx context.Context) error {
 			// invalid URLs that are understood by kine.
 			// https://github.com/k3s-io/kine/blob/v0.10.1/pkg/endpoint/endpoint.go#L277-L285
 			fmt.Sprintf("--listen-address=unix://%s", k.K0sVars.KineSocketPath),
+			// Enable metrics on port 2380. The default is 8080, which clashes with kube-router.
+			"--metrics-bind-address=:2380",
 		},
 		UID: k.uid,
 		GID: k.gid,

--- a/pkg/component/controller/metrics.go
+++ b/pkg/component/controller/metrics.go
@@ -205,7 +205,7 @@ func (m *Metrics) newKineJob() (*job, error) {
 
 	return &job{
 		log:          m.log.WithField("metrics_job", "kine"),
-		scrapeURL:    "http://localhost:8080/metrics",
+		scrapeURL:    "http://localhost:2380/metrics",
 		name:         "kine",
 		hostname:     m.hostname,
 		scrapeClient: httpClient,


### PR DESCRIPTION
## Description

The default port is 8080. This conflicts with kube-router, which since 2.x fails if it cannot bind to its metrics port. This leads to a situation where the default configuration for a single node k0s cluster is broken, as kube-router will go into a crash loop. Kube-router 1.x will not be able to provide metrics, but will simply log the error and move on. The integration tests did not cover this case properly, as the kube-router manifests did not specify a readiness probe that the inttests need to detect problems with daemon sets.

Port 2380 was chosen because it is normally used by etcd. Kine also uses port 2379 for the client API, so why not use 2380 as well?

Related:
* #4420
* #4419

Fixes:
* #4411

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings