### PR TITLE
Lessen the systemd RestartSec to 10 secs

### DIFF
--- a/pkg/install/service.go
+++ b/pkg/install/service.go
@@ -226,7 +226,7 @@ ExecStart={{.Path|cmdEscape}}{{range .Arguments}} {{.|cmdEscape}}{{end}}
 {{- if .Option.Environment}}{{range .Option.Environment}}
 Environment="{{.}}"{{end}}{{- end}}
 
-RestartSec=120
+RestartSec=10
 Delegate=yes
 KillMode=process
 LimitCORE=infinity


### PR DESCRIPTION
## Description

Currently the RestartSec is 120, which mean that systemd waits 2mins before it restarts k0s. This makes updates very slow with autopilot, i.e. with 3 controllers updating the controllers will take 6mins.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings