### PR TITLE
Make k0s reset fail if it can't reach containerd

### DIFF
--- a/pkg/container/runtime/runtime.go
+++ b/pkg/container/runtime/runtime.go
@@ -16,12 +16,15 @@ limitations under the License.
 
 package runtime
 
-import "net/url"
+import (
+	"context"
+	"net/url"
+)
 
 type ContainerRuntime interface {
-	ListContainers() ([]string, error)
-	RemoveContainer(id string) error
-	StopContainer(id string) error
+	ListContainers(ctx context.Context) ([]string, error)
+	RemoveContainer(ctx context.Context, id string) error
+	StopContainer(ctx context.Context, id string) error
 }
 
 func NewContainerRuntime(runtimeEndpoint *url.URL) ContainerRuntime {


### PR DESCRIPTION
## Description

Prior to this commit, if the containerd unix socket wasn't listening grpc.Dial would try to connect forever.

This makes the dial retry about 3 times and we retry the whole ListPods operation 3 times and after that we assume this step has failed.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings