### PR TITLE
Allow CPLB to work with externalAddress

### DIFF
--- a/docs/cplb.md
+++ b/docs/cplb.md
@@ -7,9 +7,14 @@ CPLB has two features that are independent, but normally will be used together: 
 automatic assignation of predefined IP addresses using VRRP across control plane nodes. VirtualServers allows to
 do Load Balancing to the other control plane nodes.
 
-This feature is intended to be used for external traffic. This feature is fully compatible with
+By default, CPLB is not used for internal traffic. This feature is fully compatible with
 [node-local load balancing (NLLB)](nllb.md) which means CPLB can be used for external traffic and NLLB for
 internal traffic at the same time.
+
+Additionally, CPLB can be used for internal traffic as well if [`spec.api.externalAddress`][specapi] is
+configured and the [endpoint-reconciler is disabled.](configuration.md#disabling-controller-components)
+
+[specapi]: configuration.md#specapi
 
 ## Technical functionality
 
@@ -52,9 +57,9 @@ following:
   These do not provide any sort of security against ill-intentioned attacks, they are
   safety features to prevent accidental conflicts between VRRP instances in the same
   network segment.
-* If `VirtualServers` are used, the cluster configuration mustn't specify a non-empty
-  [`spec.api.externalAddress`][specapi]. If only `VRRPInstances` are specified, a
-  non-empty [`spec.api.externalAddress`][specapi] may be specified.
+* If both `VirtualServers` and a non-empty [`spec.api.externalAddress`][specapi] are specified,
+  then the [endpoint-reconciler component must be disabled.](configuration.md#disabling-controller-components)
+  The `endpoint-reconciler` must be disabled in every control plane node.
 
 Add the following to the cluster configuration (`k0s.yaml`):
 
@@ -69,7 +74,7 @@ spec:
         - virtualIPs: ["<External address IP>/<external address IP netmask"]
           authPass: <password>
         virtualServers:
-        - ipAddress: "ipAddress"
+        - ipAddress: "<External Address>"
 ```
 
 Or alternatively, if using [`k0sctl`](k0sctl-install.md), add the following to
@@ -86,19 +91,17 @@ spec:
             type: Keepalived
             keepalived:
               vrrpInstances:
-              - virtualIPs: ["<External address IP>/<external address IP netmask>"]
+              - virtualIPs: ["<External IP address>/<external address IP netmask>"]
                 authPass: <password>
               virtualServers:
-              - ipAddress: "<External ip address>"
+              - ipAddress: "<External IP address>"
 ```
 
 Because this is a feature intended to configure the apiserver, CPLB noes not
 support dynamic configuration and in order to make changes you need to restart
 the k0s controllers to make changes.
 
-[specapi]: configuration.md#specapi
-
-## Full example using `k0sctl`
+## Full example using `k0sctl` and externalAddress
 
 The following example shows a full `k0sctl` configuration file featuring three
 controllers and three workers with control plane load balancing enabled.
@@ -115,51 +118,295 @@ spec:
       address: controller-0.k0s.lab
       user: root
       keyPath: ~/.ssh/id_rsa
-    k0sBinaryPath: /opt/k0s
-    uploadBinary: true
+    installFlags:
+    - --disable-components=endpoint-reconciler
   - role: controller
     ssh:
       address: controller-1.k0s.lab
       user: root
       keyPath: ~/.ssh/id_rsa
-    k0sBinaryPath: /opt/k0s
-    uploadBinary: true
+    installFlags:
+    - --disable-components=endpoint-reconciler
   - role: controller
     ssh:
       address: controller-2.k0s.lab
       user: root
       keyPath: ~/.ssh/id_rsa
-    k0sBinaryPath: /opt/k0s
-    uploadBinary: true
+    installFlags:
+    - --disable-components=endpoint-reconciler
   - role: worker
     ssh:
       address: worker-0.k0s.lab
       user: root
       keyPath: ~/.ssh/id_rsa
-    k0sBinaryPath: /opt/k0s
-    uploadBinary: true
   - role: worker
     ssh:
       address: worker-1.k0s.lab
       user: root
       keyPath: ~/.ssh/id_rsa
-    k0sBinaryPath: /opt/k0s
-    uploadBinary: true
   - role: worker
     ssh:
       address: worker-2.k0s.lab
       user: root
       keyPath: ~/.ssh/id_rsa
-    k0sBinaryPath: /opt/k0s
-    uploadBinary: true
   k0s:
     version: v{{{ extra.k8s_version }}}+k0s.0
     config:
       spec:
         api:
-          sans:
-          - 192.168.122.200
+          externalAddress: 192.168.122.200
         network:
+          controlPlaneLoadBalancing:
+            enabled: true
+            type: Keepalived
+            keepalived:
+              vrrpInstances:
+              - virtualIPs: ["192.168.122.200/24"]
+                authPass: Example
+              virtualServers:
+              - ipAddress: "192.168.122.200"
+```
+
+Save the above configuration into a file called `k0sctl.yaml` and apply it in
+order to bootstrap the cluster:
+
+```console
+$ k0sctl apply
+⠀⣿⣿⡇⠀⠀⢀⣴⣾⣿⠟⠁⢸⣿⣿⣿⣿⣿⣿⣿⡿⠛⠁⠀⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀█████████ █████████ ███
+⠀⣿⣿⡇⣠⣶⣿⡿⠋⠀⠀⠀⢸⣿⡇⠀⠀⠀⣠⠀⠀⢀⣠⡆⢸⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀███          ███    ███
+⠀⣿⣿⣿⣿⣟⠋⠀⠀⠀⠀⠀⢸⣿⡇⠀⢰⣾⣿⠀⠀⣿⣿⡇⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀███          ███    ███
+⠀⣿⣿⡏⠻⣿⣷⣤⡀⠀⠀⠀⠸⠛⠁⠀⠸⠋⠁⠀⠀⣿⣿⡇⠈⠉⠉⠉⠉⠉⠉⠉⠉⢹⣿⣿⠀███          ███    ███
+⠀⣿⣿⡇⠀⠀⠙⢿⣿⣦⣀⠀⠀⠀⣠⣶⣶⣶⣶⣶⣶⣿⣿⡇⢰⣶⣶⣶⣶⣶⣶⣶⣶⣾⣿⣿⠀█████████    ███    ██████████
+k0sctl  Copyright 2023, k0sctl authors.
+Anonymized telemetry of usage will be sent to the authors.
+By continuing to use k0sctl you agree to these terms:
+https://k0sproject.io/licenses/eula
+level=info msg="==> Running phase: Connect to hosts"
+level=info msg="[ssh] worker-2.k0s.lab:22: connected"
+level=info msg="[ssh] controller-2.k0s.lab:22: connected"
+level=info msg="[ssh] worker-1.k0s.lab:22: connected"
+level=info msg="[ssh] worker-0.k0s.lab:22: connected"
+level=info msg="[ssh] controller-0.k0s.lab:22: connected"
+level=info msg="[ssh] controller-1.k0s.lab:22: connected"
+level=info msg="==> Running phase: Detect host operating systems"
+level=info msg="[ssh] worker-2.k0s.lab:22: is running Fedora Linux 38 (Cloud Edition)"
+level=info msg="[ssh] controller-2.k0s.lab:22: is running Fedora Linux 38 (Cloud Edition)"
+level=info msg="[ssh] controller-0.k0s.lab:22: is running Fedora Linux 38 (Cloud Edition)"
+level=info msg="[ssh] controller-1.k0s.lab:22: is running Fedora Linux 38 (Cloud Edition)"
+level=info msg="[ssh] worker-0.k0s.lab:22: is running Fedora Linux 38 (Cloud Edition)"
+level=info msg="[ssh] worker-1.k0s.lab:22: is running Fedora Linux 38 (Cloud Edition)"
+level=info msg="==> Running phase: Acquire exclusive host lock"
+level=info msg="==> Running phase: Prepare hosts"
+level=info msg="==> Running phase: Gather host facts"
+level=info msg="[ssh] worker-2.k0s.lab:22: using worker-2.k0s.lab as hostname"
+level=info msg="[ssh] controller-0.k0s.lab:22: using controller-0.k0s.lab as hostname"
+level=info msg="[ssh] controller-2.k0s.lab:22: using controller-2.k0s.lab as hostname"
+level=info msg="[ssh] controller-1.k0s.lab:22: using controller-1.k0s.lab as hostname"
+level=info msg="[ssh] worker-1.k0s.lab:22: using worker-1.k0s.lab as hostname"
+level=info msg="[ssh] worker-0.k0s.lab:22: using worker-0.k0s.lab as hostname"
+level=info msg="[ssh] worker-2.k0s.lab:22: discovered eth0 as private interface"
+level=info msg="[ssh] controller-0.k0s.lab:22: discovered eth0 as private interface"
+level=info msg="[ssh] controller-2.k0s.lab:22: discovered eth0 as private interface"
+level=info msg="[ssh] controller-1.k0s.lab:22: discovered eth0 as private interface"
+level=info msg="[ssh] worker-1.k0s.lab:22: discovered eth0 as private interface"
+level=info msg="[ssh] worker-0.k0s.lab:22: discovered eth0 as private interface"
+level=info msg="[ssh] worker-2.k0s.lab:22: discovered 192.168.122.210 as private address"
+level=info msg="[ssh] controller-0.k0s.lab:22: discovered 192.168.122.37 as private address"
+level=info msg="[ssh] controller-2.k0s.lab:22: discovered 192.168.122.87 as private address"
+level=info msg="[ssh] controller-1.k0s.lab:22: discovered 192.168.122.185 as private address"
+level=info msg="[ssh] worker-1.k0s.lab:22: discovered 192.168.122.81 as private address"
+level=info msg="[ssh] worker-0.k0s.lab:22: discovered 192.168.122.219 as private address"
+level=info msg="==> Running phase: Validate hosts"
+level=info msg="==> Running phase: Validate facts"
+level=info msg="==> Running phase: Download k0s binaries to local host"
+level=info msg="==> Running phase: Upload k0s binaries to hosts"
+level=info msg="[ssh] controller-0.k0s.lab:22: uploading k0s binary from /opt/k0s"
+level=info msg="[ssh] controller-2.k0s.lab:22: uploading k0s binary from /opt/k0s"
+level=info msg="[ssh] worker-0.k0s.lab:22: uploading k0s binary from /opt/k0s"
+level=info msg="[ssh] controller-1.k0s.lab:22: uploading k0s binary from /opt/k0s"
+level=info msg="[ssh] worker-1.k0s.lab:22: uploading k0s binary from /opt/k0s"
+level=info msg="[ssh] worker-2.k0s.lab:22: uploading k0s binary from /opt/k0s"
+level=info msg="==> Running phase: Install k0s binaries on hosts"
+level=info msg="[ssh] controller-0.k0s.lab:22: validating configuration"
+level=info msg="[ssh] controller-1.k0s.lab:22: validating configuration"
+level=info msg="[ssh] controller-2.k0s.lab:22: validating configuration"
+level=info msg="==> Running phase: Configure k0s"
+level=info msg="[ssh] controller-0.k0s.lab:22: installing new configuration"
+level=info msg="[ssh] controller-2.k0s.lab:22: installing new configuration"
+level=info msg="[ssh] controller-1.k0s.lab:22: installing new configuration"
+level=info msg="==> Running phase: Initialize the k0s cluster"
+level=info msg="[ssh] controller-0.k0s.lab:22: installing k0s controller"
+level=info msg="[ssh] controller-0.k0s.lab:22: waiting for the k0s service to start"
+level=info msg="[ssh] controller-0.k0s.lab:22: waiting for kubernetes api to respond"
+level=info msg="==> Running phase: Install controllers"
+level=info msg="[ssh] controller-2.k0s.lab:22: validating api connection to https://192.168.122.200:6443"
+level=info msg="[ssh] controller-1.k0s.lab:22: validating api connection to https://192.168.122.200:6443"
+level=info msg="[ssh] controller-0.k0s.lab:22: generating token"
+level=info msg="[ssh] controller-1.k0s.lab:22: writing join token"
+level=info msg="[ssh] controller-1.k0s.lab:22: installing k0s controller"
+level=info msg="[ssh] controller-1.k0s.lab:22: starting service"
+level=info msg="[ssh] controller-1.k0s.lab:22: waiting for the k0s service to start"
+level=info msg="[ssh] controller-1.k0s.lab:22: waiting for kubernetes api to respond"
+level=info msg="[ssh] controller-0.k0s.lab:22: generating token"
+level=info msg="[ssh] controller-2.k0s.lab:22: writing join token"
+level=info msg="[ssh] controller-2.k0s.lab:22: installing k0s controller"
+level=info msg="[ssh] controller-2.k0s.lab:22: starting service"
+level=info msg="[ssh] controller-2.k0s.lab:22: waiting for the k0s service to start"
+level=info msg="[ssh] controller-2.k0s.lab:22: waiting for kubernetes api to respond"
+level=info msg="==> Running phase: Install workers"
+level=info msg="[ssh] worker-2.k0s.lab:22: validating api connection to https://192.168.122.200:6443"
+level=info msg="[ssh] worker-1.k0s.lab:22: validating api connection to https://192.168.122.200:6443"
+level=info msg="[ssh] worker-0.k0s.lab:22: validating api connection to https://192.168.122.200:6443"
+level=info msg="[ssh] controller-0.k0s.lab:22: generating a join token for worker 1"
+level=info msg="[ssh] controller-0.k0s.lab:22: generating a join token for worker 2"
+level=info msg="[ssh] controller-0.k0s.lab:22: generating a join token for worker 3"
+level=info msg="[ssh] worker-2.k0s.lab:22: writing join token"
+level=info msg="[ssh] worker-0.k0s.lab:22: writing join token"
+level=info msg="[ssh] worker-1.k0s.lab:22: writing join token"
+level=info msg="[ssh] worker-2.k0s.lab:22: installing k0s worker"
+level=info msg="[ssh] worker-1.k0s.lab:22: installing k0s worker"
+level=info msg="[ssh] worker-0.k0s.lab:22: installing k0s worker"
+level=info msg="[ssh] worker-2.k0s.lab:22: starting service"
+level=info msg="[ssh] worker-1.k0s.lab:22: starting service"
+level=info msg="[ssh] worker-0.k0s.lab:22: starting service"
+level=info msg="[ssh] worker-2.k0s.lab:22: waiting for node to become ready"
+level=info msg="[ssh] worker-0.k0s.lab:22: waiting for node to become ready"
+level=info msg="[ssh] worker-1.k0s.lab:22: waiting for node to become ready"
+level=info msg="==> Running phase: Release exclusive host lock"
+level=info msg="==> Running phase: Disconnect from hosts"
+level=info msg="==> Finished in 2m20s"
+level=info msg="k0s cluster version v{{{ extra.k8s_version }}}+k0s.0  is now installed"
+level=info msg="Tip: To access the cluster you can now fetch the admin kubeconfig using:"
+level=info msg="     k0sctl kubeconfig"
+```
+
+The cluster with the two nodes should be available by now. Setup the kubeconfig
+file in order to interact with it:
+
+```shell
+k0sctl kubeconfig > k0s-kubeconfig
+export KUBECONFIG=$(pwd)/k0s-kubeconfig
+```
+
+All three worker nodes are ready:
+
+```console
+$ kubectl get nodes
+NAME                   STATUS   ROLES           AGE     VERSION
+worker-0.k0s.lab       Ready    <none>          8m51s   v{{{ extra.k8s_version }}}+k0s
+worker-1.k0s.lab       Ready    <none>          8m51s   v{{{ extra.k8s_version }}}+k0s
+worker-2.k0s.lab       Ready    <none>          8m51s   v{{{ extra.k8s_version }}}+k0s
+```
+
+Each controller node has a dummy interface with the VIP and /32 netmask,
+but only one has it in the real nic:
+
+```console
+$ for i in controller-{0..2} ; do echo $i ; ssh $i -- ip -4 --oneline addr show | grep -e eth0 -e dummyvip0; done
+controller-0
+2: eth0    inet 192.168.122.37/24 brd 192.168.122.255 scope global dynamic noprefixroute eth0\       valid_lft 2381sec preferred_lft 2381sec
+2: eth0    inet 192.168.122.200/24 scope global secondary eth0\       valid_lft forever preferred_lft forever
+3: dummyvip0    inet 192.168.122.200/32 scope global dummyvip0\       valid_lft forever preferred_lft forever
+controller-1
+2: eth0    inet 192.168.122.185/24 brd 192.168.122.255 scope global dynamic noprefixroute eth0\       valid_lft 2390sec preferred_lft 2390sec
+3: dummyvip0    inet 192.168.122.200/32 scope global dummyvip0\       valid_lft forever preferred_lft forever
+controller-2
+2: eth0    inet 192.168.122.87/24 brd 192.168.122.255 scope global dynamic noprefixroute eth0\       valid_lft 2399sec preferred_lft 2399sec
+3: dummyvip0    inet 192.168.122.200/32 scope global dummyvip0\       valid_lft forever preferred_lft forever
+```
+
+The cluster is using control plane load balancing and is able to tolerate the
+outage of one controller node. Shutdown the first controller to simulate a
+failure condition:
+
+```console
+$ ssh controller-0 'sudo poweroff'
+Connection to 192.168.122.37 closed by remote host.
+```
+
+Control plane load balancing provides high availability, the VIP will have moved to a different node:
+
+```console
+$ for i in controller-{0..2} ; do echo $i ; ssh $i -- ip -4 --oneline addr show | grep -e eth0 -e dummyvip0; done
+controller-1
+2: eth0    inet 192.168.122.185/24 brd 192.168.122.255 scope global dynamic noprefixroute eth0\       valid_lft 2173sec preferred_lft 2173sec
+2: eth0    inet 192.168.122.200/24 scope global secondary eth0\       valid_lft forever preferred_lft forever
+3: dummyvip0    inet 192.168.122.200/32 scope global dummyvip0\       valid_lft forever preferred_lft forever
+controller-2
+2: eth0    inet 192.168.122.87/24 brd 192.168.122.255 scope global dynamic noprefixroute eth0\       valid_lft 2182sec preferred_lft 2182sec
+3: dummyvip0    inet 192.168.122.200/32 scope global dummyvip0\       valid_lft forever preferred_lft forever
+
+$ for i in controller-{0..2} ; do echo $i ; ipvsadm --save -n; done
+IP Virtual Server version 1.2.1 (size=4096)
+Prot LocalAddress:Port Scheduler Flags
+  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
+TCP  192.168.122.200:6443 rr persistent 360
+  -> 192.168.122.185:6443              Route   1      0          0
+  -> 192.168.122.87:6443               Route   1      0          0
+  -> 192.168.122.122:6443              Route   1      0          0
+````
+
+And the cluster will be working normally:
+
+```console
+$ kubectl get nodes
+NAME                   STATUS   ROLES           AGE     VERSION
+worker-0.k0s.lab       Ready    <none>          8m51s   v{{{ extra.k8s_version }}}+k0s
+worker-1.k0s.lab       Ready    <none>          8m51s   v{{{ extra.k8s_version }}}+k0s
+worker-2.k0s.lab       Ready    <none>          8m51s   v{{{ extra.k8s_version }}}+k0s
+```
+
+## Full example using `k0sctl` and NLLB
+
+The following example shows a full `k0sctl` configuration file featuring three
+controllers and three workers with control plane load balancing enabled.
+In this example we use 192.168.122.200 as the CPLB IP address.
+
+```yaml
+apiVersion: k0sctl.k0sproject.io/v1beta1
+kind: Cluster
+metadata:
+  name: k0s-cluster
+spec:
+  hosts:
+  - role: controller
+    ssh:
+      address: controller-0.k0s.lab
+      user: root
+      keyPath: ~/.ssh/id_rsa
+  - role: controller
+    ssh:
+      address: controller-1.k0s.lab
+      user: root
+      keyPath: ~/.ssh/id_rsa
+  - role: controller
+    ssh:
+      address: controller-2.k0s.lab
+      user: root
+      keyPath: ~/.ssh/id_rsa
+  - role: worker
+    ssh:
+      address: worker-0.k0s.lab
+      user: root
+      keyPath: ~/.ssh/id_rsa
+  - role: worker
+    ssh:
+      address: worker-1.k0s.lab
+      user: root
+      keyPath: ~/.ssh/id_rsa
+  - role: worker
+    ssh:
+      address: worker-2.k0s.lab
+      user: root
+      keyPath: ~/.ssh/id_rsa
+  k0s:
+    version: v{{{ extra.k8s_version }}}+k0s.0
+    config:
+      spec:
+        network:
+          nodeLocalLoadBalancing:
+            enabled: true
+            type: EnvoyProxy
           controlPlaneLoadBalancing:
             enabled: true
             type: Keepalived:
@@ -168,7 +415,7 @@ spec:
               - virtualIPs: ["192.168.122.200/24"]
                 authPass: Example
               virtualServers:
-              - ipAddress: "<External ip address>"
+              - ipAddress: "192.168.122.200"
 ```
 
 Save the above configuration into a file called `k0sctl.yaml` and apply it in

--- a/pkg/apis/k0s/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types.go
@@ -336,7 +336,7 @@ func (s *ClusterSpec) Validate() (errs []error) {
 	}
 
 	if s.Network != nil && s.Network.ControlPlaneLoadBalancing != nil {
-		for _, err := range s.Network.ControlPlaneLoadBalancing.Validate(s.API.ExternalAddress) {
+		for _, err := range s.Network.ControlPlaneLoadBalancing.Validate() {
 			errs = append(errs, fmt.Errorf("controlPlaneLoadBalancing: %w", err))
 		}
 	}

--- a/pkg/apis/k0s/v1beta1/cplb.go
+++ b/pkg/apis/k0s/v1beta1/cplb.go
@@ -280,7 +280,7 @@ func (k *KeepalivedSpec) validateVirtualServers() []error {
 }
 
 // Validate validates the ControlPlaneLoadBalancingSpec
-func (c *ControlPlaneLoadBalancingSpec) Validate(externalAddress string) (errs []error) {
+func (c *ControlPlaneLoadBalancingSpec) Validate() (errs []error) {
 	if c == nil {
 		return nil
 	}
@@ -293,21 +293,16 @@ func (c *ControlPlaneLoadBalancingSpec) Validate(externalAddress string) (errs [
 		errs = append(errs, fmt.Errorf("unsupported CPLB type: %s. Only allowed value: %s", c.Type, CPLBTypeKeepalived))
 	}
 
-	return append(errs, c.Keepalived.Validate(externalAddress)...)
+	return append(errs, c.Keepalived.Validate()...)
 }
 
 // Validate validates the KeepalivedSpec
-func (k *KeepalivedSpec) Validate(externalAddress string) (errs []error) {
+func (k *KeepalivedSpec) Validate() (errs []error) {
 	if k == nil {
 		return nil
 	}
 
 	errs = append(errs, k.validateVRRPInstances(nil)...)
 	errs = append(errs, k.validateVirtualServers()...)
-	// CPLB reconciler relies in watching kubernetes.default.svc endpoints
-	if externalAddress != "" && len(k.VirtualServers) > 0 {
-		errs = append(errs, errors.New(".spec.api.externalAddress and virtual servers cannot be used together"))
-	}
-
 	return errs
 }

--- a/pkg/component/controller/cplb_windows.go
+++ b/pkg/component/controller/cplb_windows.go
@@ -27,12 +27,13 @@ import (
 // Keepalived doesn't work on windows, so we cannot implement it at all.
 // Just create the interface so that the CI doesn't complain.
 type Keepalived struct {
-	K0sVars         *config.CfgVars
-	Config          *k0sAPI.KeepalivedSpec
-	DetailedLogging bool
-	LogConfig       bool
-	APIPort         int
-	KubeConfigPath  string
+	K0sVars               *config.CfgVars
+	Config                *k0sAPI.KeepalivedSpec
+	DetailedLogging       bool
+	LogConfig             bool
+	APIPort               int
+	KubeConfigPath        string
+	HasEndpointReconciler bool
 }
 
 func (k *Keepalived) Init(_ context.Context) error {


### PR DESCRIPTION
## Description

Allow this behavior if the endpoint-reconciler is disabled.

K0smotron needs to use external address for cluster API. The only limitation why we couldn't combine externalAddress and CPLB is the endpoint-reconciler, since it can be disabled, allow to run CPLB with externalAddress if the user manually disables it.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings