### PR TITLE
Use atomic.Bool instead of atomic.Value for leader status

### DIFF
--- a/pkg/component/controller/leaderelector/leasepool.go
+++ b/pkg/component/controller/leaderelector/leasepool.go
@@ -32,7 +32,7 @@ type LeasePool struct {
 
 	invocationID      string
 	stopCh            chan struct{}
-	leaderStatus      atomic.Value
+	leaderStatus      atomic.Bool
 	kubeClientFactory kubeutil.ClientFactoryInterface
 	leaseCancel       context.CancelFunc
 
@@ -41,19 +41,18 @@ type LeasePool struct {
 	name                   string
 }
 
-var _ Interface = (*LeasePool)(nil)
-var _ manager.Component = (*LeasePool)(nil)
+var (
+	_ Interface         = (*LeasePool)(nil)
+	_ manager.Component = (*LeasePool)(nil)
+)
 
 // NewLeasePool creates a new leader elector using a Kubernetes lease pool.
 func NewLeasePool(invocationID string, kubeClientFactory kubeutil.ClientFactoryInterface, name string) *LeasePool {
-	d := atomic.Value{}
-	d.Store(false)
 	return &LeasePool{
 		invocationID:      invocationID,
 		stopCh:            make(chan struct{}),
 		kubeClientFactory: kubeClientFactory,
 		log:               logrus.WithFields(logrus.Fields{"component": "poolleaderelector"}),
-		leaderStatus:      d,
 		name:              name,
 	}
 }
@@ -120,5 +119,5 @@ func (l *LeasePool) Stop() error {
 }
 
 func (l *LeasePool) IsLeader() bool {
-	return l.leaderStatus.Load().(bool)
+	return l.leaderStatus.Load()
 }


### PR DESCRIPTION
## Description

Lease pool's leader status field was an atomic.Value that is always used for booleans only. This requires pre-initializing it through Store(false) and also typecasting when retrieving.

By using atomic.Bool, the zero value is false and the value type is always bool.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [X] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [X] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings