### PR TITLE
Skip `kube-bridge` interface for api/etcd address

### DIFF
--- a/internal/pkg/iface/iface.go
+++ b/internal/pkg/iface/iface.go
@@ -64,8 +64,8 @@ func FirstPublicAddress() (string, error) {
 	}
 	ipv6addr := ""
 	for _, i := range ifs {
-		if i.Name == "vxlan.calico" {
-			// Skip calico interface
+		if i.Name == "vxlan.calico" || i.Name == "kube-bridge" {
+			// Skip calico and kube-router interfaces
 			continue
 		}
 		addresses, err := i.Addrs()


### PR DESCRIPTION
## Description

Otherwise the defaulting could pick up `kube-bridge` address as api/etcd address when restarting k0s if it sees it before any "real" address.

This happens on e.g. bootloose containers where kube-bridge is at index 11 and eth0 on index 18.



<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings