### PR TITLE
[Backport release-1.27] Use a versioned worker config stack

### DIFF
--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -144,7 +144,7 @@ func (r *Reconciler) Init(context.Context) error {
 			return err
 		}
 		return (&applier.Stack{
-			Name:      "k0s-" + constant.WorkerConfigComponentName,
+			Name:      fmt.Sprintf("k0s-%s-%s", constant.WorkerConfigComponentName, constant.KubernetesMajorMinorVersion),
 			Client:    dynamicClient,
 			Discovery: discoveryClient,
 			Resources: resources,
@@ -555,7 +555,7 @@ func buildRBACResources(configMaps []*corev1.ConfigMap) []resource {
 	sort.Strings(configMapNames)
 
 	meta := metav1.ObjectMeta{
-		Name:      fmt.Sprintf("system:bootstrappers:%s", constant.WorkerConfigComponentName),
+		Name:      fmt.Sprintf("system:bootstrappers:%s-%s", constant.WorkerConfigComponentName, constant.KubernetesMajorMinorVersion),
 		Namespace: "kube-system",
 		Labels:    applier.CommonLabels(constant.WorkerConfigComponentName),
 	}

--- a/pkg/component/controller/workerconfig/reconciler_test.go
+++ b/pkg/component/controller/workerconfig/reconciler_test.go
@@ -400,7 +400,7 @@ func TestReconciler_ResourceGeneration(t *testing.T) {
 		})
 	}
 
-	const rbacName = "system:bootstrappers:worker-config"
+	const rbacName = "system:bootstrappers:worker-config-" + constant.KubernetesMajorMinorVersion
 
 	t.Run("Role", func(t *testing.T) {
 		role := findResource(t, "Expected to find a Role named "+rbacName,
@@ -721,6 +721,7 @@ func requireKubelet(t *testing.T, resources []*unstructured.Unstructured, name s
 }
 
 func findResource(t *testing.T, failureMessage string, resources resources, probe func(*unstructured.Unstructured) bool) *unstructured.Unstructured {
+	t.Helper()
 	for _, resource := range resources {
 		if probe(resource) {
 			return resource


### PR DESCRIPTION
Backport to `release-1.27`:
* #4464

See:
* #4416