### PR TITLE
Use chmod directly in make clean-gocache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,8 +268,8 @@ check-unit: .k0sbuild.docker-image.k0s go.sum bindata
 
 .PHONY: clean-gocache
 clean-gocache:
-	-find $(K0S_GO_BUILD_CACHE)/go/mod -type d -exec chmod u+w '{}' \;
-	rm -rf $(K0S_GO_BUILD_CACHE)/go
+	-chmod -R u+w -- '$(K0S_GO_BUILD_CACHE)/go/mod'
+	rm -rf -- '$(K0S_GO_BUILD_CACHE)/go'
 
 .PHONY: clean-docker-image
 clean-docker-image: IID_FILES = .k0sbuild.docker-image.k0s


### PR DESCRIPTION
## Description

The extra find wrapper that confined the chmod only to non-writable directories was significantly slower. The unfiltered recursive chmod will make everything user-writable, which doesn't hurt when the next step is a recursive removal anyways.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings