### PR TITLE
Fix ocibundle for 32bit arm

### DIFF
--- a/docs/airgap-install.md
+++ b/docs/airgap-install.md
@@ -23,7 +23,7 @@ k0s/containerd uses OCI (Open Container Initiative) bundles for airgap installat
 
 k0s offers two methods for creating OCI bundles, one using Docker and the other using a previously set up k0s worker.
 
-**Note:** When importing the image bundle k0s uses containerd "loose" [platform matching](https://pkg.go.dev/github.com/containerd/containerd/platforms#Only). For arm/v8, it will also match arm/v7, arm/v6 and arm/v5. This means that your bundle can contain multi arch images and the import will be done using platfomr compatibility.
+**Note:** When importing the image bundle k0s uses containerd "loose" [platform matching](https://pkg.go.dev/github.com/containerd/containerd/platforms#Only). For arm/v8, it will also match arm/v7, arm/v6 and arm/v5. This means that your bundle can contain multi arch images and the import will be done using platform compatibility.
 
 ### Docker
 

--- a/docs/airgap-install.md
+++ b/docs/airgap-install.md
@@ -23,7 +23,7 @@ k0s/containerd uses OCI (Open Container Initiative) bundles for airgap installat
 
 k0s offers two methods for creating OCI bundles, one using Docker and the other using a previously set up k0s worker.
 
-**Note:** k0s strictly matches image architecture, e.g. arm/v7 images won't work for arm64.
+**Note:** When importing the image bundle k0s uses containerd "loose" [platform matching](https://pkg.go.dev/github.com/containerd/containerd/platforms#Only). For arm/v8, it will also match arm/v7, arm/v6 and arm/v5. This means that your bundle can contain multi arch images and the import will be done using platfomr compatibility.
 
 ### Docker
 

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -75,7 +75,7 @@ func (a *OCIBundleReconciler) loadOne(ctx context.Context, fpath string) error {
 			sock,
 			containerd.WithDefaultNamespace("k8s.io"),
 			containerd.WithDefaultPlatform(
-				platforms.OnlyStrict(platforms.DefaultSpec()),
+				platforms.Only(platforms.DefaultSpec()),
 			),
 		)
 		if err != nil {


### PR DESCRIPTION
We may run k0s on arm/v8 but only have images for arm/v7. Use Only() instead of OnlyStrinct() to also match arm/v7 on arm/v8.

Fixes commit 9dd47b48f7a1 (#1939 Fix airgap arm64 build. Strictly use target platform only)

ref: https://pkg.go.dev/github.com/containerd/containerd/platforms#Only

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes import of armv7 oci bundle on armv8.

Based on https://github.com/k0sproject/k0s/pull/4468
## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings