### PR TITLE
Let temporary untar dirs start with a dot

### DIFF
--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -65,7 +65,7 @@ $(bindir)/kubelet.exe $(bindir)/kube-proxy.exe: .container.kubernetes.windows
 $(bindir)/containerd.exe $(bindir)/containerd-shim-runhcs-v1.exe: .container.containerd.windows
 
 $(addprefix $(bindir)/, $(bins)): | $(bindir)
-	tardir=$$(mktemp -d -- '$(notdir $@).XXXXXX.tmp') \
+	tardir=$$(mktemp -d -- '.$(notdir $@).XXXXXX.tmp') \
 	  && trap "rm -rf -- $$tardir" INT EXIT \
 	  && docker export "$$(cat $<)" \
 	  | tar -C "$$tardir" -x bin/$(notdir $@) \


### PR DESCRIPTION
So that they are ignored by the Go tooling. Otherwise, when building in parallel, Go may try to treat these temporary directories as Go package folders and fail utterly.

https://pkg.go.dev/cmd/go#hdr-Package_lists_and_patterns

> Directory and file names that begin with "." or "_" are ignored by the go tool, as are directories named "testdata".

Fixes:
* #2660

## Description

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings