### PR TITLE
feat: unpin images from unknown oci bundles

### DIFF
--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -180,7 +180,7 @@ func (a *OCIBundleReconciler) unpinAll(ctx context.Context) error {
 
 	for _, image := range images {
 		if err := a.unpinOne(ctx, image, isvc); err != nil {
-			return fmt.Errorf("failed to unpin %s: %w", image.Name, err)
+			a.log.WithError(err).Errorf("Failed to unpin image %s", image.Name)
 		}
 	}
 	return nil

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -43,7 +43,7 @@ import (
 const (
 	// Follows a list of labels we use to control imported images.
 	ImagePinnedLabel      = "io.cri-containerd.pinned"
-	ImageSourcePathsLabel = "k0sproject.ocibundle.paths"
+	ImageSourcePathsLabel = "io.k0sproject.ocibundle-paths"
 )
 
 // OCIBundleReconciler tries to import OCI bundle into the running containerd instance
@@ -174,7 +174,7 @@ func (a *OCIBundleReconciler) unpinAll(ctx context.Context) error {
 	isvc := client.ImageService()
 	images, err := isvc.List(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to list images")
+		return fmt.Errorf("failed to list images: %w", err)
 	}
 
 	for _, image := range images {

--- a/pkg/component/worker/ocibundle_test.go
+++ b/pkg/component/worker/ocibundle_test.go
@@ -37,6 +37,7 @@ func TestGetImageSources(t *testing.T) {
 	value := map[string]time.Time{"path": when}
 	data, err := json.Marshal(value)
 	require.Nil(t, err)
+
 	image := images.Image{
 		Labels: map[string]string{
 			ImageSourcePathsLabel: string(data),
@@ -45,7 +46,7 @@ func TestGetImageSources(t *testing.T) {
 	expected := ImageSources{"path": when}
 	got, err = GetImageSources(image)
 	require.Nil(t, err)
-	require.Equal(t, expected, got)
+	require.True(t, expected["path"].Equal(got["path"]), "dates mismatch")
 
 	// test image with invalid label
 	image = images.Image{
@@ -77,7 +78,7 @@ func TestSetImageSources(t *testing.T) {
 	require.Nil(t, err)
 	got, err := GetImageSources(image)
 	require.Nil(t, err)
-	require.Equal(t, expected, got)
+	require.True(t, expected[fp.Name()].Equal(got[fp.Name()]), "dates mismatch")
 
 	// test sources replacement
 	img0, err := os.CreateTemp("", "test")
@@ -105,7 +106,7 @@ func TestSetImageSources(t *testing.T) {
 	expected = ImageSources{img1.Name(): info1.ModTime()}
 	got, err = GetImageSources(image)
 	require.Nil(t, err)
-	require.Equal(t, expected, got)
+	require.True(t, expected[img1.Name()].Equal(got[img1.Name()]), "dates mismatch")
 }
 
 func TestAddToImageSources(t *testing.T) {
@@ -137,7 +138,8 @@ func TestAddToImageSources(t *testing.T) {
 	}
 	got, err := GetImageSources(image)
 	require.Nil(t, err)
-	require.Equal(t, expected, got)
+	require.True(t, expected[img0.Name()].Equal(got[img0.Name()]), "dates mismatch")
+	require.True(t, expected[img1.Name()].Equal(got[img1.Name()]), "dates mismatch")
 
 	// test if it trims the sources
 	err = os.Remove(img0.Name())
@@ -149,5 +151,5 @@ func TestAddToImageSources(t *testing.T) {
 	expected = ImageSources{img1.Name(): info1.ModTime()}
 	got, err = GetImageSources(image)
 	require.Nil(t, err)
-	require.Equal(t, expected, got)
+	require.True(t, expected[img1.Name()].Equal(got[img1.Name()]), "dates mismatch")
 }

--- a/pkg/component/worker/ocibundle_test.go
+++ b/pkg/component/worker/ocibundle_test.go
@@ -69,7 +69,10 @@ func TestSetImageSources(t *testing.T) {
 	// test setting one source
 	fp, err := os.CreateTemp("", "test")
 	require.Nil(t, err)
-	defer os.Remove(fp.Name())
+	defer func() {
+		_ = fp.Close()
+		_ = os.Remove(fp.Name())
+	}()
 	info, err := fp.Stat()
 	require.Nil(t, err)
 	image = images.Image{}
@@ -83,7 +86,10 @@ func TestSetImageSources(t *testing.T) {
 	// test sources replacement
 	img0, err := os.CreateTemp("", "test")
 	require.Nil(t, err)
-	defer os.Remove(img0.Name())
+	defer func() {
+		_ = img0.Close()
+		_ = os.Remove(img0.Name())
+	}()
 	info0, err := img0.Stat()
 	require.Nil(t, err)
 
@@ -95,7 +101,10 @@ func TestSetImageSources(t *testing.T) {
 
 	img1, err := os.CreateTemp("", "test")
 	require.Nil(t, err)
-	defer os.Remove(img1.Name())
+	defer func() {
+		_ = img1.Close()
+		_ = os.Remove(img1.Name())
+	}()
 	info1, err := img1.Stat()
 	require.Nil(t, err)
 
@@ -113,7 +122,10 @@ func TestAddToImageSources(t *testing.T) {
 	// test replacing sources
 	img0, err := os.CreateTemp("", "test")
 	require.Nil(t, err)
-	defer os.Remove(img0.Name())
+	defer func() {
+		_ = img0.Close()
+		_ = os.Remove(img0.Name())
+	}()
 	info0, err := img0.Stat()
 	require.Nil(t, err)
 
@@ -125,7 +137,10 @@ func TestAddToImageSources(t *testing.T) {
 
 	img1, err := os.CreateTemp("", "test")
 	require.Nil(t, err)
-	defer os.Remove(img1.Name())
+	defer func() {
+		_ = img1.Close()
+		_ = os.Remove(img1.Name())
+	}()
 	info1, err := img1.Stat()
 	require.Nil(t, err)
 
@@ -142,6 +157,8 @@ func TestAddToImageSources(t *testing.T) {
 	require.True(t, expected[img1.Name()].Equal(got[img1.Name()]), "dates mismatch")
 
 	// test if it trims the sources
+	err = img0.Close()
+	require.Nil(t, err)
 	err = os.Remove(img0.Name())
 	require.Nil(t, err)
 

--- a/pkg/component/worker/ocibundle_test.go
+++ b/pkg/component/worker/ocibundle_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2020 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package worker
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/images"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetImageSources(t *testing.T) {
+	// test image without label
+	got, err := GetImageSources(images.Image{})
+	require.Nil(t, err)
+	require.Equal(t, ImageSources{}, got)
+
+	// test image with label
+	when := time.Now().Truncate(time.Hour)
+	value := map[string]time.Time{"path": when}
+	data, err := json.Marshal(value)
+	require.Nil(t, err)
+	image := images.Image{
+		Labels: map[string]string{
+			ImageSourcePathsLabel: string(data),
+		},
+	}
+	expected := ImageSources{"path": when}
+	got, err = GetImageSources(image)
+	require.Nil(t, err)
+	require.Equal(t, expected, got)
+
+	// test image with invalid label
+	image = images.Image{
+		Labels: map[string]string{
+			ImageSourcePathsLabel: "invalid",
+		},
+	}
+	_, err = GetImageSources(image)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "failed to unmarshal label")
+}
+
+func TestSetImageSources(t *testing.T) {
+	// test adding empty sources
+	image := images.Image{}
+	err := SetImageSources(&image, ImageSources{})
+	require.Nil(t, err)
+	require.Empty(t, image.Labels)
+
+	// test setting one source
+	fp, err := os.CreateTemp("", "test")
+	require.Nil(t, err)
+	defer os.Remove(fp.Name())
+	info, err := fp.Stat()
+	require.Nil(t, err)
+	image = images.Image{}
+	expected := ImageSources{fp.Name(): info.ModTime()}
+	err = SetImageSources(&image, expected)
+	require.Nil(t, err)
+	got, err := GetImageSources(image)
+	require.Nil(t, err)
+	require.Equal(t, expected, got)
+
+	// test sources replacement
+	img0, err := os.CreateTemp("", "test")
+	require.Nil(t, err)
+	defer os.Remove(img0.Name())
+	info0, err := img0.Stat()
+	require.Nil(t, err)
+
+	data, err := json.Marshal(map[string]time.Time{img0.Name(): info0.ModTime()})
+	require.Nil(t, err)
+	image = images.Image{
+		Labels: map[string]string{ImageSourcePathsLabel: string(data)},
+	}
+
+	img1, err := os.CreateTemp("", "test")
+	require.Nil(t, err)
+	defer os.Remove(img1.Name())
+	info1, err := img1.Stat()
+	require.Nil(t, err)
+
+	newsrc := ImageSources{img1.Name(): info1.ModTime()}
+	err = SetImageSources(&image, newsrc)
+	require.Nil(t, err)
+
+	expected = ImageSources{img1.Name(): info1.ModTime()}
+	got, err = GetImageSources(image)
+	require.Nil(t, err)
+	require.Equal(t, expected, got)
+}
+
+func TestAddToImageSources(t *testing.T) {
+	// test replacing sources
+	img0, err := os.CreateTemp("", "test")
+	require.Nil(t, err)
+	defer os.Remove(img0.Name())
+	info0, err := img0.Stat()
+	require.Nil(t, err)
+
+	data, err := json.Marshal(map[string]time.Time{img0.Name(): info0.ModTime()})
+	require.Nil(t, err)
+	image := images.Image{
+		Labels: map[string]string{ImageSourcePathsLabel: string(data)},
+	}
+
+	img1, err := os.CreateTemp("", "test")
+	require.Nil(t, err)
+	defer os.Remove(img1.Name())
+	info1, err := img1.Stat()
+	require.Nil(t, err)
+
+	err = AddToImageSources(&image, img1.Name(), info1.ModTime())
+	require.Nil(t, err)
+
+	expected := ImageSources{
+		img0.Name(): info0.ModTime(),
+		img1.Name(): info1.ModTime(),
+	}
+	got, err := GetImageSources(image)
+	require.Nil(t, err)
+	require.Equal(t, expected, got)
+
+	// test if it trims the sources
+	err = os.Remove(img0.Name())
+	require.Nil(t, err)
+
+	err = AddToImageSources(&image, img1.Name(), info1.ModTime())
+	require.Nil(t, err)
+
+	expected = ImageSources{img1.Name(): info1.ModTime()}
+	got, err = GetImageSources(image)
+	require.Nil(t, err)
+	require.Equal(t, expected, got)
+}

--- a/pkg/component/worker/ocibundle_test.go
+++ b/pkg/component/worker/ocibundle_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 k0s authors
+Copyright 2024 k0s authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

after importing all bundles from the oci directory we go through all containerd images and unpin all images that were imported from bundles that no longer exist on the system.

we start now to add the following label when importing:

- k0sproject.ocibundle.paths

on this label we keep a list of all oci bundles that contain such image and we only unpin it if all the oci bundles were removed from the disk.

as now we are unpinning images based on their presence on disk we start to operate also on rename and remove fs events.

this commit also address an issue where we could leave a containerd connection opened.


Fixes #4433

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings