### PR TITLE
Improve manifest stack application w.r.t. CRDs

### DIFF
--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -59,5 +59,6 @@ smoketests := \
 	check-psp \
 	check-reset \
 	check-singlenode \
+	check-stackapplier \
 	check-statussocket \
 	check-upgrade \

--- a/inttest/common/autopilot/waitfor.go
+++ b/inttest/common/autopilot/waitfor.go
@@ -56,16 +56,10 @@ func WaitForPlanState(ctx context.Context, client apclient.Interface, name strin
 
 // WaitForCRDByName waits until the CRD with the given name is established.
 func WaitForCRDByName(ctx context.Context, client extensionsclient.ApiextensionsV1Interface, name string) error {
-	// Some shortcuts for very long type names.
-	type (
-		crd     = extensionsv1.CustomResourceDefinition
-		crdList = extensionsv1.CustomResourceDefinitionList
-	)
-
-	return watch.FromClient[*crdList, crd](client.CustomResourceDefinitions()).
+	return watch.CRDs(client.CustomResourceDefinitions()).
 		WithObjectName(fmt.Sprintf("%s.%s", name, apv1beta2.GroupName)).
 		WithErrorCallback(common.RetryWatchErrors(logrus.Infof)).
-		Until(ctx, func(item *crd) (bool, error) {
+		Until(ctx, func(item *extensionsv1.CustomResourceDefinition) (bool, error) {
 			for _, cond := range item.Status.Conditions {
 				if cond.Type == extensionsv1.Established {
 					return cond.Status == extensionsv1.ConditionTrue, nil

--- a/inttest/stackapplier/rings.yaml
+++ b/inttest/stackapplier/rings.yaml
@@ -1,0 +1,82 @@
+# Have the wrong order: First the custom resources, then their definitions. Let
+# one of the the resource be a cluster resource, so that the Stack's resource
+# reordering won't let the CRD go before the CR.
+
+---
+apiVersion: k0s.example.com/v1
+kind: Character
+metadata:
+  name: frodo
+  namespace: shire
+spec:
+  speciesRef:
+    name: hobbit
+
+---
+apiVersion: k0s.example.com/v1
+kind: Species
+metadata:
+  name: hobbit
+spec:
+  characteristics: hairy feet
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: shire
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: species.k0s.example.com
+spec:
+  group: k0s.example.com
+  names:
+    kind: Species
+    singular: species
+    plural: species
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                characteristics:
+                  type: string
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: characters.k0s.example.com
+spec:
+  group: k0s.example.com
+  names:
+    kind: Character
+    singular: character
+    plural: characters
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                speciesRef:
+                  type: object
+                  properties:
+                    name:
+                      type: string

--- a/inttest/stackapplier/stackapplier_test.go
+++ b/inttest/stackapplier/stackapplier_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nllb
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/stretchr/testify/assert"
+	testifysuite "github.com/stretchr/testify/suite"
+	"sigs.k8s.io/yaml"
+)
+
+type suite struct {
+	common.BootlooseSuite
+}
+
+//go:embed rings.yaml
+var rings string
+
+func (s *suite) TestStackApplier() {
+	ctx, cancel := context.WithCancelCause(s.Context())
+	s.T().Cleanup(func() { cancel(nil) })
+
+	k0sConfig, err := yaml.Marshal(&v1beta1.ClusterConfig{
+		Spec: &v1beta1.ClusterSpec{
+			Storage: &v1beta1.StorageSpec{Type: v1beta1.KineStorageType},
+		},
+	})
+	s.Require().NoError(err)
+
+	s.WriteFileContent(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfig)
+	s.Require().NoError(s.InitController(0, "--config=/tmp/k0s.yaml", "--disable-components=control-api,konnectivity-server,kube-controller-manager,kube-scheduler"))
+	s.MakeDir(s.ControllerNode(0), "/var/lib/k0s/manifests/rings")
+	s.PutFile(s.ControllerNode(0), "/var/lib/k0s/manifests/rings/rings.yaml", rings)
+
+	kubeconfig, err := s.GetKubeConfig(s.ControllerNode(0))
+	s.Require().NoError(err)
+	client, err := dynamic.NewForConfig(kubeconfig)
+	s.Require().NoError(err)
+
+	sgv := schema.GroupVersion{Group: "k0s.example.com", Version: "v1"}
+
+	s.T().Run("hobbit", func(t *testing.T) {
+		t.Cleanup(func() {
+			if t.Failed() {
+				cancel(fmt.Errorf("%s failed", t.Name()))
+			}
+		})
+		t.Parallel()
+		species := client.Resource(sgv.WithResource("species"))
+		assert.NoError(t, watch.Unstructured(species).
+			WithObjectName("hobbit").
+			WithErrorCallback(retryWatchErrors(s.T().Logf)).
+			Until(ctx, func(item *unstructured.Unstructured) (bool, error) {
+				speciesName, found, err := unstructured.NestedString(item.Object, "spec", "characteristics")
+				if assert.NoError(t, err) && assert.True(t, found, "no characteristics found: %v", item.Object) {
+					assert.Equal(t, "hairy feet", speciesName)
+				}
+				return true, nil
+			}))
+	})
+
+	s.T().Run("frodo", func(t *testing.T) {
+		t.Cleanup(func() {
+			if t.Failed() {
+				cancel(fmt.Errorf("%s failed", t.Name()))
+			}
+		})
+		t.Parallel()
+		characters := client.Resource(sgv.WithResource("characters"))
+		assert.NoError(t, watch.Unstructured(characters.Namespace("shire")).
+			WithObjectName("frodo").
+			WithErrorCallback(retryWatchErrors(s.T().Logf)).
+			Until(ctx, func(item *unstructured.Unstructured) (bool, error) {
+				speciesName, found, err := unstructured.NestedString(item.Object, "spec", "speciesRef", "name")
+				if assert.NoError(t, err) && assert.True(t, found, "no species found: %v", item.Object) {
+					assert.Equal(t, "hobbit", speciesName)
+				}
+				return true, nil
+			}))
+	})
+}
+
+func retryWatchErrors(logf common.LogfFn) watch.ErrorCallback {
+	commonRetry := common.RetryWatchErrors(logf)
+	return func(err error) (time.Duration, error) {
+		if retryDelay, err := commonRetry(err); err == nil {
+			return retryDelay, nil
+		}
+		if apierrors.IsNotFound(err) {
+			return 350 * time.Millisecond, nil
+		}
+		return 0, err
+	}
+}
+
+func TestStackApplierSuite(t *testing.T) {
+	s := suite{
+		common.BootlooseSuite{
+			ControllerCount: 1,
+			WorkerCount:     0,
+		},
+	}
+	testifysuite.Run(t, &s)
+}

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -118,7 +118,6 @@ func (a *Applier) Apply(ctx context.Context) error {
 	err = stack.Apply(ctx, true)
 	if err != nil {
 		a.log.WithError(err).Warn("stack apply failed")
-		a.discoveryClient.Invalidate()
 	} else {
 		a.log.Debug("successfully applied stack")
 	}

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -149,6 +149,7 @@ func (a *Applier) parseFiles(files []string) ([]*unstructured.Unstructured, erro
 	}
 
 	objects, err := resource.NewBuilder(a.restClientGetter).
+		Local(). // don't fail on unknown CRDs
 		Unstructured().
 		Path(false, files...).
 		Flatten().

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -125,11 +125,6 @@ func (e *EtcdMemberReconciler) Stop() error {
 	return nil
 }
 
-type (
-	crd     = extensionsv1.CustomResourceDefinition
-	crdList = extensionsv1.CustomResourceDefinitionList
-)
-
 func (e *EtcdMemberReconciler) waitForCRD(ctx context.Context) error {
 	rc := e.clientFactory.GetRESTConfig()
 
@@ -140,7 +135,7 @@ func (e *EtcdMemberReconciler) waitForCRD(ctx context.Context) error {
 	var lastObservedVersion string
 	log := logrus.WithField("component", "etcdMemberReconciler")
 	log.Info("waiting to see EtcdMember CRD ready")
-	return watch.FromClient[*crdList, crd](ec.CustomResourceDefinitions()).
+	return watch.CRDs(ec.CustomResourceDefinitions()).
 		WithObjectName(fmt.Sprintf("%s.%s", "etcdmembers", "etcd.k0sproject.io")).
 		WithErrorCallback(func(err error) (time.Duration, error) {
 			if retryAfter, e := watch.IsRetryable(err); e == nil {
@@ -162,7 +157,7 @@ func (e *EtcdMemberReconciler) waitForCRD(ctx context.Context) error {
 			)
 			return retryAfter, nil
 		}).
-		Until(ctx, func(item *crd) (bool, error) {
+		Until(ctx, func(item *extensionsv1.CustomResourceDefinition) (bool, error) {
 			lastObservedVersion = item.ResourceVersion
 			for _, cond := range item.Status.Conditions {
 				if cond.Type == extensionsv1.Established {

--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -133,18 +133,9 @@ func (r *Reconciler) Init(context.Context) error {
 
 	clientFactory := r.clientFactory
 	apply := func(ctx context.Context, resources resources) error {
-		dynamicClient, err := clientFactory.GetDynamicClient()
-		if err != nil {
-			return err
-		}
-		discoveryClient, err := clientFactory.GetDiscoveryClient()
-		if err != nil {
-			return err
-		}
 		return (&applier.Stack{
 			Name:      fmt.Sprintf("k0s-%s-%s", constant.WorkerConfigComponentName, constant.KubernetesMajorMinorVersion),
-			Client:    dynamicClient,
-			Discovery: discoveryClient,
+			Clients:   clientFactory,
 			Resources: resources,
 		}).Apply(ctx, true)
 	}

--- a/pkg/kubernetes/watch/apiextensions.go
+++ b/pkg/kubernetes/watch/apiextensions.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func CRDs(client Provider[*v1.CustomResourceDefinitionList]) *Watcher[v1.CustomResourceDefinition] {
+	return FromClient[*v1.CustomResourceDefinitionList, v1.CustomResourceDefinition](client)
+}

--- a/pkg/kubernetes/watch/unstructured.go
+++ b/pkg/kubernetes/watch/unstructured.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func Unstructured(client Provider[*unstructured.UnstructuredList]) *Watcher[unstructured.Unstructured] {
+	return FromClient[*unstructured.UnstructuredList, unstructured.Unstructured](client)
+}


### PR DESCRIPTION
## Description

Prevent the Applier's resource.Builder to try to get a REST mapping for all the resources from the API server, which will fail in case of custom resources whose CRDs weren't applied yet. The error returned from the builder looked like this:

> unable to build resources: resource mapping not found for name: "fooResource" namespace: "default" from "/var/lib/k0s/manifests/foo/resources.yaml": no matches for kind "Foo" in version "example.com/v1"
> ensure CRDs are installed first

Collect resource errors when applying stacks: This allows k0s to apply stacks that are not well ordered, i.e. that don't declare dependencies before their dependents. By attempting to apply each resource, the dependencies will eventually be applied, allowing the dependents to be applied on the next retry.

During the stack application, reset the REST mapper each time it can't find a mapping to ensure that the error is not due to out-of-date cached data.

Wait for CRDs to be established after their application: As a result, the Applier requires fewer retries when applying stacks that contain both custom resources and their definitions.

Add an integration test to make sure that stacks that are badly ordered are eventually applied in their entirety.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings