### PR TITLE
arch: add adr on autopilot basic auth + oras support

### DIFF
--- a/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
+++ b/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
@@ -36,9 +36,9 @@ type PlanResourceURL struct {
         // Sha256 provides an optional SHA256 hash of the URL's content for verification.
         Sha256 string `json:"sha256,omitempty"`
 
-        // ArtifactPullSecrets holds a reference to a secret where Docker or Basic Auth
-        // credentials are stored. We use these credentials when pulling the artifacts from
-        // the URL.
+        // ArtifactPullSecrets holds a reference to a secret where the credentials are
+        // stored. We use these credentials when pulling the artifacts from the provided
+        // URL using any of the supported protocols (http, https, and oci).
         ArtifactPullSecret *ArtifactPullSecret `json:"artifactPullSecret,omitempty"`
 
         // Insecure indicates whether certificates in the remote URL (if using TLS) can
@@ -59,7 +59,7 @@ type ArtifactPullSecret struct {
 }
 ```
 
-The secret pointed to by the provided `ArtifactPullSecret` property is expected to by of type `kubernetes.io/dockerconfigjson` if the protocol in use is `oci://` (see below) or of type `Opaque` if protocols `http://` or `https://` are used.
+The secret pointed by the provided `ArtifactPullSecret` will be used for pulling artifacts using either HTTP[S] or OCI protocols and is expected to by of type `kubernetes.io/dockerconfigjson` if the protocol in use is `oci://` or of type `Opaque` if protocols `http://` or `https://` are used (see below for details on the Secret layout).
 
 Example configuration for OCI:
 
@@ -79,6 +79,16 @@ sha256: e95603f167cce6e3cffef5594ef06785b3c1c00d3e27d8e4fc33824fe6c38a99
 artifactPullSecret:
   namespace: kube-system
   name: artifacts-basic-auth
+```
+
+Example configuration for HTTP:
+
+```yaml
+url: http://my.file.server/binaries/k0s-v1.30.1+k0s.0
+sha256: e95603f167cce6e3cffef5594ef06785b3c1c00d3e27d8e4fc33824fe6c38a99
+artifactPullSecret:
+  namespace: kube-system
+  name: artifacts-token-based-auth
 ```
 
 ### Secrets Layout

--- a/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
+++ b/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
@@ -39,7 +39,7 @@ type PlanResourceURL struct {
         // ArtifactPullSecrets holds a reference to a secret where the credentials are
         // stored. We use these credentials when pulling the artifacts from the provided
         // URL using any of the supported protocols (http, https, and oci).
-        ArtifactPullSecret *ArtifactPullSecret `json:"artifactPullSecret,omitempty"`
+        ArtifactPullSecret *corev1.SecretReference `json:"artifactPullSecret,omitempty"`
 
         // InsecureSkipTLSVerify indicates whether certificates in the remote URL (if using
         // TLS) can be ignored.
@@ -47,19 +47,7 @@ type PlanResourceURL struct {
 }
 ```
 
-The `ArtifactPullSecret` property will be added and its struct will be defined as follow:
-
-```go
-type ArtifactPullSecret struct {
-      // Namespace of the secret.
-      Namespace string `json:"namespace"`
-
-      // Name of the secret.
-      Name string `json:"name"`
-}
-```
-
-The secret pointed by the provided `ArtifactPullSecret` will be used for pulling artifacts using either HTTP[S] or OCI protocols and is expected to by of type `kubernetes.io/dockerconfigjson` if the protocol in use is `oci://` or of type `Opaque` if protocols `http://` or `https://` are used (see below for details on the Secret layout).
+`ArtifactPullSecret` property is of type `SecretReference` as defined by `k8s.io/api/core/v1` package. The secret pointed by the provided `ArtifactPullSecret` will be used for pulling artifacts using either HTTP[S] or OCI protocols and is expected to by of type `kubernetes.io/dockerconfigjson` if the protocol in use is `oci://` or of type `Opaque` if protocols `http://` or `https://` are used (see below for details on the Secret layout).
 
 Example configuration for OCI:
 
@@ -130,7 +118,6 @@ Proposed
 ## Consequences
 
 - Users will have an additional protocol to be aware of.
-- Introduction of a new type (`ArtifactPullSecret`) when ideally existing types could be reused.
 - If the Secret referenced by `ArtifactPullSecret` does not exist, the download will fail.
 - Users need to be notified about different failure types (e.g., unreadable secret, invalid secret).
 - Additional configuration is required to handle authentication, ensuring secure access to resources.

--- a/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
+++ b/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
@@ -1,4 +1,4 @@
-# ADR 1: Add Support for ORAS Protocol and Basic Authentication in Autopilot for Artifact Retrieval
+# ADR 1: Add Support for OCI Registry and Basic Authentication
 
 ## Context
 
@@ -8,7 +8,7 @@ Enhancing Autopilot to pull artifacts directly from registries will streamline w
 
 ## Decision
 
-Implement support in Autopilot for pulling artifacts, such as k0s binaries and image bundles, directly from a registry using the [ORAS](https://oras.land/docs/) protocol. Additionally, add support for basic authentication to ensure secure access to artifacts over HTTP.
+Implement support in Autopilot for pulling artifacts, such as k0s binaries and image bundles, directly from a registry using the [ORAS](https://oras.land/docs/) client. Additionally, add support for basic authentication to ensure secure access to artifacts over HTTP.
 
 ## Solution
 
@@ -59,7 +59,7 @@ type ArtifactPullSecret struct {
 
 The secret pointed to by the provided `ArtifactPullSecret` property is expected to by of type `kubernetes.io/dockerconfigjson` if the protocol in use is `oci://` (see below) or of type `kubernetes.io/basic-auth` if protocols `http://` or `https://` are used .
 
-Example configuration for ORAS:
+Example configuration for OCI:
 
 ```yaml
 url: oci://my.registry/binaries/k0s:v1.30.1+k0s.0

--- a/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
+++ b/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
@@ -108,7 +108,7 @@ data:
 
 - The `InsecureSkipTLSVerify` property is equivalent of defining `InsecureSkipTLSVerify` on a Go HTTP client.
 - The `InsecureSkipTLSVerify` property will be valid for both `oci://` and `https://` protocols.
-- If no protocol is defined, HTTP is used.
+- If no protocol is defined, HTTPS is used.
 - If no `ArtifactPullSecret` is defined, access will be anonymous (no authentication).
 
 ## Status

--- a/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
+++ b/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
@@ -145,7 +145,8 @@ data:
   `InsecureSkipTLSVerify` on a Go HTTP client.
 - The `InsecureSkipTLSVerify` property will be valid for both `oci://` and
   `https://` protocols.
-- If no protocol is defined, HTTPS is used.
+- If a protocol is not specified or an incorrect one is provided, an error
+  state should be activated.
 - If no `SecretRef` is defined, access will be anonymous (no authentication).
 
 ## Status

--- a/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
+++ b/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
@@ -41,9 +41,9 @@ type PlanResourceURL struct {
         // URL using any of the supported protocols (http, https, and oci).
         ArtifactPullSecret *ArtifactPullSecret `json:"artifactPullSecret,omitempty"`
 
-        // Insecure indicates whether certificates in the remote URL (if using TLS) can
-        // be ignored, aka InsecureSkipVerify.
-        Insecure bool  `json:"insecure,omitempty"`
+        // InsecureSkipTLSVerify indicates whether certificates in the remote URL (if using
+        // TLS) can be ignored.
+        InsecureSkipTLSVerify bool  `json:"insecureSkipTLSVerify,omitempty"`
 }
 ```
 
@@ -118,8 +118,8 @@ data:
 
 ### Additional Details
 
-- The `Insecure` property is equivalent of defining `InsecureSkipVerify` on a Go HTTP client.
-- The `Insecure` property will be valid for both `oci://` and `https://` protocols.
+- The `InsecureSkipTLSVerify` property is equivalent of defining `InsecureSkipTLSVerify` on a Go HTTP client.
+- The `InsecureSkipTLSVerify` property will be valid for both `oci://` and `https://` protocols.
 - If no protocol is defined, HTTP is used.
 - If no `ArtifactPullSecret` is defined, access will be anonymous (no authentication).
 

--- a/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
+++ b/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
@@ -36,10 +36,10 @@ type PlanResourceURL struct {
         // Sha256 provides an optional SHA256 hash of the URL's content for verification.
         Sha256 string `json:"sha256,omitempty"`
 
-        // ArtifactPullSecrets holds a reference to a secret where the credentials are
-        // stored. We use these credentials when pulling the artifacts from the provided
-        // URL using any of the supported protocols (http, https, and oci).
-        ArtifactPullSecret *corev1.SecretReference `json:"artifactPullSecret,omitempty"`
+        // SecretRef holds a reference to a secret where the credentials are stored. We
+        // use these credentials when pulling the artifacts from the provided URL using
+        // any of the supported protocols (http, https, and oci).
+        SecretRef *corev1.SecretReference `json:"secretRef,omitempty"`
 
         // InsecureSkipTLSVerify indicates whether certificates in the remote URL (if using
         // TLS) can be ignored.
@@ -47,7 +47,7 @@ type PlanResourceURL struct {
 }
 ```
 
-`ArtifactPullSecret` property is of type `SecretReference` as defined by `k8s.io/api/core/v1` package. The secret pointed by the provided `ArtifactPullSecret` will be used for pulling artifacts using either HTTP[S] or OCI protocols and is expected to by of type `kubernetes.io/dockerconfigjson` if the protocol in use is `oci://` or of type `Opaque` if protocols `http://` or `https://` are used (see below for details on the Secret layout).
+`SecretRef` property is of type `SecretReference` as defined by `k8s.io/api/core/v1` package. The secret pointed by the provided `SecretRef` will be used for pulling artifacts using either HTTP[S] or OCI protocols and is expected to by of type `kubernetes.io/dockerconfigjson` if the protocol in use is `oci://` or of type `Opaque` if protocols `http://` or `https://` are used (see below for details on the Secret layout).
 
 Example configuration for OCI:
 
@@ -109,7 +109,7 @@ data:
 - The `InsecureSkipTLSVerify` property is equivalent of defining `InsecureSkipTLSVerify` on a Go HTTP client.
 - The `InsecureSkipTLSVerify` property will be valid for both `oci://` and `https://` protocols.
 - If no protocol is defined, HTTPS is used.
-- If no `ArtifactPullSecret` is defined, access will be anonymous (no authentication).
+- If no `SecretRef` is defined, access will be anonymous (no authentication).
 
 ## Status
 
@@ -118,7 +118,7 @@ Proposed
 ## Consequences
 
 - Users will have an additional protocol to be aware of.
-- If the Secret referenced by `ArtifactPullSecret` does not exist, the download will fail.
+- If the Secret referenced by `SecretRef` does not exist, the download will fail.
 - Users need to be notified about different failure types (e.g., unreadable secret, invalid secret).
 - Additional configuration is required to handle authentication, ensuring secure access to resources.
 - We will allow downloads from remote places using self-signed certificates if requested to.

--- a/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
+++ b/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
@@ -76,7 +76,7 @@ Example configuration for OCI:
 ```yaml
 url: oci://my.registry/binaries/k0s:v1.30.1+k0s.0
 sha256: e95603f167cce6e3cffef5594ef06785b3c1c00d3e27d8e4fc33824fe6c38a99
-artifactPullSecret:
+secretRef:
   namespace: kube-system
   name: artifacts-registry
 ```
@@ -86,7 +86,7 @@ Example configuration for HTTPS:
 ```yaml
 url: https://my.file.server/binaries/k0s-v1.30.1+k0s.0
 sha256: e95603f167cce6e3cffef5594ef06785b3c1c00d3e27d8e4fc33824fe6c38a99
-artifactPullSecret:
+secretRef:
   namespace: kube-system
   name: artifacts-basic-auth
 ```
@@ -96,7 +96,7 @@ Example configuration for HTTP:
 ```yaml
 url: http://my.file.server/binaries/k0s-v1.30.1+k0s.0
 sha256: e95603f167cce6e3cffef5594ef06785b3c1c00d3e27d8e4fc33824fe6c38a99
-artifactPullSecret:
+secretRef:
   namespace: kube-system
   name: artifacts-token-based-auth
 ```

--- a/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
+++ b/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
@@ -2,15 +2,28 @@
 
 ## Context
 
-Registries are increasingly being used as generic artifact stores, expanding beyond their traditional role of hosting container images. To align with this trend, it is beneficial for Autopilot to support pulling artifacts directly from registries. Currently, Autopilot's capabilities are limited to downloading artifacts via the HTTP[S] protocols.
+Registries are increasingly being used as generic artifact stores, expanding
+beyond their traditional role of hosting container images. To align with this
+trend, it is beneficial for Autopilot to support pulling artifacts directly
+from registries. Currently, Autopilot's capabilities are limited to downloading
+artifacts via the HTTP[S] protocols.
 
-Enhancing Autopilot to pull artifacts directly from registries will streamline workflows and improve efficiency by allowing integration and deployment of diverse artifacts without relying solely on HTTP[S] endpoints. This update will enable Autopilot to handle registry-specific protocols and authentication mechanisms, aligning it with modern deployment practices.
+Enhancing Autopilot to pull artifacts directly from registries will streamline
+workflows and improve efficiency by allowing integration and deployment of
+diverse artifacts without relying solely on HTTP[S] endpoints. This update will
+enable Autopilot to handle registry-specific protocols and authentication
+mechanisms, aligning it with modern deployment practices.
 
-Currently, Autopilot does not support the retrieval of artifacts via the HTTP protocol when authentication is required. Implementing this feature to accommodate such authentication methods would be a valuable enhancement.
+Currently, Autopilot does not support the retrieval of artifacts via the HTTP
+protocol when authentication is required. Implementing this feature to
+accommodate such authentication methods would be a valuable enhancement.
 
 ## Decision
 
-Implement support in Autopilot for pulling artifacts, such as k0s binaries and image bundles, directly from a registry using the [ORAS](https://oras.land/docs/) client. Additionally, add support for HTTP authentication to ensure secure access to artifacts.
+Implement support in Autopilot for pulling artifacts, such as k0s binaries and
+image bundles, directly from a registry using the
+[ORAS](https://oras.land/docs/) client. Additionally, add support for HTTP
+authentication to ensure secure access to artifacts.
 
 ## Solution
 
@@ -21,33 +34,42 @@ type PlanResourceURL struct {
         // URL is the URL of a downloadable resource.
         URL string `json:"url"`
 
-        // Sha256 provides an optional SHA256 hash of the URL's content for verification.
+        // Sha256 provides an optional SHA256 hash of the URL's content for
+        // verification.
         Sha256 string `json:"sha256,omitempty"`
 }
 ```
 
-We must specify to Autopilot where to access credentials for remote artifact pulls. This will be achieved by adjusting the struct as follows:
+We must specify to Autopilot where to access credentials for remote artifact
+pulls. This will be achieved by adjusting the struct as follows:
 
 ```go
 type PlanResourceURL struct {
         // URL is the URL of a downloadable resource.
         URL string `json:"url"`
 
-        // Sha256 provides an optional SHA256 hash of the URL's content for verification.
+        // Sha256 provides an optional SHA256 hash of the URL's content for
+        // verification.
         Sha256 string `json:"sha256,omitempty"`
 
-        // SecretRef holds a reference to a secret where the credentials are stored. We
-        // use these credentials when pulling the artifacts from the provided URL using
+        // SecretRef holds a reference to a secret where the credentials are
+        // stored. We use these credentials when pulling the artifacts from the
+        // provided URL using
         // any of the supported protocols (http, https, and oci).
         SecretRef *corev1.SecretReference `json:"secretRef,omitempty"`
 
-        // InsecureSkipTLSVerify indicates whether certificates in the remote URL (if using
-        // TLS) can be ignored.
+        // InsecureSkipTLSVerify indicates whether certificates in the remote
+        // URL (if using TLS) can be ignored.
         InsecureSkipTLSVerify bool  `json:"insecureSkipTLSVerify,omitempty"`
 }
 ```
 
-`SecretRef` property is of type `SecretReference` as defined by `k8s.io/api/core/v1` package. The secret pointed by the provided `SecretRef` will be used for pulling artifacts using either HTTP[S] or OCI protocols and is expected to by of type `kubernetes.io/dockerconfigjson` if the protocol in use is `oci://` or of type `Opaque` if protocols `http://` or `https://` are used (see below for details on the Secret layout).
+`SecretRef` property is of type `SecretReference` as defined by
+`k8s.io/api/core/v1` package. The secret pointed by the provided `SecretRef`
+will be used for pulling artifacts using either HTTP[S] or OCI protocols and is
+expected to by of type `kubernetes.io/dockerconfigjson` if the protocol in use
+is `oci://` or of type `Opaque` if protocols `http://` or `https://` are used
+(see below for details on the Secret layout).
 
 Example configuration for OCI:
 
@@ -81,18 +103,31 @@ artifactPullSecret:
 
 ### Secrets Layout
 
-For secrets of type `kubernetes.io/dockerconfigjson` the format is the default for Docker authentications, equal to what is used in a Pod's pull secret. For further details you can refer to the [official documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+For secrets of type `kubernetes.io/dockerconfigjson` the format is the default
+for Docker authentications, equal to what is used in a Pod's pull secret. For
+further details you can refer to the [official
+documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 
-When it comes to the `Opaque` secret layout (used for HTTP requests) Autopilot will accept the following entries:
+When it comes to the `Opaque` secret layout (used for HTTP requests) Autopilot
+will accept the following entries:
 
-- `username` and `password`: if both are set then Autopilot will attempt to pull the artifacts using [Basic Authentication](https://www.ibm.com/docs/en/cics-ts/6.1?topic=concepts-http-basic-authentication).
-- `authorization`: if this property is set then the `Authorization` [header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization) will be set to its value when pulling the artifacts.
+- `username` and `password`: if both are set then Autopilot will attempt to
+  pull the artifacts using [Basic
+  Authentication](https://www.ibm.com/docs/en/cics-ts/6.1?topic=concepts-http-basic-authentication).
+- `authorization`: if this property is set then the `Authorization`
+  [header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization)
+  will be set to its value when pulling the artifacts.
 
-No other property will be parsed and used. For sake of defining the expected behaviour in case of conflicting configurations:
+No other property will be parsed and used. For sake of defining the expected
+behaviour in case of conflicting configurations:
 
-> In the case where the three properties are set (`username`, `password`, and `authorization`) Autopilot will ignore `username` and `password`, i.e. `authorization`  takes precedence over username and password.
+> In the case where the three properties are set (`username`, `password`, and
+> `authorization`) Autopilot will ignore `username` and `password`, i.e.
+> `authorization`  takes precedence over username and password.
 
-The `authorization` entry is used as is, its content is placed directly into the `Authorization` header. For example a secret like the following will make Autopilot to set the `Authorization` header to `Bearer abc123def456ghi789jkl0`:
+The `authorization` entry is used as is, its content is placed directly into
+the `Authorization` header. For example a secret like the following will make
+Autopilot to set the `Authorization` header to `Bearer abc123def456ghi789jkl0`:
 
 ```yaml
 apiVersion: v1
@@ -106,8 +141,10 @@ data:
 
 ### Additional Details
 
-- The `InsecureSkipTLSVerify` property is equivalent of defining `InsecureSkipTLSVerify` on a Go HTTP client.
-- The `InsecureSkipTLSVerify` property will be valid for both `oci://` and `https://` protocols.
+- The `InsecureSkipTLSVerify` property is equivalent of defining
+  `InsecureSkipTLSVerify` on a Go HTTP client.
+- The `InsecureSkipTLSVerify` property will be valid for both `oci://` and
+  `https://` protocols.
 - If no protocol is defined, HTTPS is used.
 - If no `SecretRef` is defined, access will be anonymous (no authentication).
 
@@ -118,7 +155,11 @@ Proposed
 ## Consequences
 
 - Users will have an additional protocol to be aware of.
-- If the Secret referenced by `SecretRef` does not exist, the download will fail.
-- Users need to be notified about different failure types (e.g., unreadable secret, invalid secret).
-- Additional configuration is required to handle authentication, ensuring secure access to resources.
-- We will allow downloads from remote places using self-signed certificates if requested to.
+- If the Secret referenced by `SecretRef` does not exist, the download will
+  fail.
+- Users need to be notified about different failure types (e.g., unreadable
+  secret, invalid secret).
+- Additional configuration is required to handle authentication, ensuring
+  secure access to resources.
+- We will allow downloads from remote places using self-signed certificates if
+  requested to.


### PR DESCRIPTION
## Description

this pr adds an architecture decision record on adding oras and basic auth support on autopilot.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings