### PR TITLE
Check if ip6table_filter module is already loaded

### DIFF
--- a/inttest/common/airgap.go
+++ b/inttest/common/airgap.go
@@ -55,6 +55,11 @@ func (a *Airgap) LockdownMachines(ctx context.Context, nodes ...string) error {
 }
 
 func tryBlockIPv6() error {
+	// Check if ip6table_filter module is already loaded
+	if _, err := os.ReadFile("/sys/module/ip6table_filter/refcnt"); err == nil {
+		return nil
+	}
+
 	_, err := exec.LookPath("modprobe")
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

Don't try to load the module again if it's already loaded. This allows airgapping IPv6 if the test can't load the module by itself, e.g. because modprobe is not in PATH, or insufficient privileges, and so on.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings