### PR TITLE
Ignore dependabot in DCO check

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  check:
     name: DCO check
     runs-on: ubuntu-latest
     steps:
@@ -37,4 +37,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DCO_CHECK_VERBOSE: "true"
+          DCO_CHECK_EXCLUDE_PATTERN: dependabot\[bot\]@users\.noreply\.github\.com
         run: python3 dco_check.py


### PR DESCRIPTION
## Description

Dependabot adds proper sign-offs to its commits. However, the DCO check is _very_ picky: it wants the sign-off and the GitHub username email to match. This is not the case for dependabot. So exclude dependabot from it.

Fixes:
* #4543

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings