### PR TITLE
Document constraints of dynamic config install

### DIFF
--- a/docs/dynamic-configuration.md
+++ b/docs/dynamic-configuration.md
@@ -16,6 +16,7 @@ In the [k0s configuration options](configuration.md) there are some options that
 
 - `spec.api` - these options configure how the local Kubernetes API server is setup
 - `spec.storage` - these options configure how the local storage (etcd or sqlite) is setup
+- `spec.network.controlPlaneLoadBalancing` - these options configure how [Control Plane Load Balancing](cplb.md) is setup.
 
 In case of HA control plane, all the controllers will need this part of the configuration as otherwise they will not be able to get the storage and Kubernetes API server running.
 
@@ -50,6 +51,12 @@ As with any Kubernetes cluster there are certain things that just cannot be chan
 - `network.podCIDR`
 - `network.serviceCIDR`
 - `network.provider`
+- `network.controlPlaneLoadBalancing`
+
+During the manual installation of control plane nodes with `k0s install`, all these
+non-changeable options must be defined in the configuration file. This is necessary
+because these fields can be used before the dynamic configuration reconciler is
+initialized. Both k0sctl and k0smotron handle this without user intervention.
 
 ## Configuration status
 


### PR DESCRIPTION
## Description

I got a report of someone who had issues becuase the `kubernetes.default.svc` `clusterIP` was missing from the SANs of some control plane nodes. This happened because the certificate for kube-apiserver is generated without dynamic config. [In the past we saw a similar issue with specifying `spec.network.provider`](https://github.com/k0sproject/k0s/issues/3304),  but because it was reported in k0sctl we only fixed it for k0sctl.

We don't document anywhere this behavior but we copy it in  k0sctl and in k0smotron we use the same configuration for every replica of the statefulset, we should tell .

Non-changeable fields can cause issues if not defined in the configuration file. This isn't immediately obvious by reading the docs so document it explicitly.

This was in the past 

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue) (I consider this a documentation bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings