### PR TITLE
Remove the wrong default timeout from the Helm docs

### DIFF
--- a/docs/helm-charts.md
+++ b/docs/helm-charts.md
@@ -13,13 +13,12 @@ Adding Helm charts into the k0s configuration file gives you a declarative way i
 
 ### Wait for install
 
-Each chart is proccesed the same way CLI tool does with following options:
+Each chart is processed the same way CLI tool does with following options:
 
 - `--wait`
 - `--wait-for-jobs`
-- `--timeout 10m`
 
-It is possible to customize timeout by using `.Timeout` field.
+It is possible to customize the timeout by using the `timeout' field.
 
 ### Chart configuration
 
@@ -28,7 +27,7 @@ It is possible to customize timeout by using `.Timeout` field.
 | name      | -             | Release name                                                         |
 | chartname | -             | chartname in form "repository/chartname" or path to tgz file         |
 | version   | -             | version to install                                                   |
-| timeout   | 10m           | timeout to wait for release install                                  |
+| timeout   | -             | timeout to wait for release install                                  |
 | values    | -             | yaml as a string, custom chart values                                |
 | namespace | -             | namespace to install chart into                                      |
 | order     | 0             | order to apply manifest. For equal values, alphanum ordering is used |


### PR DESCRIPTION
## Description

For both Chart and ClusterConfig resources, the timeout field has never had a default.

## Type of change

- [x Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings