### PR TITLE
Set correct version number in containerd CRI config

### DIFF
--- a/pkg/component/worker/containerd/configurer.go
+++ b/pkg/component/worker/containerd/configurer.go
@@ -114,7 +114,7 @@ func generateDefaultCRIConfig(sandboxContainerImage string) ([]byte, error) {
 	}
 	// We need to use custom struct so we can unmarshal the CRI plugin config only
 	containerdConfig := struct {
-		Version int
+		Version int                    `toml:"version"`
 		Plugins map[string]interface{} `toml:"plugins"`
 	}{
 		Version: 2,

--- a/pkg/component/worker/containerd/configurer_test.go
+++ b/pkg/component/worker/containerd/configurer_test.go
@@ -57,6 +57,7 @@ func TestConfigurer_HandleImports(t *testing.T) {
 		var containerdConfig serverconfig.Config
 		require.NoError(t, serverconfig.LoadConfig(criConfigPath, &containerdConfig))
 
+		assert.Equal(t, 2, containerdConfig.Version)
 		criPluginConfig := containerdConfig.Plugins["io.containerd.grpc.v1.cri"]
 		require.NotNil(t, criPluginConfig, "No CRI plugin configuration section found")
 		snapshotter := criPluginConfig.GetPath([]string{"containerd", "snapshotter"})


### PR DESCRIPTION
## Description

The version number has to be lowercase, otherwise it won't be picked up by containerd. If the version is missing, containerd might not do the right thing when merging configuration values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings