### PR TITLE
Wait for containerd to be extracted before using it

### DIFF
--- a/pkg/component/worker/containerd/component.go
+++ b/pkg/component/worker/containerd/component.go
@@ -107,10 +107,15 @@ func (c *Component) Init(ctx context.Context) error {
 			return assets.Stage(c.K0sVars.BinDir, b, constant.BinDirMode)
 		})
 	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
 	if err := c.windowsInit(); err != nil {
 		return fmt.Errorf("windows init failed: %w", err)
 	}
-	return g.Wait()
+
+	return nil
 }
 
 func (c *Component) windowsInit() error {


### PR DESCRIPTION
## Description

On Windows, the containerd service registration was invoked without waiting for the binary extraction to complete, potentially causing errors on the first k0s startup on Windows when the containerd binary is not yet present on disk.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings