### PR TITLE
[Backport release-1.29] Document constraints of dynamic config install

### DIFF
--- a/docs/dynamic-configuration.md
+++ b/docs/dynamic-configuration.md
@@ -51,6 +51,11 @@ As with any Kubernetes cluster there are certain things that just cannot be chan
 - `network.serviceCIDR`
 - `network.provider`
 
+During the manual installation of control plane nodes with `k0s install`, all these
+non-changeable options must be defined in the configuration file. This is necessary
+because these fields can be used before the dynamic configuration reconciler is
+initialized. Both k0sctl and k0smotron handle this without user intervention.
+
 ## Configuration status
 
 The dynamic configuration reconciler operator will write status events for all the changes it detects. To see all dynamic config related events, use:


### PR DESCRIPTION
Manual backport to `release-1.29` #4559.
It's the same, except it doesn't contain the bits related to CPLB.