### PR TITLE
[Backport release-1.29] Set correct version number in containerd CRI config

### DIFF
--- a/pkg/component/worker/containerd/criconfig.go
+++ b/pkg/component/worker/containerd/criconfig.go
@@ -126,7 +126,7 @@ func escapedPath(s string) string {
 
 // We need to use custom struct so we can unmarshal the CRI plugin config only
 type config struct {
-	Version int
+	Version int                    `toml:"version"`
 	Plugins map[string]interface{} `toml:"plugins"`
 }
 

--- a/pkg/component/worker/containerd/criconfig_test.go
+++ b/pkg/component/worker/containerd/criconfig_test.go
@@ -24,6 +24,7 @@ import (
 	srvconfig "github.com/containerd/containerd/services/server/config"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,6 +85,7 @@ func TestCRIConfigurer_HandleImports(t *testing.T) {
 		err = srvconfig.LoadConfig(criRuntimePath, containerdConfig)
 		require.NoError(t, err)
 
+		assert.Equal(t, 2, containerdConfig.Version)
 		criConfig := containerdConfig.Plugins["io.containerd.grpc.v1.cri"]
 		snapshotter := criConfig.GetPath([]string{"containerd", "snapshotter"})
 		require.Equal(t, "zfs", snapshotter)


### PR DESCRIPTION
Backport to `release-1.29`:
* #4569

See:
* #4568