### PR TITLE
[Backport release-1.29] Bump golangci-lint to v1.57.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,14 +4,6 @@ run:
 
   build-tags:
     - hack
-  skip-dirs-use-default: false
-  skip-dirs:
-    - build
-    - docs
-    - embedded-bins
-    - examples
-  skip-files:
-    - "zz_*"
   tests: true
   modules-download-mode: readonly
   allow-parallel-runners: true
@@ -43,8 +35,6 @@ linters-settings:
               Usages of the k8s cloud provider are only allowed from within the
               k0s cloud provider package. This is to ensure that it's not
               leaking global flags into k0s.
-  golint:
-    min-confidence: 0
   goheader:
     template-path: .go-header.txt
     values:
@@ -60,6 +50,14 @@ linters-settings:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-dirs-use-default: false
+  exclude-dirs:
+    - build
+    - docs
+    - embedded-bins
+    - examples
+  exclude-files:
+    - "zz_*"
   exclude-rules:
     # https://github.com/denis-tingaikin/go-header/issues/18
     # This means that the header checks are ineffective for all files with build tags.

--- a/hack/tools/Makefile.variables
+++ b/hack/tools/Makefile.variables
@@ -1,3 +1,3 @@
 controller-gen_version = 0.14.0
 go-bindata_version = 3.23.0+incompatible
-golangci-lint_version = 1.56.2
+golangci-lint_version = 1.57.1

--- a/hack/tools/Makefile.variables
+++ b/hack/tools/Makefile.variables
@@ -1,3 +1,3 @@
 controller-gen_version = 0.14.0
 go-bindata_version = 3.23.0+incompatible
-golangci-lint_version = 1.55.2
+golangci-lint_version = 1.56.2


### PR DESCRIPTION
Backport to `release-1.29`:
* #4078
* #4202
* #4270