### PR TITLE
[Backport release-1.28] Bump golangci-lint to v1.57.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,16 +25,24 @@ linters:
 
 linters-settings:
   depguard:
-    packages:
-      - gopkg.in/yaml*
-    additional-guards:
-      # Only allow usages of the k8s cloud provider from within the k0s cloud
-      # provider package. This is to ensure that it's not leaking global flags
-      # into k0s.
-      - packages:
-          - k8s.io/cloud-provider*
-        ignore-file-rules:
-          - "**/pkg/k0scloudprovider/*.go"
+    rules:
+      yaml:
+        list-mode: lax
+        deny:
+          - pkg: gopkg.in/yaml.v2
+            desc: Use sigs.k8s.io/yaml.
+          - pkg: gopkg.in/yaml.v3
+            desc: Use sigs.k8s.io/yaml.
+      cloud-provider:
+        list-mode: lax
+        files:
+          - "!**/pkg/k0scloudprovider/*.go"
+        deny:
+          - pkg: k8s.io/cloud-provider
+            desc: >-
+              Usages of the k8s cloud provider are only allowed from within the
+              k0s cloud provider package. This is to ensure that it's not
+              leaking global flags into k0s.
   golint:
     min-confidence: 0
   goheader:
@@ -42,6 +50,12 @@ linters-settings:
     values:
       regexp:
         year: 202[0-9]
+
+  revive:
+    rules:
+      # This forbids to name variables "close", which seems natural for "close" functions.
+      - name: redefines-builtin-id
+        disabled: true
 
 issues:
   max-issues-per-linter: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,14 +4,6 @@ run:
 
   build-tags:
     - hack
-  skip-dirs-use-default: false
-  skip-dirs:
-    - build
-    - docs
-    - embedded-bins
-    - examples
-  skip-files:
-    - "zz_*"
   tests: true
   modules-download-mode: readonly
   allow-parallel-runners: true
@@ -43,8 +35,6 @@ linters-settings:
               Usages of the k8s cloud provider are only allowed from within the
               k0s cloud provider package. This is to ensure that it's not
               leaking global flags into k0s.
-  golint:
-    min-confidence: 0
   goheader:
     template-path: .go-header.txt
     values:
@@ -60,6 +50,14 @@ linters-settings:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-dirs-use-default: false
+  exclude-dirs:
+    - build
+    - docs
+    - embedded-bins
+    - examples
+  exclude-files:
+    - "zz_*"
   exclude-rules:
     # https://github.com/denis-tingaikin/go-header/issues/18
     # This means that the header checks are ineffective for all files with build tags.

--- a/hack/tools/Makefile.variables
+++ b/hack/tools/Makefile.variables
@@ -1,3 +1,3 @@
 controller-gen_version = 0.13.0
 go-bindata_version = 3.23.0+incompatible
-golangci-lint_version = 1.56.2
+golangci-lint_version = 1.57.1

--- a/hack/tools/Makefile.variables
+++ b/hack/tools/Makefile.variables
@@ -1,3 +1,3 @@
 controller-gen_version = 0.13.0
 go-bindata_version = 3.23.0+incompatible
-golangci-lint_version = 1.55.2
+golangci-lint_version = 1.56.2

--- a/hack/tools/Makefile.variables
+++ b/hack/tools/Makefile.variables
@@ -1,3 +1,3 @@
 controller-gen_version = 0.13.0
 go-bindata_version = 3.23.0+incompatible
-golangci-lint_version = 1.51.2
+golangci-lint_version = 1.55.2

--- a/internal/pkg/sysinfo/probes/linux/cgroup_controllers.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroup_controllers.go
@@ -56,6 +56,7 @@ type cgroupControllerProbe struct {
 
 func (c *cgroupControllerProbe) Probe(reporter probes.Reporter) error {
 	desc := probes.NewProbeDesc(fmt.Sprintf("cgroup controller %q", c.name), c.path)
+	//revive:disable:indent-error-flow
 	if sys, err := c.probeSystem(); err != nil {
 		return reportCgroupSystemErr(reporter, desc, err)
 	} else if available, err := sys.probeController(c.name); err != nil {

--- a/internal/pkg/sysinfo/probes/linux/kernel.go
+++ b/internal/pkg/sysinfo/probes/linux/kernel.go
@@ -38,6 +38,7 @@ func (l *LinuxProbes) AssertKernelRelease(assert func(string) string) {
 	l.Set("kernelRelease", func(path probes.ProbePath, current probes.Probe) probes.Probe {
 		return probes.ProbeFn(func(r probes.Reporter) error {
 			desc := probes.NewProbeDesc("Linux kernel release", path)
+			//revive:disable:indent-error-flow
 			if uname, err := l.probeUname(); err != nil {
 				return r.Error(desc, err)
 			} else if uname.osRelease.truncated {

--- a/internal/pkg/sysinfo/probes/linux/linux.go
+++ b/internal/pkg/sysinfo/probes/linux/linux.go
@@ -71,6 +71,7 @@ func (l *LinuxProbes) Probe(reporter probes.Reporter) error {
 
 func (l *LinuxProbes) probe(reporter probes.Reporter) error {
 	desc := probes.NewProbeDesc("Operating system", l.path)
+	//revive:disable:indent-error-flow
 	if uname, err := l.probeUname(); err != nil {
 		return reporter.Error(desc, err)
 	} else if uname.osName.value == "Linux" {


### PR DESCRIPTION
Backport to `release-1.28`:
* #3755
* #4592

See:
* #4078
* #4202
* #4270