### PR TITLE
Use a ten second timeout for join requests

### DIFF
--- a/pkg/token/joinclient.go
+++ b/pkg/token/joinclient.go
@@ -18,6 +18,7 @@ package token
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -27,7 +28,6 @@ import (
 	"os"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -74,16 +74,23 @@ func JoinClientFromToken(encodedToken string) (*JoinClient, error) {
 	c.joinAddress = config.Host
 	c.joinTokenType = GetTokenType(&raw)
 
-	logrus.Info("initialized join client successfully")
 	return c, nil
 }
 
+func (j *JoinClient) Address() string {
+	return j.joinAddress
+}
+
+func (j *JoinClient) JoinTokenType() string {
+	return j.joinTokenType
+}
+
 // GetCA calls the CA sync API
-func (j *JoinClient) GetCA() (v1beta1.CaResponse, error) {
+func (j *JoinClient) GetCA(ctx context.Context) (v1beta1.CaResponse, error) {
 	var caData v1beta1.CaResponse
-	req, err := http.NewRequest(http.MethodGet, j.joinAddress+"/v1beta1/ca", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, j.joinAddress+"/v1beta1/ca", nil)
 	if err != nil {
-		return caData, err
+		return caData, fmt.Errorf("failed to create join request: %w", err)
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", j.bearerToken))
 
@@ -96,7 +103,6 @@ func (j *JoinClient) GetCA() (v1beta1.CaResponse, error) {
 	if resp.StatusCode != http.StatusOK {
 		return caData, fmt.Errorf("unexpected response status: %s", resp.Status)
 	}
-	logrus.Info("got valid CA response")
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return caData, err
@@ -109,7 +115,7 @@ func (j *JoinClient) GetCA() (v1beta1.CaResponse, error) {
 }
 
 // JoinEtcd calls the etcd join API
-func (j *JoinClient) JoinEtcd(peerAddress string) (v1beta1.EtcdResponse, error) {
+func (j *JoinClient) JoinEtcd(ctx context.Context, peerAddress string) (v1beta1.EtcdResponse, error) {
 	var etcdResponse v1beta1.EtcdResponse
 	etcdRequest := v1beta1.EtcdRequest{
 		PeerAddress: peerAddress,
@@ -125,9 +131,9 @@ func (j *JoinClient) JoinEtcd(peerAddress string) (v1beta1.EtcdResponse, error) 
 		return etcdResponse, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, j.joinAddress+"/v1beta1/etcd/members", buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, j.joinAddress+"/v1beta1/etcd/members", buf)
 	if err != nil {
-		return etcdResponse, err
+		return etcdResponse, fmt.Errorf("failed to create join request: %w", err)
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", j.bearerToken))
 	resp, err := j.httpClient.Do(req)
@@ -149,8 +155,4 @@ func (j *JoinClient) JoinEtcd(peerAddress string) (v1beta1.EtcdResponse, error) 
 	}
 
 	return etcdResponse, nil
-}
-
-func (j *JoinClient) JoinTokenType() string {
-	return j.joinTokenType
 }

--- a/pkg/token/joinclient.go
+++ b/pkg/token/joinclient.go
@@ -97,9 +97,6 @@ func (j *JoinClient) GetCA() (v1beta1.CaResponse, error) {
 		return caData, fmt.Errorf("unexpected response status: %s", resp.Status)
 	}
 	logrus.Info("got valid CA response")
-	if resp.Body == nil {
-		return caData, fmt.Errorf("response body is nil")
-	}
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return caData, err

--- a/pkg/token/joinclient_test.go
+++ b/pkg/token/joinclient_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package token_test
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/k0sproject/k0s/pkg/token"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJoinClient_Cancellation(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name          string
+		funcUnderTest func(context.Context, *token.JoinClient) error
+	}{
+		{"GetCA", func(ctx context.Context, c *token.JoinClient) error {
+			_, err := c.GetCA(ctx)
+			return err
+		}},
+		{"JoinEtcd", func(ctx context.Context, c *token.JoinClient) error {
+			_, err := c.JoinEtcd(ctx, "")
+			return err
+		}},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			clientContext, cancelClientContext := context.WithCancelCause(context.Background())
+			joinURL := startFakeJoinServer(t, func(_ http.ResponseWriter, req *http.Request) {
+				cancelClientContext(assert.AnError) // cancel the client's context
+				<-req.Context().Done()              // block forever
+			})
+
+			kubeconfig, err := token.GenerateKubeconfig(joinURL.String(), nil, "", "")
+			require.NoError(t, err)
+			tok, err := token.JoinEncode(bytes.NewReader(kubeconfig))
+			require.NoError(t, err)
+
+			underTest, err := token.JoinClientFromToken(tok)
+			require.NoError(t, err)
+
+			err = test.funcUnderTest(clientContext, underTest)
+			assert.ErrorIs(t, err, context.Canceled, "Expected the call to be cancelled")
+			assert.Same(t, context.Cause(clientContext), assert.AnError, "Didn't receive an HTTP request")
+		})
+	}
+}
+
+func startFakeJoinServer(t *testing.T, handler func(http.ResponseWriter, *http.Request)) *url.URL {
+	requestCtx, cancelRequests := context.WithCancel(context.Background())
+
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	server := &http.Server{
+		Addr:        listener.Addr().String(),
+		Handler:     http.HandlerFunc(handler),
+		BaseContext: func(net.Listener) context.Context { return requestCtx },
+	}
+
+	serverError := make(chan error)
+	go func() { defer close(serverError); serverError <- server.Serve(listener) }()
+
+	t.Cleanup(func() {
+		cancelRequests()
+		if !assert.NoError(t, server.Shutdown(context.Background()), "Couldn't shutdown HTTP server") {
+			return
+		}
+		assert.ErrorIs(t, <-serverError, http.ErrServerClosed, "HTTP server terminated unexpectedly")
+	})
+
+	return &url.URL{Scheme: "http", Host: server.Addr}
+}


### PR DESCRIPTION
## Description

This prevents k0s from hanging on idle network connections, such as random glitches, badly behaving load balancers, and so on.

Add a context to the `JoinClient` methods and call them with a context that times out after 10 seconds when joining a controller. This has the side effect that joining will also be interruptible by SIGTERM and Ctrl+C.

Fixes #4557.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings