### PR TITLE
Determine new etcd member join names via etcd extra-args

### DIFF
--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -160,9 +160,13 @@ func (e *Etcd) Start(ctx context.Context) error {
 
 	logrus.Info("Starting etcd")
 
-	name, err := os.Hostname()
-	if err != nil {
+	var name string
+	if etcdName, ok := e.Config.ExtraArgs["name"]; ok {
+		name = etcdName
+	} else if hostName, err := os.Hostname(); err != nil {
 		return err
+	} else {
+		name = hostName
 	}
 
 	peerURL := fmt.Sprintf("https://%s:2380", e.Config.PeerAddress)


### PR DESCRIPTION
## Description

This allows for overriding the etcd member name via the extraArgs setting.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings