### PR TITLE
Obtain containerd config from binary

### DIFF
--- a/pkg/component/worker/containerd/component.go
+++ b/pkg/component/worker/containerd/component.go
@@ -26,8 +26,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"syscall"
 	"time"
 
@@ -68,6 +70,7 @@ type Component struct {
 	OCIBundlePath string
 	confPath      string
 	importsPath   string
+	defaultConfig []byte
 }
 
 func NewComponent(logLevel string, vars *config.CfgVars, profile *workerconfig.Profile) *Component {
@@ -104,10 +107,29 @@ func (c *Component) Init(ctx context.Context) error {
 		return err
 	}
 
+	if err := c.loadDefaultConfig(ctx); err != nil {
+		return fmt.Errorf("failed to obtain containerd default configuration: %w", err)
+	}
+
 	if err := c.windowsInit(); err != nil {
 		return fmt.Errorf("windows init failed: %w", err)
 	}
 
+	return nil
+}
+
+func (c *Component) loadDefaultConfig(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, assets.BinPath("containerd", c.K0sVars.BinDir), "config", "default")
+	config, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			err = fmt.Errorf("%s: %s", exitErr.Error(), bytes.TrimSpace(exitErr.Stderr))
+		}
+		return err
+	}
+
+	c.defaultConfig = config
 	return nil
 }
 
@@ -192,9 +214,10 @@ func (c *Component) setupConfig() error {
 	}
 
 	configurer := &configurer{
-		loadPath:   filepath.Join(c.importsPath, "*.toml"),
-		pauseImage: c.Profile.PauseImage.URI(),
-		log:        logrus.WithField("component", "containerd"),
+		loadPath:      filepath.Join(c.importsPath, "*.toml"),
+		pauseImage:    c.Profile.PauseImage.URI(),
+		log:           logrus.WithField("component", "containerd"),
+		defaultConfig: slices.Clone(c.defaultConfig),
 	}
 
 	config, err := configurer.handleImports()


### PR DESCRIPTION
## Description

This decouples k0s from containerd's internals and allows it to better integrate with non-k0s-built containerd binaries.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings