### PR TITLE
Install packages before airgapping

### DIFF
--- a/inttest/common/airgap.go
+++ b/inttest/common/airgap.go
@@ -155,10 +155,10 @@ localAddrs:
 
 func (a *Airgap) airgapMachine(ctx context.Context, name, v4CIDRs, v6CIDRs string) error {
 	const airgapScript = `
+		apk add --no-cache %s
 		v4Cidrs='%s'
 		v6Cidrs='%s'
 		if [ -n "$v4Cidrs" ]; then
-			apk add --no-cache iptables
 			for cidr in $v4Cidrs; do
 				iptables -A INPUT -s $cidr -j ACCEPT
 				iptables -A OUTPUT -d $cidr -j ACCEPT
@@ -168,7 +168,6 @@ func (a *Airgap) airgapMachine(ctx context.Context, name, v4CIDRs, v6CIDRs strin
 		fi
 
 		if [ -n "$v6Cidrs" ]; then
-			apk add --no-cache ip6tables
 			for cidr in $v6Cidrs; do
 				ip6tables -A INPUT -s $cidr -j ACCEPT
 				ip6tables -A OUTPUT -d $cidr -j ACCEPT
@@ -183,6 +182,18 @@ func (a *Airgap) airgapMachine(ctx context.Context, name, v4CIDRs, v6CIDRs strin
 		fi
 	`
 
+	var packages []string
+	if v4CIDRs != "" {
+		packages = append(packages, "iptables")
+	}
+	if v6CIDRs != "" {
+		packages = append(packages, "ip6tables")
+	}
+
+	if len(packages) < 1 {
+		return nil
+	}
+
 	a.Logf("Airgapping %s", name)
 
 	ssh, err := a.SSH(ctx, name)
@@ -192,6 +203,6 @@ func (a *Airgap) airgapMachine(ctx context.Context, name, v4CIDRs, v6CIDRs strin
 	defer ssh.Disconnect()
 
 	return ssh.Exec(ctx, "sh -e -", SSHStreams{
-		In: strings.NewReader(fmt.Sprintf(airgapScript, v4CIDRs, v6CIDRs)),
+		In: strings.NewReader(fmt.Sprintf(airgapScript, strings.Join(packages, " "), v4CIDRs, v6CIDRs)),
 	})
 }


### PR DESCRIPTION
## Description

Installing ip6tables after disrupting IPv4 traffic will fail utterly if the machine uses IPv4 for package installations. Install both packages in lockstep before actually disrupting any traffic.

Fixes:
* #4609

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings