### PR TITLE
Also add kube-proxy mode to uploaded artifact names

### DIFF
--- a/.github/workflows/ostests-e2e.yaml
+++ b/.github/workflows/ostests-e2e.yaml
@@ -210,7 +210,7 @@ jobs:
         if: always() && (steps.e2e-retrieve-parallel.conclusion == 'success' || steps.e2e-retrieve-serial.conclusion == 'success')
         uses: actions/upload-artifact@v4
         with:
-          name: ostests-e2e-${{ inputs.os }}-${{ inputs.network-provider }}-sonobuoy-results
+          name: ostests-e2e-${{ inputs.os }}-${{ inputs.network-provider }}-${{ inputs.kube-proxy-mode }}-sonobuoy-results
           path: |
             inttest/sonobuoy-e2e-parallel.tar.gz
             inttest/sonobuoy-e2e-serial.tar.gz
@@ -233,5 +233,5 @@ jobs:
         if: always() && steps.tf-init.conclusion == 'success'
         uses: actions/upload-artifact@v4
         with:
-          name: ostests-e2e-${{ inputs.os }}-${{ inputs.network-provider }}-k0sctl-logs
+          name: ostests-e2e-${{ inputs.os }}-${{ inputs.network-provider }}-${{ inputs.kube-proxy-mode }}-k0sctl-logs
           path: ~/.cache/k0sctl/k0sctl.log


### PR DESCRIPTION
## Description

This allows for running the e2e test matrix for multiple kube-proxy modes at the same time. Otherwise, some uploads would fail due to duplicate artifact names.

Fixes:
* #3501

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings