### PR TITLE
Use the Kubernetes REST client for joining

### DIFF
--- a/pkg/token/joinclient.go
+++ b/pkg/token/joinclient.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"k8s.io/client-go/tools/clientcmd"
@@ -115,17 +114,8 @@ func (j *JoinClient) GetCA(ctx context.Context) (v1beta1.CaResponse, error) {
 }
 
 // JoinEtcd calls the etcd join API
-func (j *JoinClient) JoinEtcd(ctx context.Context, peerAddress string) (v1beta1.EtcdResponse, error) {
+func (j *JoinClient) JoinEtcd(ctx context.Context, etcdRequest v1beta1.EtcdRequest) (v1beta1.EtcdResponse, error) {
 	var etcdResponse v1beta1.EtcdResponse
-	etcdRequest := v1beta1.EtcdRequest{
-		PeerAddress: peerAddress,
-	}
-	name, err := os.Hostname()
-	if err != nil {
-		return etcdResponse, err
-	}
-	etcdRequest.Node = name
-
 	buf := new(bytes.Buffer)
 	if err := json.NewEncoder(buf).Encode(etcdRequest); err != nil {
 		return etcdResponse, err

--- a/pkg/token/joinclient_test.go
+++ b/pkg/token/joinclient_test.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"testing"
 
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/token"
 
 	"github.com/stretchr/testify/assert"
@@ -42,7 +43,7 @@ func TestJoinClient_Cancellation(t *testing.T) {
 			return err
 		}},
 		{"JoinEtcd", func(ctx context.Context, c *token.JoinClient) error {
-			_, err := c.JoinEtcd(ctx, "")
+			_, err := c.JoinEtcd(ctx, k0sv1beta1.EtcdRequest{})
 			return err
 		}},
 	} {

--- a/pkg/token/joinclient_test.go
+++ b/pkg/token/joinclient_test.go
@@ -19,6 +19,10 @@ package token_test
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -27,9 +31,73 @@ import (
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/token"
 
+	"github.com/cloudflare/cfssl/csr"
+	"github.com/cloudflare/cfssl/initca"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestJoinClient_GetCA(t *testing.T) {
+	t.Parallel()
+
+	joinURL, certData := startFakeJoinServer(t, func(res http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/some/sub/path/v1beta1/ca", req.RequestURI)
+		assert.Equal(t, []string{"Bearer the-token"}, req.Header["Authorization"])
+		_, err := res.Write([]byte("{}"))
+		assert.NoError(t, err)
+	})
+
+	joinURL.Path = "/some/sub/path"
+	kubeconfig, err := token.GenerateKubeconfig(joinURL.String(), certData, t.Name(), "the-token")
+	require.NoError(t, err)
+	tok, err := token.JoinEncode(bytes.NewReader(kubeconfig))
+	require.NoError(t, err)
+
+	underTest, err := token.JoinClientFromToken(tok)
+	require.NoError(t, err)
+
+	response, err := underTest.GetCA(context.TODO())
+	assert.NoError(t, err)
+	assert.Zero(t, response)
+}
+
+func TestJoinClient_JoinEtcd(t *testing.T) {
+	t.Parallel()
+
+	joinURL, certData := startFakeJoinServer(t, func(res http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/some/sub/path/v1beta1/etcd/members", req.RequestURI)
+		assert.Equal(t, []string{"Bearer the-token"}, req.Header["Authorization"])
+
+		if body, err := io.ReadAll(req.Body); assert.NoError(t, err) {
+			var data map[string]string
+			if assert.NoError(t, json.Unmarshal(body, &data)) {
+				assert.Equal(t, map[string]string{
+					"node":        "the-node",
+					"peerAddress": "the-peer-address",
+				}, data)
+			}
+		}
+
+		_, err := res.Write([]byte("{}"))
+		assert.NoError(t, err)
+	})
+
+	joinURL.Path = "/some/sub/path"
+	kubeconfig, err := token.GenerateKubeconfig(joinURL.String(), certData, t.Name(), "the-token")
+	require.NoError(t, err)
+	tok, err := token.JoinEncode(bytes.NewReader(kubeconfig))
+	require.NoError(t, err)
+
+	underTest, err := token.JoinClientFromToken(tok)
+	require.NoError(t, err)
+
+	response, err := underTest.JoinEtcd(context.TODO(), k0sv1beta1.EtcdRequest{
+		Node:        "the-node",
+		PeerAddress: "the-peer-address",
+	})
+	assert.NoError(t, err)
+	assert.Zero(t, response)
+}
 
 func TestJoinClient_Cancellation(t *testing.T) {
 	t.Parallel()
@@ -52,12 +120,12 @@ func TestJoinClient_Cancellation(t *testing.T) {
 			t.Parallel()
 
 			clientContext, cancelClientContext := context.WithCancelCause(context.Background())
-			joinURL := startFakeJoinServer(t, func(_ http.ResponseWriter, req *http.Request) {
+			joinURL, certData := startFakeJoinServer(t, func(_ http.ResponseWriter, req *http.Request) {
 				cancelClientContext(assert.AnError) // cancel the client's context
 				<-req.Context().Done()              // block forever
 			})
 
-			kubeconfig, err := token.GenerateKubeconfig(joinURL.String(), nil, "", "")
+			kubeconfig, err := token.GenerateKubeconfig(joinURL.String(), certData, "", "")
 			require.NoError(t, err)
 			tok, err := token.JoinEncode(bytes.NewReader(kubeconfig))
 			require.NoError(t, err)
@@ -72,23 +140,44 @@ func TestJoinClient_Cancellation(t *testing.T) {
 	}
 }
 
-func startFakeJoinServer(t *testing.T, handler func(http.ResponseWriter, *http.Request)) *url.URL {
+func startFakeJoinServer(t *testing.T, handler func(http.ResponseWriter, *http.Request)) (*url.URL, []byte) {
 	requestCtx, cancelRequests := context.WithCancel(context.Background())
+	var ok bool
 
 	listener, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		require.NoError(t, err)
 	}
+	defer func() {
+		if !ok {
+			assert.NoError(t, listener.Close())
+		}
+	}()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	certData, _, keyData, err := initca.New(&csr.CertificateRequest{
+		KeyRequest: csr.NewKeyRequest(),
+		CN:         fmt.Sprintf("localhost:%d", addr.Port),
+		Hosts:      []string{addr.IP.String()},
+	})
+	if !assert.NoError(t, err) {
+		assert.NoError(t, listener.Close())
+		t.FailNow()
+	}
+	cert, err := tls.X509KeyPair(certData, keyData)
+	require.NoError(t, err)
 
 	server := &http.Server{
-		Addr:        listener.Addr().String(),
+		Addr: addr.String(),
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{cert},
+		},
 		Handler:     http.HandlerFunc(handler),
 		BaseContext: func(net.Listener) context.Context { return requestCtx },
 	}
-
 	serverError := make(chan error)
-	go func() { defer close(serverError); serverError <- server.Serve(listener) }()
-
+	ok = true
+	go func() { defer close(serverError); serverError <- server.ServeTLS(listener, "", "") }()
 	t.Cleanup(func() {
 		cancelRequests()
 		if !assert.NoError(t, server.Shutdown(context.Background()), "Couldn't shutdown HTTP server") {
@@ -97,5 +186,5 @@ func startFakeJoinServer(t *testing.T, handler func(http.ResponseWriter, *http.R
 		assert.ErrorIs(t, <-serverError, http.ErrServerClosed, "HTTP server terminated unexpectedly")
 	})
 
-	return &url.URL{Scheme: "http", Host: server.Addr}
+	return &url.URL{Scheme: "https", Host: server.Addr}, certData
 }


### PR DESCRIPTION
## Description

This makes the code a lot easier.

Augment the unit tests for the `JoinClient` with the happy cases, so that there's test coverage for this change:
* Capture new member node names in etcd controller. This moves the side effect of the `os.Hostname()` call out of the client, so that it doesn't influence the tests.
* Change the fake HTTP server to HTTPS, which will test the certificate handling properly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings