### PR TITLE
[Backport release-1.27] Use statically initialized runtime schemes

### DIFF
--- a/pkg/autopilot/controller/root_controller.go
+++ b/pkg/autopilot/controller/root_controller.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2"
-	apscheme "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset/scheme"
 	apcli "github.com/k0sproject/k0s/pkg/autopilot/client"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
@@ -143,6 +142,7 @@ func (c *rootController) Run(ctx context.Context) error {
 // and starts it in a goroutine.
 func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *logrus.Entry, event LeaseEventStatus) error {
 	managerOpts := crman.Options{
+		Scheme:                 scheme,
 		Port:                   c.cfg.ManagerPort,
 		MetricsBindAddress:     c.cfg.MetricsBindAddr,
 		HealthProbeBindAddress: c.cfg.HealthProbeBindAddr,
@@ -151,11 +151,6 @@ func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *
 	mgr, err := cr.NewManager(c.autopilotClientFactory.RESTConfig(), managerOpts)
 	if err != nil {
 		logger.WithError(err).Error("unable to start controller manager")
-		return err
-	}
-
-	if err := apscheme.AddToScheme(mgr.GetScheme()); err != nil {
-		logger.WithError(err).Error("unable to register autopilot scheme")
 		return err
 	}
 

--- a/pkg/autopilot/controller/root_worker.go
+++ b/pkg/autopilot/controller/root_worker.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	apscheme "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset/scheme"
 	apcli "github.com/k0sproject/k0s/pkg/autopilot/client"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	aproot "github.com/k0sproject/k0s/pkg/autopilot/controller/root"
@@ -58,6 +57,7 @@ func (w *rootWorker) Run(ctx context.Context) error {
 	logger := w.log
 
 	managerOpts := crman.Options{
+		Scheme:                 scheme,
 		Port:                   w.cfg.ManagerPort,
 		MetricsBindAddress:     w.cfg.MetricsBindAddr,
 		HealthProbeBindAddress: w.cfg.HealthProbeBindAddr,
@@ -77,10 +77,6 @@ func (w *rootWorker) Run(ctx context.Context) error {
 		}),
 	); err != nil {
 		logger.WithError(err).Fatal("unable to start controller manager")
-	}
-
-	if err := apscheme.AddToScheme(mgr.GetScheme()); err != nil {
-		logger.WithError(err).Fatal("unable to register autopilot scheme")
 	}
 
 	// In some cases, we need to wait on the worker side until controller deploys all autopilot CRDs

--- a/pkg/autopilot/controller/scheme.go
+++ b/pkg/autopilot/controller/scheme.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	autopilotv1beta2sscheme "github.com/k0sproject/k0s/pkg/apis/autopilot.k0sproject.io/v1beta2/clientset/scheme"
 	k0sscheme "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/clientset/scheme"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -28,4 +29,5 @@ var scheme = runtime.NewScheme()
 func init() {
 	utilruntime.Must(k8sscheme.AddToScheme(scheme))
 	utilruntime.Must(k0sscheme.AddToScheme(scheme))
+	utilruntime.Must(autopilotv1beta2sscheme.AddToScheme(scheme))
 }

--- a/pkg/autopilot/controller/scheme.go
+++ b/pkg/autopilot/controller/scheme.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	k0sscheme "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/clientset/scheme"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+var scheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(k8sscheme.AddToScheme(scheme))
+	utilruntime.Must(k0sscheme.AddToScheme(scheme))
+}

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
 	apiretry "k8s.io/client-go/util/retry"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/config"
@@ -370,7 +371,7 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 		Kind:  "Chart",
 	}
 
-	mgr, err := ctrlManager.New(clientConfig, ctrlManager.Options{
+	mgr, err := controllerruntime.NewManager(clientConfig, ctrlManager.Options{
 		MetricsBindAddress: "0",
 		Logger:             logrusr.New(ec.L),
 		Controller:         config.Controller{},
@@ -388,11 +389,6 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 		return nil
 	}, retry.Context(ctx)); err != nil {
 		return fmt.Errorf("can't start ExtensionsReconciler, helm CRD is not registred, check CRD registration reconciler: %w", err)
-	}
-	// examples say to not use GetScheme in production, but it is unclear at the moment
-	// which scheme should be in use
-	if err := v1beta1.AddToScheme(mgr.GetScheme()); err != nil {
-		return fmt.Errorf("can't register Chart crd: %w", err)
 	}
 
 	if err := builder.

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -35,6 +35,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/release"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
@@ -371,7 +372,13 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 		Kind:  "Chart",
 	}
 
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		return err
+	}
+
 	mgr, err := controllerruntime.NewManager(clientConfig, ctrlManager.Options{
+		Scheme:             scheme,
 		MetricsBindAddress: "0",
 		Logger:             logrusr.New(ec.L),
 		Controller:         config.Controller{},


### PR DESCRIPTION
Backport to `release-1.27`:
* #4601

See:
* #4537
* #4532
* #4636