### PR TITLE
Allow nulls for helm values

### DIFF
--- a/pkg/apis/helm/v1beta1/generic_hash.go
+++ b/pkg/apis/helm/v1beta1/generic_hash.go
@@ -38,6 +38,10 @@ func cleanUpInterfaceMap(in map[string]interface{}) map[string]interface{} {
 
 // Cleans up the value in the map, recurses in case of arrays and maps
 func cleanUpMapValue(v interface{}) interface{} {
+	// Keep null values as nil to avoid type mismatches
+	if v == nil {
+		return nil
+	}
 	switch v := v.(type) {
 	case []interface{}:
 		return cleanUpInterfaceArray(v)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

While we ​​clean up the values we convert null values to strings, which breaks some use cases. For instance:

```
apiVersion: k0s.k0sproject.io/v1beta1
kind: ClusterConfig
metadata:
  name: k0s
spec:
  extensions:
    helm:
      repositories:
      - name: aws-cloud-controller-manager
        url: https://kubernetes.github.io/cloud-provider-aws
      charts:
      - name: aws-cloud-controller-manager
        namespace: kube-system
        chartname: aws-cloud-controller-manager/aws-cloud-controller-manager
        version: "0.0.8"
        values: |
          nodeSelector: null
          args:
           - --v=2
```

causes the error: 

```
* DaemonSet in version "v1" cannot be handled as a DaemonSet: json: cannot unmarshal string into Go struct field PodSpec.spec.template.spec.nodeSelector of type map[string]string
```

but it works perfectly with the helm cli.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings