### PR TITLE
Unify view of the world for the fake clients

### DIFF
--- a/internal/testutil/fakeclient/tracker.go
+++ b/internal/testutil/fakeclient/tracker.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fakeclient
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"unsafe"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/testing"
+)
+
+// Creates a new fake clientset backed by the given ObjectTracker.
+// This should only be used with the auto-generated fake clientsets.
+// Discovery() will return nil.
+func NewClientset[T any](discovery *discoveryfake.FakeDiscovery, tracker testing.ObjectTracker) *T {
+	p := new(T)
+
+	// Assume that a pointer to T is a fake client.
+	c := any(p).(testing.FakeClient)
+
+	// This wire code is adopted from the generated fake clients.
+	c.AddReactor("*", "*", testing.ObjectReaction(tracker))
+	c.AddWatchReactor("*", func(action testing.Action) (bool, watch.Interface, error) {
+		watch, err := tracker.Watch(action.GetResource(), action.GetNamespace())
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	// Set the fake clientset's discovery and tracker.
+	ty := reflect.TypeOf(p).Elem()
+	for i := 0; i < ty.NumField(); i++ {
+		f := ty.Field(i)
+		if f.Name == "discovery" && f.Type == reflect.TypeFor[*discoveryfake.FakeDiscovery]() {
+			*(**discoveryfake.FakeDiscovery)(unsafe.Add(unsafe.Pointer(p), f.Offset)) = discovery
+		} else if f.Name == "tracker" && f.Type == reflect.TypeFor[testing.ObjectTracker]() {
+			*(*testing.ObjectTracker)(unsafe.Add(unsafe.Pointer(p), f.Offset)) = tracker
+		}
+	}
+
+	return p
+}
+
+func TypedObjectTrackerFrom(scheme *runtime.Scheme, dynamicClient *fake.FakeDynamicClient) *TransformingObjectTracker {
+	return &TransformingObjectTracker{
+		Inner: dynamicClient.Tracker(),
+		Internalize: func(o runtime.Object) (runtime.Object, error) {
+			return toUnstructured(scheme, o)
+		},
+		Externalize: func(o runtime.Object, gvk schema.GroupVersionKind) (runtime.Object, error) {
+			return fromUnstructured(scheme, o, gvk)
+		},
+	}
+}
+
+type TransformingObjectTracker struct {
+	Inner       testing.ObjectTracker
+	Internalize func(runtime.Object) (runtime.Object, error)
+	Externalize func(runtime.Object, schema.GroupVersionKind) (runtime.Object, error)
+}
+
+var _ testing.ObjectTracker = (*TransformingObjectTracker)(nil)
+
+// Add implements testing.ObjectTracker.
+func (t *TransformingObjectTracker) Add(obj runtime.Object) error {
+	internal, err := t.Internalize(obj)
+	if err != nil {
+		return fmt.Errorf("failed to internalize object: %w", err)
+	}
+	return t.Inner.Add(internal)
+}
+
+// Create implements testing.ObjectTracker.
+func (t *TransformingObjectTracker) Create(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
+	internal, err := t.Internalize(obj)
+	if err != nil {
+		return fmt.Errorf("failed to internalize object: %w", err)
+	}
+	return t.Inner.Create(gvr, internal, ns)
+}
+
+// Delete implements testing.ObjectTracker.
+func (t *TransformingObjectTracker) Delete(gvr schema.GroupVersionResource, ns string, name string) error {
+	return t.Inner.Delete(gvr, ns, ns)
+}
+
+// Get implements testing.ObjectTracker.
+func (t *TransformingObjectTracker) Get(gvr schema.GroupVersionResource, ns string, name string) (runtime.Object, error) {
+	obj, err := t.Inner.Get(gvr, ns, name)
+	if err != nil {
+		return nil, err
+	}
+
+	external, err := t.Externalize(obj, obj.GetObjectKind().GroupVersionKind())
+	if err != nil {
+		return obj, fmt.Errorf("failed to externalize object: %w", err)
+	}
+
+	return external, nil
+}
+
+// List implements testing.ObjectTracker.
+func (t *TransformingObjectTracker) List(gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, ns string) (runtime.Object, error) {
+	obj, err := t.Inner.List(gvr, gvk, ns)
+	if err != nil {
+		return nil, err
+	}
+
+	external, err := t.Externalize(obj, gvk)
+	if err != nil {
+		return obj, fmt.Errorf("failed to externalize object: %w", err)
+	}
+
+	return external, nil
+}
+
+// Update implements testing.ObjectTracker.
+func (t *TransformingObjectTracker) Update(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
+	internal, err := t.Internalize(obj)
+	if err != nil {
+		return fmt.Errorf("failed to internalize object: %w", err)
+	}
+	return t.Inner.Update(gvr, internal, ns)
+}
+
+// Watch implements testing.ObjectTracker.
+func (t *TransformingObjectTracker) Watch(gvr schema.GroupVersionResource, ns string) (watch.Interface, error) {
+	w, err := t.Inner.Watch(gvr, ns)
+	if err != nil {
+		return w, err
+	}
+
+	internal := w.ResultChan()
+	external := make(chan watch.Event, cap(internal))
+
+	go func() {
+		defer close(external)
+		for e := range internal {
+			if e.Object != nil {
+				gvk := e.Object.GetObjectKind().GroupVersionKind()
+				if external, err := t.Externalize(e.Object, gvk); err == nil {
+					e.Object = external
+				} else {
+					e = watch.Event{
+						Type: watch.Error,
+						Object: &metav1.Status{
+							Status:  metav1.StatusFailure,
+							Message: err.Error(),
+							Code:    http.StatusInternalServerError,
+						},
+					}
+				}
+			}
+
+			external <- e
+		}
+	}()
+
+	return &watcher{external, w.Stop}, nil
+}
+
+type watcher struct {
+	result <-chan watch.Event
+	stop   func()
+}
+
+// ResultChan implements watch.Interface.
+func (w *watcher) ResultChan() <-chan watch.Event { return w.result }
+
+// Stop implements watch.Interface.
+func (w *watcher) Stop() { w.stop() }
+
+func toUnstructured(scheme *runtime.Scheme, obj runtime.Object) (runtime.Object, error) {
+	var u unstructured.Unstructured
+	if err := scheme.Convert(obj, &u, nil); err != nil {
+		return obj, err
+	}
+
+	if meta.IsListType(obj) {
+		if u.IsList() {
+			return u.ToList()
+		}
+		return obj, fmt.Errorf("not an unstructured list: %T", obj)
+	}
+
+	return &u, nil
+}
+
+func fromUnstructured(scheme *runtime.Scheme, obj runtime.Object, gvk schema.GroupVersionKind) (runtime.Object, error) {
+	if !meta.IsListType(obj) {
+		external, err := scheme.New(gvk)
+		if err != nil {
+			return obj, err
+		}
+
+		err = scheme.Convert(obj, external, nil)
+		if err != nil {
+			return obj, err
+		}
+
+		external.GetObjectKind().SetGroupVersionKind(gvk)
+		return external, nil
+	}
+
+	var items []runtime.Object
+	if err := meta.EachListItem(obj, func(obj runtime.Object) error {
+		if typed, err := fromUnstructured(scheme, obj, gvk); err != nil {
+			return err
+		} else {
+			items = append(items, typed)
+			return nil
+		}
+	}); err != nil {
+		return obj, err
+	}
+
+	listGVK := gvk
+	listGVK.Kind = listGVK.Kind + "List"
+
+	list, err := scheme.New(listGVK)
+	if err != nil {
+		return obj, err
+	}
+
+	if err := meta.SetList(list, items); err != nil {
+		return obj, err
+	}
+
+	return list, nil
+}

--- a/internal/testutil/kube_client.go
+++ b/internal/testutil/kube_client.go
@@ -41,7 +41,7 @@ import (
 var _ kubeutil.ClientFactoryInterface = (*FakeClientFactory)(nil)
 
 // NewFakeClientFactory creates new client factory which uses internally only the kube fake client interface
-func NewFakeClientFactory(objects ...runtime.Object) FakeClientFactory {
+func NewFakeClientFactory(objects ...runtime.Object) *FakeClientFactory {
 	rawDiscovery := &discoveryfake.FakeDiscovery{Fake: &kubetesting.Fake{}}
 
 	// Remember to list all "xyzList" types for resource types we use with the fake client
@@ -55,7 +55,7 @@ func NewFakeClientFactory(objects ...runtime.Object) FakeClientFactory {
 		{Group: "apps", Version: "v1", Resource: "deployments"}:                               "DeploymentList",
 	}
 
-	return FakeClientFactory{
+	return &FakeClientFactory{
 		Client:          fake.NewSimpleClientset(objects...),
 		DynamicClient:   dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvkLists),
 		DiscoveryClient: memory.NewMemCacheClient(rawDiscovery),
@@ -72,29 +72,29 @@ type FakeClientFactory struct {
 	RESTClient      rest.Interface
 }
 
-func (f FakeClientFactory) GetClient() (kubernetes.Interface, error) {
+func (f *FakeClientFactory) GetClient() (kubernetes.Interface, error) {
 	return f.Client, nil
 }
 
-func (f FakeClientFactory) GetDynamicClient() (dynamic.Interface, error) {
+func (f *FakeClientFactory) GetDynamicClient() (dynamic.Interface, error) {
 	return f.DynamicClient, nil
 }
 
-func (f FakeClientFactory) GetDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+func (f *FakeClientFactory) GetDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
 	return f.DiscoveryClient, nil
 }
 
-func (f FakeClientFactory) GetConfigClient() (cfgClient.ClusterConfigInterface, error) {
+func (f *FakeClientFactory) GetConfigClient() (cfgClient.ClusterConfigInterface, error) {
 	return nil, fmt.Errorf("NOT IMPLEMENTED")
 }
 
-func (f FakeClientFactory) GetRESTClient() (rest.Interface, error) {
+func (f *FakeClientFactory) GetRESTClient() (rest.Interface, error) {
 	return f.RESTClient, nil
 }
-func (f FakeClientFactory) GetRESTConfig() *rest.Config {
+func (f *FakeClientFactory) GetRESTConfig() *rest.Config {
 	return &rest.Config{}
 }
 
-func (f FakeClientFactory) GetEtcdMemberClient() (etcdMemberClient.EtcdMemberInterface, error) {
+func (f *FakeClientFactory) GetEtcdMemberClient() (etcdMemberClient.EtcdMemberInterface, error) {
 	return nil, fmt.Errorf("NOT IMPLEMENTED")
 }

--- a/internal/testutil/kube_client.go
+++ b/internal/testutil/kube_client.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	discoveryfake "k8s.io/client-go/discovery/fake"
@@ -30,6 +29,7 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	restfake "k8s.io/client-go/rest/fake"
 	kubetesting "k8s.io/client-go/testing"
 
@@ -42,22 +42,13 @@ var _ kubeutil.ClientFactoryInterface = (*FakeClientFactory)(nil)
 
 // NewFakeClientFactory creates new client factory which uses internally only the kube fake client interface
 func NewFakeClientFactory(objects ...runtime.Object) *FakeClientFactory {
-	rawDiscovery := &discoveryfake.FakeDiscovery{Fake: &kubetesting.Fake{}}
+	scheme := kubernetesscheme.Scheme
 
-	// Remember to list all "xyzList" types for resource types we use with the fake client
-	// and use "list" verb on
-	gvkLists := map[schema.GroupVersionResource]string{
-		{Group: "", Version: "v1", Resource: "pods"}:                                          "PodList",
-		{Group: "", Version: "v1", Resource: "namespaces"}:                                    "NamespaceList",
-		{Group: "", Version: "v1", Resource: "nodes"}:                                         "NodeList",
-		{Group: "", Version: "v1", Resource: "configmaps"}:                                    "ConfigMapList",
-		{Group: "certificates.k8s.io", Version: "v1", Resource: "certificatesigningrequests"}: "CertificateSigningRequestList",
-		{Group: "apps", Version: "v1", Resource: "deployments"}:                               "DeploymentList",
-	}
+	rawDiscovery := &discoveryfake.FakeDiscovery{Fake: &kubetesting.Fake{}}
 
 	return &FakeClientFactory{
 		Client:          fake.NewSimpleClientset(objects...),
-		DynamicClient:   dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvkLists),
+		DynamicClient:   dynamicfake.NewSimpleDynamicClient(scheme),
 		DiscoveryClient: memory.NewMemCacheClient(rawDiscovery),
 		RawDiscovery:    rawDiscovery,
 		RESTClient:      &restfake.RESTClient{},

--- a/internal/testutil/kube_client.go
+++ b/internal/testutil/kube_client.go
@@ -18,10 +18,18 @@ package testutil
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
 
-	"k8s.io/client-go/rest"
+	k0sscheme "github.com/k0sproject/k0s/pkg/client/clientset/scheme"
+	etcdv1beta1 "github.com/k0sproject/k0s/pkg/client/clientset/typed/etcd/v1beta1"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/client/clientset/typed/k0s/v1beta1"
+	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	discoveryfake "k8s.io/client-go/discovery/fake"
@@ -30,27 +38,31 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	restfake "k8s.io/client-go/rest/fake"
-	kubetesting "k8s.io/client-go/testing"
-
-	etcdMemberClient "github.com/k0sproject/k0s/pkg/client/clientset/typed/etcd/v1beta1"
-	cfgClient "github.com/k0sproject/k0s/pkg/client/clientset/typed/k0s/v1beta1"
-	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 )
 
 var _ kubeutil.ClientFactoryInterface = (*FakeClientFactory)(nil)
 
 // NewFakeClientFactory creates new client factory which uses internally only the kube fake client interface
 func NewFakeClientFactory(objects ...runtime.Object) *FakeClientFactory {
-	scheme := kubernetesscheme.Scheme
+	// Create a scheme containing all the kinds and types that k0s knows about.
+	scheme := runtime.NewScheme()
+	utilruntime.Must(kubernetesscheme.AddToScheme(scheme))
+	utilruntime.Must(k0sscheme.AddToScheme(scheme))
 
-	rawDiscovery := &discoveryfake.FakeDiscovery{Fake: &kubetesting.Fake{}}
+	// Create a dynamic fake client that can deal with all that.
+	fakeDynamic := dynamicfake.NewSimpleDynamicClient(scheme, objects...)
+	fakeDynamic.Resources = makeAPIResourceLists(scheme)
+
+	// Create a fake discovery client backed by the dynamic fake client.
+	fakeDiscovery := &discoveryfake.FakeDiscovery{Fake: &fakeDynamic.Fake}
 
 	return &FakeClientFactory{
 		Client:          fake.NewSimpleClientset(objects...),
-		DynamicClient:   dynamicfake.NewSimpleDynamicClient(scheme),
-		DiscoveryClient: memory.NewMemCacheClient(rawDiscovery),
-		RawDiscovery:    rawDiscovery,
+		DynamicClient:   fakeDynamic,
+		DiscoveryClient: memory.NewMemCacheClient(fakeDiscovery),
+		RawDiscovery:    fakeDiscovery,
 		RESTClient:      &restfake.RESTClient{},
 	}
 }
@@ -75,7 +87,7 @@ func (f *FakeClientFactory) GetDiscoveryClient() (discovery.CachedDiscoveryInter
 	return f.DiscoveryClient, nil
 }
 
-func (f *FakeClientFactory) GetConfigClient() (cfgClient.ClusterConfigInterface, error) {
+func (f *FakeClientFactory) GetConfigClient() (k0sv1beta1.ClusterConfigInterface, error) {
 	return nil, fmt.Errorf("NOT IMPLEMENTED")
 }
 
@@ -86,6 +98,57 @@ func (f *FakeClientFactory) GetRESTConfig() *rest.Config {
 	return &rest.Config{}
 }
 
-func (f *FakeClientFactory) GetEtcdMemberClient() (etcdMemberClient.EtcdMemberInterface, error) {
+func (f *FakeClientFactory) GetEtcdMemberClient() (etcdv1beta1.EtcdMemberInterface, error) {
 	return nil, fmt.Errorf("NOT IMPLEMENTED")
+}
+
+// Extracts all kinds from scheme and builds API resource lists for fake discovery clients.
+func makeAPIResourceLists(scheme *runtime.Scheme) (allResources []*metav1.APIResourceList) {
+	// Create the array of API resource lists. Ensure that the preferred version
+	// of any given group comes first. This is important for the fake discovery
+	// client, as it will bluntly pick the first version as the preferred one.
+	for _, gv := range scheme.PrioritizedVersionsAllGroups() {
+		var resources []metav1.APIResource
+		for kind, ty := range scheme.KnownTypes(gv) {
+			// Skip list kinds themselves.
+			if o, ok := reflect.New(ty).Interface().(runtime.Object); ok && meta.IsListType(o) {
+				continue
+			}
+
+			// Skip kinds that don't have an associated list kind.
+			if !scheme.Recognizes(gv.WithKind(kind + "List")) {
+				continue
+			}
+
+			plural, singular := meta.UnsafeGuessKindToResource(gv.WithKind(kind))
+			resource := metav1.APIResource{
+				Name:         plural.Resource,
+				SingularName: singular.Resource,
+				Kind:         kind,
+				Verbs:        metav1.Verbs{"get", "list", "watch", "create", "update", "patch", "delete"},
+			}
+
+			// Some duct tape for guessing cluster resources.
+			// FIXME: Is there any way to figure this out reliably? We could scan
+			// the clientsets if the factory methods have a string argument for
+			// the namespace or not.
+			switch {
+			case strings.Contains(kind, "Node"),
+				strings.Contains(kind, "Namespace"),
+				strings.Contains(kind, "Cluster"):
+				resource.Namespaced = false
+			default:
+				resource.Namespaced = true
+			}
+
+			resources = append(resources, resource)
+		}
+
+		allResources = append(allResources, &metav1.APIResourceList{
+			GroupVersion: gv.String(),
+			APIResources: resources,
+		})
+	}
+
+	return
 }

--- a/pkg/applier/applier_test.go
+++ b/pkg/applier/applier_test.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -98,25 +96,6 @@ spec:
 	require.NoError(t, os.WriteFile(fmt.Sprintf("%s/test-deploy.yaml", dir), []byte(templateDeployment), 0400))
 
 	fakes := kubeutil.NewFakeClientFactory()
-	verbs := []string{"get", "list", "delete", "create"}
-	fakes.RawDiscovery.Resources = []*metav1.APIResourceList{
-		{
-			GroupVersion: corev1.SchemeGroupVersion.String(),
-			APIResources: []metav1.APIResource{
-				{Name: "nodes", Namespaced: false, Kind: "Node", Verbs: verbs},
-				{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: verbs},
-				{Name: "configmaps", Namespaced: true, Kind: "ConfigMap", Verbs: verbs},
-				{Name: "namespaces", Namespaced: false, Kind: "Namespace", Verbs: verbs},
-			},
-		},
-		{
-			GroupVersion: appsv1.SchemeGroupVersion.String(),
-			APIResources: []metav1.APIResource{
-				{Name: "deployments", Namespaced: true, Kind: "Deployment", Verbs: verbs},
-			},
-		},
-	}
-
 	a := applier.NewApplier(dir, fakes)
 
 	ctx := context.Background()


### PR DESCRIPTION
## Description

In order for the typed clients to share the same view of the world as the dynamic client, they all must share the same (wrapped) object tracker. Create typed clients using the dynamic client's object tracker and transform between typed and unstructured objects.

Use the auto-generated runtime schemes in the fake discovery client. The client is usually auto-detecting the list types from the scheme. By not passing a new, empty scheme, but the default scheme, there's no longer the need to manually manage the item to list type map. Support API resource discovery by taking all the GVKs out of the scheme and convert those to some API resource lists to be added to the discovery client. The conversion is just a best guess, but will suffice for testing needs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings