### PR TITLE
Extract smoketests job into its own file

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,7 +50,7 @@ jobs:
         id: generate-smoketest-matrix
         run: |
           ./vars.sh FROM=inttest smoketests | jq --raw-input --raw-output \
-              'split(" ") | [ .[] | select(. != "") ] | "smoketests=" + tojson' >>$GITHUB_OUTPUT
+              'split(" ") | [ .[] | select(startswith("check-")) | .[6:] ] | "smoketests=" + tojson' >>$GITHUB_OUTPUT
 
       - name: "Generate :: Autopilot test matrix"
         id: generate-autopilot-matrix

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -222,55 +222,14 @@ jobs:
           - controllerworker
           - ha3x3
 
-    name: "Autopilot tests :: ${{ matrix.version }} :: ${{ matrix.smoke-suite }}"
+    name: "Autopilot test :: ${{ matrix.version }} :: ${{ matrix.smoke-suite }}"
     needs: [prepare, build-k0s]
-    runs-on: ubuntu-22.04
 
-    env:
-      K0S_VERSION: ${{ matrix.version }}
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Reclaim runner disk space
-        run: .github/workflows/reclaim-runner-disk-space.bash
-
-      - name: Prepare build environment
-        run: .github/workflows/prepare-build-env.sh
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Download compiled executable
-        uses: actions/download-artifact@v4
-        with:
-          name: k0s-linux-amd64
-
-      - name: Download latest release
-        run: |
-          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo "k0s-$K0S_VERSION" "https://github.com/k0sproject/k0s/releases/download/$K0S_VERSION/k0s-$K0S_VERSION-amd64"
-          chmod +x "k0s-$K0S_VERSION"
-
-      - name: k0s sysinfo
-        run: |
-          chmod +x k0s
-          ./k0s sysinfo
-
-      - name: Run inttest
-        run: |
-          make -C inttest check-ap-${{ matrix.smoke-suite }} K0S_UPDATE_FROM_BIN="../k0s-$K0S_VERSION"
-
-      - name: Collect k0s logs and support bundle
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: autopilot-tests-${{ matrix.version }}-${{ matrix.smoke-suite }}-files
-          path: |
-            /tmp/*.log
-            /tmp/support-bundle.tar.gz
+    uses: ./.github/workflows/smoketest.yaml
+    with:
+      name: ap-${{ matrix.smoke-suite }}
+      job-name: autopilot-test
+      k0s-reference-version: ${{ matrix.version }}
 
   smoketest-arm:
     name: Smoke test on armv7/arm64

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -206,63 +206,12 @@ jobs:
       matrix:
         smoke-suite: ${{ fromJson(needs.prepare.outputs.smoketest-matrix) }}
 
-    name: "Smoke tests :: ${{ matrix.smoke-suite }}"
+    name: "Smoke test :: ${{ matrix.smoke-suite }}"
     needs: [prepare, build-k0s, build-airgap-image-bundle]
-    runs-on: ubuntu-22.04
 
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Reclaim runner disk space
-        run: .github/workflows/reclaim-runner-disk-space.bash
-
-      - name: Prepare build environment
-        run: .github/workflows/prepare-build-env.sh
-
-      - name: Prepare docker for ipv6 dual-stack tests
-        if: contains(matrix.smoke-suite, 'dualstack')
-        run: .github/workflows/prepare-docker-ipv6.sh
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Download compiled executable
-        uses: actions/download-artifact@v4
-        with:
-          name: k0s-linux-amd64
-
-      - name: k0s sysinfo
-        run: |
-          chmod +x k0s
-          ./k0s sysinfo
-
-      - name: Download airgap image bundle
-        if: contains(matrix.smoke-suite, 'airgap')
-        uses: actions/download-artifact@v4
-        with:
-          name: airgap-image-bundle-linux-amd64
-
-      - name: Run inttest
-        run: make -C inttest ${{ matrix.smoke-suite }}
-
-      - name: Collect k0s logs and support bundle
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: smoketests-${{ matrix.smoke-suite }}-files
-          path: |
-            /tmp/*.log
-            /tmp/support-bundle.tar.gz
-
-      - name: Collect sonobuoy results
-        if: failure() && contains(matrix.smoke-suite, 'conformance')
-        uses: actions/upload-artifact@v4
-        with:
-          name: smoketests-${{ matrix.smoke-suite }}-sonobuoy-results
-          path: /tmp/*_sonobuoy_*.tar.gz
+    uses: ./.github/workflows/smoketest.yaml
+    with:
+      name: ${{ matrix.smoke-suite }}
 
   autopilot-tests:
     strategy:

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -62,7 +62,7 @@ jobs:
           SMOKETEST_NAME: check-${{ inputs.name }}
         run: make -C inttest "$SMOKETEST_NAME"
 
-      - name: Collect k0s logs and support bundle
+      - name: Collect k0s logs, support bundle and conformance test results
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -70,10 +70,4 @@ jobs:
           path: |
             /tmp/*.log
             /tmp/support-bundle.tar.gz
-
-      - name: Collect sonobuoy results
-        if: failure() && contains(inputs.name, 'conformance')
-        uses: actions/upload-artifact@v4
-        with:
-          name: smoketest-${{ inputs.name }}-sonobuoy-results
-          path: /tmp/*_sonobuoy_*.tar.gz
+            /tmp/*_sonobuoy_*.tar.gz

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -10,13 +10,24 @@ on:
         type: string
         required: true
         description: The integration test name to be executed.
+      job-name:
+        type: string
+        default: smoketest
+        description: >-
+          The name to use for the test job.
+          Will be used as a prefix for artifact uploads.
+      k0s-reference-version:
+        type: string
+        description: >-
+          The k0s release version to be used as a reference.
+          Mostly used for Autopilot upgrade checks.
 
 permissions:
   contents: read
 
 jobs:
   smoketest:
-    name: Smoke test
+    name: ${{ inputs.job-name }}
     runs-on: ubuntu-22.04
 
     steps:
@@ -57,6 +68,16 @@ jobs:
         with:
           name: airgap-image-bundle-linux-amd64
 
+      - name: Download k0s reference release
+        if: inputs.k0s-reference-version != ''
+        env:
+          K0S_VERSION: ${{ inputs.k0s-reference-version }}
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSLo "k0s-$K0S_VERSION" --retry 5 --retry-all-errors "https://github.com/k0sproject/k0s/releases/download/$K0S_VERSION/k0s-$K0S_VERSION-amd64"
+          chmod +x "k0s-$K0S_VERSION"
+          k0sRealPath="$(realpath "k0s-$K0S_VERSION")"
+          echo K0S_UPDATE_FROM_PATH="$k0sRealPath" >>"$GITHUB_ENV"
+
       - name: Run inttest
         env:
           SMOKETEST_NAME: check-${{ inputs.name }}
@@ -66,7 +87,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: smoketest-${{ inputs.name }}-files
+          name: ${{ inputs.job-name }}-${{ inputs.name }}-files
           path: |
             /tmp/*.log
             /tmp/support-bundle.tar.gz

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -58,7 +58,9 @@ jobs:
           name: airgap-image-bundle-linux-amd64
 
       - name: Run inttest
-        run: make -C inttest ${{ inputs.name }}
+        env:
+          SMOKETEST_NAME: check-${{ inputs.name }}
+        run: make -C inttest "$SMOKETEST_NAME"
 
       - name: Collect k0s logs and support bundle
         if: failure()

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024 k0s authors
+
+name: Smoke test
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        type: string
+        required: true
+        description: The integration test name to be executed.
+
+permissions:
+  contents: read
+
+jobs:
+  smoketest:
+    name: Smoke test
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          show-progress: false
+
+      - name: Reclaim runner disk space
+        run: .github/workflows/reclaim-runner-disk-space.bash
+
+      - name: Prepare build environment
+        run: .github/workflows/prepare-build-env.sh
+
+      - name: Prepare Docker for ipv6 dual-stack tests
+        if: contains(inputs.name, 'dualstack')
+        run: .github/workflows/prepare-docker-ipv6.sh
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Download compiled executable
+        uses: actions/download-artifact@v4
+        with:
+          name: k0s-linux-amd64
+
+      - name: k0s sysinfo
+        run: |
+          chmod +x k0s
+          ./k0s sysinfo
+
+      - name: Download airgap image bundle
+        if: contains(inputs.name, 'airgap')
+        uses: actions/download-artifact@v4
+        with:
+          name: airgap-image-bundle-linux-amd64
+
+      - name: Run inttest
+        run: make -C inttest ${{ inputs.name }}
+
+      - name: Collect k0s logs and support bundle
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoketest-${{ inputs.name }}-files
+          path: |
+            /tmp/*.log
+            /tmp/support-bundle.tar.gz
+
+      - name: Collect sonobuoy results
+        if: failure() && contains(inputs.name, 'conformance')
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoketest-${{ inputs.name }}-sonobuoy-results
+          path: /tmp/*_sonobuoy_*.tar.gz


### PR DESCRIPTION
## Description

This allows for integrating the smoke tests and autopilot tests into a single job template. Downloading the k0s release was the only difference. Add an optional input for that.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings