### PR TITLE
Integrate controllerworker test into autopilot matrix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -269,8 +269,11 @@ jobs:
       fail-fast: false
       matrix:
         version: ${{fromJson(needs.prepare.outputs.autopilot-matrix)}}
+        smoke-suite:
+          - controllerworker
+          - ha3x3
 
-    name: "Autopilot tests :: ${{ matrix.version }}"
+    name: "Autopilot tests :: ${{ matrix.version }} :: ${{ matrix.smoke-suite }}"
     needs: [prepare, build-k0s]
     runs-on: ubuntu-22.04
 
@@ -309,13 +312,13 @@ jobs:
 
       - name: Run inttest
         run: |
-          make -C inttest check-ap-ha3x3 K0S_UPDATE_FROM_BIN="../k0s-$K0S_VERSION"
+          make -C inttest check-ap-${{ matrix.smoke-suite }} K0S_UPDATE_FROM_BIN="../k0s-$K0S_VERSION"
 
       - name: Collect k0s logs and support bundle
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: autopilot-tests-${{ matrix.version }}-files
+          name: autopilot-tests-${{ matrix.version }}-${{ matrix.smoke-suite }}-files
           path: |
             /tmp/*.log
             /tmp/support-bundle.tar.gz


### PR DESCRIPTION
## Description

This way, the hardcoded k0s version in the test is no longer needed. Currently, there's no practical way to reliably determine the actual Kubernetes version from a dev build of k0s. So simply remove the initial kubelet version check.

See:
* https://github.com/k0sproject/k0s/pull/4457#discussion_r1609316718

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings