### PR TITLE
Add hardening/retry flags to curl invocations

### DIFF
--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -137,7 +137,7 @@ jobs:
         id: k0sctl
         run: |
           # download k0sctl
-          curl --silent -L "https://github.com/k0sproject/k0sctl/releases/download/${K0SCTL_VERSION}/k0sctl-linux-x64" -o k0sctl
+          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo k0sctl "https://github.com/k0sproject/k0sctl/releases/download/${K0SCTL_VERSION}/k0sctl-linux-x64"
           chmod +x ./k0sctl
           ./k0sctl apply -c k0sctl.yaml
 

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -30,8 +30,8 @@ jobs:
           # https://github.com/christophebedard/dco-check/releases/tag/0.4.0
           DCO_CHECK_VERSION: 30353d8deedf393cf55ba33355e71da7fdd095c7
         run: |
-          curl 'https://raw.githubusercontent.com/christophebedard/dco-check/${{ env.DCO_CHECK_VERSION }}/dco_check/dco_check.py' \
-            --retry 5 --retry-all-errors --proto '=https' --tlsv1.2 -sSLfo dco_check.py
+          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo dco_check.py \
+            'https://raw.githubusercontent.com/christophebedard/dco-check/${{ env.DCO_CHECK_VERSION }}/dco_check/dco_check.py'
 
       - name: Run DCO check
         env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           k0sSortVersion=$(./vars.sh FROM=. k0s_sort_version)
           mkdir -p build/cache/bin
-          curl -sSLo build/cache/bin/k0s_sort --retry 5 --retry-all-errors "https://github.com/k0sproject/version/releases/download/$k0sSortVersion/k0s_sort-linux-amd64"
+          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo build/cache/bin/k0s_sort "https://github.com/k0sproject/version/releases/download/$k0sSortVersion/k0s_sort-linux-amd64"
           chmod +x build/cache/bin/k0s_sort
           export PATH="$(realpath build/cache/bin):$PATH"
 
@@ -302,7 +302,7 @@ jobs:
 
       - name: Download latest release
         run: |
-          curl -L -o "k0s-$K0S_VERSION" "https://github.com/k0sproject/k0s/releases/download/$K0S_VERSION/k0s-$K0S_VERSION-amd64"
+          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo "k0s-$K0S_VERSION" "https://github.com/k0sproject/k0s/releases/download/$K0S_VERSION/k0s-$K0S_VERSION-amd64"
           chmod +x "k0s-$K0S_VERSION"
 
       - name: k0s sysinfo

--- a/.github/workflows/ostests-e2e.yaml
+++ b/.github/workflows/ostests-e2e.yaml
@@ -108,7 +108,7 @@ jobs:
           jq --version
 
           mkdir -p "$(dirname -- "$TF_VAR_k0sctl_executable_path")"
-          curl -sSLo "$TF_VAR_k0sctl_executable_path" "https://github.com/k0sproject/k0sctl/releases/download/${K0SCTL_VERSION}/k0sctl-linux-x64"
+          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo "$TF_VAR_k0sctl_executable_path" "https://github.com/k0sproject/k0sctl/releases/download/${K0SCTL_VERSION}/k0sctl-linux-x64"
           chmod +x -- "$TF_VAR_k0sctl_executable_path"
           "$TF_VAR_k0sctl_executable_path" version
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -38,7 +38,7 @@ jobs:
 
           k0sSortVersion=$(./vars.sh FROM=. k0s_sort_version)
           mkdir -p build/cache/bin
-          curl -sSLo build/cache/bin/k0s_sort --retry 5 --retry-all-errors "https://github.com/k0sproject/version/releases/download/$k0sSortVersion/k0s_sort-linux-amd64"
+          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo build/cache/bin/k0s_sort --retry 5 --retry-all-errors "https://github.com/k0sproject/version/releases/download/$k0sSortVersion/k0s_sort-linux-amd64"
           chmod +x build/cache/bin/k0s_sort
           printf '%s\n' "$(realpath build/cache/bin)" >>"$GITHUB_PATH"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
-          curl -sSLo cosign https://github.com/sigstore/cosign/releases/download/v2.2.3/cosign-linux-amd64
+          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo cosign https://github.com/sigstore/cosign/releases/download/v2.2.3/cosign-linux-amd64
           chmod +x ./cosign
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false --output-file=k0s.sig k0s
           cat k0s.sig
@@ -192,7 +192,7 @@ jobs:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
-          curl -sSLo cosign https://github.com/sigstore/cosign/releases/download/v2.2.3/cosign-linux-amd64
+          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo cosign https://github.com/sigstore/cosign/releases/download/v2.2.3/cosign-linux-amd64
           chmod +x ./cosign
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false --output-file=k0s.exe.sig k0s.exe
           cat k0s.exe.sig
@@ -260,7 +260,7 @@ jobs:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
-          curl -sSLo cosign https://github.com/sigstore/cosign/releases/download/v2.2.3/cosign-linux-arm64
+          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo cosign https://github.com/sigstore/cosign/releases/download/v2.2.3/cosign-linux-arm64
           chmod +x ./cosign
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false --output-file=k0s.sig k0s
           cat k0s.sig
@@ -347,7 +347,7 @@ jobs:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
-          curl -sSLo cosign https://github.com/sigstore/cosign/releases/download/v2.2.3/cosign-linux-arm
+          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo cosign https://github.com/sigstore/cosign/releases/download/v2.2.3/cosign-linux-arm
           chmod +x ./cosign
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false --output-file=k0s.sig k0s
           cat k0s.sig
@@ -601,7 +601,7 @@ jobs:
       - name: Create k0s Cluster using k0sctl
         run: |
           # download k0sctl
-          curl --silent -L "https://github.com/k0sproject/k0sctl/releases/download/${K0SCTL_VERSION}/k0sctl-linux-x64" -o k0sctl
+          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo "https://github.com/k0sproject/k0sctl/releases/download/${K0SCTL_VERSION}/k0sctl-linux-x64" -o k0sctl
           chmod +x ./k0sctl
           ./k0sctl apply -c k0sctl.yaml
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -49,7 +49,7 @@ k0s k0s.exe::
 	touch -- '$@.etag'
 	@downloadUrl="$$($(MAKE) --no-print-directory -s '.$@-download-url')" \
 	  && echo "Download URL for $@ $(TARGET_VERSION): $$downloadUrl" \
-	  && curl -Lo '$@.tmp' --etag-compare '$@.etag' --etag-save '$@.etag.tmp' -- "$$downloadUrl"
+	  && curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -Lfo '$@.tmp' --etag-compare '$@.etag' --etag-save '$@.etag.tmp' -- "$$downloadUrl"
 	if [ -f '$@.tmp' ]; then \
 	  mv -- '$@.tmp' '$@' && touch -r '$@' -- '$@.etag.tmp'; \
 	fi

--- a/docs/examples/gitops-flux.md
+++ b/docs/examples/gitops-flux.md
@@ -17,7 +17,7 @@ Let's start by installing k0s. Any k0s deployment option will do, but to keep th
 Run these three commands to download k0s, install and start it:
 
   ```shell
-  curl -sSLf https://get.k0s.sh | sudo sh
+  curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
   sudo k0s install controller --single
   sudo k0s start
   ```
@@ -42,7 +42,7 @@ To proceed with Flux, install the Flux CLI, which is used for configuring Flux t
 or
 
   ```shell
-  curl -s https://fluxcd.io/install.sh | sudo bash
+  curl --proto '=https' --tlsv1.2 -sSf https://fluxcd.io/install.sh | sudo bash
   ```
 
 For more details of the Flux installation, check the [Flux documentation](https://fluxcd.io/docs/get-started/).

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,7 +15,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
     Run the k0s download script to download the latest stable version of k0s and make it executable from /usr/local/bin/k0s.
 
     ```shell
-    curl -sSLf https://get.k0s.sh | sudo sh
+    curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
     ```
 
 2. Install k0s as a service

--- a/docs/k0s-multi-node.md
+++ b/docs/k0s-multi-node.md
@@ -17,7 +17,7 @@ You can speed up the use of the `k0s` command by enabling [shell completion](she
 Run the k0s download script to download the latest stable version of k0s and make it executable from /usr/bin/k0s.
 
 ```shell
-curl -sSLf https://get.k0s.sh | sudo sh
+curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
 ```
 
 The download script accepts the following environment variables:
@@ -30,7 +30,7 @@ The download script accepts the following environment variables:
 **Note**: If you require environment variables and use sudo, you can do:
 
 ```shell
-curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v{{{ extra.k8s_version }}}+k0s.0 sh
+curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo K0S_VERSION=v{{{ extra.k8s_version }}}+k0s.0 sh
 ```
 
 ### 2. Bootstrap a controller node

--- a/docs/raspberry-pi4.md
+++ b/docs/raspberry-pi4.md
@@ -135,7 +135,7 @@ Use the k0s download script (as one command) to download the latest stable k0s
 and make it executable in `/usr/bin/k0s`.
 
 ```shell
-curl -sSLf https://get.k0s.sh | sudo sh
+curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
 ```
 
 At this point you can run `k0s`:

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -22,7 +22,7 @@ sudo k0s stop
 Now you can replace the old k0s binary file. The easiest way is to use the download script. It will download the latest k0s binary and replace the old binary with it. You can also do this manually without the download script.
 
 ```shell
-curl -sSLf https://get.k0s.sh | sudo sh
+curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
 ```
 
 Then you can start the service (with the upgraded k0s) and your upgrade is done.

--- a/embedded-bins/iptables/Dockerfile
+++ b/embedded-bins/iptables/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add build-base curl pkgconf \
 	libnftnl-dev
 
 ARG VERSION
-RUN curl -L https://www.netfilter.org/projects/iptables/files/iptables-$VERSION.tar.xz \
+RUN curl --proto '=https' --tlsv1.2 -L https://www.netfilter.org/projects/iptables/files/iptables-$VERSION.tar.xz \
 	| tar -C / -Jx
 
 ARG TARGET_OS

--- a/embedded-bins/keepalived/Dockerfile
+++ b/embedded-bins/keepalived/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add build-base curl \
 	libnl3-dev libnl3-static
 
 ARG VERSION
-RUN curl -L https://www.keepalived.org/software/keepalived-$VERSION.tar.gz \
+RUN curl --proto '=https' --tlsv1.2 -L https://www.keepalived.org/software/keepalived-$VERSION.tar.gz \
 	| tar -C / -zx
 
 RUN cd /keepalived-$VERSION \

--- a/embedded-bins/runc/Dockerfile
+++ b/embedded-bins/runc/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add build-base git \
 ENV GOPATH=/go
 
 ARG LIBSECCOMP_VERSION=2.5.5
-RUN curl -L https://github.com/seccomp/libseccomp/releases/download/v$LIBSECCOMP_VERSION/libseccomp-$LIBSECCOMP_VERSION.tar.gz \
+RUN curl --proto '=https' --tlsv1.2 -L https://github.com/seccomp/libseccomp/releases/download/v$LIBSECCOMP_VERSION/libseccomp-$LIBSECCOMP_VERSION.tar.gz \
 	| tar -C / -zx
 
 RUN cd /libseccomp-$LIBSECCOMP_VERSION && ./configure --sysconfdir=/etc --enable-static

--- a/examples/bootloose-ha-controllers/Dockerfile
+++ b/examples/bootloose-ha-controllers/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/k0sproject/bootloose-ubuntu18.04
 
 ADD k0s.service /etc/systemd/system/k0s.service
 
-RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.30.2/bin/linux/amd64/kubectl && \
+RUN curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -Lfo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.30.2/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf

--- a/hack/get-calico.sh
+++ b/hack/get-calico.sh
@@ -25,7 +25,7 @@ DIR="static/manifests/calico"
 
 mkdir -p $DIR
 
-curl --silent -L "https://raw.githubusercontent.com/projectcalico/calico/v$CALICO_VERSION/manifests/calico.yaml" \
+curl --proto '=https' --tlsv1.2 -sSL "https://raw.githubusercontent.com/projectcalico/calico/v$CALICO_VERSION/manifests/calico.yaml" \
   | $CSPLIT_BINARY --digits=2 --quiet --prefix=$DIR/ -- - "/---/" "{*}"
 
 for f in "$DIR"/*; do

--- a/hack/tool/Dockerfile
+++ b/hack/tool/Dockerfile
@@ -9,11 +9,11 @@ RUN go build -o /tool
 FROM builder AS builder-terraform
 ARG ARCH
 ENV TERRAFORM_VERSION=1.3.3
-RUN curl -Lo /terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip && unzip /terraform.zip
+RUN curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -Lfo /terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip && unzip /terraform.zip
 
 FROM builder AS builder-aws
 ARG HARDWARE
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-${HARDWARE}.zip" -o "/tmp/awscliv2.zip" && \
+RUN curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -fo "/tmp/awscliv2.zip" "https://awscli.amazonaws.com/awscli-exe-linux-${HARDWARE}.zip" && \
     cd /tmp && \
     unzip awscliv2.zip && \
     ./aws/install && \

--- a/hack/tools/run-autopilot-matrix-tests.sh
+++ b/hack/tools/run-autopilot-matrix-tests.sh
@@ -17,7 +17,7 @@ fi
 
 while IFS=',' read -ra VERSION; do
   for ver in "${VERSION[@]}"; do
-    curl -L -o k0s-${ver} https://github.com/k0sproject/k0s/releases/download/${ver}/k0s-${ver}-${ARCH}
+    curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -Lfo k0s-${ver} https://github.com/k0sproject/k0s/releases/download/${ver}/k0s-${ver}-${ARCH}
     chmod +x k0s-${ver}
 
     while IFS=',' read -ra TESTARR; do

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -4,7 +4,7 @@ K0S_UPDATE_TO_VERSION ?= $(shell ../k0s version)
 
 sonobuoy_url = https://github.com/vmware-tanzu/sonobuoy/releases/download/v${sonobuoy_version}/sonobuoy_${sonobuoy_version}_$(OS)_$(ARCH).tar.gz
 
-curl = curl -L --silent
+curl = curl --proto '=https' --tlsv1.2 -sSL
 
 bins = bin/sonobuoy
 

--- a/inttest/bootloose-alpine/Dockerfile
+++ b/inttest/bootloose-alpine/Dockerfile
@@ -38,31 +38,31 @@ RUN sed -i -e 's/^\(tty[0-9]\)/# \1/' /etc/inittab
 RUN sed -i -e 's/^root:!:/root::/' /etc/shadow
 
 # Put kubectl into place to ease up debugging
-RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBERNETES_VERSION/bin/linux/$TARGETARCH/kubectl \
+RUN curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -Lfo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBERNETES_VERSION/bin/linux/$TARGETARCH/kubectl \
   && chmod +x /usr/local/bin/kubectl
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
 # Install troublbeshoot support bundle
-RUN curl -Lo - https://github.com/replicatedhq/troubleshoot/releases/download/$TROUBLESHOOT_VERSION/support-bundle_linux_$TARGETARCH.tar.gz \
+RUN curl --proto '=https' --tlsv1.2 -L https://github.com/replicatedhq/troubleshoot/releases/download/$TROUBLESHOOT_VERSION/support-bundle_linux_$TARGETARCH.tar.gz \
   | tar xzO support-bundle >/usr/local/bin/kubectl-supportbundle \
   && chmod +x /usr/local/bin/kubectl-supportbundle
 
 # Put helm into place to ease up debugging and for helm integration tests
-RUN curl -L https://get.helm.sh/helm-v$HELM_VERSION-linux-$TARGETARCH.tar.gz \
+RUN curl --proto '=https' --tlsv1.2 -L https://get.helm.sh/helm-v$HELM_VERSION-linux-$TARGETARCH.tar.gz \
   | tar xz linux-$TARGETARCH/helm -C /usr/local/bin --strip-components=1 \
   && chmod +x /usr/local/bin/helm
 
 # Install etcd for smoke tests with external etcd
 # No arm binaries available (check-externaletcd won't work on ARMv7)
 RUN if [ "$TARGETARCH" != arm ]; then \
-    curl -L https://github.com/etcd-io/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-$TARGETARCH.tar.gz \
+    curl --proto '=https' --tlsv1.2 -L https://github.com/etcd-io/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-$TARGETARCH.tar.gz \
       | tar xz -C /opt --strip-components=1; \
   fi
 
 # Install cri-dockerd shim for custom CRI testing
 # No arm binaries available (check-byocri won't work on ARMv7)
 RUN if [ "$TARGETARCH" != arm ]; then \
-    curl -sSfLo /tmp/cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v$CRI_DOCKERD_VERSION/cri-dockerd-$CRI_DOCKERD_VERSION.$TARGETARCH.tgz \
+    curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo /tmp/cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v$CRI_DOCKERD_VERSION/cri-dockerd-$CRI_DOCKERD_VERSION.$TARGETARCH.tgz \
       && tar xf /tmp/cri-dockerd.tgz --directory /tmp/ \
       && mv /tmp/cri-dockerd/cri-dockerd /usr/local/bin/cri-dockerd \
       && rm -rf /tmp/cri-dockerd \


### PR DESCRIPTION
## Description

Enforce HTTPS with TLS 1.2+ for security reasons. Add -f to all curl invocations that are not used as a pipe input, so that non-successful HTTP status codes produce a non-zero exit code. Add retry flags to all curl invocations that write to the file system.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings