### PR TITLE
Fix testify.Suite Run() usages across tests

### DIFF
--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/k0sproject/k0s/inttest/common"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -77,9 +76,9 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 		assert.Equal(t, "", out)
 	})
 
-	s.T().Run("k0sStart", func(t *testing.T) {
-		assert := assert.New(t)
-		require := require.New(t)
+	s.Run("k0sStart", func() {
+		assert := s.Assertions
+		require := s.Require()
 
 		_, err = ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s start")
 		require.NoError(err)
@@ -124,8 +123,8 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 	_, err = ssh.ExecWithOutput(s.Context(), "while pidof k0s containerd kubelet; do sleep 0.1s; done")
 	s.Require().NoError(err)
 
-	s.T().Run("k0sReset", func(t *testing.T) {
-		assert := assert.New(t)
+	s.Run("k0sReset", func() {
+		assert := s.Assertions
 		resetOutput, err := ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s reset --debug")
 		s.T().Logf("Reset executed with output:\n%s", resetOutput)
 

--- a/inttest/configchange/config_test.go
+++ b/inttest/configchange/config_test.go
@@ -97,7 +97,7 @@ func (s *ConfigSuite) TestK0sGetsUp() {
 	s.Require().NoError(err)
 	defer eventWatch.Stop()
 
-	s.T().Run("changing cni should fail", func(t *testing.T) {
+	s.Run("changing cni should fail", func() {
 		originalConfig, err := cfgClient.Get(s.Context(), "k0s", metav1.GetOptions{})
 		s.Require().NoError(err)
 		newConfig := originalConfig.DeepCopy()
@@ -116,7 +116,7 @@ func (s *ConfigSuite) TestK0sGetsUp() {
 		s.Equal("cannot change CNI provider from kuberouter to calico", event.Message)
 	})
 
-	s.T().Run("setting bad ip address should fail", func(t *testing.T) {
+	s.Run("setting bad ip address should fail", func() {
 		originalConfig, err := cfgClient.Get(context.Background(), "k0s", metav1.GetOptions{})
 		s.Require().NoError(err)
 		newConfig := originalConfig.DeepCopy()
@@ -134,7 +134,7 @@ func (s *ConfigSuite) TestK0sGetsUp() {
 		s.Equal("FailedReconciling", event.Reason)
 	})
 
-	s.T().Run("changing kuberouter MTU should work", func(t *testing.T) {
+	s.Run("changing kuberouter MTU should work", func() {
 		originalConfig, err := cfgClient.Get(context.Background(), "k0s", metav1.GetOptions{})
 		s.Require().NoError(err)
 		newConfig := originalConfig.DeepCopy()

--- a/inttest/customdomain/customdomain_test.go
+++ b/inttest/customdomain/customdomain_test.go
@@ -48,7 +48,7 @@ func (s *CustomDomainSuite) TestK0sGetsUpWithCustomDomain() {
 	s.T().Log("waiting to see CNI pods ready")
 	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "CNI did not start")
 
-	s.T().Run("check custom domain existence in pod", func(t *testing.T) {
+	s.Run("check custom domain existence in pod", func() {
 		// All done via SSH as it's much simpler :)
 		// e.g. execing via client-go is super complex and would require too much wiring
 		ssh, err := s.SSH(s.Context(), s.ControllerNode(0))

--- a/inttest/customports/customports_test.go
+++ b/inttest/customports/customports_test.go
@@ -137,7 +137,7 @@ func (s *customPortsSuite) TestControllerJoinsWithCustomPort() {
 	s.Require().NoError(common.WaitForPodLogs(s.Context(), kc, "kube-system"))
 
 	// https://github.com/k0sproject/k0s/issues/1202
-	s.T().Run("kubeconfigIncludesExternalAddress", func(t *testing.T) {
+	s.Run("kubeconfigIncludesExternalAddress", func() {
 		ssh, err := s.SSH(s.Context(), s.ControllerNode(0))
 		s.Require().NoError(err)
 		defer ssh.Disconnect()

--- a/inttest/embedded-binaries/embedded_binaries_test.go
+++ b/inttest/embedded-binaries/embedded_binaries_test.go
@@ -49,7 +49,7 @@ func (s *EmbeddedBinariesSuite) TestK0sGetsUp() {
 	s.Require().NoError(err)
 	defer sshC1.Disconnect()
 
-	s.T().Run("controller0", func(t *testing.T) {
+	s.Run("controller0", func() {
 		var testCases = []struct {
 			cmd        string
 			checkError bool
@@ -70,7 +70,7 @@ func (s *EmbeddedBinariesSuite) TestK0sGetsUp() {
 		}
 
 		for _, tc := range testCases {
-			t.Run(tc.cmd, func(_ *testing.T) {
+			s.Run(tc.cmd, func() {
 				out, err := sshC0.ExecWithOutput(s.Context(), fmt.Sprintf("/var/lib/k0s/bin/%s", tc.cmd))
 				if tc.checkError {
 					s.Require().NoError(err, tc.cmd, out)
@@ -82,7 +82,7 @@ func (s *EmbeddedBinariesSuite) TestK0sGetsUp() {
 		}
 	})
 
-	s.T().Run("controller1", func(t *testing.T) {
+	s.Run("controller1", func() {
 		var testCases = []struct {
 			cmd        string
 			checkError bool
@@ -92,7 +92,7 @@ func (s *EmbeddedBinariesSuite) TestK0sGetsUp() {
 		}
 
 		for _, tc := range testCases {
-			t.Run("", func(_ *testing.T) {
+			s.Run("", func() {
 				out, err := sshC1.ExecWithOutput(s.Context(), fmt.Sprintf("/var/lib/k0s/bin/%s", tc.cmd))
 				if tc.checkError {
 					s.Require().NoError(err, tc.cmd, out)

--- a/inttest/kine/kine_test.go
+++ b/inttest/kine/kine_test.go
@@ -76,7 +76,7 @@ func (s *KineSuite) TestK0sGetsUp() {
 		})
 	})
 
-	s.T().Run("metrics", func(t *testing.T) {
+	s.Run("metrics", func() {
 		s.Require().NoError(common.WaitForDeployment(s.Context(), kc, "k0s-pushgateway", "k0s-system"))
 		s.Require().NoError(wait.PollImmediateInfiniteWithContext(s.Context(), 5*time.Second, func(ctx context.Context) (bool, error) {
 			b, err := kc.RESTClient().Get().AbsPath("/api/v1/namespaces/k0s-system/services/http:k0s-pushgateway:http/proxy/metrics").DoRaw(s.Context())

--- a/inttest/kubectl/kubectl_test.go
+++ b/inttest/kubectl/kubectl_test.go
@@ -175,15 +175,15 @@ func (s *KubectlSuite) TestEmbeddedKubectl() {
 	}
 
 	for _, command := range commands {
-		s.T().Run(command.name, func(t *testing.T) {
-			execTest(t, fmt.Sprintf(command.cmdline, "/usr/local/bin/k0s"), command.check)
+		s.Run(command.name, func() {
+			execTest(s.T(), fmt.Sprintf(command.cmdline, "/usr/local/bin/k0s"), command.check)
 		})
 	}
 
 	for _, callingConvention := range kubectlCallingConventions {
 		for _, command := range kubectlCommands {
-			s.T().Run(fmt.Sprint(callingConvention.name, "_", command.name), func(t *testing.T) {
-				execTest(t, fmt.Sprintf(command.cmdline, callingConvention.cmdline), command.check)
+			s.Run(fmt.Sprint(callingConvention.name, "_", command.name), func() {
+				execTest(s.T(), fmt.Sprintf(command.cmdline, callingConvention.cmdline), command.check)
 			})
 		}
 	}

--- a/inttest/kuberouter/kuberouter_hairpin_test.go
+++ b/inttest/kuberouter/kuberouter_hairpin_test.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/k0sproject/k0s/inttest/common"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -57,11 +55,11 @@ func (s *KubeRouterHairpinSuite) TestK0sGetsUp() {
 	err = common.WaitForPod(s.Context(), kc, "hairpin-pod", "default")
 	s.Require().NoError(err)
 
-	s.T().Run("check hairpin mode", func(t *testing.T) {
+	s.Run("check hairpin mode", func() {
 		// All done via SSH as it's much simpler :)
 		// e.g. execing via client-go is super complex and would require too much wiring
 		ssh, err := s.SSH(s.Context(), s.ControllerNode(0))
-		require.NoError(t, err)
+		s.Require().NoError(err)
 		defer ssh.Disconnect()
 
 		const curl = "k0s kc exec -n default hairpin-pod -c curl -- curl"
@@ -78,16 +76,16 @@ func (s *KubeRouterHairpinSuite) TestK0sGetsUp() {
 				"pod can reach itself via service name",
 			},
 		} {
-			t.Run(test.desc, func(t *testing.T) {
+			s.Run(test.desc, func() {
 				err = wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
 					output, err := ssh.ExecWithOutput(s.Context(), fmt.Sprintf("%s --connect-timeout 5 -sS http://%s", curl, test.dnsName))
 					if err != nil {
-						t.Log(output)
+						s.T().Log(output)
 						return false, nil
 					}
-					return assert.Contains(t, output, "Thank you for using nginx."), nil
+					return s.Contains(output, "Thank you for using nginx."), nil
 				})
-				require.NoError(t, err)
+				s.Require().NoError(err)
 			})
 		}
 	})

--- a/inttest/stackapplier/stackapplier_test.go
+++ b/inttest/stackapplier/stackapplier_test.go
@@ -77,7 +77,7 @@ func (s *suite) TestStackApplier() {
 		species := client.Resource(sgv.WithResource("species"))
 		assert.NoError(t, watch.Unstructured(species).
 			WithObjectName("hobbit").
-			WithErrorCallback(retryWatchErrors(s.T().Logf)).
+			WithErrorCallback(retryWatchErrors(t.Logf)).
 			Until(ctx, func(item *unstructured.Unstructured) (bool, error) {
 				speciesName, found, err := unstructured.NestedString(item.Object, "spec", "characteristics")
 				if assert.NoError(t, err) && assert.True(t, found, "no characteristics found: %v", item.Object) {
@@ -97,7 +97,7 @@ func (s *suite) TestStackApplier() {
 		characters := client.Resource(sgv.WithResource("characters"))
 		assert.NoError(t, watch.Unstructured(characters.Namespace("shire")).
 			WithObjectName("frodo").
-			WithErrorCallback(retryWatchErrors(s.T().Logf)).
+			WithErrorCallback(retryWatchErrors(t.Logf)).
 			Until(ctx, func(item *unstructured.Unstructured) (bool, error) {
 				speciesName, found, err := unstructured.NestedString(item.Object, "spec", "speciesRef", "name")
 				if assert.NoError(t, err) && assert.True(t, found, "no species found: %v", item.Object) {

--- a/pkg/apis/k0s/v1beta1/api_test.go
+++ b/pkg/apis/k0s/v1beta1/api_test.go
@@ -28,13 +28,13 @@ type APISuite struct {
 }
 
 func (s *APISuite) TestValidation() {
-	s.T().Run("defaults_are_valid", func(t *testing.T) {
+	s.Run("defaults_are_valid", func() {
 		a := DefaultAPISpec()
 
 		s.NoError(errors.Join(a.Validate()...))
 	})
 
-	s.T().Run("accepts_ipv6_as_address", func(t *testing.T) {
+	s.Run("accepts_ipv6_as_address", func() {
 		ipV6Addr := "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
 		a := APISpec{Address: ipV6Addr}
 		a.setDefaults()
@@ -43,7 +43,7 @@ func (s *APISuite) TestValidation() {
 		s.NoError(errors.Join(a.Validate()...))
 	})
 
-	s.T().Run("invalid_api_address", func(t *testing.T) {
+	s.Run("invalid_api_address", func() {
 		a := APISpec{
 			Address: "something.that.is.not.valid//(())",
 		}
@@ -56,7 +56,7 @@ func (s *APISuite) TestValidation() {
 		}
 	})
 
-	s.T().Run("invalid_sans_address", func(t *testing.T) {
+	s.Run("invalid_sans_address", func() {
 		a := APISpec{
 			SANs: []string{
 				"something.that.is.not.valid//(())",

--- a/pkg/apis/k0s/v1beta1/network_test.go
+++ b/pkg/apis/k0s/v1beta1/network_test.go
@@ -27,33 +27,33 @@ type NetworkSuite struct {
 }
 
 func (s *NetworkSuite) TestAddresses() {
-	s.T().Run("DNS_default_service_cidr", func(t *testing.T) {
+	s.Run("DNS_default_service_cidr", func() {
 		n := DefaultNetwork()
 		dns, err := n.DNSAddress()
 		s.Require().NoError(err)
 		s.Equal("10.96.0.10", dns)
 	})
-	s.T().Run("DNS_uses_non_default_service_cidr", func(t *testing.T) {
+	s.Run("DNS_uses_non_default_service_cidr", func() {
 		n := DefaultNetwork()
 		n.ServiceCIDR = "10.96.0.248/29"
 		dns, err := n.DNSAddress()
 		s.Require().NoError(err)
 		s.Equal("10.96.0.250", dns)
 	})
-	s.T().Run("Internal_api_address_default", func(t *testing.T) {
+	s.Run("Internal_api_address_default", func() {
 		n := DefaultNetwork()
 		api, err := n.InternalAPIAddresses()
 		s.Require().NoError(err)
 		s.Equal([]string{"10.96.0.1"}, api)
 	})
-	s.T().Run("Internal_api_address_non_default_single_stack", func(t *testing.T) {
+	s.Run("Internal_api_address_non_default_single_stack", func() {
 		n := DefaultNetwork()
 		n.ServiceCIDR = "10.96.0.248/29"
 		api, err := n.InternalAPIAddresses()
 		s.Require().NoError(err)
 		s.Equal([]string{"10.96.0.249"}, api)
 	})
-	s.T().Run("Internal_api_address_non_default_dual_stack", func(t *testing.T) {
+	s.Run("Internal_api_address_non_default_dual_stack", func() {
 		n := DefaultNetwork()
 		n.ServiceCIDR = "10.96.0.248/29"
 		n.DualStack.Enabled = true
@@ -63,18 +63,18 @@ func (s *NetworkSuite) TestAddresses() {
 		s.Equal([]string{"10.96.0.249", "fd00::1"}, api)
 	})
 
-	s.T().Run("BuildServiceCIDR ordering", func(t *testing.T) {
-		t.Run("single_stack_default", func(t *testing.T) {
+	s.Run("BuildServiceCIDR ordering", func() {
+		s.Run("single_stack_default", func() {
 			n := DefaultNetwork()
 			s.Equal(n.ServiceCIDR, n.BuildServiceCIDR("10.96.0.249"))
 		})
-		t.Run("dual_stack_api_listens_on_ipv4", func(t *testing.T) {
+		s.Run("dual_stack_api_listens_on_ipv4", func() {
 			n := DefaultNetwork()
 			n.DualStack.Enabled = true
 			n.DualStack.IPv6ServiceCIDR = "fd00::/108"
 			s.Equal(n.ServiceCIDR+","+n.DualStack.IPv6ServiceCIDR, n.BuildServiceCIDR("10.96.0.249"))
 		})
-		t.Run("dual_stack_api_listens_on_ipv6", func(t *testing.T) {
+		s.Run("dual_stack_api_listens_on_ipv6", func() {
 			n := DefaultNetwork()
 			n.DualStack.Enabled = true
 			n.DualStack.IPv6ServiceCIDR = "fd00::/108"
@@ -194,13 +194,13 @@ spec:
 }
 
 func (s *NetworkSuite) TestValidation() {
-	s.T().Run("defaults_are_valid", func(t *testing.T) {
+	s.Run("defaults_are_valid", func() {
 		n := DefaultNetwork()
 
 		s.Nil(n.Validate())
 	})
 
-	s.T().Run("invalid_provider", func(t *testing.T) {
+	s.Run("invalid_provider", func() {
 		n := DefaultNetwork()
 		n.Provider = "foobar"
 
@@ -209,7 +209,7 @@ func (s *NetworkSuite) TestValidation() {
 		s.Len(errors, 1)
 	})
 
-	s.T().Run("invalid_pod_cidr", func(t *testing.T) {
+	s.Run("invalid_pod_cidr", func() {
 		n := DefaultNetwork()
 		n.PodCIDR = "foobar"
 
@@ -219,7 +219,7 @@ func (s *NetworkSuite) TestValidation() {
 		}
 	})
 
-	s.T().Run("invalid_service_cidr", func(t *testing.T) {
+	s.Run("invalid_service_cidr", func() {
 		n := DefaultNetwork()
 		n.ServiceCIDR = "foobar"
 
@@ -229,7 +229,7 @@ func (s *NetworkSuite) TestValidation() {
 		}
 	})
 
-	s.T().Run("invalid_cluster_domain", func(t *testing.T) {
+	s.Run("invalid_cluster_domain", func() {
 		n := DefaultNetwork()
 		n.ClusterDomain = ".invalid-cluster-domain"
 
@@ -239,7 +239,7 @@ func (s *NetworkSuite) TestValidation() {
 		}
 	})
 
-	s.T().Run("invalid_ipv6_service_cidr", func(t *testing.T) {
+	s.Run("invalid_ipv6_service_cidr", func() {
 		n := DefaultNetwork()
 		n.Calico = DefaultCalico()
 		n.Calico.Mode = "bird"
@@ -255,7 +255,7 @@ func (s *NetworkSuite) TestValidation() {
 		}
 	})
 
-	s.T().Run("invalid_ipv6_pod_cidr", func(t *testing.T) {
+	s.Run("invalid_ipv6_pod_cidr", func() {
 		n := DefaultNetwork()
 		n.Calico = DefaultCalico()
 		n.Calico.Mode = "bird"
@@ -271,7 +271,7 @@ func (s *NetworkSuite) TestValidation() {
 		}
 	})
 
-	s.T().Run("invalid_mode_for_kube_proxy", func(t *testing.T) {
+	s.Run("invalid_mode_for_kube_proxy", func() {
 		n := DefaultNetwork()
 		n.KubeProxy.Mode = "foobar"
 
@@ -281,7 +281,7 @@ func (s *NetworkSuite) TestValidation() {
 		}
 	})
 
-	s.T().Run("valid_proxy_disabled_for_dualstack", func(t *testing.T) {
+	s.Run("valid_proxy_disabled_for_dualstack", func() {
 		n := DefaultNetwork()
 		n.Calico = DefaultCalico()
 		n.Calico.Mode = "bird"

--- a/pkg/apis/k0s/v1beta1/storage_test.go
+++ b/pkg/apis/k0s/v1beta1/storage_test.go
@@ -175,7 +175,7 @@ func (s *storageSuite) TestValidation() {
 	}
 
 	for _, tt := range validStorageSpecs {
-		s.T().Run(tt.desc, func(t *testing.T) {
+		s.Run(tt.desc, func() {
 			s.Nil(tt.spec.Validate())
 		})
 	}
@@ -230,7 +230,7 @@ func (s *storageSuite) TestValidation() {
 	}
 
 	for _, tt := range singleValidationErrorCases {
-		s.T().Run(tt.desc, func(t *testing.T) {
+		s.Run(tt.desc, func() {
 			errs := tt.spec.Validate()
 			s.NotNil(errs)
 			s.Len(errs, 1)
@@ -238,7 +238,7 @@ func (s *storageSuite) TestValidation() {
 		})
 	}
 
-	s.T().Run("external_cluster_endpoints_and_etcd_prefix_cannot_be_empty", func(t *testing.T) {
+	s.Run("external_cluster_endpoints_and_etcd_prefix_cannot_be_empty", func() {
 		spec := &StorageSpec{
 			Type: EtcdStorageType,
 			Etcd: &EtcdConfig{
@@ -319,7 +319,7 @@ func (s *storageSuite) TestIsTLSEnabled() {
 	}
 
 	for _, tt := range storageSpecs {
-		s.T().Run(tt.desc, func(t *testing.T) {
+		s.Run(tt.desc, func() {
 			result := tt.spec.Etcd.IsTLSEnabled()
 			s.Equal(result, tt.expectedResult)
 		})


### PR DESCRIPTION
## Description

The suite retains its own `testing.T` pointer, which is used for the suite's assertions. Whenever a sub-test is created via `suite.T().Run(...)`, the suite's internal pointer remains unchanged and points to the parent test. Using the suite in the sub-test should then be avoided to not run into errors like this:

> test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test

An alternative is to use `suite.Run()` directly. This will adjust the test pointer as long as the test func is running. This way, the suite remains usable in the sub-test. Note that this only works for non-parallel tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings