### PR TITLE
Support for running OS tests for Debian 12 on arm64

### DIFF
--- a/.github/workflows/build-k0s.yml
+++ b/.github/workflows/build-k0s.yml
@@ -18,13 +18,28 @@ env:
 jobs:
   build:
     name: ${{ inputs.target-os }}-${{ inputs.target-arch }}
-    runs-on: ubuntu-22.04
+    runs-on: >-
+      ${{
+           inputs.target-arch == 'arm'   && fromJSON('["self-hosted", "linux", "arm"]')
+        || inputs.target-arch == 'arm64' && fromJSON('["self-hosted", "linux", "arm64"]')
+        || 'ubuntu-22.04'
+      }}
 
     env:
       TARGET_OS: ${{ inputs.target-os }}
       TARGET_ARCH: ${{ inputs.target-arch }}
 
     steps:
+      - name: Set up Docker Context for Buildx
+        if: inputs.target-arch != 'amd64'
+        run: docker context create builders
+
+      - name: Set up Docker Buildx
+        if: inputs.target-arch != 'amd64'
+        uses: docker/setup-buildx-action@v3
+        with:
+          endpoint: builders
+
       - name: "Build :: Checkout"
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ostests-e2e.yaml
+++ b/.github/workflows/ostests-e2e.yaml
@@ -20,6 +20,10 @@ on:
         type: string
         description: The operating system to test.
         required: true
+      arch:
+        type: string
+        description: The processor architecture to test.
+        default: amd64
       network-provider:
         type: string
         description: The k0s network provider to test.
@@ -96,11 +100,12 @@ jobs:
         if: inputs.k0s-version == ''
         uses: actions/download-artifact@v4
         with:
-          name: k0s-linux-amd64
+          name: k0s-linux-${{ inputs.arch }}
           path: ${{ github.workspace }}/.cache
 
       - name: "Terraform :: Requisites :: Prepare"
         env:
+          OSTESTS_ARCH: ${{ inputs.arch }}
           K0S_VERSION: ${{ inputs.k0s-version }}
           K0S_EXECUTABLE_PATH: ${{ github.workspace }}/.cache/k0s
         run: |
@@ -118,6 +123,9 @@ jobs:
             echo TF_VAR_k0s_executable_path="$K0S_EXECUTABLE_PATH" >>"$GITHUB_ENV"
           fi
 
+          if [ "$OSTESTS_ARCH" != amd64 ]; then
+            echo TF_VAR_arch="$OSTESTS_ARCH" >>"$GITHUB_ENV"
+          fi
           echo TF_VAR_k0s_version="$K0S_VERSION" >>"$GITHUB_ENV"
 
       - name: "Terraform :: Setup"
@@ -210,7 +218,7 @@ jobs:
         if: always() && (steps.e2e-retrieve-parallel.conclusion == 'success' || steps.e2e-retrieve-serial.conclusion == 'success')
         uses: actions/upload-artifact@v4
         with:
-          name: ostests-e2e-${{ inputs.os }}-${{ inputs.network-provider }}-${{ inputs.kube-proxy-mode }}-sonobuoy-results
+          name: ostests-e2e-${{ inputs.os }}-${{ inputs.arch }}-${{ inputs.network-provider }}-${{ inputs.kube-proxy-mode }}-sonobuoy-results
           path: |
             inttest/sonobuoy-e2e-parallel.tar.gz
             inttest/sonobuoy-e2e-serial.tar.gz
@@ -233,5 +241,5 @@ jobs:
         if: always() && steps.tf-init.conclusion == 'success'
         uses: actions/upload-artifact@v4
         with:
-          name: ostests-e2e-${{ inputs.os }}-${{ inputs.network-provider }}-${{ inputs.kube-proxy-mode }}-k0sctl-logs
+          name: ostests-e2e-${{ inputs.os }}-${{ inputs.arch }}-${{ inputs.network-provider }}-${{ inputs.kube-proxy-mode }}-k0sctl-logs
           path: ~/.cache/k0sctl/k0sctl.log

--- a/.github/workflows/ostests-matrix.yaml
+++ b/.github/workflows/ostests-matrix.yaml
@@ -34,6 +34,11 @@ on:
             "rocky_8", "rocky_9",
             "ubuntu_2004", "ubuntu_2204", "ubuntu_2304"
           ]
+      arch:
+        type: string
+        description: The processor architecture to test.
+        required: true
+        default: amd64
       network-providers:
         type: string
         description: The k0s network providers to test.
@@ -53,20 +58,22 @@ on:
             "ipvs"
           ]
 
+run-name: "OS tests :: ${{ inputs.arch }}"
+
 jobs:
   build:
     name: Build
     if: inputs.k0s-version == ''
     uses: ./.github/workflows/build-k0s.yml
-    with: { target-os: linux, target-arch: amd64 }
+    with: { target-os: linux, target-arch: "${{ inputs.arch }}" }
 
   e2e-tests:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(github.event.inputs.oses) }}
-        network-provider: ${{ fromJSON(github.event.inputs.network-providers) }}
-        kube-proxy-mode: ${{ fromJSON(github.event.inputs.kube-proxy-modes) }}
+        os: ${{ fromJSON(inputs.oses) }}
+        network-provider: ${{ fromJSON(inputs.network-providers) }}
+        kube-proxy-mode: ${{ fromJSON(inputs.kube-proxy-modes) }}
 
     name: "${{ matrix.os }} :: ${{ matrix.network-provider }} :: ${{ matrix.kube-proxy-mode }}"
     needs: build
@@ -77,6 +84,7 @@ jobs:
       e2e-concurrency-level: ${{ fromJSON(inputs.e2e-concurrency-level) }} # infamous GH workflows bug that looses type information (actions/runner#2206)
       e2e-focus: ${{ inputs.e2e-focus }}
       os: ${{ matrix.os }}
+      arch: ${{ inputs.arch }}
       network-provider: ${{ matrix.network-provider }}
       kube-proxy-mode: ${{ matrix.kube-proxy-mode }}
     secrets:

--- a/hack/ostests/README.md
+++ b/hack/ostests/README.md
@@ -49,6 +49,7 @@ other ways described [here][tf-config].
 
 ```shell
 export TF_VAR_os=alpine_3_17
+export TF_VAR_arch=x86_64
 export TF_VAR_k0s_version=stable
 export TF_VAR_k0s_network_provider=calico
 export TF_VAR_k0s_kube_proxy_mode=ipvs
@@ -89,6 +90,14 @@ terraform apply
 * `ubuntu_2004`: Ubuntu 20.04 LTS
 * `ubuntu_2204`: Ubuntu 22.04 LTS
 * `ubuntu_2304`: Ubuntu 23.04
+
+### `arch`: Node architecture
+
+The underlying processor architecture for the to-be-provisioned cluster. Note
+that not all operating systems support all architectures.
+
+* `x86_64`
+* `arm64`
 
 ### `k0sctl_skip`: Skip k0s provisioning altogether
 

--- a/hack/ostests/main.tf
+++ b/hack/ostests/main.tf
@@ -27,6 +27,7 @@ module "os" {
   source = "./modules/os"
 
   os                       = var.os
+  arch                     = var.arch
   additional_ingress_cidrs = [local.podCIDR]
 }
 

--- a/hack/ostests/modules/infra/main.tf
+++ b/hack/ostests/modules/infra/main.tf
@@ -9,8 +9,9 @@ resource "aws_key_pair" "ssh" {
 
 locals {
   default_node_config = {
-    instance_type = "t3a.small"
-  }
+    x86_64 = { instance_type = "t3a.small" }
+    arm64  = { instance_type = "t4g.small" }
+  }[var.os.arch]
 
   node_roles = {
     controller = {

--- a/hack/ostests/modules/infra/variables.tf
+++ b/hack/ostests/modules/infra/variables.tf
@@ -10,6 +10,7 @@ variable "resource_name_prefix" {
 
 variable "os" {
   type = object({
+    arch = string
     node_configs = object({
       default = object({
         ami_id = string
@@ -29,6 +30,11 @@ variable "os" {
   })
 
   description = "The OS configuration."
+
+  validation {
+    condition     = contains(["x86_64", "arm64"], var.os.arch)
+    error_message = "Invalid processor architecture."
+  }
 }
 
 variable "additional_ingress_cidrs" {

--- a/hack/ostests/modules/os/os_al2023.tf
+++ b/hack/ostests/modules/os/os_al2023.tf
@@ -26,6 +26,13 @@ data "aws_ami" "al2023" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Amazon Linux 2023."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_alpine_3_17.tf
+++ b/hack/ostests/modules/os/os_alpine_3_17.tf
@@ -28,6 +28,13 @@ data "aws_ami" "alpine_3_17" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Alpine Linux 3.17."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_centos_7.tf
+++ b/hack/ostests/modules/os/os_centos_7.tf
@@ -26,6 +26,13 @@ data "aws_ami" "centos_7" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for CentOS Linux 7 (Core)."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_centos_8.tf
+++ b/hack/ostests/modules/os/os_centos_8.tf
@@ -26,6 +26,13 @@ data "aws_ami" "centos_8" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for CentOS Stream 8."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_centos_9.tf
+++ b/hack/ostests/modules/os/os_centos_9.tf
@@ -26,6 +26,13 @@ data "aws_ami" "centos_9" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for CentOS Stream 9."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_debian_10.tf
+++ b/hack/ostests/modules/os/os_debian_10.tf
@@ -26,6 +26,13 @@ data "aws_ami" "debian_10" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Debian GNU/Linux 10 (buster)."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_debian_11.tf
+++ b/hack/ostests/modules/os/os_debian_11.tf
@@ -26,6 +26,13 @@ data "aws_ami" "debian_11" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Debian GNU/Linux 11 (bullseye)."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_debian_12.tf
+++ b/hack/ostests/modules/os/os_debian_12.tf
@@ -4,17 +4,17 @@ data "aws_ami" "debian_12" {
   count = var.os == "debian_12" ? 1 : 0
 
   owners      = ["136693071363"]
-  name_regex  = "^debian-12-amd64-\\d+-\\d+$"
+  name_regex  = "^debian-12-(amd64|arm64)-\\d+-\\d+$"
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["debian-12-amd64-*-*"]
+    values = ["debian-12-*-*-*"]
   }
 
   filter {
     name   = "architecture"
-    values = ["x86_64"]
+    values = [var.arch]
   }
 
   filter {
@@ -25,13 +25,6 @@ data "aws_ami" "debian_12" {
   filter {
     name   = "virtualization-type"
     values = ["hvm"]
-  }
-
-  lifecycle {
-    precondition {
-      condition     = var.arch == "x86_64"
-      error_message = "Unsupported architecture for Debian GNU/Linux 12 (bookworm)."
-    }
   }
 }
 

--- a/hack/ostests/modules/os/os_debian_12.tf
+++ b/hack/ostests/modules/os/os_debian_12.tf
@@ -26,6 +26,13 @@ data "aws_ami" "debian_12" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Debian GNU/Linux 12 (bookworm)."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_fcos_38.tf
+++ b/hack/ostests/modules/os/os_fcos_38.tf
@@ -26,6 +26,13 @@ data "aws_ami" "fcos_38" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Fedora CoreOS 38."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_fedora_38.tf
+++ b/hack/ostests/modules/os/os_fedora_38.tf
@@ -26,6 +26,13 @@ data "aws_ami" "fedora_38" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Fedora Linux 38 (Cloud Edition)."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_flatcar.tf
+++ b/hack/ostests/modules/os/os_flatcar.tf
@@ -26,6 +26,13 @@ data "aws_ami" "flatcar" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Flatcar Container Linux."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_oracle_7_9.tf
+++ b/hack/ostests/modules/os/os_oracle_7_9.tf
@@ -27,6 +27,13 @@ data "aws_ami" "oracle_7_9" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Oracle Linux Server 7.9."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_oracle_8_7.tf
+++ b/hack/ostests/modules/os/os_oracle_8_7.tf
@@ -27,6 +27,13 @@ data "aws_ami" "oracle_8_7" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Oracle Linux Server 8.7."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_oracle_9_1.tf
+++ b/hack/ostests/modules/os/os_oracle_9_1.tf
@@ -27,6 +27,13 @@ data "aws_ami" "oracle_9_1" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Oracle Linux Server 9.1."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_rhel_7.tf
+++ b/hack/ostests/modules/os/os_rhel_7.tf
@@ -26,6 +26,13 @@ data "aws_ami" "rhel_7" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Red Hat Enterprise Linux Server 7.9 (Maipo)."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_rhel_8.tf
+++ b/hack/ostests/modules/os/os_rhel_8.tf
@@ -26,6 +26,13 @@ data "aws_ami" "rhel_8" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Red Hat Enterprise Linux 8.6 (Ootpa)."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_rhel_9.tf
+++ b/hack/ostests/modules/os/os_rhel_9.tf
@@ -26,6 +26,13 @@ data "aws_ami" "rhel_9" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Red Hat Enterprise Linux 9.0 (Plow)."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_rocky_8.tf
+++ b/hack/ostests/modules/os/os_rocky_8.tf
@@ -26,6 +26,13 @@ data "aws_ami" "rocky_8" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Rocky Linux 8.7 (Green Obsidian)."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_rocky_9.tf
+++ b/hack/ostests/modules/os/os_rocky_9.tf
@@ -26,6 +26,13 @@ data "aws_ami" "rocky_9" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Rocky Linux 9.2 (Blue Onyx)."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_ubuntu_2004.tf
+++ b/hack/ostests/modules/os/os_ubuntu_2004.tf
@@ -26,6 +26,13 @@ data "aws_ami" "ubuntu_2004" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Ubuntu 20.04 LTS."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_ubuntu_2204.tf
+++ b/hack/ostests/modules/os/os_ubuntu_2204.tf
@@ -26,6 +26,13 @@ data "aws_ami" "ubuntu_2204" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Ubuntu 22.04 LTS."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/os_ubuntu_2304.tf
+++ b/hack/ostests/modules/os/os_ubuntu_2304.tf
@@ -26,6 +26,13 @@ data "aws_ami" "ubuntu_2304" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.arch == "x86_64"
+      error_message = "Unsupported architecture for Ubuntu 23.04."
+    }
+  }
 }
 
 locals {

--- a/hack/ostests/modules/os/outputs.tf
+++ b/hack/ostests/modules/os/outputs.tf
@@ -1,4 +1,4 @@
 output "os" {
-  value       = local.os[var.os]
+  value       = merge(local.os[var.os], { arch = var.arch })
   description = "The OS confguration."
 }

--- a/hack/ostests/modules/os/variables.tf
+++ b/hack/ostests/modules/os/variables.tf
@@ -3,6 +3,11 @@ variable "os" {
   description = "The OS which is to be configured."
 }
 
+variable "arch" {
+  type        = string
+  description = "The architecture for the OS."
+}
+
 variable "additional_ingress_cidrs" {
   type        = list(string)
   nullable    = false

--- a/hack/ostests/variables.tf
+++ b/hack/ostests/variables.tf
@@ -35,6 +35,12 @@ variable "os" {
   description = "The underlying OS for the to-be-provisioned cluster."
 }
 
+variable "arch" {
+  type        = string
+  description = "The underlying processor architecture for the to-be-provisioned cluster."
+  default     = "x86_64"
+}
+
 variable "k0sctl_skip" {
   type        = bool
   description = "Skip k0s provisoning altogether."


### PR DESCRIPTION
## Description

Select the self-hosted ARM runners when building k0s if the architecture is arm or arm64. The k0s build system doesn't support cross-compilation, so the only way to get ARM binaries is to build on ARM. Add the "arch" variable to the ostests Terraform modules. Select the correct default instance type based on the arch. Add arm64 support for Debian 12.  Add the arch parameter to the ostests matrix so that it can also run on arm64.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings