### PR TITLE
Cleanup unknown Helm chart manifest files

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -415,7 +415,6 @@ func (c *command) start(ctx context.Context) error {
 		}
 		clusterComponents.Add(ctx, controller.NewCRD(helmSaver, "helm"))
 		clusterComponents.Add(ctx, controller.NewExtensionsController(
-			helmSaver,
 			c.K0sVars,
 			adminClientFactory,
 			leaderElector,

--- a/pkg/apis/k0s/v1beta1/extensions.go
+++ b/pkg/apis/k0s/v1beta1/extensions.go
@@ -18,7 +18,6 @@ package v1beta1
 
 import (
 	"errors"
-	"fmt"
 
 	"helm.sh/helm/v3/pkg/chartutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -100,11 +99,6 @@ type Chart struct {
 	// A duration string is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 	Timeout metav1.Duration `json:"timeout"`
 	Order   int             `json:"order"`
-}
-
-// ManifestFileName returns filename to use for the crd manifest
-func (c Chart) ManifestFileName() string {
-	return fmt.Sprintf("%d_helm_extension_%s.yaml", c.Order, c.Name)
 }
 
 // Validate performs validation

--- a/pkg/apis/k0s/v1beta1/extenstions_test.go
+++ b/pkg/apis/k0s/v1beta1/extenstions_test.go
@@ -84,31 +84,6 @@ func TestValidation(t *testing.T) {
 		})
 
 	})
-
-	t.Run("chart_manifest_name", func(t *testing.T) {
-		chart := Chart{
-			Name:      "release",
-			ChartName: "k0s/chart",
-			TargetNS:  "default",
-		}
-
-		chart1 := Chart{
-			Name:      "release",
-			ChartName: "k0s/chart",
-			TargetNS:  "default",
-			Order:     1,
-		}
-
-		chart2 := Chart{
-			Name:      "release",
-			ChartName: "k0s/chart",
-			TargetNS:  "default",
-			Order:     2,
-		}
-		assert.Equal(t, chart.ManifestFileName(), "0_helm_extension_release.yaml")
-		assert.Equal(t, chart1.ManifestFileName(), "1_helm_extension_release.yaml")
-		assert.Equal(t, chart2.ManifestFileName(), "2_helm_extension_release.yaml")
-	})
 }
 
 func TestDurationParsing(t *testing.T) {

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -28,8 +28,8 @@ import (
 	"github.com/avast/retry-go"
 	"github.com/bombsimon/logrusr/v4"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
-	"github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
-	k0sAPI "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	helmv1beta1 "github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	k0sscheme "github.com/k0sproject/k0s/pkg/client/clientset/scheme"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/manager"
@@ -85,7 +85,7 @@ const (
 )
 
 // Run runs the extensions controller
-func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0sAPI.ClusterConfig) error {
+func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0sv1beta1.ClusterConfig) error {
 	ec.L.Info("Extensions reconciliation started")
 	defer ec.L.Info("Extensions reconciliation finished")
 
@@ -102,9 +102,9 @@ func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0
 	return errors.Join(errs...)
 }
 
-func (ec *ExtensionsController) configureStorage(clusterConfig *k0sAPI.ClusterConfig) (*k0sAPI.HelmExtensions, error) {
+func (ec *ExtensionsController) configureStorage(clusterConfig *k0sv1beta1.ClusterConfig) (*k0sv1beta1.HelmExtensions, error) {
 	helmSettings := clusterConfig.Spec.Extensions.Helm
-	if clusterConfig.Spec.Extensions.Storage.Type != k0sAPI.OpenEBSLocal {
+	if clusterConfig.Spec.Extensions.Storage.Type != k0sv1beta1.OpenEBSLocal {
 		return helmSettings, nil
 	}
 
@@ -120,7 +120,7 @@ func (ec *ExtensionsController) configureStorage(clusterConfig *k0sAPI.ClusterCo
 	return helmSettings, nil
 }
 
-func addOpenEBSHelmExtension(helmSpec *k0sAPI.HelmExtensions, storageExtension *k0sAPI.StorageExtension) (*k0sAPI.HelmExtensions, error) {
+func addOpenEBSHelmExtension(helmSpec *k0sv1beta1.HelmExtensions, storageExtension *k0sv1beta1.StorageExtension) (*k0sv1beta1.HelmExtensions, error) {
 	openEBSValues := map[string]interface{}{
 		"localprovisioner": map[string]interface{}{
 			"hostpathClass": map[string]interface{}{
@@ -135,16 +135,16 @@ func addOpenEBSHelmExtension(helmSpec *k0sAPI.HelmExtensions, storageExtension *
 		return nil, err
 	}
 	if helmSpec == nil {
-		helmSpec = &k0sAPI.HelmExtensions{
-			Repositories: k0sAPI.RepositoriesSettings{},
-			Charts:       k0sAPI.ChartsSettings{},
+		helmSpec = &k0sv1beta1.HelmExtensions{
+			Repositories: k0sv1beta1.RepositoriesSettings{},
+			Charts:       k0sv1beta1.ChartsSettings{},
 		}
 	}
-	helmSpec.Repositories = append(helmSpec.Repositories, k0sAPI.Repository{
+	helmSpec.Repositories = append(helmSpec.Repositories, k0sv1beta1.Repository{
 		Name: "openebs-internal",
 		URL:  constant.OpenEBSRepository,
 	})
-	helmSpec.Charts = append(helmSpec.Charts, k0sAPI.Chart{
+	helmSpec.Charts = append(helmSpec.Charts, k0sv1beta1.Chart{
 		Name:      "openebs",
 		ChartName: "openebs-internal/openebs",
 		TargetNS:  "openebs",
@@ -166,7 +166,7 @@ func yamlifyValues(values map[string]interface{}) (string, error) {
 // reconcileHelmExtensions creates instance of Chart CR for each chart of the config file
 // it also reconciles repositories settings
 // the actual helm install/update/delete management is done by ChartReconciler structure
-func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sAPI.HelmExtensions) error {
+func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.HelmExtensions) error {
 	if helmSpec == nil {
 		return nil
 	}
@@ -183,7 +183,7 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sAPI.HelmExt
 			Name:     "addon_crd_manifest",
 			Template: chartCrdTemplate,
 			Data: struct {
-				k0sAPI.Chart
+				k0sv1beta1.Chart
 				Finalizer string
 			}{
 				Chart:     chart,
@@ -195,13 +195,18 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sAPI.HelmExt
 			errs = append(errs, fmt.Errorf("can't create chart CR instance %q: %w", chart.ChartName, err))
 			continue
 		}
-		if err := ec.saver.Save(chart.ManifestFileName(), buf.Bytes()); err != nil {
+		if err := ec.saver.Save(chartManifestFileName(&chart), buf.Bytes()); err != nil {
 			errs = append(errs, fmt.Errorf("can't save addon CRD manifest for chart CR instance %q: %w", chart.ChartName, err))
 			continue
 		}
 	}
 
 	return errors.Join(errs...)
+}
+
+// Determines the file name to use when storing a chart as a manifest on disk.
+func chartManifestFileName(c *k0sv1beta1.Chart) string {
+	return fmt.Sprintf("%d_helm_extension_%s.yaml", c.Order, c.Name)
 }
 
 type ChartReconciler struct {
@@ -218,7 +223,7 @@ func (cr *ChartReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 	cr.L.Tracef("Got helm chart reconciliation request: %s", req)
 	defer cr.L.Tracef("Finished processing helm chart reconciliation request: %s", req)
 
-	var chartInstance v1beta1.Chart
+	var chartInstance helmv1beta1.Chart
 
 	if err := cr.Client.Get(ctx, req.NamespacedName, &chartInstance); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -253,14 +258,14 @@ func (cr *ChartReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 	return reconcile.Result{}, nil
 }
 
-func (cr *ChartReconciler) uninstall(ctx context.Context, chart v1beta1.Chart) error {
+func (cr *ChartReconciler) uninstall(ctx context.Context, chart helmv1beta1.Chart) error {
 	if err := cr.helm.UninstallRelease(ctx, chart.Status.ReleaseName, chart.Status.Namespace); err != nil {
 		return fmt.Errorf("can't uninstall release `%s/%s`: %w", chart.Status.Namespace, chart.Status.ReleaseName, err)
 	}
 	return nil
 }
 
-func removeFinalizer(ctx context.Context, c client.Client, chart *v1beta1.Chart) error {
+func removeFinalizer(ctx context.Context, c client.Client, chart *helmv1beta1.Chart) error {
 	idx := slices.Index(chart.Finalizers, finalizerName)
 	if idx < 0 {
 		return nil
@@ -284,7 +289,7 @@ func removeFinalizer(ctx context.Context, c client.Client, chart *v1beta1.Chart)
 
 const defaultTimeout = time.Duration(10 * time.Minute)
 
-func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart v1beta1.Chart) error {
+func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart helmv1beta1.Chart) error {
 	var err error
 	var chartRelease *release.Release
 	timeout, err := time.ParseDuration(chart.Spec.Timeout)
@@ -344,7 +349,7 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart v1bet
 	return nil
 }
 
-func (cr *ChartReconciler) chartNeedsUpgrade(chart v1beta1.Chart) bool {
+func (cr *ChartReconciler) chartNeedsUpgrade(chart helmv1beta1.Chart) bool {
 	return !(chart.Status.Namespace == chart.Spec.Namespace &&
 		chart.Status.ReleaseName == chart.Spec.ReleaseName &&
 		chart.Status.Version == chart.Spec.Version &&
@@ -356,9 +361,9 @@ func (cr *ChartReconciler) chartNeedsUpgrade(chart v1beta1.Chart) bool {
 // to complete and the chart may have been updated in the meantime. If returns the error returned
 // by the Update operation. Moreover, if the chart has indeed changed in the meantime we already
 // have an event for it so we will see it again soon.
-func (cr *ChartReconciler) updateStatus(ctx context.Context, chart v1beta1.Chart, chartRelease *release.Release, err error) error {
+func (cr *ChartReconciler) updateStatus(ctx context.Context, chart helmv1beta1.Chart, chartRelease *release.Release, err error) error {
 	nsn := types.NamespacedName{Namespace: chart.Namespace, Name: chart.Name}
-	var updchart v1beta1.Chart
+	var updchart helmv1beta1.Chart
 	if err := cr.Get(ctx, nsn, &updchart); err != nil {
 		return fmt.Errorf("can't get updated version of chart %s: %w", chart.Name, err)
 	}
@@ -383,7 +388,7 @@ func (cr *ChartReconciler) updateStatus(ctx context.Context, chart v1beta1.Chart
 	return nil
 }
 
-func (ec *ExtensionsController) addRepo(repo k0sAPI.Repository) error {
+func (ec *ExtensionsController) addRepo(repo k0sv1beta1.Repository) error {
 	return ec.helm.AddRepository(repo)
 }
 
@@ -419,7 +424,7 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 		return fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
 	}
 	gk := schema.GroupKind{
-		Group: v1beta1.GroupName,
+		Group: helmv1beta1.GroupName,
 		Kind:  "Chart",
 	}
 
@@ -448,7 +453,7 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 
 	if err := builder.
 		ControllerManagedBy(mgr).
-		For(&v1beta1.Chart{},
+		For(&helmv1beta1.Chart{},
 			builder.WithPredicates(predicate.And(
 				predicate.GenerationChangedPredicate{},
 				predicate.NewPredicateFuncs(func(object client.Object) bool {

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -17,11 +17,14 @@ limitations under the License.
 package controller
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
 	"slices"
 	"time"
 
@@ -59,24 +62,24 @@ import (
 
 // Helm watch for Chart crd
 type ExtensionsController struct {
-	saver         manifestsSaver
 	L             *logrus.Entry
 	helm          *helm.Commands
 	kubeConfig    string
 	leaderElector leaderelector.Interface
+	manifestsDir  string
 }
 
 var _ manager.Component = (*ExtensionsController)(nil)
 var _ manager.Reconciler = (*ExtensionsController)(nil)
 
 // NewExtensionsController builds new HelmAddons
-func NewExtensionsController(s manifestsSaver, k0sVars *config.CfgVars, kubeClientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface) *ExtensionsController {
+func NewExtensionsController(k0sVars *config.CfgVars, kubeClientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface) *ExtensionsController {
 	return &ExtensionsController{
-		saver:         s,
 		L:             logrus.WithFields(logrus.Fields{"component": "extensions_controller"}),
 		helm:          helm.NewCommands(k0sVars),
 		kubeConfig:    k0sVars.AdminKubeConfigPath,
 		leaderElector: leaderElector,
+		manifestsDir:  filepath.Join(k0sVars.ManifestsDir, "helm"),
 	}
 }
 
@@ -178,8 +181,13 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.Hel
 		}
 	}
 
+	var fileNamesToKeep []string
 	for _, chart := range helmSpec.Charts {
+		fileName := chartManifestFileName(&chart)
+		fileNamesToKeep = append(fileNamesToKeep, fileName)
+
 		tw := templatewriter.TemplateWriter{
+			Path:     filepath.Join(ec.manifestsDir, fileName),
 			Name:     "addon_crd_manifest",
 			Template: chartCrdTemplate,
 			Data: struct {
@@ -190,15 +198,35 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.Hel
 				Finalizer: finalizerName,
 			},
 		}
-		buf := bytes.NewBuffer([]byte{})
-		if err := tw.WriteToBuffer(buf); err != nil {
-			errs = append(errs, fmt.Errorf("can't create chart CR instance %q: %w", chart.ChartName, err))
+		if err := tw.Write(); err != nil {
+			errs = append(errs, fmt.Errorf("can't write file for Helm chart manifest %q: %w", chart.ChartName, err))
 			continue
 		}
-		if err := ec.saver.Save(chartManifestFileName(&chart), buf.Bytes()); err != nil {
-			errs = append(errs, fmt.Errorf("can't save addon CRD manifest for chart CR instance %q: %w", chart.ChartName, err))
-			continue
+
+		ec.L.Infof("Wrote Helm chart manifest file %q", tw.Path)
+	}
+
+	if err := filepath.WalkDir(ec.manifestsDir, func(path string, entry fs.DirEntry, err error) error {
+		switch {
+		case !entry.Type().IsRegular():
+			ec.L.Debugf("Keeping %v as it is not a regular file", entry)
+		case slices.Contains(fileNamesToKeep, entry.Name()):
+			ec.L.Debugf("Keeping %v as it belongs to a known Helm extension", entry)
+		case !isChartManifestFileName(entry.Name()):
+			ec.L.Debugf("Keeping %v as it is not a Helm chart manifest file", entry)
+		default:
+			if err := os.Remove(path); err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					errs = append(errs, fmt.Errorf("failed to remove Helm chart manifest file, the Chart resource will remain in the cluster: %w", err))
+				}
+			} else {
+				ec.L.Infof("Removed Helm chart manifest file %q", path)
+			}
 		}
+
+		return nil
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("failed to walk Helm chart manifest directory: %w", err))
 	}
 
 	return errors.Join(errs...)
@@ -207,6 +235,11 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.Hel
 // Determines the file name to use when storing a chart as a manifest on disk.
 func chartManifestFileName(c *k0sv1beta1.Chart) string {
 	return fmt.Sprintf("%d_helm_extension_%s.yaml", c.Order, c.Name)
+}
+
+// Determines if the given file name is in the format for chart manifest file names.
+func isChartManifestFileName(fileName string) bool {
+	return regexp.MustCompile(`^-?[0-9]+_helm_extension_.+\.yaml$`).MatchString(fileName)
 }
 
 type ChartReconciler struct {

--- a/pkg/component/controller/extensions_controller_test.go
+++ b/pkg/component/controller/extensions_controller_test.go
@@ -198,3 +198,29 @@ func TestConfigureStorage(t *testing.T) {
 	}
 
 }
+
+func TestChartManifestFileName(t *testing.T) {
+	chart := k0sv1beta1.Chart{
+		Name:      "release",
+		ChartName: "k0s/chart",
+		TargetNS:  "default",
+	}
+
+	chart1 := k0sv1beta1.Chart{
+		Name:      "release",
+		ChartName: "k0s/chart",
+		TargetNS:  "default",
+		Order:     1,
+	}
+
+	chart2 := k0sv1beta1.Chart{
+		Name:      "release",
+		ChartName: "k0s/chart",
+		TargetNS:  "default",
+		Order:     2,
+	}
+
+	assert.Equal(t, chartManifestFileName(&chart), "0_helm_extension_release.yaml")
+	assert.Equal(t, chartManifestFileName(&chart1), "1_helm_extension_release.yaml")
+	assert.Equal(t, chartManifestFileName(&chart2), "2_helm_extension_release.yaml")
+}

--- a/pkg/component/controller/extensions_controller_test.go
+++ b/pkg/component/controller/extensions_controller_test.go
@@ -223,4 +223,5 @@ func TestChartManifestFileName(t *testing.T) {
 	assert.Equal(t, chartManifestFileName(&chart), "0_helm_extension_release.yaml")
 	assert.Equal(t, chartManifestFileName(&chart1), "1_helm_extension_release.yaml")
 	assert.Equal(t, chartManifestFileName(&chart2), "2_helm_extension_release.yaml")
+	assert.True(t, isChartManifestFileName("0_helm_extension_release.yaml"))
 }


### PR DESCRIPTION
## Description

Keep track of the generated filenames when reconciling Helm Chart extensions. After all files have been synchronized, remove any remaining unknown Helm chart manifest files. This way the synchronization will work correctly even if the Helm chart extension names and orders are changed. Collect errors during reconciliation in extension controller. This way, the reconciliation gets as close as possible to the desired state, even if some things in between are failing.

Fixes:
* #4698

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings