### PR TITLE
bug: make sure we close opened containerd connections

### DIFF
--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -82,6 +82,7 @@ func (a *OCIBundleReconciler) loadOne(ctx context.Context, fpath string) error {
 			return fmt.Errorf("failed to connect to containerd: %w", err)
 		}
 		if _, err = client.ListImages(ctx); err != nil {
+			_ = client.Close()
 			return fmt.Errorf("failed to communicate with containerd: %w", err)
 		}
 		return nil


### PR DESCRIPTION

## Description

if we fail to list images using the containerd client we better close the connection before creating a new one.


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings