### PR TITLE
[helm] don't start reconciler before leaderelection

### DIFF
--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -64,6 +65,12 @@ type ExtensionsController struct {
 	kubeConfig    string
 	leaderElector leaderelector.Interface
 	manifestsDir  string
+	startChan     chan struct{}
+	mux           sync.Mutex
+	mgr           crman.Manager
+	mgrCtx        context.Context
+	mgrCancelFn   context.CancelFunc
+	controllerCtx context.Context
 }
 
 var _ manager.Component = (*ExtensionsController)(nil)
@@ -377,9 +384,76 @@ func (ec *ExtensionsController) Init(_ context.Context) error {
 
 // Start
 func (ec *ExtensionsController) Start(ctx context.Context) error {
+	ec.L.Debug("Starting")
+	ec.startChan = make(chan struct{}, 1)
+
+	// Do the first validation before setting callbacks
+	ec.mgrCtx, ec.mgrCancelFn = context.WithCancel(ctx)
+	var err error
+	ec.mgr, err = ec.instantiateManager(ec.mgrCtx)
+	if err != nil {
+		ec.L.WithError(err).Error("Can't instantiate controller-runtime manager")
+		ec.mgrCancelFn()
+		return err
+	}
+
+	ec.leaderElector.AddLostLeaseCallback(ec.leaseLost)
+
+	ec.leaderElector.AddAcquiredLeaseCallback(ec.leaseAcquired)
+
+	// It's possible that by the time we added the callback, we are already the leader,
+	// If this is true the callback will not be called, so we need to check if we are
+	// the leader and notify the channel manually
+	if ec.leaderElector.IsLeader() {
+		ec.leaseAcquired()
+	}
+
+	go ec.watchStartChan()
+	return nil
+}
+
+func (ec *ExtensionsController) leaseLost() {
+	ec.mux.Lock()
+	defer ec.mux.Unlock()
+	ec.L.Warn("Lost leader lease, stopping controller-manager")
+	ec.mgrCancelFn()
+	ec.mgr = nil
+}
+
+func (ec *ExtensionsController) watchStartChan() {
+	ec.L.Debug("Watching start channel")
+	for range ec.startChan {
+		ec.L.Info("Acquired leader lease")
+		ec.mux.Lock()
+		if ec.mgr == nil {
+			ec.L.Info("Instantiating controller-runtime manager")
+			ec.mgrCtx, ec.mgrCancelFn = context.WithCancel(ec.controllerCtx)
+			var err error
+			ec.mgr, err = ec.instantiateManager(ec.controllerCtx)
+			if err != nil {
+				ec.L.WithError(err).Error("Can't instantiate controller-runtime manager")
+				ec.mux.Unlock()
+				return
+			}
+		}
+		ec.mux.Unlock()
+		ec.startControllerManager()
+	}
+	ec.L.Info("Start channel closed, stopping controller-manager")
+}
+
+func (ec *ExtensionsController) leaseAcquired() {
+	ec.L.Info("Acquired leader lease")
+	select {
+	case ec.startChan <- struct{}{}:
+	default:
+	}
+}
+
+func (ec *ExtensionsController) instantiateManager(ctx context.Context) (crman.Manager, error) {
 	clientConfig, err := clientcmd.BuildConfigFromFlags("", ec.kubeConfig)
 	if err != nil {
-		return fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
+		return nil, fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
 	}
 	gk := schema.GroupKind{
 		Group: helmv1beta1.GroupName,
@@ -395,7 +469,7 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 		Controller: ctrlconfig.Controller{},
 	})
 	if err != nil {
-		return fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
+		return nil, fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
 	}
 	if err := retry.Do(func() error {
 		_, err := mgr.GetRESTMapper().RESTMapping(gk)
@@ -406,7 +480,7 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 		ec.L.Info("Extensions CRD is ready, going nuts")
 		return nil
 	}, retry.Context(ctx)); err != nil {
-		return fmt.Errorf("can't start ExtensionsReconciler, helm CRD is not registred, check CRD registration reconciler: %w", err)
+		return nil, fmt.Errorf("can't start ExtensionsReconciler, helm CRD is not registered, check CRD registration reconciler: %w", err)
 	}
 
 	if err := builder.
@@ -426,19 +500,25 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 			helm:          ec.helm,
 			L:             ec.L.WithField("extensions_type", "helm"),
 		}); err != nil {
-		return fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
+		return nil, fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
 	}
+	return mgr, nil
+}
 
+func (ec *ExtensionsController) startControllerManager() {
 	go func() {
-		if err := mgr.Start(ctx); err != nil {
+		ec.L.Info("Starting controller-manager")
+		if err := ec.mgr.Start(ec.mgrCtx); err != nil {
 			ec.L.WithError(err).Error("Controller manager working loop exited")
 		}
 	}()
-
-	return nil
 }
 
 // Stop
 func (ec *ExtensionsController) Stop() error {
+	ec.L.Info("Stopping extensions controller")
+	ec.mgrCancelFn()
+	close(ec.startChan)
+	ec.L.Debug("Stopped extensions controller")
 	return nil
 }


### PR DESCRIPTION
## Description

Prior to this commit it was possible that some charts weren't reconciled due to lack of active leaders. See #4637 for further details.

Fixes #4637

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings