### PR TITLE
Overhaul dual-stack docs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Prepare build environment
         run: .github/workflows/prepare-build-env.sh
 
-      - name: Prepare docker for ipv6 dualstack tests
+      - name: Prepare docker for ipv6 dual-stack tests
         if: contains(matrix.smoke-suite, 'dualstack')
         run: .github/workflows/prepare-docker-ipv6.sh
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,13 +209,13 @@ FELIX_FEATUREDETECTOVERRIDE: "ChecksumOffloadBroken=true"
 
 `FELIX_FEATUREDETECTOVERRIDE: ChecksumOffloadBroken=true` disables VXLAN offloading because of [projectcalico/calico#4727](https://github.com/projectcalico/calico/issues/4727).
 
-In SingleStack mode there are additional vars:
+In single-stack mode, there are additional vars:
 
 ```shell
 FELIX_IPV6SUPPORT: "false"
 ```
 
-In DualStack mode there are additional vars:
+In dual-stack mode, there are additional vars:
 
 ```shell
 CALICO_IPV6POOL_NAT_OUTGOING: "true"

--- a/docs/dual-stack.md
+++ b/docs/dual-stack.md
@@ -1,36 +1,61 @@
-# Dual-stack Networking
+# IPv4/IPv6 dual-stack networking
 
-**Note:** Dual stack networking setup requires that you configure Calico or a custom CNI as the CNI provider.
+Enabling dual-stack networking in k0s allows your cluster to handle both IPv4 and
+IPv6 addresses. Follow the configuration examples below to set up dual-stack mode.
 
-Use the following `k0s.yaml` as a template to enable dual-stack networking. This configuration will set up bundled calico CNI, enable feature gates for the Kubernetes components, and set up `kubernetes-controller-manager`.
+## Enabling dual-stack using the default CNI (kube-router)
+
+In order to enable dual-stack networking using the default CNI provider, use the
+following example configuration:
 
 ```yaml
 spec:
   network:
-    podCIDR: "10.244.0.0/16"
-    serviceCIDR: "10.96.0.0/12"
-    provider: calico
-    calico:
-      mode: "bird"
+    # kube-router is the default CNI provider
+    # provider: kube-router
+    podCIDR: 10.244.0.0/16
+    serviceCIDR: 10.96.0.0/12
     dualStack:
       enabled: true
-      IPv6podCIDR: "fd00::/108"
-      IPv6serviceCIDR: "fd01::/108"
+      IPv6podCIDR: fd00::/108
+      IPv6serviceCIDR: fd01::/108
 ```
 
-## CNI Settings: Calico
+This configuration will set up all Kubernetes components and kube-router
+accordingly for dual-stack networking.
 
-For cross-pod connectivity, use BIRD for the backend. Calico does not support tunneling for the IPv6, and thus VXLAN and IPIP backends do not work.
+## Using Calico as the CNI provider
 
-**Note**: In any Calico mode other than cross-pod, the pods can only reach pods on the same node.
+Calico does not support IPv6 tunneling in the default `vxlan` mode, so if you
+prefer to use Calico as your CNI provider, make sure to select `bird` mode. Use
+the following example configuration:
 
-## CNI Settings: External CNI
+```yaml
+spec:
+  network:
+    provider: calico
+    calico:
+      mode: bird
+    podCIDR: 10.244.0.0/16
+    serviceCIDR: 10.96.0.0/12
+    dualStack:
+      enabled: true
+      IPv6podCIDR: fd00::/108
+      IPv6serviceCIDR: fd01::/108
+```
 
-Although the `k0s.yaml` dualStack section enables all of the neccessary feature gates for the Kubernetes components, for use with an external CNI it must be set up to support IPv6.
+## Custom CNI providers
+
+While the dual-stack configuration section configures all components managed by
+k0s for dual-stack operation, the custom CNI provider must also be configured
+accordingly. Refer to the documentation for your specific CNI provider to ensure
+a proper dual-stack setup that matches that of k0s.
 
 ## Additional Resources
 
+For more detailed information and troubleshooting, refer to the following resources:
+
 * <https://kubernetes.io/docs/concepts/services-networking/dual-stack/>
 * <https://kubernetes.io/docs/tasks/network/validate-dual-stack/>
-* <https://www.projectcalico.org/dual-stack-operation-with-calico-on-kubernetes/>
-* <https://docs.projectcalico.org/networking/ipv6>
+* <https://www.tigera.io/blog/dual-stack-operation-with-calico-on-kubernetes/>
+* <https://docs.tigera.io/calico/3.27/networking/ipam/ipv6#enable-dual-stack>

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -24,7 +24,6 @@ You can opt-out of having k0s manage the network setup and choose instead to use
 Kube-router is built into k0s, and so by default the distribution uses it for network provision. Kube-router uses the standard Linux networking stack and toolset, and you can set up CNI networking without any overlays by using BGP as the main mechanism for in-cluster networking.
 
 - Uses bit less resources (~15%)
-- Does NOT support dual-stack (IPv4/IPv6) networking
 - Does NOT support Windows nodes
 
 ### Calico
@@ -32,7 +31,6 @@ Kube-router is built into k0s, and so by default the distribution uses it for ne
 In addition to Kube-router, k0s also offers [Calico] as an alternative, built-in network provider. Calico is a layer 3 container networking solution that routes packets to pods. It supports, for example, pod-specific network policies that help to secure kubernetes clusters in demanding use cases. Calico uses the vxlan overlay network by default, and you can configure it to support ipip (IP-in-IP).
 
 - Uses bit more resources
-- Supports dual-stack (IPv4/IPv6) networking
 - Supports Windows nodes
 
 ## Controller-Worker communication

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ nav:
       - Manifest Deployer: manifests.md
       - Helm Charts: helm-charts.md
       - Cloud Providers: cloud-providers.md
-      - IPv4/IPv6 Dual-Stack: dual-stack.md
+      - IPv4/IPv6 dual-stack networking: dual-stack.md
       - Control Plane High Availability: high-availability.md
       - Node-local load balancing: nllb.md
       - Control plane load balancing: cplb.md

--- a/pkg/apis/k0s/v1beta1/network.go
+++ b/pkg/apis/k0s/v1beta1/network.go
@@ -102,7 +102,7 @@ func (n *Network) Validate() []error {
 
 	if n.DualStack.Enabled {
 		if n.Provider == "calico" && n.Calico.Mode != "bird" {
-			errors = append(errors, field.Forbidden(field.NewPath("calico", "mode"), "dual stack for calico is only supported for mode `bird`"))
+			errors = append(errors, field.Forbidden(field.NewPath("calico", "mode"), "dual-stack for calico is only supported for mode `bird`"))
 		}
 		_, _, err := net.ParseCIDR(n.DualStack.IPv6PodCIDR)
 		if err != nil {

--- a/pkg/component/worker/static_pods.go
+++ b/pkg/component/worker/static_pods.go
@@ -349,7 +349,7 @@ func (s *staticPods) Start(ctx context.Context) error {
 	}
 
 	// Open a TCP port to listen for incoming HTTP requests.
-	listener, err := net.Listen("tcp", "127.0.0.1:") // FIXME: Support IPv6 / dual stack?
+	listener, err := net.Listen("tcp", "127.0.0.1:") // FIXME: Support IPv6 / dual-stack?
 	if err != nil {
 		s.transition(staticPodsStarting, staticPodsInitialized)
 		return err


### PR DESCRIPTION
## Description

Kube-router supports dual-stack now. Reflect that in the docs. Use coherent spelling of "dual-stack" using a hyphen. Fix broken hyperlinks.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings