### PR TITLE
[Backport release-1.29] Cleanup unknown Helm chart manifest files

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -389,7 +389,6 @@ func (c *command) start(ctx context.Context) error {
 		}
 		clusterComponents.Add(ctx, controller.NewCRD(helmSaver, []string{"helm"}))
 		clusterComponents.Add(ctx, controller.NewExtensionsController(
-			helmSaver,
 			c.K0sVars,
 			adminClientFactory,
 			leaderElector,

--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -21,13 +21,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/inttest/common"
-	"github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
+	helmv1beta1 "github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	k0sclientset "github.com/k0sproject/k0s/pkg/client/clientset"
+	"github.com/k0sproject/k0s/pkg/constant"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -54,7 +58,7 @@ func (as *AddonsSuite) TestHelmBasedAddons() {
 	fileAddonName := "tgz-addon"
 	as.PutFile(as.ControllerNode(0), "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithAddon, addonName))
 	as.pullHelmChart(as.ControllerNode(0))
-	as.Require().NoError(as.InitController(0, "--config=/tmp/k0s.yaml"))
+	as.Require().NoError(as.InitController(0, "--config=/tmp/k0s.yaml", "--enable-dynamic-config"))
 	as.NoError(as.RunWorkers())
 	kc, err := as.KubeClient(as.ControllerNode(0))
 	as.Require().NoError(err)
@@ -65,6 +69,8 @@ func (as *AddonsSuite) TestHelmBasedAddons() {
 	as.waitForTestRelease(fileAddonName, "0.6.0", "kube-system", 1)
 
 	as.AssertSomeKubeSystemPods(kc)
+
+	as.Run("Rename chart in Helm extension", func() { as.renameChart(ctx) })
 
 	values := map[string]interface{}{
 		"replicaCount": 2,
@@ -93,7 +99,47 @@ func (as *AddonsSuite) pullHelmChart(node string) {
 	as.Require().NoError(err)
 }
 
-func (as *AddonsSuite) deleteRelease(chart *v1beta1.Chart) {
+func (as *AddonsSuite) renameChart(ctx context.Context) {
+	restConfig, err := as.GetKubeConfig(as.ControllerNode(0))
+	as.Require().NoError(err)
+	k0sClients, err := k0sclientset.NewForConfig(restConfig)
+	as.Require().NoError(err)
+
+	configs := k0sClients.K0sV1beta1().ClusterConfigs(constant.ClusterConfigNamespace)
+	cfg, err := configs.Get(ctx, constant.ClusterConfigObjectName, metav1.GetOptions{})
+	as.Require().NoError(err)
+
+	i := slices.IndexFunc(cfg.Spec.Extensions.Helm.Charts, func(c k0sv1beta1.Chart) bool {
+		return c.Name == "tgz-addon"
+	})
+	as.Require().GreaterOrEqual(i, 0, "Didn't find tgz-addon in %v", cfg.Spec.Extensions.Helm.Charts)
+	cfg.Spec.Extensions.Helm.Charts[i].Name = "tgz-renamed-addon"
+
+	cfg, err = configs.Update(ctx, cfg, metav1.UpdateOptions{FieldManager: as.T().Name()})
+	as.Require().NoError(err)
+	if data, err := yaml.Marshal(cfg); as.NoError(err) {
+		as.T().Logf("%s", data)
+	}
+
+	as.Require().NoError(wait.PollUntilContextCancel(ctx, 350*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		charts, err := k0sClients.HelmV1beta1().Charts(constant.ClusterConfigNamespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		hasChart := func(name string) bool {
+			return slices.IndexFunc(charts.Items, func(c helmv1beta1.Chart) bool {
+				return c.Name == name
+			}) >= 0
+		}
+
+		return !hasChart("k0s-addon-chart-tgz-addon") && hasChart("k0s-addon-chart-tgz-renamed-addon"), nil
+	}), "While waiting for Chart resource to be swapped")
+
+	as.waitForTestRelease("tgz-renamed-addon", "0.6.0", "kube-system", 1)
+}
+
+func (as *AddonsSuite) deleteRelease(chart *helmv1beta1.Chart) {
 	ctx := as.Context()
 	as.T().Logf("Deleting chart %s/%s", chart.Namespace, chart.Name)
 	ssh, err := as.SSH(ctx, as.ControllerNode(0))
@@ -124,7 +170,7 @@ func (as *AddonsSuite) deleteRelease(chart *v1beta1.Chart) {
 		return true, nil
 	}))
 
-	helmScheme, err := v1beta1.SchemeBuilder.Build()
+	helmScheme, err := helmv1beta1.SchemeBuilder.Build()
 	as.Require().NoError(err)
 	chartClient, err := client.New(cfg, client.Options{Scheme: helmScheme})
 	as.Require().NoError(err)
@@ -132,7 +178,7 @@ func (as *AddonsSuite) deleteRelease(chart *v1beta1.Chart) {
 	as.T().Logf("Expecting chart %s/%s to be deleted", chart.Namespace, chart.Name)
 	var lastResourceVersion string
 	as.Require().NoError(wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
-		var found v1beta1.Chart
+		var found helmv1beta1.Chart
 		err := chartClient.Get(ctx, client.ObjectKey{Namespace: chart.Namespace, Name: chart.Name}, &found)
 		switch {
 		case err == nil:
@@ -154,13 +200,13 @@ func (as *AddonsSuite) deleteRelease(chart *v1beta1.Chart) {
 }
 
 func (as *AddonsSuite) deleteUninstalledChart(ctx context.Context) {
-	spec := v1beta1.ChartSpec{
+	spec := helmv1beta1.ChartSpec{
 		ChartName:   "whatever",
 		ReleaseName: "nonexistent",
 		Namespace:   "default",
 		Version:     "1",
 	}
-	status := v1beta1.ChartStatus{
+	status := helmv1beta1.ChartStatus{
 		ReleaseName: spec.ReleaseName,
 		Namespace:   spec.Namespace,
 		Version:     spec.Version,
@@ -168,7 +214,7 @@ func (as *AddonsSuite) deleteUninstalledChart(ctx context.Context) {
 		Revision:    1,
 		ValuesHash:  spec.HashValues(),
 	}
-	chart := &v1beta1.Chart{
+	chart := &helmv1beta1.Chart{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "bogus",
 			Namespace:  "kube-system",
@@ -179,7 +225,7 @@ func (as *AddonsSuite) deleteUninstalledChart(ctx context.Context) {
 	cfg, err := as.GetKubeConfig(as.ControllerNode(0))
 	as.Require().NoError(err)
 
-	scheme, err := v1beta1.SchemeBuilder.Build()
+	scheme, err := helmv1beta1.SchemeBuilder.Build()
 	as.Require().NoError(err)
 	crClient, err := client.New(cfg, client.Options{Scheme: scheme})
 	as.Require().NoError(err)
@@ -215,7 +261,7 @@ func (as *AddonsSuite) deleteUninstalledChart(ctx context.Context) {
 	as.T().Logf("Expecting bogus chart %s/%s to be deleted", chart.Namespace, chart.Name)
 	var lastResourceVersion string
 	as.Require().NoError(wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
-		var found v1beta1.Chart
+		var found helmv1beta1.Chart
 		err := crClient.Get(ctx, client.ObjectKey{Namespace: chart.Namespace, Name: chart.Name}, &found)
 		switch {
 		case err == nil:
@@ -236,18 +282,18 @@ func (as *AddonsSuite) deleteUninstalledChart(ctx context.Context) {
 	}))
 }
 
-func (as *AddonsSuite) waitForTestRelease(addonName, appVersion string, namespace string, rev int64) *v1beta1.Chart {
+func (as *AddonsSuite) waitForTestRelease(addonName, appVersion string, namespace string, rev int64) *helmv1beta1.Chart {
 	ctx := as.Context()
 	as.T().Logf("waiting to see %s release ready in kube API, generation %d", addonName, rev)
 
 	cfg, err := as.GetKubeConfig(as.ControllerNode(0))
 	as.Require().NoError(err)
 
-	helmScheme, err := v1beta1.SchemeBuilder.Build()
+	helmScheme, err := helmv1beta1.SchemeBuilder.Build()
 	as.Require().NoError(err)
 	chartClient, err := client.New(cfg, client.Options{Scheme: helmScheme})
 	as.Require().NoError(err)
-	var chart v1beta1.Chart
+	var chart helmv1beta1.Chart
 	var lastResourceVersion string
 	as.Require().NoError(wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(pollCtx context.Context) (done bool, err error) {
 		err = chartClient.Get(pollCtx, client.ObjectKey{

--- a/pkg/apis/k0s/v1beta1/extensions.go
+++ b/pkg/apis/k0s/v1beta1/extensions.go
@@ -18,7 +18,6 @@ package v1beta1
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -98,11 +97,6 @@ type Chart struct {
 	TargetNS  string        `json:"namespace"`
 	Timeout   time.Duration `json:"timeout"`
 	Order     int           `json:"order"`
-}
-
-// ManifestFileName returns filename to use for the crd manifest
-func (c Chart) ManifestFileName() string {
-	return fmt.Sprintf("%d_helm_extension_%s.yaml", c.Order, c.Name)
 }
 
 // Validate performs validation

--- a/pkg/apis/k0s/v1beta1/extenstions_test.go
+++ b/pkg/apis/k0s/v1beta1/extenstions_test.go
@@ -81,30 +81,4 @@ func TestValidation(t *testing.T) {
 		})
 
 	})
-
-	t.Run("chart_manifest_name", func(t *testing.T) {
-		chart := Chart{
-			Name:      "release",
-			ChartName: "k0s/chart",
-			TargetNS:  "default",
-		}
-
-		chart1 := Chart{
-			Name:      "release",
-			ChartName: "k0s/chart",
-			TargetNS:  "default",
-			Order:     1,
-		}
-
-		chart2 := Chart{
-			Name:      "release",
-			ChartName: "k0s/chart",
-			TargetNS:  "default",
-			Order:     2,
-		}
-		assert.Equal(t, chart.ManifestFileName(), "0_helm_extension_release.yaml")
-		assert.Equal(t, chart1.ManifestFileName(), "1_helm_extension_release.yaml")
-		assert.Equal(t, chart2.ManifestFileName(), "2_helm_extension_release.yaml")
-	})
-
 }

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -28,8 +28,8 @@ import (
 	"github.com/bombsimon/logrusr/v4"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	helmapi "github.com/k0sproject/k0s/pkg/apis/helm"
-	"github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
-	k0sAPI "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	helmv1beta1 "github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	k0sscheme "github.com/k0sproject/k0s/pkg/client/clientset/scheme"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/manager"
@@ -85,7 +85,7 @@ const (
 )
 
 // Run runs the extensions controller
-func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0sAPI.ClusterConfig) error {
+func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0sv1beta1.ClusterConfig) error {
 	ec.L.Info("Extensions reconciliation started")
 	defer ec.L.Info("Extensions reconciliation finished")
 
@@ -102,9 +102,9 @@ func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0
 	return errors.Join(errs...)
 }
 
-func (ec *ExtensionsController) configureStorage(clusterConfig *k0sAPI.ClusterConfig) (*k0sAPI.HelmExtensions, error) {
+func (ec *ExtensionsController) configureStorage(clusterConfig *k0sv1beta1.ClusterConfig) (*k0sv1beta1.HelmExtensions, error) {
 	helmSettings := clusterConfig.Spec.Extensions.Helm
-	if clusterConfig.Spec.Extensions.Storage.Type != k0sAPI.OpenEBSLocal {
+	if clusterConfig.Spec.Extensions.Storage.Type != k0sv1beta1.OpenEBSLocal {
 		return helmSettings, nil
 	}
 
@@ -120,7 +120,7 @@ func (ec *ExtensionsController) configureStorage(clusterConfig *k0sAPI.ClusterCo
 	return helmSettings, nil
 }
 
-func addOpenEBSHelmExtension(helmSpec *k0sAPI.HelmExtensions, storageExtension *k0sAPI.StorageExtension) (*k0sAPI.HelmExtensions, error) {
+func addOpenEBSHelmExtension(helmSpec *k0sv1beta1.HelmExtensions, storageExtension *k0sv1beta1.StorageExtension) (*k0sv1beta1.HelmExtensions, error) {
 	openEBSValues := map[string]interface{}{
 		"localprovisioner": map[string]interface{}{
 			"hostpathClass": map[string]interface{}{
@@ -135,16 +135,16 @@ func addOpenEBSHelmExtension(helmSpec *k0sAPI.HelmExtensions, storageExtension *
 		return nil, err
 	}
 	if helmSpec == nil {
-		helmSpec = &k0sAPI.HelmExtensions{
-			Repositories: k0sAPI.RepositoriesSettings{},
-			Charts:       k0sAPI.ChartsSettings{},
+		helmSpec = &k0sv1beta1.HelmExtensions{
+			Repositories: k0sv1beta1.RepositoriesSettings{},
+			Charts:       k0sv1beta1.ChartsSettings{},
 		}
 	}
-	helmSpec.Repositories = append(helmSpec.Repositories, k0sAPI.Repository{
+	helmSpec.Repositories = append(helmSpec.Repositories, k0sv1beta1.Repository{
 		Name: "openebs-internal",
 		URL:  constant.OpenEBSRepository,
 	})
-	helmSpec.Charts = append(helmSpec.Charts, k0sAPI.Chart{
+	helmSpec.Charts = append(helmSpec.Charts, k0sv1beta1.Chart{
 		Name:      "openebs",
 		ChartName: "openebs-internal/openebs",
 		TargetNS:  "openebs",
@@ -166,7 +166,7 @@ func yamlifyValues(values map[string]interface{}) (string, error) {
 // reconcileHelmExtensions creates instance of Chart CR for each chart of the config file
 // it also reconciles repositories settings
 // the actual helm install/update/delete management is done by ChartReconciler structure
-func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sAPI.HelmExtensions) error {
+func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.HelmExtensions) error {
 	if helmSpec == nil {
 		return nil
 	}
@@ -183,7 +183,7 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sAPI.HelmExt
 			Name:     "addon_crd_manifest",
 			Template: chartCrdTemplate,
 			Data: struct {
-				k0sAPI.Chart
+				k0sv1beta1.Chart
 				Finalizer string
 			}{
 				Chart:     chart,
@@ -195,13 +195,18 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sAPI.HelmExt
 			errs = append(errs, fmt.Errorf("can't create chart CR instance %q: %w", chart.ChartName, err))
 			continue
 		}
-		if err := ec.saver.Save(chart.ManifestFileName(), buf.Bytes()); err != nil {
+		if err := ec.saver.Save(chartManifestFileName(&chart), buf.Bytes()); err != nil {
 			errs = append(errs, fmt.Errorf("can't save addon CRD manifest for chart CR instance %q: %w", chart.ChartName, err))
 			continue
 		}
 	}
 
 	return errors.Join(errs...)
+}
+
+// Determines the file name to use when storing a chart as a manifest on disk.
+func chartManifestFileName(c *k0sv1beta1.Chart) string {
+	return fmt.Sprintf("%d_helm_extension_%s.yaml", c.Order, c.Name)
 }
 
 type ChartReconciler struct {
@@ -218,7 +223,7 @@ func (cr *ChartReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 	cr.L.Tracef("Got helm chart reconciliation request: %s", req)
 	defer cr.L.Tracef("Finished processing helm chart reconciliation request: %s", req)
 
-	var chartInstance v1beta1.Chart
+	var chartInstance helmv1beta1.Chart
 
 	if err := cr.Client.Get(ctx, req.NamespacedName, &chartInstance); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -253,14 +258,14 @@ func (cr *ChartReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 	return reconcile.Result{}, nil
 }
 
-func (cr *ChartReconciler) uninstall(ctx context.Context, chart v1beta1.Chart) error {
+func (cr *ChartReconciler) uninstall(ctx context.Context, chart helmv1beta1.Chart) error {
 	if err := cr.helm.UninstallRelease(ctx, chart.Status.ReleaseName, chart.Status.Namespace); err != nil {
 		return fmt.Errorf("can't uninstall release `%s/%s`: %w", chart.Status.Namespace, chart.Status.ReleaseName, err)
 	}
 	return nil
 }
 
-func removeFinalizer(ctx context.Context, c client.Client, chart *v1beta1.Chart) error {
+func removeFinalizer(ctx context.Context, c client.Client, chart *helmv1beta1.Chart) error {
 	idx := slices.Index(chart.Finalizers, finalizerName)
 	if idx < 0 {
 		return nil
@@ -284,7 +289,7 @@ func removeFinalizer(ctx context.Context, c client.Client, chart *v1beta1.Chart)
 
 const defaultTimeout = time.Duration(10 * time.Minute)
 
-func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart v1beta1.Chart) error {
+func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart helmv1beta1.Chart) error {
 	var err error
 	var chartRelease *release.Release
 	timeout, err := time.ParseDuration(chart.Spec.Timeout)
@@ -344,7 +349,7 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart v1bet
 	return nil
 }
 
-func (cr *ChartReconciler) chartNeedsUpgrade(chart v1beta1.Chart) bool {
+func (cr *ChartReconciler) chartNeedsUpgrade(chart helmv1beta1.Chart) bool {
 	return !(chart.Status.Namespace == chart.Spec.Namespace &&
 		chart.Status.ReleaseName == chart.Spec.ReleaseName &&
 		chart.Status.Version == chart.Spec.Version &&
@@ -356,9 +361,9 @@ func (cr *ChartReconciler) chartNeedsUpgrade(chart v1beta1.Chart) bool {
 // to complete and the chart may have been updated in the meantime. If returns the error returned
 // by the Update operation. Moreover, if the chart has indeed changed in the meantime we already
 // have an event for it so we will see it again soon.
-func (cr *ChartReconciler) updateStatus(ctx context.Context, chart v1beta1.Chart, chartRelease *release.Release, err error) error {
+func (cr *ChartReconciler) updateStatus(ctx context.Context, chart helmv1beta1.Chart, chartRelease *release.Release, err error) error {
 	nsn := types.NamespacedName{Namespace: chart.Namespace, Name: chart.Name}
-	var updchart v1beta1.Chart
+	var updchart helmv1beta1.Chart
 	if err := cr.Get(ctx, nsn, &updchart); err != nil {
 		return fmt.Errorf("can't get updated version of chart %s: %w", chart.Name, err)
 	}
@@ -383,7 +388,7 @@ func (cr *ChartReconciler) updateStatus(ctx context.Context, chart v1beta1.Chart
 	return nil
 }
 
-func (ec *ExtensionsController) addRepo(repo k0sAPI.Repository) error {
+func (ec *ExtensionsController) addRepo(repo k0sv1beta1.Repository) error {
 	return ec.helm.AddRepository(repo)
 }
 
@@ -448,7 +453,7 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 
 	if err := builder.
 		ControllerManagedBy(mgr).
-		For(&v1beta1.Chart{},
+		For(&helmv1beta1.Chart{},
 			builder.WithPredicates(predicate.And(
 				predicate.GenerationChangedPredicate{},
 				predicate.NewPredicateFuncs(func(object client.Object) bool {

--- a/pkg/component/controller/extensions_controller_test.go
+++ b/pkg/component/controller/extensions_controller_test.go
@@ -198,3 +198,29 @@ func TestConfigureStorage(t *testing.T) {
 	}
 
 }
+
+func TestChartManifestFileName(t *testing.T) {
+	chart := k0sv1beta1.Chart{
+		Name:      "release",
+		ChartName: "k0s/chart",
+		TargetNS:  "default",
+	}
+
+	chart1 := k0sv1beta1.Chart{
+		Name:      "release",
+		ChartName: "k0s/chart",
+		TargetNS:  "default",
+		Order:     1,
+	}
+
+	chart2 := k0sv1beta1.Chart{
+		Name:      "release",
+		ChartName: "k0s/chart",
+		TargetNS:  "default",
+		Order:     2,
+	}
+
+	assert.Equal(t, chartManifestFileName(&chart), "0_helm_extension_release.yaml")
+	assert.Equal(t, chartManifestFileName(&chart1), "1_helm_extension_release.yaml")
+	assert.Equal(t, chartManifestFileName(&chart2), "2_helm_extension_release.yaml")
+}

--- a/pkg/component/controller/extensions_controller_test.go
+++ b/pkg/component/controller/extensions_controller_test.go
@@ -223,4 +223,5 @@ func TestChartManifestFileName(t *testing.T) {
 	assert.Equal(t, chartManifestFileName(&chart), "0_helm_extension_release.yaml")
 	assert.Equal(t, chartManifestFileName(&chart1), "1_helm_extension_release.yaml")
 	assert.Equal(t, chartManifestFileName(&chart2), "2_helm_extension_release.yaml")
+	assert.True(t, isChartManifestFileName("0_helm_extension_release.yaml"))
 }


### PR DESCRIPTION
Backport to `release-1.29`:
* #4717