### PR TITLE
Telemetry component cleanup

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -193,9 +193,11 @@ func (c *command) start(ctx context.Context) error {
 		return err
 	}
 	logrus.Infof("DNS address: %s", dnsAddress)
-	var storageBackend manager.Component
 
-	switch nodeConfig.Spec.Storage.Type {
+	var storageBackend manager.Component
+	storageType := nodeConfig.Spec.Storage.Type
+
+	switch storageType {
 	case v1beta1.KineStorageType:
 		storageBackend = &controller.Kine{
 			Config:  nodeConfig.Spec.Storage.Kine,
@@ -548,6 +550,7 @@ func (c *command) start(ctx context.Context) error {
 	if telemetry.IsEnabled() {
 		clusterComponents.Add(ctx, &telemetry.Component{
 			K0sVars:           c.K0sVars,
+			StorageType:       storageType,
 			KubeClientFactory: adminClientFactory,
 		})
 	} else {

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -545,11 +545,15 @@ func (c *command) start(ctx context.Context) error {
 		})
 	}
 
-	clusterComponents.Add(ctx, &telemetry.Component{
-		Version:           build.Version,
-		K0sVars:           c.K0sVars,
-		KubeClientFactory: adminClientFactory,
-	})
+	if telemetry.IsEnabled() {
+		clusterComponents.Add(ctx, &telemetry.Component{
+			Version:           build.Version,
+			K0sVars:           c.K0sVars,
+			KubeClientFactory: adminClientFactory,
+		})
+	} else {
+		logrus.Info("Telemetry is disabled")
+	}
 
 	clusterComponents.Add(ctx, &controller.Autopilot{
 		K0sVars:            c.K0sVars,

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -547,7 +547,6 @@ func (c *command) start(ctx context.Context) error {
 
 	if telemetry.IsEnabled() {
 		clusterComponents.Add(ctx, &telemetry.Component{
-			Version:           build.Version,
 			K0sVars:           c.K0sVars,
 			KubeClientFactory: adminClientFactory,
 		})

--- a/pkg/telemetry/component.go
+++ b/pkg/telemetry/component.go
@@ -33,8 +33,8 @@ import (
 
 // Component is a telemetry component for k0s component manager
 type Component struct {
-	clusterConfig     *v1beta1.ClusterConfig
 	K0sVars           *config.CfgVars
+	StorageType       string
 	KubeClientFactory kubeutil.ClientFactoryInterface
 
 	log    *logrus.Entry
@@ -75,7 +75,6 @@ func (c *Component) Reconcile(ctx context.Context, clusterCfg *v1beta1.ClusterCo
 		// We must have the worker stuff already running, do nothing
 		return nil
 	}
-	c.clusterConfig = clusterCfg
 	clients, err := c.KubeClientFactory.GetClient()
 	if err != nil {
 		return err

--- a/pkg/telemetry/component.go
+++ b/pkg/telemetry/component.go
@@ -23,10 +23,12 @@ import (
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/config"
-
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
-	"github.com/sirupsen/logrus"
+
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/segmentio/analytics-go"
+	"github.com/sirupsen/logrus"
 )
 
 // Component is a telemetry component for k0s component manager
@@ -36,7 +38,7 @@ type Component struct {
 	Version           string
 	KubeClientFactory kubeutil.ClientFactoryInterface
 
-	analyticsClient analyticsClient
+	analyticsClient analytics.Client
 
 	log    *logrus.Entry
 	stopCh chan struct{}
@@ -56,7 +58,7 @@ func (c *Component) Init(_ context.Context) error {
 		return nil
 	}
 
-	c.analyticsClient = newSegmentClient(segmentToken)
+	c.analyticsClient = analytics.New(segmentToken)
 	c.log.Info("segment client has been init")
 	return nil
 }

--- a/pkg/telemetry/component.go
+++ b/pkg/telemetry/component.go
@@ -35,7 +35,6 @@ import (
 type Component struct {
 	clusterConfig     *v1beta1.ClusterConfig
 	K0sVars           *config.CfgVars
-	Version           string
 	KubeClientFactory kubeutil.ClientFactoryInterface
 
 	log    *logrus.Entry

--- a/pkg/telemetry/component.go
+++ b/pkg/telemetry/component.go
@@ -116,7 +116,7 @@ func (c *Component) Reconcile(ctx context.Context, clusterCfg *v1beta1.ClusterCo
 	return nil
 }
 
-func (c Component) run(ctx context.Context) {
+func (c *Component) run(ctx context.Context) {
 	c.stopCh = make(chan struct{})
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()

--- a/pkg/telemetry/component.go
+++ b/pkg/telemetry/component.go
@@ -53,11 +53,6 @@ var interval = time.Minute * 10
 func (c *Component) Init(_ context.Context) error {
 	c.log = logrus.WithField("component", "telemetry")
 
-	if segmentToken == "" {
-		c.log.Info("no token, telemetry is disabled")
-		return nil
-	}
-
 	c.analyticsClient = analytics.New(segmentToken)
 	c.log.Info("segment client has been init")
 	return nil
@@ -70,10 +65,6 @@ func (c *Component) Start(_ context.Context) error {
 
 // Run does nothing
 func (c *Component) Stop() error {
-	if segmentToken == "" {
-		c.log.Info("no token, telemetry is disabled")
-		return nil
-	}
 	if c.stopCh != nil {
 		close(c.stopCh)
 	}
@@ -91,10 +82,6 @@ func (c *Component) Reconcile(ctx context.Context, clusterCfg *v1beta1.ClusterCo
 	}
 	if c.stopCh != nil {
 		// We must have the worker stuff already running, do nothing
-		return nil
-	}
-	if segmentToken == "" {
-		c.log.Info("no token, telemetry is disabled")
 		return nil
 	}
 	c.clusterConfig = clusterCfg

--- a/pkg/telemetry/segment.go
+++ b/pkg/telemetry/segment.go
@@ -24,9 +24,14 @@ var segmentToken = ""
 
 const heartbeatEvent = "cluster-heartbeat"
 
+func IsEnabled() bool {
+	return segmentToken != ""
+}
+
 func NewDefaultSegmentClient() analytics.Client {
-	if segmentToken == "" {
+	if !IsEnabled() {
 		return nil
 	}
+
 	return analytics.New(segmentToken)
 }

--- a/pkg/telemetry/segment.go
+++ b/pkg/telemetry/segment.go
@@ -24,19 +24,9 @@ var segmentToken = ""
 
 const heartbeatEvent = "cluster-heartbeat"
 
-// Analytics is the interface used for our analytics client.
-type analyticsClient interface {
-	Enqueue(msg analytics.Message) error
-	Close() error
-}
-
-func NewDefaultSegmentClient() analyticsClient {
+func NewDefaultSegmentClient() analytics.Client {
 	if segmentToken == "" {
 		return nil
 	}
-	return newSegmentClient(segmentToken)
-}
-
-func newSegmentClient(segmentToken string) analyticsClient {
 	return analytics.New(segmentToken)
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -59,7 +59,7 @@ func (td telemetryData) asProperties() analytics.Properties {
 	}
 }
 
-func (c Component) collectTelemetry(ctx context.Context) (telemetryData, error) {
+func (c *Component) collectTelemetry(ctx context.Context) (telemetryData, error) {
 	var err error
 	data := telemetryData{}
 
@@ -85,7 +85,7 @@ func (c Component) collectTelemetry(ctx context.Context) (telemetryData, error) 
 	return data, nil
 }
 
-func (c Component) getStorageType() string {
+func (c *Component) getStorageType() string {
 	switch c.clusterConfig.Spec.Storage.Type {
 	case v1beta1.EtcdStorageType, v1beta1.KineStorageType:
 		return c.clusterConfig.Spec.Storage.Type
@@ -93,7 +93,7 @@ func (c Component) getStorageType() string {
 	return "unknown"
 }
 
-func (c Component) getClusterID(ctx context.Context) (string, error) {
+func (c *Component) getClusterID(ctx context.Context) (string, error) {
 	ns, err := c.kubernetesClient.CoreV1().Namespaces().Get(ctx,
 		"kube-system",
 		metav1.GetOptions{})
@@ -104,7 +104,7 @@ func (c Component) getClusterID(ctx context.Context) (string, error) {
 	return fmt.Sprintf("kube-system:%s", ns.UID), nil
 }
 
-func (c Component) getWorkerData(ctx context.Context) ([]workerData, workerSums, error) {
+func (c *Component) getWorkerData(ctx context.Context) ([]workerData, workerSums, error) {
 	nodes, err := c.kubernetesClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, workerSums{}, err
@@ -129,7 +129,7 @@ func (c Component) getWorkerData(ctx context.Context) ([]workerData, workerSums,
 	return wds, workerSums{cpuTotal: cpuTotal, memTotal: memTotal}, nil
 }
 
-func (c Component) sendTelemetry(ctx context.Context) {
+func (c *Component) sendTelemetry(ctx context.Context) {
 	data, err := c.collectTelemetry(ctx)
 	if err != nil {
 		c.log.WithError(err).Warning("can't prepare telemetry data")
@@ -159,7 +159,7 @@ func (c Component) sendTelemetry(ctx context.Context) {
 	}
 }
 
-func (c Component) addCustomData(ctx context.Context, analyticCtx *analytics.Context) {
+func (c *Component) addCustomData(ctx context.Context, analyticCtx *analytics.Context) {
 	cm, err := c.kubernetesClient.CoreV1().ConfigMaps("kube-system").Get(ctx, "k0s-telemetry", metav1.GetOptions{})
 	if err != nil {
 		return

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -21,13 +21,15 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/segmentio/analytics-go"
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	"github.com/k0sproject/k0s/pkg/build"
+	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
-	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/segmentio/analytics-go"
 )
 
 type telemetryData struct {
@@ -141,7 +143,7 @@ func (c *Component) sendTelemetry(ctx context.Context, analyticsClient analytics
 		Extra: map[string]interface{}{"direct": true},
 	}
 
-	hostData.App.Version = c.Version
+	hostData.App.Version = build.Version
 	hostData.App.Name = "k0s"
 	hostData.App.Namespace = "k0s"
 	hostData.Extra["cpuArch"] = runtime.GOARCH

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -130,7 +130,7 @@ func getWorkerData(ctx context.Context, clients kubernetes.Interface) ([]workerD
 	return wds, workerSums{cpuTotal: cpuTotal, memTotal: memTotal}, nil
 }
 
-func (c *Component) sendTelemetry(ctx context.Context, clients kubernetes.Interface) {
+func (c *Component) sendTelemetry(ctx context.Context, analyticsClient analytics.Client, clients kubernetes.Interface) {
 	data, err := c.collectTelemetry(ctx, clients)
 	if err != nil {
 		c.log.WithError(err).Warning("can't prepare telemetry data")
@@ -150,7 +150,7 @@ func (c *Component) sendTelemetry(ctx context.Context, clients kubernetes.Interf
 	addCustomData(ctx, &hostData, clients)
 
 	c.log.WithField("data", data).WithField("hostdata", hostData).Info("sending telemetry")
-	if err := c.analyticsClient.Enqueue(analytics.Track{
+	if err := analyticsClient.Enqueue(analytics.Track{
 		AnonymousId: "(removed)",
 		Event:       heartbeatEvent,
 		Properties:  data.asProperties(),

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/build"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 
@@ -66,7 +65,7 @@ func (c *Component) collectTelemetry(ctx context.Context, clients kubernetes.Int
 	var err error
 	data := telemetryData{}
 
-	data.StorageType = c.getStorageType()
+	data.StorageType = c.StorageType
 	data.ClusterID, err = getClusterID(ctx, clients)
 
 	if err != nil {
@@ -86,14 +85,6 @@ func (c *Component) collectTelemetry(ctx context.Context, clients kubernetes.Int
 		return data, fmt.Errorf("can't collect control plane nodes count: %w", err)
 	}
 	return data, nil
-}
-
-func (c *Component) getStorageType() string {
-	switch c.clusterConfig.Spec.Storage.Type {
-	case v1beta1.EtcdStorageType, v1beta1.KineStorageType:
-		return c.clusterConfig.Spec.Storage.Type
-	}
-	return "unknown"
 }
 
 func getClusterID(ctx context.Context, clients kubernetes.Interface) (string, error) {


### PR DESCRIPTION
## Description

- Updated all telemetry component methods to use pointer receivers in order to preserve any assignments within these methods.
- Pass on the analytics and Kubernetes clients as arguments instead of storing them in the struct.
- Remove the internal `analyticsClient` abstraction, which was basically a copy of the `analytics.Client` interface.
- Replace segment token checks with a global one that prevents the component from being added in the first place.
- Use the version constant directly in the telemetry instead of carrying it along in a struct field.
- Have the storage type stored as a struct field, instead of getting it from the cluster configuration. The storage type is part of the node config and cannot be reconciled.
- Add a mutex: The Start/Stop methods and the Reconcile method may be called concurrently by different goroutines. Ensure that there's no races when starting and stopping the telemetry loop. Also replace the bespoke for loop with `wait.UntilWithContext`, which is tailor-made for that purpose.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings