### PR TITLE
Add controller lease counter component after API server

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -248,11 +248,8 @@ func (c *command) start(ctx context.Context) error {
 
 	if enableKonnectivity {
 		nodeComponents.Add(ctx, &controller.Konnectivity{
-			SingleNode:                 c.SingleNode,
-			LogLevel:                   c.LogLevels.Konnectivity,
 			K0sVars:                    c.K0sVars,
-			KubeClientFactory:          adminClientFactory,
-			NodeConfig:                 nodeConfig,
+			LogLevel:                   c.LogLevels.Konnectivity,
 			EventEmitter:               prober.NewEventEmitter(),
 			K0sControllersLeaseCounter: controllerLeaseCounter,
 		})
@@ -519,11 +516,8 @@ func (c *command) start(ctx context.Context) error {
 
 	if enableKonnectivity {
 		clusterComponents.Add(ctx, &controller.KonnectivityAgent{
-			SingleNode:                 c.SingleNode,
-			LogLevel:                   c.LogLevels.Konnectivity,
 			K0sVars:                    c.K0sVars,
-			KubeClientFactory:          adminClientFactory,
-			NodeConfig:                 nodeConfig,
+			APIServerHost:              nodeConfig.Spec.API.APIAddress(),
 			EventEmitter:               prober.NewEventEmitter(),
 			K0sControllersLeaseCounter: controllerLeaseCounter,
 		})

--- a/internal/sync/value/latest.go
+++ b/internal/sync/value/latest.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package value
+
+import "sync/atomic"
+
+// A value that can be atomically updated, where each update invalidates the
+// previous value. Whenever the value changes, an associated expiration channel
+// is closed. Callers can use this to be notified of updates. The zero value of
+// Latest holds a zero value of T.
+//
+// Latest is useful when some shared state is updated frequently, and readers
+// don't need to keep track of every value, just the latest one. Latest makes
+// this easy, as there's no need to maintain a separate channel for each reader.
+//
+// Example Usage:
+//
+//	package main
+//
+//	import (
+//		"fmt"
+//		"sync"
+//		"time"
+//
+//		"github.com/k0sproject/k0s/internal/sync/value"
+//	)
+//
+//	func main() {
+//		// Declare a zero latest value
+//		var l value.Latest[int]
+//
+//		fmt.Println("Zero value:", l.Get()) // Output: Zero value: 0
+//
+//		// Set the value
+//		l.Set(42)
+//		fmt.Println("Value set to 42")
+//
+//		// Peek at the current value and get the expiration channel
+//		value, expired := l.Peek()
+//		fmt.Println("Peeked value:", value) // Output: Peeked value: 42
+//
+//		// Use a goroutine to watch for expiration
+//		var wg sync.WaitGroup
+//		wg.Add(1)
+//		go func() {
+//			defer wg.Done()
+//			<-expired
+//			fmt.Println("Value expired, new value:", l.Get()) // Output: Value expired, new value: 84
+//		}()
+//
+//		// Set a new value, which will expire the previous value
+//		time.Sleep(1 * time.Second) // Simulate some delay
+//		l.Set(84)
+//		fmt.Println("New value set to 84")
+//
+//		wg.Wait() // Wait for the watcher goroutine to finish
+//	}
+type Latest[T any] struct {
+	p atomic.Pointer[val[T]]
+}
+
+func NewLatest[T any](value T) *Latest[T] {
+	latest := new(Latest[T])
+	latest.Set(value)
+	return latest
+}
+
+// Retrieves the latest value and its associated expiration channel. If no value
+// was previously set, it returns the zero value of T and an expiration channel
+// that is closed as soon as a value is set.
+func (l *Latest[T]) Peek() (T, <-chan struct{}) {
+	if loaded := l.p.Load(); loaded != nil {
+		return loaded.inner, loaded.ch
+	}
+
+	value := val[T]{ch: make(chan struct{})}
+	if !l.p.CompareAndSwap(nil, &value) {
+		loaded := l.p.Load()
+		return loaded.inner, loaded.ch
+	}
+
+	return value.inner, value.ch
+}
+
+// Sets a new value and closes the expiration channel of the previous value.
+func (l *Latest[T]) Set(value T) {
+	if old := l.p.Swap(&val[T]{value, make(chan struct{})}); old != nil {
+		close(old.ch)
+	}
+}
+
+type val[T any] struct {
+	inner T
+	ch    chan struct{}
+}

--- a/internal/sync/value/latest_test.go
+++ b/internal/sync/value/latest_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package value_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/k0s/internal/sync/value"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLatest(t *testing.T) {
+	var underTest value.Latest[int]
+	value, expired := underTest.Peek()
+	assert.Zero(t, value, "Zero latest should return zero value")
+	assert.NotNil(t, expired)
+
+	var got int
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-expired
+		got, _ = underTest.Peek()
+	}()
+
+	time.Sleep(10 * time.Millisecond) // Simulate some delay
+	underTest.Set(42)
+	wg.Wait()
+
+	assert.Equal(t, 42, got)
+
+	newValue, newExpired := underTest.Peek()
+	assert.Equal(t, 42, newValue)
+	assert.NotEqual(t, expired, newExpired)
+}

--- a/pkg/autopilot/controller/updates/clusterinfo.go
+++ b/pkg/autopilot/controller/updates/clusterinfo.go
@@ -36,7 +36,7 @@ type ClusterInfo struct {
 	K0sVersion             string
 	StorageType            string
 	ClusterID              string
-	ControlPlaneNodesCount int
+	ControlPlaneNodesCount uint
 	WorkerData             WorkerData
 	CNIProvider            string
 	Arch                   string
@@ -121,7 +121,7 @@ func CollectData(ctx context.Context, kc kubernetes.Interface) (*ClusterInfo, er
 	}
 
 	// Collect control plane node count
-	ci.ControlPlaneNodesCount, err = kubeutil.GetControlPlaneNodeCount(ctx, kc)
+	ci.ControlPlaneNodesCount, err = kubeutil.CountActiveControllerLeases(ctx, kc)
 	if err != nil {
 		return ci, fmt.Errorf("can't collect control plane nodes count: %w", err)
 	}

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -43,17 +43,16 @@ import (
 
 // Konnectivity implements the component interface for konnectivity server
 type Konnectivity struct {
-	K0sVars                    *config.CfgVars
-	LogLevel                   string
-	K0sControllersLeaseCounter *K0sControllersLeaseCounter
+	K0sVars     *config.CfgVars
+	LogLevel    string
+	ServerCount func() (uint, <-chan struct{})
 
-	supervisor      *supervisor.Supervisor
-	uid             int
-	serverCount     int
-	serverCountChan <-chan int
-	stopFunc        context.CancelFunc
-	clusterConfig   *v1beta1.ClusterConfig
-	log             *logrus.Entry
+	supervisor *supervisor.Supervisor
+	uid        int
+
+	stopFunc      context.CancelFunc
+	clusterConfig *v1beta1.ClusterConfig
+	log           *logrus.Entry
 
 	*prober.EventEmitter
 }
@@ -97,21 +96,50 @@ func (k *Konnectivity) Init(ctx context.Context) error {
 
 // Run ..
 func (k *Konnectivity) Start(ctx context.Context) error {
-	// Buffered chan to send updates for the count of servers
-	k.serverCountChan = k.K0sControllersLeaseCounter.Subscribe()
+	serverCount, serverCountChanged := k.ServerCount()
 
-	// To make the server start, add "dummy" 0 into the channel
-	if err := k.runServer(0); err != nil {
-		k.EmitWithPayload("failed to run konnectivity server", err)
-		return fmt.Errorf("failed to run konnectivity server: %w", err)
+	if err := k.runServer(serverCount); err != nil {
+		k.EmitWithPayload("failed to start konnectivity server", err)
+		return fmt.Errorf("failed to start konnectivity server: %w", err)
 	}
 
-	go k.watchControllerCountChanges(ctx)
+	go func() {
+		var retry <-chan time.Time
+		for {
+			select {
+			case <-serverCountChanged:
+				prevServerCount := serverCount
+				serverCount, serverCountChanged = k.ServerCount()
+				// restart only if the server count actually changed
+				if serverCount == prevServerCount {
+					continue
+				}
+
+			case <-retry:
+				k.Emit("retrying to start konnectivity server")
+				k.log.Info("Retrying to start konnectivity server")
+
+			case <-ctx.Done():
+				k.Emit("stopped konnectivity server")
+				k.log.Info("stopping konnectivity server reconfig loop")
+				return
+			}
+
+			retry = nil
+
+			if err := k.runServer(serverCount); err != nil {
+				k.EmitWithPayload("failed to start konnectivity server", err)
+				k.log.WithError(err).Errorf("Failed to start konnectivity server")
+				retry = time.After(10 * time.Second)
+				continue
+			}
+		}
+	}()
 
 	return nil
 }
 
-func (k *Konnectivity) serverArgs(count int) []string {
+func (k *Konnectivity) serverArgs(count uint) []string {
 	return stringmap.StringMap{
 		"--uds-name":                 filepath.Join(k.K0sVars.KonnectivitySocketDir, "konnectivity-server.sock"),
 		"--cluster-cert":             filepath.Join(k.K0sVars.CertRootDir, "server.crt"),
@@ -131,42 +159,14 @@ func (k *Konnectivity) serverArgs(count int) []string {
 		"--v":                        k.LogLevel,
 		"--enable-profiling":         "false",
 		"--delete-existing-uds-file": "true",
-		"--server-count":             strconv.Itoa(count),
+		"--server-count":             strconv.FormatUint(uint64(count), 10),
 		"--server-id":                k.K0sVars.InvocationID,
 		"--proxy-strategies":         "destHost,default",
 		"--cipher-suites":            constant.AllowedTLS12CipherSuiteNames(),
 	}.ToArgs()
 }
 
-// runs the supervisor and restarts if the calculated server count changes
-func (k *Konnectivity) watchControllerCountChanges(ctx context.Context) {
-	// previousArgs := stringmap.StringMap{}
-	for {
-		k.log.Debug("waiting for server count change")
-		select {
-		case <-ctx.Done():
-			k.Emit("stopped konnectivity server")
-			logrus.Info("stopping konnectivity server reconfig loop")
-			return
-		case count := <-k.serverCountChan:
-			if k.clusterConfig == nil {
-				k.Emit("skipping konnectivity server start, cluster config not yet available")
-				continue
-			}
-			// restart only if the count actually changes and we've got the global config
-			if count != k.serverCount {
-				if err := k.runServer(count); err != nil {
-					k.EmitWithPayload("failed to run konnectivity server", err)
-					logrus.Errorf("failed to run konnectivity server: %s", err)
-					continue
-				}
-			}
-			k.serverCount = count
-		}
-	}
-}
-
-func (k *Konnectivity) runServer(count int) error {
+func (k *Konnectivity) runServer(count uint) error {
 	// Stop supervisor
 	if k.supervisor != nil {
 		k.EmitWithPayload("restarting konnectivity server due to server count change",
@@ -186,12 +186,9 @@ func (k *Konnectivity) runServer(count int) error {
 	}
 	err := k.supervisor.Supervise()
 	if err != nil {
-		k.EmitWithPayload("failed to run konnectivity server", err)
-		k.log.Errorf("failed to start konnectivity supervisor: %s", err)
 		k.supervisor = nil // not to make the next loop to try to stop it first
 		return err
 	}
-	k.serverCount = count
 	k.EmitWithPayload("started konnectivity server", map[string]interface{}{"serverCount": count})
 
 	return nil

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -38,18 +38,13 @@ import (
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/k0scontext"
-	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/pkg/supervisor"
 )
 
 // Konnectivity implements the component interface for konnectivity server
 type Konnectivity struct {
-	K0sVars    *config.CfgVars
-	LogLevel   string
-	SingleNode bool
-	// used for lease lock
-	KubeClientFactory          kubeutil.ClientFactoryInterface
-	NodeConfig                 *v1beta1.ClusterConfig
+	K0sVars                    *config.CfgVars
+	LogLevel                   string
 	K0sControllersLeaseCounter *K0sControllersLeaseCounter
 
 	supervisor      *supervisor.Supervisor

--- a/pkg/component/controller/konnectivityagent.go
+++ b/pkg/component/controller/konnectivityagent.go
@@ -29,17 +29,12 @@ import (
 	"github.com/k0sproject/k0s/pkg/component/prober"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
-	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/sirupsen/logrus"
 )
 
 type KonnectivityAgent struct {
-	K0sVars    *config.CfgVars
-	LogLevel   string
-	SingleNode bool
-	// used for lease lock
-	KubeClientFactory          kubeutil.ClientFactoryInterface
-	NodeConfig                 *v1beta1.ClusterConfig
+	K0sVars                    *config.CfgVars
+	APIServerHost              string
 	K0sControllersLeaseCounter *K0sControllersLeaseCounter
 
 	serverCount       int
@@ -115,7 +110,7 @@ func (k *KonnectivityAgent) writeKonnectivityAgent() error {
 	cfg := konnectivityAgentConfig{
 		// Since the konnectivity server runs with hostNetwork=true this is the
 		// IP address of the master machine
-		ProxyServerHost: k.NodeConfig.Spec.API.APIAddress(), // TODO: should it be an APIAddress?
+		ProxyServerHost: k.APIServerHost,
 		ProxyServerPort: uint16(k.clusterConfig.Spec.Konnectivity.AgentPort),
 		Image:           k.clusterConfig.Spec.Images.Konnectivity.URI(),
 		ServerCount:     k.serverCount,

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -35,7 +35,7 @@ type telemetryData struct {
 	StorageType            string
 	ClusterID              string
 	WorkerNodesCount       int
-	ControlPlaneNodesCount int
+	ControlPlaneNodesCount uint
 	WorkerData             []workerData
 	CPUTotal               int64
 	MEMTotal               int64
@@ -54,7 +54,7 @@ func (td telemetryData) asProperties() analytics.Properties {
 		"storageType":            td.StorageType,
 		"clusterID":              td.ClusterID,
 		"workerNodesCount":       td.WorkerNodesCount,
-		"controlPlaneNodesCount": td.ControlPlaneNodesCount,
+		"controlPlaneNodesCount": int(td.ControlPlaneNodesCount),
 		"workerData":             td.WorkerData,
 		"memTotal":               td.MEMTotal,
 		"cpuTotal":               td.CPUTotal,
@@ -80,7 +80,7 @@ func (c *Component) collectTelemetry(ctx context.Context, clients kubernetes.Int
 	data.WorkerData = wds
 	data.MEMTotal = sums.memTotal
 	data.CPUTotal = sums.cpuTotal
-	data.ControlPlaneNodesCount, err = kubeutil.GetControlPlaneNodeCount(ctx, clients)
+	data.ControlPlaneNodesCount, err = kubeutil.CountActiveControllerLeases(ctx, clients)
 	if err != nil {
 		return data, fmt.Errorf("can't collect control plane nodes count: %w", err)
 	}


### PR DESCRIPTION
## Description

The controller lease counter requires the API server to be up and running in order to work properly. It cannot acquire or count leases before the API server is up, nor can it release the lease after the API server is shut down.

Move the counter component down in the controller start method, so that it's started after the API server. Decouple the actual controller count value from the counter component by putting it directly into the start method. Let the counter component update that value, and let the konnectivity components consume those updates.

Introduce `internal/sync.Latest` as a small abstraction for values that may change over time and will be consumed by multiple observers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings