### PR TITLE
Separate the initialization and reconciliation in ClusterConfigReconciler

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -377,24 +377,23 @@ func (c *command) start(ctx context.Context) error {
 	var configSource clusterconfig.ConfigSource
 	// For backwards compatibility, use file as config source by default
 	if c.EnableDynamicConfig {
-		configSource, err = clusterconfig.NewAPIConfigSource(adminClientFactory)
-	} else {
-		configSource, err = clusterconfig.NewStaticSource(nodeConfig)
-	}
-	if err != nil {
-		return err
-	}
-	defer configSource.Stop()
-
-	// The CRDs are only required if the config is stored in the cluster.
-	if configSource.NeedToStoreInitialConfig() {
+		// The CRDs are only required if the config is stored in the cluster.
 		apiConfigSaver, err := controller.NewManifestsSaver("api-config", c.K0sVars.DataDir)
 		if err != nil {
 			return fmt.Errorf("failed to initialize api-config manifests saver: %w", err)
 		}
 
 		clusterComponents.Add(ctx, controller.NewCRD(apiConfigSaver, "v1beta1", controller.WithCRDAssetsDir("k0s")))
+
+		configSource, err = clusterconfig.NewAPIConfigSource(adminClientFactory)
+		if err != nil {
+			return err
+		}
+	} else {
+		configSource = clusterconfig.NewStaticSource(nodeConfig)
 	}
+
+	defer configSource.Stop()
 
 	cfgReconciler, err := controller.NewClusterConfigReconciler(
 		leaderElector,

--- a/pkg/component/controller/clusterConfig.go
+++ b/pkg/component/controller/clusterConfig.go
@@ -41,20 +41,20 @@ import (
 
 // ClusterConfigReconciler reconciles a ClusterConfig object
 type ClusterConfigReconciler struct {
-	ComponentManager  *manager.Manager
 	KubeClientFactory kubeutil.ClientFactoryInterface
 
 	log          *logrus.Entry
+	reconciler   manager.Reconciler
 	configSource clusterconfig.ConfigSource
 }
 
 // NewClusterConfigReconciler creates a new clusterConfig reconciler
-func NewClusterConfigReconciler(mgr *manager.Manager, kubeClientFactory kubeutil.ClientFactoryInterface, configSource clusterconfig.ConfigSource) *ClusterConfigReconciler {
+func NewClusterConfigReconciler(reconciler manager.Reconciler, kubeClientFactory kubeutil.ClientFactoryInterface, configSource clusterconfig.ConfigSource) *ClusterConfigReconciler {
 	return &ClusterConfigReconciler{
-		ComponentManager:  mgr,
 		KubeClientFactory: kubeClientFactory,
 		log:               logrus.WithFields(logrus.Fields{"component": "clusterConfig-reconciler"}),
 		configSource:      configSource,
+		reconciler:        reconciler,
 	}
 }
 
@@ -76,7 +76,7 @@ func (r *ClusterConfigReconciler) Start(ctx context.Context) error {
 				if err != nil {
 					err = fmt.Errorf("failed to validate cluster configuration: %w", err)
 				} else {
-					err = r.ComponentManager.Reconcile(ctx, cfg)
+					err = r.reconciler.Reconcile(ctx, cfg)
 				}
 				r.reportStatus(statusCtx, cfg, err)
 				if err != nil {

--- a/pkg/component/controller/clusterConfig.go
+++ b/pkg/component/controller/clusterConfig.go
@@ -182,8 +182,7 @@ func NewClusterConfigInitializer(kubeClientFactory kubeutil.ClientFactoryInterfa
 
 func (i *ClusterConfigInitializer) ensureClusterConfigExistence(ctx context.Context) error {
 	// We need to wait until the cluster configuration exists or we succeed in creating it.
-	return wait.PollImmediateWithContext(ctx, 1*time.Second, 20*time.Second, func(ctx context.Context) (bool, error) {
-		var err error
+	return wait.PollUntilContextTimeout(ctx, 1*time.Second, 20*time.Second, true, func(ctx context.Context) (_ bool, err error) {
 		if i.leaderElector.IsLeader() {
 			err = i.createClusterConfig(ctx)
 			if err == nil {

--- a/pkg/component/controller/clusterconfig/apiconfigsource.go
+++ b/pkg/component/controller/clusterconfig/apiconfigsource.go
@@ -97,7 +97,3 @@ func (a apiConfigSource) Stop() {
 		close(a.resultChan)
 	}
 }
-
-func (a *apiConfigSource) NeedToStoreInitialConfig() bool {
-	return true
-}

--- a/pkg/component/controller/clusterconfig/configsource.go
+++ b/pkg/component/controller/clusterconfig/configsource.go
@@ -29,6 +29,4 @@ type ConfigSource interface {
 	ResultChan() <-chan *v1beta1.ClusterConfig
 	// Stop stops sending config events
 	Stop()
-	// NeedToStoreInitialConfig tells the configsource user if the initial config should be stored in the api or not
-	NeedToStoreInitialConfig() bool
 }

--- a/pkg/component/controller/clusterconfig/staticsource.go
+++ b/pkg/component/controller/clusterconfig/staticsource.go
@@ -30,11 +30,11 @@ type staticSource struct {
 	resultChan   chan *v1beta1.ClusterConfig
 }
 
-func NewStaticSource(staticConfig *v1beta1.ClusterConfig) (ConfigSource, error) {
+func NewStaticSource(staticConfig *v1beta1.ClusterConfig) ConfigSource {
 	return &staticSource{
 		staticConfig: staticConfig,
 		resultChan:   make(chan *v1beta1.ClusterConfig),
-	}, nil
+	}
 }
 
 func (s *staticSource) Release(context.Context) {

--- a/pkg/component/controller/clusterconfig/staticsource.go
+++ b/pkg/component/controller/clusterconfig/staticsource.go
@@ -47,7 +47,3 @@ func (s *staticSource) ResultChan() <-chan *v1beta1.ClusterConfig {
 }
 
 func (*staticSource) Stop() {}
-
-func (s *staticSource) NeedToStoreInitialConfig() bool {
-	return false
-}


### PR DESCRIPTION
## Description

The cluster config initialization and the reconciliation are two independent things. The `ClusterConfigReconciler` did both of them at the same time. By separating the initialization part into the `ClusterConfigInitializer`, there's a clearer separation of concerns, and no longer the need to have a `NeedToStoreInitialConfig` method on config sources. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings