### PR TITLE
[Backport release-1.28] Cleanup unknown Helm chart manifest files

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -388,7 +388,6 @@ func (c *command) start(ctx context.Context) error {
 		}
 		clusterComponents.Add(ctx, controller.NewCRD(helmSaver, []string{"helm"}))
 		clusterComponents.Add(ctx, controller.NewExtensionsController(
-			helmSaver,
 			c.K0sVars,
 			adminClientFactory,
 			leaderElector,

--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -29,8 +30,11 @@ import (
 
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/inttest/common"
-	"github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	helmv1beta1 "github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	k0sclientset "github.com/k0sproject/k0s/pkg/client/clientset"
+	"github.com/k0sproject/k0s/pkg/constant"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -43,12 +47,14 @@ type AddonsSuite struct {
 }
 
 func (as *AddonsSuite) TestHelmBasedAddons() {
+	ctx := as.Context()
+
 	addonName := "test-addon"
 	ociAddonName := "oci-addon"
 	fileAddonName := "tgz-addon"
 	as.PutFile(as.ControllerNode(0), "/tmp/k0s.yaml", fmt.Sprintf(k0sConfigWithAddon, addonName))
 	as.pullHelmChart(as.ControllerNode(0))
-	as.Require().NoError(as.InitController(0, "--config=/tmp/k0s.yaml"))
+	as.Require().NoError(as.InitController(0, "--config=/tmp/k0s.yaml", "--enable-dynamic-config"))
 	as.NoError(as.RunWorkers())
 	kc, err := as.KubeClient(as.ControllerNode(0))
 	as.Require().NoError(err)
@@ -59,6 +65,8 @@ func (as *AddonsSuite) TestHelmBasedAddons() {
 	as.waitForTestRelease(fileAddonName, "0.6.0", "kube-system", 1)
 
 	as.AssertSomeKubeSystemPods(kc)
+
+	as.Run("Rename chart in Helm extension", func() { as.renameChart(ctx) })
 
 	values := map[string]interface{}{
 		"replicaCount": 2,
@@ -86,7 +94,47 @@ func (as *AddonsSuite) pullHelmChart(node string) {
 	as.Require().NoError(err)
 }
 
-func (as *AddonsSuite) deleteRelease(chart *v1beta1.Chart) {
+func (as *AddonsSuite) renameChart(ctx context.Context) {
+	restConfig, err := as.GetKubeConfig(as.ControllerNode(0))
+	as.Require().NoError(err)
+	k0sClients, err := k0sclientset.NewForConfig(restConfig)
+	as.Require().NoError(err)
+
+	configs := k0sClients.K0sV1beta1().ClusterConfigs(constant.ClusterConfigNamespace)
+	cfg, err := configs.Get(ctx, constant.ClusterConfigObjectName, metav1.GetOptions{})
+	as.Require().NoError(err)
+
+	i := slices.IndexFunc(cfg.Spec.Extensions.Helm.Charts, func(c k0sv1beta1.Chart) bool {
+		return c.Name == "tgz-addon"
+	})
+	as.Require().GreaterOrEqual(i, 0, "Didn't find tgz-addon in %v", cfg.Spec.Extensions.Helm.Charts)
+	cfg.Spec.Extensions.Helm.Charts[i].Name = "tgz-renamed-addon"
+
+	cfg, err = configs.Update(ctx, cfg, metav1.UpdateOptions{FieldManager: as.T().Name()})
+	as.Require().NoError(err)
+	if data, err := yaml.Marshal(cfg); as.NoError(err) {
+		as.T().Logf("%s", data)
+	}
+
+	as.Require().NoError(wait.PollUntilContextCancel(ctx, 350*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		charts, err := k0sClients.HelmV1beta1().Charts(constant.ClusterConfigNamespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		hasChart := func(name string) bool {
+			return slices.IndexFunc(charts.Items, func(c helmv1beta1.Chart) bool {
+				return c.Name == name
+			}) >= 0
+		}
+
+		return !hasChart("k0s-addon-chart-tgz-addon") && hasChart("k0s-addon-chart-tgz-renamed-addon"), nil
+	}), "While waiting for Chart resource to be swapped")
+
+	as.waitForTestRelease("tgz-renamed-addon", "0.6.0", "kube-system", 1)
+}
+
+func (as *AddonsSuite) deleteRelease(chart *helmv1beta1.Chart) {
 	ctx := as.Context()
 	as.T().Logf("Deleting chart %s/%s", chart.Namespace, chart.Name)
 	ssh, err := as.SSH(ctx, as.ControllerNode(0))
@@ -100,7 +148,7 @@ func (as *AddonsSuite) deleteRelease(chart *v1beta1.Chart) {
 	as.Require().NoError(err)
 	as.Require().NoError(wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(pollCtx context.Context) (done bool, err error) {
 		as.T().Logf("Expecting have no secrets left for release %s/%s", chart.Namespace, chart.Name)
-		items, err := k8sclient.CoreV1().Secrets("default").List(pollCtx, v1.ListOptions{
+		items, err := k8sclient.CoreV1().Secrets("default").List(pollCtx, metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("name=%s", chart.Name),
 		})
 		if err != nil {
@@ -118,19 +166,19 @@ func (as *AddonsSuite) deleteRelease(chart *v1beta1.Chart) {
 	}))
 }
 
-func (as *AddonsSuite) waitForTestRelease(addonName, appVersion string, namespace string, rev int64) *v1beta1.Chart {
+func (as *AddonsSuite) waitForTestRelease(addonName, appVersion string, namespace string, rev int64) *helmv1beta1.Chart {
 	ctx := as.Context()
 	as.T().Logf("waiting to see %s release ready in kube API, generation %d", addonName, rev)
 
 	cfg, err := as.GetKubeConfig(as.ControllerNode(0))
 	as.Require().NoError(err)
-	err = v1beta1.AddToScheme(scheme.Scheme)
+	err = helmv1beta1.AddToScheme(scheme.Scheme)
 	as.Require().NoError(err)
 	chartClient, err := client.New(cfg, client.Options{
 		Scheme: scheme.Scheme,
 	})
 	as.Require().NoError(err)
-	var chart v1beta1.Chart
+	var chart helmv1beta1.Chart
 	var lastResourceVersion string
 	as.Require().NoError(wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(pollCtx context.Context) (done bool, err error) {
 		err = chartClient.Get(pollCtx, client.ObjectKey{
@@ -189,7 +237,7 @@ func (as *AddonsSuite) checkCustomValues(releaseName string) error {
 	}
 	return wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(pollCtx context.Context) (done bool, err error) {
 		serverDeployment := fmt.Sprintf("%s-echo-server", releaseName)
-		d, err := kc.AppsV1().Deployments("default").Get(pollCtx, serverDeployment, v1.GetOptions{})
+		d, err := kc.AppsV1().Deployments("default").Get(pollCtx, serverDeployment, metav1.GetOptions{})
 		if err != nil {
 			if ctxErr := context.Cause(ctx); ctxErr != nil {
 				return false, errors.Join(err, ctxErr)

--- a/pkg/apis/k0s/v1beta1/extensions.go
+++ b/pkg/apis/k0s/v1beta1/extensions.go
@@ -18,7 +18,6 @@ package v1beta1
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -97,11 +96,6 @@ type Chart struct {
 	TargetNS  string        `json:"namespace"`
 	Timeout   time.Duration `json:"timeout"`
 	Order     int           `json:"order"`
-}
-
-// ManifestFileName returns filename to use for the crd manifest
-func (c Chart) ManifestFileName() string {
-	return fmt.Sprintf("%d_helm_extension_%s.yaml", c.Order, c.Name)
 }
 
 // Validate performs validation

--- a/pkg/apis/k0s/v1beta1/extenstions_test.go
+++ b/pkg/apis/k0s/v1beta1/extenstions_test.go
@@ -81,30 +81,4 @@ func TestValidation(t *testing.T) {
 		})
 
 	})
-
-	t.Run("chart_manifest_name", func(t *testing.T) {
-		chart := Chart{
-			Name:      "release",
-			ChartName: "k0s/chart",
-			TargetNS:  "default",
-		}
-
-		chart1 := Chart{
-			Name:      "release",
-			ChartName: "k0s/chart",
-			TargetNS:  "default",
-			Order:     1,
-		}
-
-		chart2 := Chart{
-			Name:      "release",
-			ChartName: "k0s/chart",
-			TargetNS:  "default",
-			Order:     2,
-		}
-		assert.Equal(t, chart.ManifestFileName(), "0_helm_extension_release.yaml")
-		assert.Equal(t, chart1.ManifestFileName(), "1_helm_extension_release.yaml")
-		assert.Equal(t, chart2.ManifestFileName(), "2_helm_extension_release.yaml")
-	})
-
 }

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -17,10 +17,14 @@ limitations under the License.
 package controller
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -57,24 +61,24 @@ import (
 
 // Helm watch for Chart crd
 type ExtensionsController struct {
-	saver         manifestsSaver
 	L             *logrus.Entry
 	helm          *helm.Commands
 	kubeConfig    string
 	leaderElector leaderelector.Interface
+	manifestsDir  string
 }
 
 var _ manager.Component = (*ExtensionsController)(nil)
 var _ manager.Reconciler = (*ExtensionsController)(nil)
 
 // NewExtensionsController builds new HelmAddons
-func NewExtensionsController(s manifestsSaver, k0sVars *config.CfgVars, kubeClientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface) *ExtensionsController {
+func NewExtensionsController(k0sVars *config.CfgVars, kubeClientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface) *ExtensionsController {
 	return &ExtensionsController{
-		saver:         s,
 		L:             logrus.WithFields(logrus.Fields{"component": "extensions_controller"}),
 		helm:          helm.NewCommands(k0sVars),
 		kubeConfig:    k0sVars.AdminKubeConfigPath,
 		leaderElector: leaderElector,
+		manifestsDir:  filepath.Join(k0sVars.ManifestsDir, "helm"),
 	}
 }
 
@@ -163,8 +167,13 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.Hel
 		}
 	}
 
+	var fileNamesToKeep []string
 	for _, chart := range helmSpec.Charts {
+		fileName := chartManifestFileName(&chart)
+		fileNamesToKeep = append(fileNamesToKeep, fileName)
+
 		tw := templatewriter.TemplateWriter{
+			Path:     filepath.Join(ec.manifestsDir, fileName),
 			Name:     "addon_crd_manifest",
 			Template: chartCrdTemplate,
 			Data: struct {
@@ -175,15 +184,35 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.Hel
 				Finalizer: finalizerName,
 			},
 		}
-		buf := bytes.NewBuffer([]byte{})
-		if err := tw.WriteToBuffer(buf); err != nil {
-			errs = append(errs, fmt.Errorf("can't create chart CR instance %q: %w", chart.ChartName, err))
+		if err := tw.Write(); err != nil {
+			errs = append(errs, fmt.Errorf("can't write file for Helm chart manifest %q: %w", chart.ChartName, err))
 			continue
 		}
-		if err := ec.saver.Save(chartManifestFileName(&chart), buf.Bytes()); err != nil {
-			errs = append(errs, fmt.Errorf("can't save addon CRD manifest for chart CR instance %q: %w", chart.ChartName, err))
-			continue
+
+		ec.L.Infof("Wrote Helm chart manifest file %q", tw.Path)
+	}
+
+	if err := filepath.WalkDir(ec.manifestsDir, func(path string, entry fs.DirEntry, err error) error {
+		switch {
+		case !entry.Type().IsRegular():
+			ec.L.Debugf("Keeping %v as it is not a regular file", entry)
+		case slices.Contains(fileNamesToKeep, entry.Name()):
+			ec.L.Debugf("Keeping %v as it belongs to a known Helm extension", entry)
+		case !isChartManifestFileName(entry.Name()):
+			ec.L.Debugf("Keeping %v as it is not a Helm chart manifest file", entry)
+		default:
+			if err := os.Remove(path); err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					errs = append(errs, fmt.Errorf("failed to remove Helm chart manifest file, the Chart resource will remain in the cluster: %w", err))
+				}
+			} else {
+				ec.L.Infof("Removed Helm chart manifest file %q", path)
+			}
 		}
+
+		return nil
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("failed to walk Helm chart manifest directory: %w", err))
 	}
 
 	return errors.Join(errs...)
@@ -192,6 +221,11 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.Hel
 // Determines the file name to use when storing a chart as a manifest on disk.
 func chartManifestFileName(c *k0sv1beta1.Chart) string {
 	return fmt.Sprintf("%d_helm_extension_%s.yaml", c.Order, c.Name)
+}
+
+// Determines if the given file name is in the format for chart manifest file names.
+func isChartManifestFileName(fileName string) bool {
+	return regexp.MustCompile(`^-?[0-9]+_helm_extension_.+\.yaml$`).MatchString(fileName)
 }
 
 type ChartReconciler struct {

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -28,6 +28,7 @@ import (
 	helmapi "github.com/k0sproject/k0s/pkg/apis/helm"
 	"github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
 	k0sAPI "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	k0sscheme "github.com/k0sproject/k0s/pkg/client/clientset/scheme"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/config"
@@ -37,7 +38,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/release"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
@@ -375,13 +375,8 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 		Kind:  "Chart",
 	}
 
-	scheme := runtime.NewScheme()
-	if err := v1beta1.AddToScheme(scheme); err != nil {
-		return err
-	}
-
 	mgr, err := controllerruntime.NewManager(clientConfig, crman.Options{
-		Scheme: scheme,
+		Scheme: k0sscheme.Scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
 		},

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -37,7 +38,7 @@ import (
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/release"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
@@ -155,9 +156,10 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sAPI.HelmExt
 		return nil
 	}
 
+	var errs []error
 	for _, repo := range helmSpec.Repositories {
 		if err := ec.addRepo(repo); err != nil {
-			return fmt.Errorf("can't init repository %q: %w", repo.URL, err)
+			errs = append(errs, fmt.Errorf("can't init repository %q: %w", repo.URL, err))
 		}
 	}
 
@@ -175,13 +177,16 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sAPI.HelmExt
 		}
 		buf := bytes.NewBuffer([]byte{})
 		if err := tw.WriteToBuffer(buf); err != nil {
-			return fmt.Errorf("can't create chart CR instance %q: %w", chart.ChartName, err)
+			errs = append(errs, fmt.Errorf("can't create chart CR instance %q: %w", chart.ChartName, err))
+			continue
 		}
 		if err := ec.saver.Save(chart.ManifestFileName(), buf.Bytes()); err != nil {
-			return fmt.Errorf("can't save addon CRD manifest for chart CR instance %q: %w", chart.ChartName, err)
+			errs = append(errs, fmt.Errorf("can't save addon CRD manifest for chart CR instance %q: %w", chart.ChartName, err))
+			continue
 		}
 	}
-	return nil
+
+	return errors.Join(errs...)
 }
 
 type ChartReconciler struct {
@@ -201,7 +206,7 @@ func (cr *ChartReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 	var chartInstance v1beta1.Chart
 
 	if err := cr.Client.Get(ctx, req.NamespacedName, &chartInstance); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -27,8 +27,8 @@ import (
 	"github.com/bombsimon/logrusr/v4"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	helmapi "github.com/k0sproject/k0s/pkg/apis/helm"
-	"github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
-	k0sAPI "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	helmv1beta1 "github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	k0sscheme "github.com/k0sproject/k0s/pkg/client/clientset/scheme"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/manager"
@@ -83,14 +83,14 @@ const (
 )
 
 // Run runs the extensions controller
-func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0sAPI.ClusterConfig) error {
+func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0sv1beta1.ClusterConfig) error {
 	ec.L.Info("Extensions reconciliation started")
 	defer ec.L.Info("Extensions reconciliation finished")
 
 	helmSettings := clusterConfig.Spec.Extensions.Helm
 	var err error
 	switch clusterConfig.Spec.Extensions.Storage.Type {
-	case k0sAPI.OpenEBSLocal:
+	case k0sv1beta1.OpenEBSLocal:
 		helmSettings, err = addOpenEBSHelmExtension(helmSettings, clusterConfig.Spec.Extensions.Storage)
 		if err != nil {
 			ec.L.WithError(err).Error("Can't add openebs helm extension")
@@ -105,7 +105,7 @@ func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0
 	return nil
 }
 
-func addOpenEBSHelmExtension(helmSpec *k0sAPI.HelmExtensions, storageExtension *k0sAPI.StorageExtension) (*k0sAPI.HelmExtensions, error) {
+func addOpenEBSHelmExtension(helmSpec *k0sv1beta1.HelmExtensions, storageExtension *k0sv1beta1.StorageExtension) (*k0sv1beta1.HelmExtensions, error) {
 	openEBSValues := map[string]interface{}{
 		"localprovisioner": map[string]interface{}{
 			"hostpathClass": map[string]interface{}{
@@ -120,16 +120,16 @@ func addOpenEBSHelmExtension(helmSpec *k0sAPI.HelmExtensions, storageExtension *
 		return nil, err
 	}
 	if helmSpec == nil {
-		helmSpec = &k0sAPI.HelmExtensions{
-			Repositories: k0sAPI.RepositoriesSettings{},
-			Charts:       k0sAPI.ChartsSettings{},
+		helmSpec = &k0sv1beta1.HelmExtensions{
+			Repositories: k0sv1beta1.RepositoriesSettings{},
+			Charts:       k0sv1beta1.ChartsSettings{},
 		}
 	}
-	helmSpec.Repositories = append(helmSpec.Repositories, k0sAPI.Repository{
+	helmSpec.Repositories = append(helmSpec.Repositories, k0sv1beta1.Repository{
 		Name: "openebs-internal",
 		URL:  constant.OpenEBSRepository,
 	})
-	helmSpec.Charts = append(helmSpec.Charts, k0sAPI.Chart{
+	helmSpec.Charts = append(helmSpec.Charts, k0sv1beta1.Chart{
 		Name:      "openebs",
 		ChartName: "openebs-internal/openebs",
 		TargetNS:  "openebs",
@@ -151,7 +151,7 @@ func yamlifyValues(values map[string]interface{}) (string, error) {
 // reconcileHelmExtensions creates instance of Chart CR for each chart of the config file
 // it also reconciles repositories settings
 // the actual helm install/update/delete management is done by ChartReconciler structure
-func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sAPI.HelmExtensions) error {
+func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.HelmExtensions) error {
 	if helmSpec == nil {
 		return nil
 	}
@@ -168,7 +168,7 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sAPI.HelmExt
 			Name:     "addon_crd_manifest",
 			Template: chartCrdTemplate,
 			Data: struct {
-				k0sAPI.Chart
+				k0sv1beta1.Chart
 				Finalizer string
 			}{
 				Chart:     chart,
@@ -180,13 +180,18 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sAPI.HelmExt
 			errs = append(errs, fmt.Errorf("can't create chart CR instance %q: %w", chart.ChartName, err))
 			continue
 		}
-		if err := ec.saver.Save(chart.ManifestFileName(), buf.Bytes()); err != nil {
+		if err := ec.saver.Save(chartManifestFileName(&chart), buf.Bytes()); err != nil {
 			errs = append(errs, fmt.Errorf("can't save addon CRD manifest for chart CR instance %q: %w", chart.ChartName, err))
 			continue
 		}
 	}
 
 	return errors.Join(errs...)
+}
+
+// Determines the file name to use when storing a chart as a manifest on disk.
+func chartManifestFileName(c *k0sv1beta1.Chart) string {
+	return fmt.Sprintf("%d_helm_extension_%s.yaml", c.Order, c.Name)
 }
 
 type ChartReconciler struct {
@@ -203,7 +208,7 @@ func (cr *ChartReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 	cr.L.Tracef("Got helm chart reconciliation request: %s", req)
 	defer cr.L.Tracef("Finished processing helm chart reconciliation request: %s", req)
 
-	var chartInstance v1beta1.Chart
+	var chartInstance helmv1beta1.Chart
 
 	if err := cr.Client.Get(ctx, req.NamespacedName, &chartInstance); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -232,7 +237,7 @@ func (cr *ChartReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 	cr.L.Debugf("Installed or updated reconciliation request: %s", req)
 	return reconcile.Result{}, nil
 }
-func (cr *ChartReconciler) uninstall(ctx context.Context, chart v1beta1.Chart) error {
+func (cr *ChartReconciler) uninstall(ctx context.Context, chart helmv1beta1.Chart) error {
 	if err := cr.helm.UninstallRelease(ctx, chart.Status.ReleaseName, chart.Status.Namespace); err != nil {
 		return fmt.Errorf("can't uninstall release `%s/%s`: %w", chart.Status.Namespace, chart.Status.ReleaseName, err)
 	}
@@ -241,7 +246,7 @@ func (cr *ChartReconciler) uninstall(ctx context.Context, chart v1beta1.Chart) e
 
 const defaultTimeout = time.Duration(10 * time.Minute)
 
-func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart v1beta1.Chart) error {
+func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart helmv1beta1.Chart) error {
 	var err error
 	var chartRelease *release.Release
 	timeout, err := time.ParseDuration(chart.Spec.Timeout)
@@ -301,7 +306,7 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart v1bet
 	return nil
 }
 
-func (cr *ChartReconciler) chartNeedsUpgrade(chart v1beta1.Chart) bool {
+func (cr *ChartReconciler) chartNeedsUpgrade(chart helmv1beta1.Chart) bool {
 	return !(chart.Status.Namespace == chart.Spec.Namespace &&
 		chart.Status.ReleaseName == chart.Spec.ReleaseName &&
 		chart.Status.Version == chart.Spec.Version &&
@@ -313,9 +318,9 @@ func (cr *ChartReconciler) chartNeedsUpgrade(chart v1beta1.Chart) bool {
 // to complete and the chart may have been updated in the meantime. If returns the error returned
 // by the Update operation. Moreover, if the chart has indeed changed in the meantime we already
 // have an event for it so we will see it again soon.
-func (cr *ChartReconciler) updateStatus(ctx context.Context, chart v1beta1.Chart, chartRelease *release.Release, err error) error {
+func (cr *ChartReconciler) updateStatus(ctx context.Context, chart helmv1beta1.Chart, chartRelease *release.Release, err error) error {
 	nsn := types.NamespacedName{Namespace: chart.Namespace, Name: chart.Name}
-	var updchart v1beta1.Chart
+	var updchart helmv1beta1.Chart
 	if err := cr.Get(ctx, nsn, &updchart); err != nil {
 		return fmt.Errorf("can't get updated version of chart %s: %w", chart.Name, err)
 	}
@@ -340,7 +345,7 @@ func (cr *ChartReconciler) updateStatus(ctx context.Context, chart v1beta1.Chart
 	return nil
 }
 
-func (ec *ExtensionsController) addRepo(repo k0sAPI.Repository) error {
+func (ec *ExtensionsController) addRepo(repo k0sv1beta1.Repository) error {
 	return ec.helm.AddRepository(repo)
 }
 
@@ -405,7 +410,7 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 
 	if err := builder.
 		ControllerManagedBy(mgr).
-		For(&v1beta1.Chart{},
+		For(&helmv1beta1.Chart{},
 			builder.WithPredicates(predicate.And(
 				predicate.GenerationChangedPredicate{},
 				predicate.NewPredicateFuncs(func(object client.Object) bool {

--- a/pkg/component/controller/extensions_controller_test.go
+++ b/pkg/component/controller/extensions_controller_test.go
@@ -160,4 +160,5 @@ func TestChartManifestFileName(t *testing.T) {
 	assert.Equal(t, chartManifestFileName(&chart), "0_helm_extension_release.yaml")
 	assert.Equal(t, chartManifestFileName(&chart1), "1_helm_extension_release.yaml")
 	assert.Equal(t, chartManifestFileName(&chart2), "2_helm_extension_release.yaml")
+	assert.True(t, isChartManifestFileName("0_helm_extension_release.yaml"))
 }

--- a/pkg/component/controller/extensions_controller_test.go
+++ b/pkg/component/controller/extensions_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -133,4 +134,30 @@ func TestChartNeedsUpgrade(t *testing.T) {
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
+}
+
+func TestChartManifestFileName(t *testing.T) {
+	chart := k0sv1beta1.Chart{
+		Name:      "release",
+		ChartName: "k0s/chart",
+		TargetNS:  "default",
+	}
+
+	chart1 := k0sv1beta1.Chart{
+		Name:      "release",
+		ChartName: "k0s/chart",
+		TargetNS:  "default",
+		Order:     1,
+	}
+
+	chart2 := k0sv1beta1.Chart{
+		Name:      "release",
+		ChartName: "k0s/chart",
+		TargetNS:  "default",
+		Order:     2,
+	}
+
+	assert.Equal(t, chartManifestFileName(&chart), "0_helm_extension_release.yaml")
+	assert.Equal(t, chartManifestFileName(&chart1), "1_helm_extension_release.yaml")
+	assert.Equal(t, chartManifestFileName(&chart2), "2_helm_extension_release.yaml")
 }


### PR DESCRIPTION
Backport to `release-1.28`:
* #4737

As #4635 was necessary for this backport, this PR also reverts 961f3034dfdabc646e9d705b4d56a89520962644, which was a replacement for #4635 when backporting #4585 in #4601.

See:
* #4705
* #4698