### PR TITLE
[Backport release-1.27] Cleanup unknown Helm chart manifest files

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -356,7 +356,6 @@ func (c *command) start(ctx context.Context) error {
 		}
 		c.ClusterComponents.Add(ctx, controller.NewCRD(helmSaver, []string{"helm"}))
 		c.ClusterComponents.Add(ctx, controller.NewExtensionsController(
-			helmSaver,
 			c.K0sVars,
 			adminClientFactory,
 			leaderElector,

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/extensions.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/extensions.go
@@ -18,7 +18,6 @@ package v1beta1
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -97,11 +96,6 @@ type Chart struct {
 	TargetNS  string        `json:"namespace"`
 	Timeout   time.Duration `json:"timeout"`
 	Order     int           `json:"order"`
-}
-
-// ManifestFileName returns filename to use for the crd manifest
-func (c Chart) ManifestFileName() string {
-	return fmt.Sprintf("%d_helm_extension_%s.yaml", c.Order, c.Name)
 }
 
 // Validate performs validation

--- a/pkg/apis/k0s.k0sproject.io/v1beta1/extenstions_test.go
+++ b/pkg/apis/k0s.k0sproject.io/v1beta1/extenstions_test.go
@@ -81,30 +81,4 @@ func TestValidation(t *testing.T) {
 		})
 
 	})
-
-	t.Run("chart_manifest_name", func(t *testing.T) {
-		chart := Chart{
-			Name:      "release",
-			ChartName: "k0s/chart",
-			TargetNS:  "default",
-		}
-
-		chart1 := Chart{
-			Name:      "release",
-			ChartName: "k0s/chart",
-			TargetNS:  "default",
-			Order:     1,
-		}
-
-		chart2 := Chart{
-			Name:      "release",
-			ChartName: "k0s/chart",
-			TargetNS:  "default",
-			Order:     2,
-		}
-		assert.Equal(t, chart.ManifestFileName(), "0_helm_extension_release.yaml")
-		assert.Equal(t, chart1.ManifestFileName(), "1_helm_extension_release.yaml")
-		assert.Equal(t, chart2.ManifestFileName(), "2_helm_extension_release.yaml")
-	})
-
 }

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -17,10 +17,14 @@ limitations under the License.
 package controller
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -54,24 +58,24 @@ import (
 
 // Helm watch for Chart crd
 type ExtensionsController struct {
-	saver         manifestsSaver
 	L             *logrus.Entry
 	helm          *helm.Commands
 	kubeConfig    string
 	leaderElector leaderelector.Interface
+	manifestsDir  string
 }
 
 var _ manager.Component = (*ExtensionsController)(nil)
 var _ manager.Reconciler = (*ExtensionsController)(nil)
 
 // NewExtensionsController builds new HelmAddons
-func NewExtensionsController(s manifestsSaver, k0sVars constant.CfgVars, kubeClientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface) *ExtensionsController {
+func NewExtensionsController(k0sVars constant.CfgVars, kubeClientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface) *ExtensionsController {
 	return &ExtensionsController{
-		saver:         s,
 		L:             logrus.WithFields(logrus.Fields{"component": "extensions_controller"}),
 		helm:          helm.NewCommands(k0sVars),
 		kubeConfig:    k0sVars.AdminKubeConfigPath,
 		leaderElector: leaderElector,
+		manifestsDir:  filepath.Join(k0sVars.ManifestsDir, "helm"),
 	}
 }
 
@@ -160,8 +164,13 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.Hel
 		}
 	}
 
+	var fileNamesToKeep []string
 	for _, chart := range helmSpec.Charts {
+		fileName := chartManifestFileName(&chart)
+		fileNamesToKeep = append(fileNamesToKeep, fileName)
+
 		tw := templatewriter.TemplateWriter{
+			Path:     filepath.Join(ec.manifestsDir, fileName),
 			Name:     "addon_crd_manifest",
 			Template: chartCrdTemplate,
 			Data: struct {
@@ -172,15 +181,35 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.Hel
 				Finalizer: finalizerName,
 			},
 		}
-		buf := bytes.NewBuffer([]byte{})
-		if err := tw.WriteToBuffer(buf); err != nil {
-			errs = append(errs, fmt.Errorf("can't create chart CR instance %q: %w", chart.ChartName, err))
+		if err := tw.Write(); err != nil {
+			errs = append(errs, fmt.Errorf("can't write file for Helm chart manifest %q: %w", chart.ChartName, err))
 			continue
 		}
-		if err := ec.saver.Save(chartManifestFileName(&chart), buf.Bytes()); err != nil {
-			errs = append(errs, fmt.Errorf("can't save addon CRD manifest for chart CR instance %q: %w", chart.ChartName, err))
-			continue
+
+		ec.L.Infof("Wrote Helm chart manifest file %q", tw.Path)
+	}
+
+	if err := filepath.WalkDir(ec.manifestsDir, func(path string, entry fs.DirEntry, err error) error {
+		switch {
+		case !entry.Type().IsRegular():
+			ec.L.Debugf("Keeping %v as it is not a regular file", entry)
+		case slices.Contains(fileNamesToKeep, entry.Name()):
+			ec.L.Debugf("Keeping %v as it belongs to a known Helm extension", entry)
+		case !isChartManifestFileName(entry.Name()):
+			ec.L.Debugf("Keeping %v as it is not a Helm chart manifest file", entry)
+		default:
+			if err := os.Remove(path); err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					errs = append(errs, fmt.Errorf("failed to remove Helm chart manifest file, the Chart resource will remain in the cluster: %w", err))
+				}
+			} else {
+				ec.L.Infof("Removed Helm chart manifest file %q", path)
+			}
 		}
+
+		return nil
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("failed to walk Helm chart manifest directory: %w", err))
 	}
 
 	return errors.Join(errs...)
@@ -189,6 +218,11 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.Hel
 // Determines the file name to use when storing a chart as a manifest on disk.
 func chartManifestFileName(c *k0sv1beta1.Chart) string {
 	return fmt.Sprintf("%d_helm_extension_%s.yaml", c.Order, c.Name)
+}
+
+// Determines if the given file name is in the format for chart manifest file names.
+func isChartManifestFileName(fileName string) bool {
+	return regexp.MustCompile(`^-?[0-9]+_helm_extension_.+\.yaml$`).MatchString(fileName)
 }
 
 type ChartReconciler struct {

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -26,9 +26,9 @@ import (
 	"github.com/avast/retry-go"
 	"github.com/bombsimon/logrusr/v2"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
-	"github.com/k0sproject/k0s/pkg/apis/helm.k0sproject.io/v1beta1"
+	helmv1beta1 "github.com/k0sproject/k0s/pkg/apis/helm.k0sproject.io/v1beta1"
 	helmscheme "github.com/k0sproject/k0s/pkg/apis/helm.k0sproject.io/v1beta1/clientset/scheme"
-	k0sAPI "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/constant"
@@ -80,14 +80,14 @@ const (
 )
 
 // Run runs the extensions controller
-func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0sAPI.ClusterConfig) error {
+func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0sv1beta1.ClusterConfig) error {
 	ec.L.Info("Extensions reconciliation started")
 	defer ec.L.Info("Extensions reconciliation finished")
 
 	helmSettings := clusterConfig.Spec.Extensions.Helm
 	var err error
 	switch clusterConfig.Spec.Extensions.Storage.Type {
-	case k0sAPI.OpenEBSLocal:
+	case k0sv1beta1.OpenEBSLocal:
 		helmSettings, err = addOpenEBSHelmExtension(helmSettings, clusterConfig.Spec.Extensions.Storage)
 		if err != nil {
 			ec.L.WithError(err).Error("Can't add openebs helm extension")
@@ -102,7 +102,7 @@ func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0
 	return nil
 }
 
-func addOpenEBSHelmExtension(helmSpec *k0sAPI.HelmExtensions, storageExtension *k0sAPI.StorageExtension) (*k0sAPI.HelmExtensions, error) {
+func addOpenEBSHelmExtension(helmSpec *k0sv1beta1.HelmExtensions, storageExtension *k0sv1beta1.StorageExtension) (*k0sv1beta1.HelmExtensions, error) {
 	openEBSValues := map[string]interface{}{
 		"localprovisioner": map[string]interface{}{
 			"hostpathClass": map[string]interface{}{
@@ -117,16 +117,16 @@ func addOpenEBSHelmExtension(helmSpec *k0sAPI.HelmExtensions, storageExtension *
 		return nil, err
 	}
 	if helmSpec == nil {
-		helmSpec = &k0sAPI.HelmExtensions{
-			Repositories: k0sAPI.RepositoriesSettings{},
-			Charts:       k0sAPI.ChartsSettings{},
+		helmSpec = &k0sv1beta1.HelmExtensions{
+			Repositories: k0sv1beta1.RepositoriesSettings{},
+			Charts:       k0sv1beta1.ChartsSettings{},
 		}
 	}
-	helmSpec.Repositories = append(helmSpec.Repositories, k0sAPI.Repository{
+	helmSpec.Repositories = append(helmSpec.Repositories, k0sv1beta1.Repository{
 		Name: "openebs-internal",
 		URL:  constant.OpenEBSRepository,
 	})
-	helmSpec.Charts = append(helmSpec.Charts, k0sAPI.Chart{
+	helmSpec.Charts = append(helmSpec.Charts, k0sv1beta1.Chart{
 		Name:      "openebs",
 		ChartName: "openebs-internal/openebs",
 		TargetNS:  "openebs",
@@ -148,7 +148,7 @@ func yamlifyValues(values map[string]interface{}) (string, error) {
 // reconcileHelmExtensions creates instance of Chart CR for each chart of the config file
 // it also reconciles repositories settings
 // the actual helm install/update/delete management is done by ChartReconciler structure
-func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sAPI.HelmExtensions) error {
+func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.HelmExtensions) error {
 	if helmSpec == nil {
 		return nil
 	}
@@ -165,7 +165,7 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sAPI.HelmExt
 			Name:     "addon_crd_manifest",
 			Template: chartCrdTemplate,
 			Data: struct {
-				k0sAPI.Chart
+				k0sv1beta1.Chart
 				Finalizer string
 			}{
 				Chart:     chart,
@@ -177,13 +177,18 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sAPI.HelmExt
 			errs = append(errs, fmt.Errorf("can't create chart CR instance %q: %w", chart.ChartName, err))
 			continue
 		}
-		if err := ec.saver.Save(chart.ManifestFileName(), buf.Bytes()); err != nil {
+		if err := ec.saver.Save(chartManifestFileName(&chart), buf.Bytes()); err != nil {
 			errs = append(errs, fmt.Errorf("can't save addon CRD manifest for chart CR instance %q: %w", chart.ChartName, err))
 			continue
 		}
 	}
 
 	return errors.Join(errs...)
+}
+
+// Determines the file name to use when storing a chart as a manifest on disk.
+func chartManifestFileName(c *k0sv1beta1.Chart) string {
+	return fmt.Sprintf("%d_helm_extension_%s.yaml", c.Order, c.Name)
 }
 
 type ChartReconciler struct {
@@ -200,7 +205,7 @@ func (cr *ChartReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 	cr.L.Tracef("Got helm chart reconciliation request: %s", req)
 	defer cr.L.Tracef("Finished processing helm chart reconciliation request: %s", req)
 
-	var chartInstance v1beta1.Chart
+	var chartInstance helmv1beta1.Chart
 
 	if err := cr.Client.Get(ctx, req.NamespacedName, &chartInstance); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -229,7 +234,7 @@ func (cr *ChartReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 	cr.L.Debugf("Installed or updated reconciliation request: %s", req)
 	return reconcile.Result{}, nil
 }
-func (cr *ChartReconciler) uninstall(ctx context.Context, chart v1beta1.Chart) error {
+func (cr *ChartReconciler) uninstall(ctx context.Context, chart helmv1beta1.Chart) error {
 	if err := cr.helm.UninstallRelease(ctx, chart.Status.ReleaseName, chart.Status.Namespace); err != nil {
 		return fmt.Errorf("can't uninstall release `%s/%s`: %w", chart.Status.Namespace, chart.Status.ReleaseName, err)
 	}
@@ -238,7 +243,7 @@ func (cr *ChartReconciler) uninstall(ctx context.Context, chart v1beta1.Chart) e
 
 const defaultTimeout = time.Duration(10 * time.Minute)
 
-func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart v1beta1.Chart) error {
+func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart helmv1beta1.Chart) error {
 	var err error
 	var chartRelease *release.Release
 	timeout, err := time.ParseDuration(chart.Spec.Timeout)
@@ -298,7 +303,7 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart v1bet
 	return nil
 }
 
-func (cr *ChartReconciler) chartNeedsUpgrade(chart v1beta1.Chart) bool {
+func (cr *ChartReconciler) chartNeedsUpgrade(chart helmv1beta1.Chart) bool {
 	return !(chart.Status.Namespace == chart.Spec.Namespace &&
 		chart.Status.ReleaseName == chart.Spec.ReleaseName &&
 		chart.Status.Version == chart.Spec.Version &&
@@ -310,9 +315,9 @@ func (cr *ChartReconciler) chartNeedsUpgrade(chart v1beta1.Chart) bool {
 // to complete and the chart may have been updated in the meantime. If returns the error returned
 // by the Update operation. Moreover, if the chart has indeed changed in the meantime we already
 // have an event for it so we will see it again soon.
-func (cr *ChartReconciler) updateStatus(ctx context.Context, chart v1beta1.Chart, chartRelease *release.Release, err error) error {
+func (cr *ChartReconciler) updateStatus(ctx context.Context, chart helmv1beta1.Chart, chartRelease *release.Release, err error) error {
 	nsn := types.NamespacedName{Namespace: chart.Namespace, Name: chart.Name}
-	var updchart v1beta1.Chart
+	var updchart helmv1beta1.Chart
 	if err := cr.Get(ctx, nsn, &updchart); err != nil {
 		return fmt.Errorf("can't get updated version of chart %s: %w", chart.Name, err)
 	}
@@ -337,7 +342,7 @@ func (cr *ChartReconciler) updateStatus(ctx context.Context, chart v1beta1.Chart
 	return nil
 }
 
-func (ec *ExtensionsController) addRepo(repo k0sAPI.Repository) error {
+func (ec *ExtensionsController) addRepo(repo k0sv1beta1.Repository) error {
 	return ec.helm.AddRepository(repo)
 }
 
@@ -373,7 +378,7 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 		return fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
 	}
 	gk := schema.GroupKind{
-		Group: v1beta1.SchemeGroupVersion.Group,
+		Group: helmv1beta1.SchemeGroupVersion.Group,
 		Kind:  "Chart",
 	}
 
@@ -400,7 +405,7 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 
 	if err := builder.
 		ControllerManagedBy(mgr).
-		For(&v1beta1.Chart{},
+		For(&helmv1beta1.Chart{},
 			builder.WithPredicates(predicate.And(
 				predicate.GenerationChangedPredicate{},
 				predicate.NewPredicateFuncs(func(object client.Object) bool {

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bombsimon/logrusr/v2"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/apis/helm.k0sproject.io/v1beta1"
+	helmscheme "github.com/k0sproject/k0s/pkg/apis/helm.k0sproject.io/v1beta1/clientset/scheme"
 	k0sAPI "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/manager"
@@ -35,7 +36,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/release"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
@@ -372,13 +372,8 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 		Kind:  "Chart",
 	}
 
-	scheme := runtime.NewScheme()
-	if err := v1beta1.AddToScheme(scheme); err != nil {
-		return err
-	}
-
 	mgr, err := controllerruntime.NewManager(clientConfig, ctrlManager.Options{
-		Scheme:             scheme,
+		Scheme:             helmscheme.Scheme,
 		MetricsBindAddress: "0",
 		Logger:             logrusr.New(ec.L),
 		Controller:         config.Controller{},

--- a/pkg/component/controller/extensions_controller_test.go
+++ b/pkg/component/controller/extensions_controller_test.go
@@ -160,4 +160,5 @@ func TestChartManifestFileName(t *testing.T) {
 	assert.Equal(t, chartManifestFileName(&chart), "0_helm_extension_release.yaml")
 	assert.Equal(t, chartManifestFileName(&chart1), "1_helm_extension_release.yaml")
 	assert.Equal(t, chartManifestFileName(&chart2), "2_helm_extension_release.yaml")
+	assert.True(t, isChartManifestFileName("0_helm_extension_release.yaml"))
 }

--- a/pkg/component/controller/extensions_controller_test.go
+++ b/pkg/component/controller/extensions_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/pkg/apis/helm.k0sproject.io/v1beta1"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s.k0sproject.io/v1beta1"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -133,4 +134,30 @@ func TestChartNeedsUpgrade(t *testing.T) {
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
+}
+
+func TestChartManifestFileName(t *testing.T) {
+	chart := k0sv1beta1.Chart{
+		Name:      "release",
+		ChartName: "k0s/chart",
+		TargetNS:  "default",
+	}
+
+	chart1 := k0sv1beta1.Chart{
+		Name:      "release",
+		ChartName: "k0s/chart",
+		TargetNS:  "default",
+		Order:     1,
+	}
+
+	chart2 := k0sv1beta1.Chart{
+		Name:      "release",
+		ChartName: "k0s/chart",
+		TargetNS:  "default",
+		Order:     2,
+	}
+
+	assert.Equal(t, chartManifestFileName(&chart), "0_helm_extension_release.yaml")
+	assert.Equal(t, chartManifestFileName(&chart1), "1_helm_extension_release.yaml")
+	assert.Equal(t, chartManifestFileName(&chart2), "2_helm_extension_release.yaml")
 }


### PR DESCRIPTION
Backport to `release-1.27`:
* #4762

Instead of reverting the backport of 961f3034dfdabc646e9d705b4d56a89520962644, use the helm clientset instead (764cde837472ace9d64382df7f44b10bd3e15bc3).

See:
* #4705
* #4698