### PR TITLE
Install QEMU emulator in e2e ostests if needed

### DIFF
--- a/.github/workflows/ostests-e2e.yaml
+++ b/.github/workflows/ostests-e2e.yaml
@@ -118,6 +118,9 @@ jobs:
           "$TF_VAR_k0sctl_executable_path" version
 
           if [ -z "$K0S_VERSION" ]; then
+            if [ "$OSTESTS_ARCH" != amd64 ]; then
+              docker run --privileged --rm tonistiigi/binfmt --install "$OSTESTS_ARCH"
+            fi
             chmod +x -- "$K0S_EXECUTABLE_PATH"
             K0S_VERSION="$("$K0S_EXECUTABLE_PATH" version)"
             echo TF_VAR_k0s_executable_path="$K0S_EXECUTABLE_PATH" >>"$GITHUB_ENV"


### PR DESCRIPTION
## Description

This allows for getting the k0s version from the binary if it's for a different architecture. Another approach could be to pass on the k0s version from the build job into the e2e job, but since there's already a k0s-version variable with a special meaning for an empty value, there's not a straight forward way to do this without making things even more complicated.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings