### PR TITLE
Ensure that cgroups is mounted with openrc

### DIFF
--- a/pkg/install/service.go
+++ b/pkg/install/service.go
@@ -94,7 +94,7 @@ func EnsureService(args []string, envVars []string, force bool) error {
 			"LaunchdConfig":  launchdConfig,
 		}
 	case "linux-openrc":
-		deps = []string{"need net", "use dns", "after firewall"}
+		deps = []string{"need cgroups", "need net", "use dns", "after firewall"}
 		svcConfig.Option = map[string]interface{}{
 			"OpenRCScript": openRCScript,
 		}


### PR DESCRIPTION
The worker will fail without it, and it does not hurt to always enable it for the controllers.

ref: https://github.com/k0sproject/k0sctl/issues/688

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/k0sproject/k0sctl/issues/688

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings