### PR TITLE
bug: add support for image tag and digest

### DIFF
--- a/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
@@ -18,10 +18,12 @@ package v1beta1
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/k0sproject/k0s/internal/pkg/iface"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -63,6 +65,31 @@ func TestEmptyClusterSpec(t *testing.T) {
 
 	errs := underTest.Validate()
 	assert.Nil(t, errs)
+}
+
+func TestClusterSpecCustomImages(t *testing.T) {
+	underTest := ClusterConfig{
+		Spec: &ClusterSpec{
+			Images: &ClusterImages{
+				DefaultPullPolicy: string(corev1.PullIfNotPresent),
+				Konnectivity: ImageSpec{
+					Image:   "foo",
+					Version: "v1",
+				},
+				PushGateway: ImageSpec{
+					Image:   "bar",
+					Version: "v2@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+				},
+				MetricsServer: ImageSpec{
+					Image:   "baz",
+					Version: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+				},
+			},
+		},
+	}
+
+	errs := underTest.Validate()
+	assert.Nil(t, errs, fmt.Sprintf("%v", errs))
 }
 
 func TestEtcdDefaults(t *testing.T) {

--- a/pkg/apis/k0s/v1beta1/images.go
+++ b/pkg/apis/k0s/v1beta1/images.go
@@ -35,7 +35,7 @@ type ImageSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	Image string `json:"image"`
 
-	// +kubebuilder:validation:Pattern="[\\w][\\w.-]{0,127}"
+	// +kubebuilder:validation:Pattern="^[\\w][\\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$"
 	Version string `json:"version"`
 }
 
@@ -51,7 +51,8 @@ func (s *ImageSpec) Validate(path *field.Path) (errs field.ErrorList) {
 		errs = append(errs, field.Invalid(path.Child("image"), s.Image, "must not have leading or trailing whitespace"))
 	}
 
-	versionRe := regexp.MustCompile(`^` + reference.TagRegexp.String() + `$`)
+	// Validate the image contains a tag and optional digest
+	versionRe := regexp.MustCompile(`^` + reference.TagRegexp.String() + `(?:@` + reference.DigestRegexp.String() + `)?$`)
 	if !versionRe.MatchString(s.Version) {
 		errs = append(errs, field.Invalid(path.Child("version"), s.Version, "must match regular expression: "+versionRe.String()))
 	}

--- a/pkg/apis/k0s/v1beta1/nllb_test.go
+++ b/pkg/apis/k0s/v1beta1/nllb_test.go
@@ -100,7 +100,7 @@ spec:
 		},
 		{
 			"version", `"*"`,
-			`network: nodeLocalLoadBalancing.envoyProxy.image.version: Invalid value: "*": must match regular expression: ^[\w][\w.-]{0,127}$`,
+			`network: nodeLocalLoadBalancing.envoyProxy.image.version: Invalid value: "*": must match regular expression: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$`,
 		},
 	} {
 		t.Run(test.field+"_invalid", func(t *testing.T) {

--- a/static/manifests/k0s/CustomResourceDefinition/k0s.k0sproject.io_clusterconfigs.yaml
+++ b/static/manifests/k0s/CustomResourceDefinition/k0s.k0sproject.io_clusterconfigs.yaml
@@ -232,7 +232,7 @@ spec:
                             minLength: 1
                             type: string
                           version:
-                            pattern: '[\w][\w.-]{0,127}'
+                            pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
                             type: string
                         required:
                         - image
@@ -245,7 +245,7 @@ spec:
                             minLength: 1
                             type: string
                           version:
-                            pattern: '[\w][\w.-]{0,127}'
+                            pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
                             type: string
                         required:
                         - image
@@ -258,7 +258,7 @@ spec:
                             minLength: 1
                             type: string
                           version:
-                            pattern: '[\w][\w.-]{0,127}'
+                            pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
                             type: string
                         required:
                         - image
@@ -272,7 +272,7 @@ spec:
                         minLength: 1
                         type: string
                       version:
-                        pattern: '[\w][\w.-]{0,127}'
+                        pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
                         type: string
                     required:
                     - image
@@ -292,7 +292,7 @@ spec:
                         minLength: 1
                         type: string
                       version:
-                        pattern: '[\w][\w.-]{0,127}'
+                        pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
                         type: string
                     required:
                     - image
@@ -305,7 +305,7 @@ spec:
                         minLength: 1
                         type: string
                       version:
-                        pattern: '[\w][\w.-]{0,127}'
+                        pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
                         type: string
                     required:
                     - image
@@ -322,7 +322,7 @@ spec:
                             minLength: 1
                             type: string
                           version:
-                            pattern: '[\w][\w.-]{0,127}'
+                            pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
                             type: string
                         required:
                         - image
@@ -335,7 +335,7 @@ spec:
                             minLength: 1
                             type: string
                           version:
-                            pattern: '[\w][\w.-]{0,127}'
+                            pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
                             type: string
                         required:
                         - image
@@ -349,7 +349,7 @@ spec:
                         minLength: 1
                         type: string
                       version:
-                        pattern: '[\w][\w.-]{0,127}'
+                        pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
                         type: string
                     required:
                     - image
@@ -362,7 +362,7 @@ spec:
                         minLength: 1
                         type: string
                       version:
-                        pattern: '[\w][\w.-]{0,127}'
+                        pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
                         type: string
                     required:
                     - image
@@ -375,7 +375,7 @@ spec:
                         minLength: 1
                         type: string
                       version:
-                        pattern: '[\w][\w.-]{0,127}'
+                        pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
                         type: string
                     required:
                     - image
@@ -775,7 +775,7 @@ spec:
                                 minLength: 1
                                 type: string
                               version:
-                                pattern: '[\w][\w.-]{0,127}'
+                                pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
                                 type: string
                             required:
                             - image


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When adding an envoy image with tag and digest I get a failure:

>  invalid node config: spec: network: nodeLocalLoadBalancing.envoyProxy.image.version: Invalid value: "1.29.5-r0@sha256:7856e4d51f6631b1121c79ec93958897f1d90a52ce8d1d3513cff73df6821a2b": must match regular expression: ^[\w][\w.-]{0,127}$

This change adds support for an optional digested image reference.

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings