### PR TITLE
[Backport release-1.30] bug: add support for image tag and digest

### DIFF
--- a/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
@@ -18,10 +18,12 @@ package v1beta1
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/k0sproject/k0s/internal/pkg/iface"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -63,6 +65,31 @@ func TestEmptyClusterSpec(t *testing.T) {
 
 	errs := underTest.Validate()
 	assert.Nil(t, errs)
+}
+
+func TestClusterSpecCustomImages(t *testing.T) {
+	underTest := ClusterConfig{
+		Spec: &ClusterSpec{
+			Images: &ClusterImages{
+				DefaultPullPolicy: string(corev1.PullIfNotPresent),
+				Konnectivity: ImageSpec{
+					Image:   "foo",
+					Version: "v1",
+				},
+				PushGateway: ImageSpec{
+					Image:   "bar",
+					Version: "v2@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+				},
+				MetricsServer: ImageSpec{
+					Image:   "baz",
+					Version: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+				},
+			},
+		},
+	}
+
+	errs := underTest.Validate()
+	assert.Nil(t, errs, fmt.Sprintf("%v", errs))
 }
 
 func TestEtcdDefaults(t *testing.T) {

--- a/pkg/apis/k0s/v1beta1/images.go
+++ b/pkg/apis/k0s/v1beta1/images.go
@@ -48,7 +48,8 @@ func (s *ImageSpec) Validate(path *field.Path) (errs field.ErrorList) {
 		errs = append(errs, field.Invalid(path.Child("image"), s.Image, "must not have leading or trailing whitespace"))
 	}
 
-	versionRe := regexp.MustCompile(`^` + docker.TagRegexp.String() + `$`)
+	// Validate the image contains a tag and optional digest
+	versionRe := regexp.MustCompile(`^` + docker.TagRegexp.String() + `(?:@` + docker.DigestRegexp.String() + `)?$`)
 	if !versionRe.MatchString(s.Version) {
 		errs = append(errs, field.Invalid(path.Child("version"), s.Version, "must match regular expression: "+versionRe.String()))
 	}

--- a/pkg/apis/k0s/v1beta1/nllb_test.go
+++ b/pkg/apis/k0s/v1beta1/nllb_test.go
@@ -100,7 +100,7 @@ spec:
 		},
 		{
 			"version", `"*"`,
-			`network: nodeLocalLoadBalancing.envoyProxy.image.version: Invalid value: "*": must match regular expression: ^[\w][\w.-]{0,127}$`,
+			`network: nodeLocalLoadBalancing.envoyProxy.image.version: Invalid value: "*": must match regular expression: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$`,
 		},
 	} {
 		t.Run(test.field+"_invalid", func(t *testing.T) {


### PR DESCRIPTION
Backport to `release-1.30`:
* #4792