### PR TITLE
Correct the image override YAML snippet in the docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -484,7 +484,6 @@ If you want the list of default images and their versions to be included, use `k
 - `spec.images.coredns`
 - `spec.images.pause`
 - `spec.images.calico.cni`
-- `spec.images.calico.flexvolume`
 - `spec.images.calico.node`
 - `spec.images.calico.kubecontrollers`
 - `spec.images.kuberouter.cni`
@@ -500,15 +499,20 @@ If `spec.images.default_pull_policy` is set and not empty, it will be used as a 
 ```yaml
 images:
   repository: "my.own.repo"
-  konnectivity:
-    image: calico/kube-controllers
-    version: v3.16.2
+  calico:
+    kubecontrollers:
+      image: quay.io/k0sproject/calico-kube-controllers
+      version: v3.27.3-0
   metricsserver:
     image: quay.io/k0sproject/metrics-server
     version: v0.7.1-0
 ```
 
-In the runtime the image names are calculated as `my.own.repo/calico/kube-controllers:v3.16.2` and `my.own.repo/k0sproject/metrics-server:v0.7.1-0`. This only affects the the imgages pull location, and thus omitting an image specification here will not disable component deployment.
+In the runtime the image names are calculated as
+`my.own.repo/k0sproject/calico-kube-controllers:v3.27.3-0` and
+`my.own.repo/k0sproject/metrics-server:v0.7.1-0`. This only affects the the
+images pull location, and thus omitting an image specification here will not
+disable component deployment.
 
 ### `spec.extensions.helm`
 


### PR DESCRIPTION
## Description

The values were referencing a Calico image below the konnectivity key. Remove the non-existing flexdriver field. Also hard-wrap the paragraph below the snippet.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings