### PR TITLE
fix: ClusterImages.Validate images

### DIFF
--- a/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
@@ -18,7 +18,6 @@ package v1beta1
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/k0sproject/k0s/internal/pkg/iface"
@@ -74,7 +73,7 @@ func TestClusterSpecCustomImages(t *testing.T) {
 		},
 	}
 	errs := defaultTestCase.Validate()
-	assert.Nil(t, errs, fmt.Sprintf("%v", errs))
+	assert.Nilf(t, errs, "%v", errs)
 
 	validTestCase := ClusterConfig{
 		Spec: &ClusterSpec{
@@ -92,7 +91,7 @@ func TestClusterSpecCustomImages(t *testing.T) {
 	}
 
 	errs = validTestCase.Validate()
-	assert.Nil(t, errs, fmt.Sprintf("%v", errs))
+	assert.Nilf(t, errs, "%v", errs)
 
 	invalidTestCase := ClusterConfig{
 		Spec: &ClusterSpec{
@@ -104,9 +103,19 @@ func TestClusterSpecCustomImages(t *testing.T) {
 		// digest only is currently not supported
 		Version: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
 	}
+	invalidTestCase.Spec.Images.Calico.CNI = ImageSpec{
+		Image: "qux",
+		// digest only is currently not supported
+		Version: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+	}
+	invalidTestCase.Spec.Images.KubeRouter.CNI = ImageSpec{
+		Image: "quux",
+		// digest only is currently not supported
+		Version: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+	}
 
 	errs = invalidTestCase.Validate()
-	assert.Len(t, errs, 1)
+	assert.Len(t, errs, 3)
 }
 
 func TestEtcdDefaults(t *testing.T) {

--- a/pkg/apis/k0s/v1beta1/images.go
+++ b/pkg/apis/k0s/v1beta1/images.go
@@ -122,11 +122,8 @@ func (ci *ClusterImages) Validate(path *field.Path) (errs field.ErrorList) {
 	errs = append(errs, ci.KubeProxy.Validate(path.Child("kubeproxy"))...)
 	errs = append(errs, ci.CoreDNS.Validate(path.Child("coredns"))...)
 	errs = append(errs, ci.Pause.Validate(path.Child("pause"))...)
-	errs = append(errs, ci.Calico.CNI.Validate(path.Child("calico").Child("cni"))...)
-	errs = append(errs, ci.Calico.Node.Validate(path.Child("calico").Child("node"))...)
-	errs = append(errs, ci.Calico.KubeControllers.Validate(path.Child("calico").Child("kubecontrollers"))...)
-	errs = append(errs, ci.KubeRouter.CNI.Validate(path.Child("kuberouter").Child("cni"))...)
-	errs = append(errs, ci.KubeRouter.CNIInstaller.Validate(path.Child("kuberouter").Child("cniInstaller"))...)
+	errs = append(errs, ci.Calico.Validate(path.Child("calico"))...)
+	errs = append(errs, ci.KubeRouter.Validate(path.Child("kuberouter"))...)
 	return
 }
 
@@ -156,10 +153,29 @@ type CalicoImageSpec struct {
 	KubeControllers ImageSpec `json:"kubecontrollers,omitempty"`
 }
 
+func (s *CalicoImageSpec) Validate(path *field.Path) (errs field.ErrorList) {
+	if s == nil {
+		return
+	}
+	errs = append(errs, s.CNI.Validate(path.Child("cni"))...)
+	errs = append(errs, s.Node.Validate(path.Child("node"))...)
+	errs = append(errs, s.KubeControllers.Validate(path.Child("kubecontrollers"))...)
+	return
+}
+
 // KubeRouterImageSpec config group for kube-router related images
 type KubeRouterImageSpec struct {
 	CNI          ImageSpec `json:"cni,omitempty"`
 	CNIInstaller ImageSpec `json:"cniInstaller,omitempty"`
+}
+
+func (s *KubeRouterImageSpec) Validate(path *field.Path) (errs field.ErrorList) {
+	if s == nil {
+		return
+	}
+	errs = append(errs, s.CNI.Validate(path.Child("cni"))...)
+	errs = append(errs, s.CNIInstaller.Validate(path.Child("cniInstaller"))...)
+	return
 }
 
 // DefaultClusterImages default image settings

--- a/pkg/apis/k0s/v1beta1/images.go
+++ b/pkg/apis/k0s/v1beta1/images.go
@@ -116,6 +116,17 @@ func (ci *ClusterImages) Validate(path *field.Path) (errs field.ErrorList) {
 		}))
 	}
 
+	errs = append(errs, ci.Konnectivity.Validate(path.Child("konnectivity"))...)
+	errs = append(errs, ci.PushGateway.Validate(path.Child("pushgateway"))...)
+	errs = append(errs, ci.MetricsServer.Validate(path.Child("metricsserver"))...)
+	errs = append(errs, ci.KubeProxy.Validate(path.Child("kubeproxy"))...)
+	errs = append(errs, ci.CoreDNS.Validate(path.Child("coredns"))...)
+	errs = append(errs, ci.Pause.Validate(path.Child("pause"))...)
+	errs = append(errs, ci.Calico.CNI.Validate(path.Child("calico").Child("cni"))...)
+	errs = append(errs, ci.Calico.Node.Validate(path.Child("calico").Child("node"))...)
+	errs = append(errs, ci.Calico.KubeControllers.Validate(path.Child("calico").Child("kubecontrollers"))...)
+	errs = append(errs, ci.KubeRouter.CNI.Validate(path.Child("kuberouter").Child("cni"))...)
+	errs = append(errs, ci.KubeRouter.CNIInstaller.Validate(path.Child("kuberouter").Child("cniInstaller"))...)
 	return
 }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

ClusterImages.Validate does not currently call Validate on the nested ImageSpecs resulting in the possibility of including invalid images. This change adds validation for all ImageSpecs under the ClusterImages struct.

Follow up to https://github.com/k0sproject/k0s/pull/4792

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings