### PR TITLE
[Backport release-1.29] Bump Go to v1.22.5

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.19
 alpine_patch_version = $(alpine_version).2
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.22.1
+go_version = 1.22.2
 
 runc_version = 1.1.13
 runc_buildimage = $(golang_buildimage)

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.19
 alpine_patch_version = $(alpine_version).2
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.22.3
+go_version = 1.22.4
 
 runc_version = 1.1.13
 runc_buildimage = $(golang_buildimage)

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.19
 alpine_patch_version = $(alpine_version).2
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.22.2
+go_version = 1.22.3
 
 runc_version = 1.1.13
 runc_buildimage = $(golang_buildimage)

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.19
 alpine_patch_version = $(alpine_version).2
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.22.0
+go_version = 1.22.1
 
 runc_version = 1.1.13
 runc_buildimage = $(golang_buildimage)

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.19
 alpine_patch_version = $(alpine_version).2
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.22.4
+go_version = 1.22.5
 
 runc_version = 1.1.13
 runc_buildimage = $(golang_buildimage)

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.19
 alpine_patch_version = $(alpine_version).2
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.21.12
+go_version = 1.22.0
 
 runc_version = 1.1.13
 runc_buildimage = $(golang_buildimage)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k0sproject/k0s
 
-go 1.21.0
+go 1.22
 
 // k0s
 require (

--- a/hack/tool/go.mod
+++ b/hack/tool/go.mod
@@ -1,6 +1,6 @@
 module tool
 
-go 1.21.0
+go 1.22
 
 require (
 	github.com/hashicorp/terraform-exec v0.20.0


### PR DESCRIPTION
Backport to `release-1.29`:
* #4115
* #4170
* #4235
* #4389
* #4562
* #4765

See:
* #4550
* #4748

Upstream Kubernetes did the same.