### PR TITLE
Remove unused error return type from Supervisor.Stop

### DIFF
--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -201,7 +201,8 @@ func (a *APIServer) writeKonnectivityConfig() error {
 
 // Stop stops APIServer
 func (a *APIServer) Stop() error {
-	return a.supervisor.Stop()
+	a.supervisor.Stop()
+	return nil
 }
 
 // Health-check interface

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -143,11 +143,8 @@ func (a *Manager) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterCon
 	// Stop in case there's process running already and we need to change the config
 	if a.supervisor != nil {
 		logger.Info("reconcile has nothing to do")
-		err := a.supervisor.Stop()
+		a.supervisor.Stop()
 		a.supervisor = nil
-		if err != nil {
-			return err
-		}
 	}
 
 	a.supervisor = &supervisor.Supervisor{
@@ -166,7 +163,7 @@ func (a *Manager) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterCon
 // Stop stops Manager
 func (a *Manager) Stop() error {
 	if a.supervisor != nil {
-		return a.supervisor.Stop()
+		a.supervisor.Stop()
 	}
 	return nil
 }

--- a/pkg/component/controller/cplb_unix.go
+++ b/pkg/component/controller/cplb_unix.go
@@ -157,10 +157,7 @@ func (k *Keepalived) Stop() error {
 	}
 
 	k.log.Infof("Stopping keepalived")
-	if err := k.supervisor.Stop(); err != nil {
-		// Failed to stop keepalived. Don't delete the VIP, just in case.
-		return fmt.Errorf("failed to stop keepalived: %w", err)
-	}
+	k.supervisor.Stop()
 
 	k.log.Infof("Deleting dummy interface")
 	link, err := netlink.LinkByName(dummyLinkName)

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -251,7 +251,8 @@ func (e *Etcd) Stop() error {
 		return nil
 	}
 
-	return e.supervisor.Stop()
+	e.supervisor.Stop()
+	return nil
 }
 
 func (e *Etcd) setupCerts(ctx context.Context) error {

--- a/pkg/component/controller/k0scontrolapi.go
+++ b/pkg/component/controller/k0scontrolapi.go
@@ -65,5 +65,6 @@ func (m *K0SControlAPI) Start(_ context.Context) error {
 
 // Stop stops k0s api
 func (m *K0SControlAPI) Stop() error {
-	return m.supervisor.Stop()
+	m.supervisor.Stop()
+	return nil
 }

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -128,7 +128,8 @@ func (k *Kine) Start(ctx context.Context) error {
 
 // Stop stops kine
 func (k *Kine) Stop() error {
-	return k.supervisor.Stop()
+	k.supervisor.Stop()
+	return nil
 }
 
 const hcKey = "/k0s-health-check"

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -176,9 +176,7 @@ func (k *Konnectivity) runServer(count int) error {
 	if k.supervisor != nil {
 		k.EmitWithPayload("restarting konnectivity server due to server count change",
 			map[string]interface{}{"serverCount": count})
-		if err := k.supervisor.Stop(); err != nil {
-			k.log.Errorf("failed to stop supervisor: %s", err)
-		}
+		k.supervisor.Stop()
 	}
 
 	k.supervisor = &supervisor.Supervisor{
@@ -228,7 +226,8 @@ func (k *Konnectivity) Stop() error {
 		return nil
 	}
 	logrus.Debug("about to stop konnectivity supervisor")
-	return k.supervisor.Stop()
+	k.supervisor.Stop()
+	return nil
 }
 
 func (k *Konnectivity) health(ctx context.Context, path string) error {

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -66,7 +66,7 @@ func (a *Scheduler) Start(_ context.Context) error {
 // Stop stops Scheduler
 func (a *Scheduler) Stop() error {
 	if a.supervisor != nil {
-		return a.supervisor.Stop()
+		a.supervisor.Stop()
 	}
 	return nil
 }
@@ -105,11 +105,8 @@ func (a *Scheduler) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterC
 	// Stop in case there's process running already and we need to change the config
 	if a.supervisor != nil {
 		logrus.WithField("component", kubeSchedulerComponentName).Info("reconcile has nothing to do")
-		err := a.supervisor.Stop()
+		a.supervisor.Stop()
 		a.supervisor = nil
-		if err != nil {
-			return err
-		}
 	}
 
 	a.supervisor = &supervisor.Supervisor{

--- a/pkg/component/worker/containerd/component.go
+++ b/pkg/component/worker/containerd/component.go
@@ -311,7 +311,8 @@ func (c *Component) Stop() error {
 	if runtime.GOOS == "windows" {
 		return c.windowsStop()
 	}
-	return c.supervisor.Stop()
+	c.supervisor.Stop()
+	return nil
 }
 
 // This is the md5sum of the default k0s containerd config file before 1.27

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -262,7 +262,8 @@ func (k *Kubelet) Start(ctx context.Context) error {
 
 // Stop stops kubelet
 func (k *Kubelet) Stop() error {
-	return k.supervisor.Stop()
+	k.supervisor.Stop()
+	return nil
 }
 
 func (k *Kubelet) prepareLocalKubeletConfig(kubeletConfigData kubeletConfig) (string, error) {

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -225,12 +225,12 @@ func (s *Supervisor) Supervise() error {
 }
 
 // Stop stops the supervised
-func (s *Supervisor) Stop() error {
+func (s *Supervisor) Stop() {
 	s.startStopMutex.Lock()
 	defer s.startStopMutex.Unlock()
 	if s.cancel == nil || s.log == nil {
 		s.log.Warn("Not started")
-		return nil
+		return
 	}
 	s.log.Debug("Sending stop message")
 
@@ -240,7 +240,6 @@ func (s *Supervisor) Stop() error {
 	if s.done != nil {
 		<-s.done
 	}
-	return nil
 }
 
 // Prepare the env for exec:


### PR DESCRIPTION
## Description

This method always returns a nil error, and it doesn't implement any interface, so removing the error return type makes sense and allows us to remove quite a bit of error handling from callers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings