### PR TITLE
Use dynamic base IDs for NLLB envoy process

### DIFF
--- a/pkg/component/worker/nllb/envoy.go
+++ b/pkg/component/worker/nllb/envoy.go
@@ -282,6 +282,7 @@ func makePodManifest(params *envoyParams, podParams *envoyPodParams) corev1.Pod 
 				Image:           podParams.image.URI(),
 				ImagePullPolicy: podParams.pullPolicy,
 				Ports:           ports,
+				Args:            []string{"-c", "/etc/envoy/envoy.yaml", "--use-dynamic-base-id"},
 				SecurityContext: &corev1.SecurityContext{
 					ReadOnlyRootFilesystem:   ptr.To(true),
 					Privileged:               ptr.To(false),


### PR DESCRIPTION
## Description

Envoy uses some abstract UDP sockets with fixed names for its hot-reloading facilities. Since the NLLB envoy process runs on the host network, and abstract sockets are [part of the network namespace][1], this is a blocker for running multiple envoy processes in parallel without tuning their startup parameters, so that they don't use the same socket names and fail.

The [`--use-dynamic-base-id`][2] CLI flag makes envoy pick random base IDs (the base ID is part of the abstract socket names) and retry for a while until it can bind to a socket that is not already in use. This makes NLLB work well with any other envoys that may be running on the k0s worker's host machine.

Now that we are providing custom arguments to the image, we need to duplicate the default ones, which is the reference to the configuration file.

[1]: https://www.man7.org/linux/man-pages/man7/network_namespaces.7.html
[2]: https://www.envoyproxy.io/docs/envoy/v1.31.0/operations/cli.html#cmdoption-use-dynamic-base-id

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings