### PR TITLE
Validate storage type

### DIFF
--- a/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
@@ -51,7 +51,7 @@ metadata:
 
 	c, err := ConfigFromString(yamlData)
 	assert.NoError(t, err)
-	assert.Equal(t, "etcd", c.Spec.Storage.Type)
+	assert.Equal(t, EtcdStorageType, c.Spec.Storage.Type)
 	addr, err := iface.FirstPublicAddress()
 	assert.NoError(t, err)
 	assert.Equal(t, addr, c.Spec.Storage.Etcd.PeerAddress)
@@ -131,7 +131,7 @@ spec:
 
 	c, err := ConfigFromString(yamlData)
 	assert.NoError(t, err)
-	assert.Equal(t, "etcd", c.Spec.Storage.Type)
+	assert.Equal(t, EtcdStorageType, c.Spec.Storage.Type)
 	addr, err := iface.FirstPublicAddress()
 	assert.NoError(t, err)
 	assert.Equal(t, addr, c.Spec.Storage.Etcd.PeerAddress)

--- a/pkg/apis/k0s/v1beta1/storage.go
+++ b/pkg/apis/k0s/v1beta1/storage.go
@@ -22,14 +22,15 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
-
-	"k8s.io/utils/strings/slices"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/k0sproject/k0s/internal/pkg/iface"
 	"github.com/k0sproject/k0s/pkg/constant"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/sirupsen/logrus"
 )
 
 var _ Validateable = (*StorageSpec)(nil)
@@ -115,6 +116,12 @@ func (s *StorageSpec) Validate() []error {
 	}
 
 	var errors []error
+
+	if s.Type == "" {
+		errors = append(errors, field.Required(field.NewPath("type"), ""))
+	} else if types := []StorageType{EtcdStorageType, KineStorageType}; !slices.Contains(types, s.Type) {
+		errors = append(errors, field.NotSupported(field.NewPath("type"), s.Type, types))
+	}
 
 	if s.Etcd != nil && s.Etcd.ExternalCluster != nil {
 		errors = append(errors, validateRequiredProperties(s.Etcd.ExternalCluster)...)

--- a/pkg/apis/k0s/v1beta1/storage.go
+++ b/pkg/apis/k0s/v1beta1/storage.go
@@ -32,12 +32,6 @@ import (
 	"github.com/k0sproject/k0s/pkg/constant"
 )
 
-// supported storage types
-const (
-	EtcdStorageType = "etcd"
-	KineStorageType = "kine"
-)
-
 var _ Validateable = (*StorageSpec)(nil)
 
 // StorageSpec defines the storage related config options
@@ -46,10 +40,20 @@ type StorageSpec struct {
 	Kine *KineConfig `json:"kine,omitempty"`
 
 	// Type of the data store (valid values:etcd or kine)
-	// +kubebuilder:validation:Enum=etcd;kine
 	// +kubebuilder:default="etcd"
-	Type string `json:"type,omitempty"`
+	Type StorageType `json:"type,omitempty"`
 }
+
+// StorageType describes which type of bacing storage should be used for the
+// Kubernetes API server. The default is [NllbTypeEnvoyProxy].
+// +kubebuilder:validation:Enum=etcd;kine
+type StorageType string
+
+// supported storage types
+const (
+	EtcdStorageType StorageType = "etcd"
+	KineStorageType StorageType = "kine"
+)
 
 // KineConfig defines the Kine related config options
 type KineConfig struct {

--- a/pkg/apis/k0s/v1beta1/storage_test.go
+++ b/pkg/apis/k0s/v1beta1/storage_test.go
@@ -172,6 +172,12 @@ func (s *storageSuite) TestValidation() {
 				},
 			},
 		},
+		{
+			desc: "kine_is_valid",
+			spec: &StorageSpec{
+				Type: KineStorageType,
+			},
+		},
 	}
 
 	for _, tt := range validStorageSpecs {
@@ -185,6 +191,18 @@ func (s *storageSuite) TestValidation() {
 		spec           *StorageSpec
 		expectedErrMsg string
 	}{
+		{
+			desc:           "type_is_required",
+			spec:           &StorageSpec{},
+			expectedErrMsg: "type: Required value",
+		},
+		{
+			desc: "unknown_types_are_rejected",
+			spec: &StorageSpec{
+				Type: StorageType("bogus"),
+			},
+			expectedErrMsg: `type: Unsupported value: "bogus": supported values: "etcd", "kine"`,
+		},
 		{
 			desc: "external_cluster_endpoints_cannot_be_null",
 			spec: &StorageSpec{

--- a/pkg/apis/k0s/v1beta1/storage_test.go
+++ b/pkg/apis/k0s/v1beta1/storage_test.go
@@ -112,7 +112,7 @@ spec:
 `
 	c, err := ConfigFromString(yaml)
 	assert.NoError(t, err)
-	assert.Equal(t, "kine", c.Spec.Storage.Type)
+	assert.Equal(t, KineStorageType, c.Spec.Storage.Type)
 	assert.NotNil(t, c.Spec.Storage.Kine)
 
 	expectedPath := "/var/lib/k0s/db/state.db"

--- a/pkg/autopilot/controller/updates/clusterinfo.go
+++ b/pkg/autopilot/controller/updates/clusterinfo.go
@@ -34,7 +34,7 @@ import (
 // ClusterInfo holds cluster related information that the update server can use to determine which updates to push to clusters
 type ClusterInfo struct {
 	K0sVersion             string
-	StorageType            string
+	StorageType            v1beta1.StorageType
 	ClusterID              string
 	ControlPlaneNodesCount int
 	WorkerData             WorkerData
@@ -56,7 +56,7 @@ func (ci *ClusterInfo) AsMap() map[string]string {
 	}
 	workerData := base64.StdEncoding.EncodeToString(wd)
 	return map[string]string{
-		"K0S_StorageType":            ci.StorageType,
+		"K0S_StorageType":            string(ci.StorageType),
 		"K0S_ClusterID":              ci.ClusterID,
 		"K0S_ControlPlaneNodesCount": fmt.Sprintf("%d", ci.ControlPlaneNodesCount),
 		"K0S_WorkerData":             workerData,

--- a/pkg/component/controller/metrics.go
+++ b/pkg/component/controller/metrics.go
@@ -49,7 +49,7 @@ type Metrics struct {
 	K0sVars     *config.CfgVars
 	saver       manifestsSaver
 	restClient  rest.Interface
-	storageType string
+	storageType v1beta1.StorageType
 
 	clusterConfig *v1beta1.ClusterConfig
 	tickerDone    context.CancelFunc
@@ -60,7 +60,7 @@ var _ manager.Component = (*Metrics)(nil)
 var _ manager.Reconciler = (*Metrics)(nil)
 
 // NewMetrics creates new Metrics reconciler
-func NewMetrics(k0sVars *config.CfgVars, saver manifestsSaver, clientCF kubernetes.ClientFactoryInterface, storageType string) (*Metrics, error) {
+func NewMetrics(k0sVars *config.CfgVars, saver manifestsSaver, clientCF kubernetes.ClientFactoryInterface, storageType v1beta1.StorageType) (*Metrics, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, err

--- a/pkg/config/cfgvars.go
+++ b/pkg/config/cfgvars.go
@@ -41,26 +41,26 @@ const (
 // Some of the variables are duplicates of the ones in the CLIOptions struct
 // for historical and convenience reasons.
 type CfgVars struct {
-	InvocationID               string // Unique ID for this invocation of k0s
-	AdminKubeConfigPath        string // The cluster admin kubeconfig location
-	BinDir                     string // location for all pki related binaries
-	CertRootDir                string // CertRootDir defines the root location for all pki related artifacts
-	DataDir                    string // Data directory containing k0s state
-	EtcdCertDir                string // EtcdCertDir contains etcd certificates
-	EtcdDataDir                string // EtcdDataDir contains etcd state
-	KineSocketPath             string // The unix socket path for kine
-	KonnectivitySocketDir      string // location of konnectivity's socket path
-	KubeletAuthConfigPath      string // KubeletAuthConfigPath defines the default kubelet auth config path
-	KubeletVolumePluginDir     string // location for kubelet plugins volume executables
-	ManifestsDir               string // location for all stack manifests
-	RunDir                     string // location of supervised pid files and sockets
-	KonnectivityKubeConfigPath string // location for konnectivity kubeconfig
-	OCIBundleDir               string // location for OCI bundles
-	DefaultStorageType         string // Default backend storage
-	RuntimeConfigPath          string // A static copy of the config loaded at startup
-	StatusSocketPath           string // The unix socket path for k0s status API
-	StartupConfigPath          string // The path to the config file used at startup
-	EnableDynamicConfig        bool   // EnableDynamicConfig enables dynamic config
+	InvocationID               string              // Unique ID for this invocation of k0s
+	AdminKubeConfigPath        string              // The cluster admin kubeconfig location
+	BinDir                     string              // location for all pki related binaries
+	CertRootDir                string              // CertRootDir defines the root location for all pki related artifacts
+	DataDir                    string              // Data directory containing k0s state
+	EtcdCertDir                string              // EtcdCertDir contains etcd certificates
+	EtcdDataDir                string              // EtcdDataDir contains etcd state
+	KineSocketPath             string              // The unix socket path for kine
+	KonnectivitySocketDir      string              // location of konnectivity's socket path
+	KubeletAuthConfigPath      string              // KubeletAuthConfigPath defines the default kubelet auth config path
+	KubeletVolumePluginDir     string              // location for kubelet plugins volume executables
+	ManifestsDir               string              // location for all stack manifests
+	RunDir                     string              // location of supervised pid files and sockets
+	KonnectivityKubeConfigPath string              // location for konnectivity kubeconfig
+	OCIBundleDir               string              // location for OCI bundles
+	DefaultStorageType         v1beta1.StorageType // Default backend storage
+	RuntimeConfigPath          string              // A static copy of the config loaded at startup
+	StatusSocketPath           string              // The unix socket path for k0s status API
+	StartupConfigPath          string              // The path to the config file used at startup
+	EnableDynamicConfig        bool                // EnableDynamicConfig enables dynamic config
 
 	// Helm config
 	HelmHome             string

--- a/pkg/config/cfgvars_test.go
+++ b/pkg/config/cfgvars_test.go
@@ -80,7 +80,7 @@ func TestWithCommand_DefaultsAndOverrides(t *testing.T) {
 	testCases := []struct {
 		name                string
 		flagValue           any
-		expectedStorageType string
+		expectedStorageType v1beta1.StorageType
 	}{
 		{
 			name:                "single flag is set to false",

--- a/pkg/telemetry/component.go
+++ b/pkg/telemetry/component.go
@@ -36,7 +36,7 @@ import (
 // Component is a telemetry component for k0s component manager
 type Component struct {
 	K0sVars           *config.CfgVars
-	StorageType       string
+	StorageType       v1beta1.StorageType
 	KubeClientFactory kubeutil.ClientFactoryInterface
 
 	log *logrus.Entry

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/build"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 
@@ -32,7 +33,7 @@ import (
 )
 
 type telemetryData struct {
-	StorageType            string
+	StorageType            v1beta1.StorageType
 	ClusterID              string
 	WorkerNodesCount       int
 	ControlPlaneNodesCount int
@@ -51,7 +52,7 @@ type workerSums struct {
 
 func (td telemetryData) asProperties() analytics.Properties {
 	return analytics.Properties{
-		"storageType":            td.StorageType,
+		"storageType":            string(td.StorageType),
 		"clusterID":              td.ClusterID,
 		"workerNodesCount":       td.WorkerNodesCount,
 		"controlPlaneNodesCount": td.ControlPlaneNodesCount,


### PR DESCRIPTION
## Description

There was no validation for the k0s storage type yet. Introduce the `StorageType` newtype and validate its values in the StorageSpec's `Validate` method.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings