### PR TITLE
Allow all kine schemes to be joined except the local ones

### DIFF
--- a/pkg/apis/k0s/v1beta1/storage.go
+++ b/pkg/apis/k0s/v1beta1/storage.go
@@ -67,20 +67,11 @@ func DefaultStorageSpec() *StorageSpec {
 
 // IsJoinable returns true only if the storage config is such that another controller can join the cluster
 func (s *StorageSpec) IsJoinable() bool {
-	if s.Type == EtcdStorageType {
+	switch s.Type {
+	case EtcdStorageType:
 		return !s.Etcd.IsExternalClusterUsed()
-	}
-
-	if strings.HasPrefix(s.Kine.DataSource, "sqlite:") {
-		return false
-	}
-
-	if strings.HasPrefix(s.Kine.DataSource, "mysql:") {
-		return true
-	}
-
-	if strings.HasPrefix(s.Kine.DataSource, "postgres:") {
-		return true
+	case KineStorageType:
+		return s.Kine.IsJoinable()
 	}
 
 	return false
@@ -187,6 +178,22 @@ func DefaultKineConfig(dataDir string) *KineConfig {
 			RawQuery: "mode=rwc&_journal=WAL&cache=shared",
 		}).String(),
 	}
+}
+
+func (k *KineConfig) IsJoinable() bool {
+	if strings.HasPrefix(k.DataSource, "sqlite:") {
+		return false
+	}
+
+	if strings.HasPrefix(k.DataSource, "mysql:") {
+		return true
+	}
+
+	if strings.HasPrefix(k.DataSource, "postgres:") {
+		return true
+	}
+
+	return false
 }
 
 // GetEndpointsAsString returns comma-separated list of external cluster endpoints if exist

--- a/pkg/apis/k0s/v1beta1/storage_test.go
+++ b/pkg/apis/k0s/v1beta1/storage_test.go
@@ -85,6 +85,36 @@ func TestStorageSpec_IsJoinable(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "kine-jetstream",
+			storage: StorageSpec{
+				Type: "kine",
+				Kine: &KineConfig{
+					DataSource: "jetstream://",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "kine-nats",
+			storage: StorageSpec{
+				Type: "kine",
+				Kine: &KineConfig{
+					DataSource: "nats://",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "kine-nats-noembed",
+			storage: StorageSpec{
+				Type: "kine",
+				Kine: &KineConfig{
+					DataSource: "nats://?noEmbed",
+				},
+			},
+			want: true,
+		},
+		{
 			name: "kine-unknown",
 			storage: StorageSpec{
 				Type: "kine",
@@ -92,14 +122,22 @@ func TestStorageSpec_IsJoinable(t *testing.T) {
 					DataSource: "unknown://foobar",
 				},
 			},
+			want: true,
+		},
+		{
+			name: "kine-none",
+			storage: StorageSpec{
+				Type: "kine",
+				Kine: &KineConfig{
+					DataSource: "",
+				},
+			},
 			want: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.storage.IsJoinable(); got != tt.want {
-				t.Errorf("StorageSpec.IsJoinable() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, tt.storage.IsJoinable())
 		})
 	}
 }


### PR DESCRIPTION
## Description

Instead of whitelisting all the schemes, it is probably better to blacklist the ones that are known to be local. This allows for joining e.g. when external NATS storage is used via the jetstream scheme.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings