### PR TITLE
Allow reading config file from stdin

### DIFF
--- a/pkg/config/cfgvars.go
+++ b/pkg/config/cfgvars.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -67,6 +68,7 @@ type CfgVars struct {
 	HelmRepositoryCache  string
 	HelmRepositoryConfig string
 
+	stdin      io.Reader
 	nodeConfig *v1beta1.ClusterConfig
 	origin     CfgVarsOriginType
 }
@@ -89,11 +91,14 @@ type CfgVarOption func(*CfgVars)
 
 // Command represents cobra.Command
 type command interface {
+	InOrStdin() io.Reader
 	Flags() *pflag.FlagSet
 }
 
 func WithCommand(cmd command) CfgVarOption {
 	return func(c *CfgVars) {
+		c.stdin = cmd.InOrStdin()
+
 		flags := cmd.Flags()
 
 		if f, err := flags.GetString("data-dir"); err == nil && f != "" {
@@ -193,6 +198,7 @@ func NewCfgVars(cobraCmd command, dirs ...string) (*CfgVars, error) {
 		HelmRepositoryCache:  filepath.Join(helmHome, "cache"),
 		HelmRepositoryConfig: filepath.Join(helmHome, "repositories.yaml"),
 
+		stdin:  os.Stdin,
 		origin: CfgVarsOriginDefault,
 	}
 
@@ -238,17 +244,31 @@ func (c *CfgVars) NodeConfig() (*v1beta1.ClusterConfig, error) {
 
 	var nodeConfig *v1beta1.ClusterConfig
 
-	cfgContent, err := os.ReadFile(c.StartupConfigPath)
-	if errors.Is(err, os.ErrNotExist) && c.StartupConfigPath == defaultConfigPath {
-		nodeConfig = v1beta1.DefaultClusterConfig(c.defaultStorageSpec())
-	} else if err == nil {
-		cfg, err := v1beta1.ConfigFromString(string(cfgContent), c.defaultStorageSpec())
+	if c.StartupConfigPath == "-" {
+		configReader := c.stdin
+		c.stdin = nil
+		if configReader == nil {
+			return nil, errors.New("stdin already grabbed")
+		}
+
+		var err error
+		nodeConfig, err = v1beta1.ConfigFromReader(configReader, c.defaultStorageSpec())
 		if err != nil {
 			return nil, err
 		}
-		nodeConfig = cfg
 	} else {
-		return nil, err
+		cfgContent, err := os.ReadFile(c.StartupConfigPath)
+		if errors.Is(err, os.ErrNotExist) && c.StartupConfigPath == defaultConfigPath {
+			nodeConfig = v1beta1.DefaultClusterConfig(c.defaultStorageSpec())
+		} else if err == nil {
+			cfg, err := v1beta1.ConfigFromString(string(cfgContent), c.defaultStorageSpec())
+			if err != nil {
+				return nil, err
+			}
+			nodeConfig = cfg
+		} else {
+			return nil, err
+		}
 	}
 
 	if nodeConfig.Spec.Storage.Type == v1beta1.KineStorageType && nodeConfig.Spec.Storage.Kine == nil {


### PR DESCRIPTION
## Description

This was documented to be supported for a long time, but never really worked, except for "k0s config validate".

When constructing the `CfgVars` struct, capture stdin, or the cobra command's input if specified. When constructing the node config, check if a hyphen was given as the startup path. If so, grab the previously saved input reader and get the config from there.

Fixes #2917.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings