### PR TITLE
[Backport release-1.29] [helm] don't start reconciler before leaderelection

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"syscall"
 	"time"
 
@@ -57,7 +58,6 @@ import (
 	"github.com/k0sproject/k0s/pkg/token"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 )
 
 type command config.CLIOptions

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/k0sproject/k0s/pkg/config"
@@ -34,7 +35,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 )
 
 func checkKubectlInPath() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -19,12 +19,12 @@ package cmd_test
 import (
 	"bytes"
 	"io"
+	"slices"
 	"testing"
 
 	"github.com/k0sproject/k0s/cmd"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/slices"
 )
 
 // TestRootCmd_Flags ensures that no unwanted global flags have been registered

--- a/inttest/ap-ha3x3/ha3x3_test.go
+++ b/inttest/ap-ha3x3/ha3x3_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -32,7 +33,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/exp/slices"
 )
 
 type ha3x3Suite struct {

--- a/inttest/nllb/nllb_test.go
+++ b/inttest/nllb/nllb_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -39,7 +40,6 @@ import (
 
 	testifysuite "github.com/stretchr/testify/suite"
 	"go.uber.org/multierr"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"sigs.k8s.io/yaml"
 )

--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -21,12 +21,12 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -41,7 +42,6 @@ import (
 	"github.com/k0sproject/k0s/pkg/helm"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -67,6 +68,12 @@ type ExtensionsController struct {
 	kubeConfig    string
 	leaderElector leaderelector.Interface
 	manifestsDir  string
+	startChan     chan struct{}
+	mux           sync.Mutex
+	mgr           crman.Manager
+	mgrCtx        context.Context
+	mgrCancelFn   context.CancelFunc
+	controllerCtx context.Context
 }
 
 var _ manager.Component = (*ExtensionsController)(nil)
@@ -452,9 +459,76 @@ func (ec *ExtensionsController) Init(_ context.Context) error {
 
 // Start
 func (ec *ExtensionsController) Start(ctx context.Context) error {
+	ec.L.Debug("Starting")
+	ec.startChan = make(chan struct{}, 1)
+
+	// Do the first validation before setting callbacks
+	ec.mgrCtx, ec.mgrCancelFn = context.WithCancel(ctx)
+	var err error
+	ec.mgr, err = ec.instantiateManager(ec.mgrCtx)
+	if err != nil {
+		ec.L.WithError(err).Error("Can't instantiate controller-runtime manager")
+		ec.mgrCancelFn()
+		return err
+	}
+
+	ec.leaderElector.AddLostLeaseCallback(ec.leaseLost)
+
+	ec.leaderElector.AddAcquiredLeaseCallback(ec.leaseAcquired)
+
+	// It's possible that by the time we added the callback, we are already the leader,
+	// If this is true the callback will not be called, so we need to check if we are
+	// the leader and notify the channel manually
+	if ec.leaderElector.IsLeader() {
+		ec.leaseAcquired()
+	}
+
+	go ec.watchStartChan()
+	return nil
+}
+
+func (ec *ExtensionsController) leaseLost() {
+	ec.mux.Lock()
+	defer ec.mux.Unlock()
+	ec.L.Warn("Lost leader lease, stopping controller-manager")
+	ec.mgrCancelFn()
+	ec.mgr = nil
+}
+
+func (ec *ExtensionsController) watchStartChan() {
+	ec.L.Debug("Watching start channel")
+	for range ec.startChan {
+		ec.L.Info("Acquired leader lease")
+		ec.mux.Lock()
+		if ec.mgr == nil {
+			ec.L.Info("Instantiating controller-runtime manager")
+			ec.mgrCtx, ec.mgrCancelFn = context.WithCancel(ec.controllerCtx)
+			var err error
+			ec.mgr, err = ec.instantiateManager(ec.controllerCtx)
+			if err != nil {
+				ec.L.WithError(err).Error("Can't instantiate controller-runtime manager")
+				ec.mux.Unlock()
+				return
+			}
+		}
+		ec.mux.Unlock()
+		ec.startControllerManager()
+	}
+	ec.L.Info("Start channel closed, stopping controller-manager")
+}
+
+func (ec *ExtensionsController) leaseAcquired() {
+	ec.L.Info("Acquired leader lease")
+	select {
+	case ec.startChan <- struct{}{}:
+	default:
+	}
+}
+
+func (ec *ExtensionsController) instantiateManager(ctx context.Context) (crman.Manager, error) {
 	clientConfig, err := clientcmd.BuildConfigFromFlags("", ec.kubeConfig)
 	if err != nil {
-		return fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
+		return nil, fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
 	}
 	gk := schema.GroupKind{
 		Group: helmapi.GroupName,
@@ -470,7 +544,7 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 		Controller: ctrlconfig.Controller{},
 	})
 	if err != nil {
-		return fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
+		return nil, fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
 	}
 	if err := retry.Do(func() error {
 		_, err := mgr.GetRESTMapper().RESTMapping(gk)
@@ -481,7 +555,7 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 		ec.L.Info("Extensions CRD is ready, going nuts")
 		return nil
 	}, retry.Context(ctx)); err != nil {
-		return fmt.Errorf("can't start ExtensionsReconciler, helm CRD is not registred, check CRD registration reconciler: %w", err)
+		return nil, fmt.Errorf("can't start ExtensionsReconciler, helm CRD is not registered, check CRD registration reconciler: %w", err)
 	}
 
 	if err := builder.
@@ -501,19 +575,25 @@ func (ec *ExtensionsController) Start(ctx context.Context) error {
 			helm:          ec.helm,
 			L:             ec.L.WithField("extensions_type", "helm"),
 		}); err != nil {
-		return fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
+		return nil, fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
 	}
+	return mgr, nil
+}
 
+func (ec *ExtensionsController) startControllerManager() {
 	go func() {
-		if err := mgr.Start(ctx); err != nil {
+		ec.L.Info("Starting controller-manager")
+		if err := ec.mgr.Start(ec.mgrCtx); err != nil {
 			ec.L.WithError(err).Error("Controller manager working loop exited")
 		}
 	}()
-
-	return nil
 }
 
 // Stop
 func (ec *ExtensionsController) Stop() error {
+	ec.L.Info("Stopping extensions controller")
+	ec.mgrCancelFn()
+	close(ec.startChan)
+	ec.L.Debug("Stopped extensions controller")
 	return nil
 }

--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -24,6 +24,7 @@ import (
 	"math"
 	"net"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -52,7 +53,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"go.uber.org/multierr"
-	"golang.org/x/exp/slices"
 	"sigs.k8s.io/yaml"
 )
 
@@ -492,10 +492,10 @@ func (r *Reconciler) generateResources(snapshot *snapshot) (resources, error) {
 	}
 
 	// Ensure a stable order, so that reflect.DeepEqual on slices will work.
-	slices.SortFunc(objects, func(l, r resource) bool {
+	slices.SortFunc(objects, func(l, r resource) int {
 		x := strings.Join([]string{l.GetObjectKind().GroupVersionKind().Kind, l.GetNamespace(), l.GetName()}, "/")
 		y := strings.Join([]string{r.GetObjectKind().GroupVersionKind().Kind, r.GetNamespace(), r.GetName()}, "/")
-		return x < y
+		return strings.Compare(x, y)
 	})
 
 	resources, err := applier.ToUnstructuredSlice(nil, objects...)

--- a/pkg/component/controller/workerconfig/snapshot.go
+++ b/pkg/component/controller/workerconfig/snapshot.go
@@ -17,12 +17,12 @@ limitations under the License.
 package workerconfig
 
 import (
+	"slices"
+
 	"github.com/k0sproject/k0s/internal/pkg/net"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
-
-	"golang.org/x/exp/slices"
 )
 
 // snapshot holds a snapshot of the parts that influence worker configurations.

--- a/pkg/component/worker/config/config.go
+++ b/pkg/component/worker/config/config.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 
 	"github.com/k0sproject/k0s/internal/pkg/net"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
@@ -30,7 +31,6 @@ import (
 	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	"go.uber.org/multierr"
-	"golang.org/x/exp/slices"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/component/worker/nllb/reconciler.go
+++ b/pkg/component/worker/nllb/reconciler.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -38,7 +40,6 @@ import (
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
-	"golang.org/x/exp/slices"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -320,8 +321,8 @@ func (r *Reconciler) runReconcileLoop(ctx context.Context) {
 			}
 
 			desiredAPIServers = slices.Clone(profile.APIServerAddresses)
-			slices.SortFunc(desiredAPIServers, func(l, r k0snet.HostPort) bool {
-				return l.String() < r.String()
+			slices.SortFunc(desiredAPIServers, func(l, r k0snet.HostPort) int {
+				return strings.Compare(l.String(), r.String())
 			})
 
 		case <-ticker.C:

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -19,6 +19,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -29,7 +30,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/exp/slices"
 )
 
 var (

--- a/pkg/config/cli_test.go
+++ b/pkg/config/cli_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package config
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func TestAvailableComponents_SortedAndUnique(t *testing.T) {

--- a/pkg/constant/constant_shared_test.go
+++ b/pkg/constant/constant_shared_test.go
@@ -22,13 +22,13 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"golang.org/x/exp/slices"
 	"golang.org/x/tools/go/packages"
 )
 


### PR DESCRIPTION
Manual cherry-pick of #4714. The cherry pick of #4714 works automatically after cherry-picking #4039. This one however had a small conflict in go.mod and conflict in the imports of `pkg/component/controller/extensions_controller.go`. The changes were trivial so if it passes CI I trust it.

The backport itself is trivial. @jnummelin I assign it to you because we discussed this yesterday. 