### PR TITLE
Allow multiple addresses in k0s cloud provider

### DIFF
--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -40,10 +40,10 @@ Adding a static IP address to a node using `kubectl`:
 ```shell
 kubectl annotate \
     node <node> \
-    k0sproject.io/node-ip-external=<external IP>
+    k0sproject.io/node-ip-external=<external IP>[,<external IP 2>][,<external IP 3>]
 ```
 
-Both IPv4 and IPv6 addresses are supported.
+Both IPv4 and IPv6 addresses and multiple comma-separated values are supported.
 
 ### Defaults
 

--- a/pkg/k0scloudprovider/addresses.go
+++ b/pkg/k0scloudprovider/addresses.go
@@ -17,6 +17,8 @@ limitations under the License.
 package k0scloudprovider
 
 import (
+	"strings"
+
 	v1 "k8s.io/api/core/v1"
 	cloudproviderapi "k8s.io/cloud-provider/api"
 )
@@ -82,6 +84,8 @@ func populateExternalAddress(addrs *[]v1.NodeAddress, node *v1.Node) {
 
 	// Search the nodes annotations for any external IP address definitions.
 	if externalIP, ok := node.Annotations[ExternalIPAnnotation]; ok {
-		*addrs = append(*addrs, v1.NodeAddress{Type: v1.NodeExternalIP, Address: externalIP})
+		for _, addr := range strings.Split(externalIP, ",") {
+			*addrs = append(*addrs, v1.NodeAddress{Type: v1.NodeExternalIP, Address: addr})
+		}
 	}
 }

--- a/pkg/k0scloudprovider/addresses_test.go
+++ b/pkg/k0scloudprovider/addresses_test.go
@@ -121,7 +121,7 @@ func TestPopulateInternalAddress(t *testing.T) {
 
 var testDataPopulateExternalAddress = []populateAddressTestData{
 	{
-		name: "Equality",
+		name: "Equality single address",
 		input: &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -134,6 +134,23 @@ var testDataPopulateExternalAddress = []populateAddressTestData{
 		},
 		output: []v1.NodeAddress{
 			{Type: v1.NodeExternalIP, Address: "1.2.3.4"},
+		},
+	},
+	{
+		name: "Equality multiple addresses",
+		input: &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					ExternalIPAnnotation: "1.2.3.4,2041:0000:140F::875B:131B",
+				},
+			},
+			Status: v1.NodeStatus{
+				Addresses: []v1.NodeAddress{},
+			},
+		},
+		output: []v1.NodeAddress{
+			{Type: v1.NodeExternalIP, Address: "1.2.3.4"},
+			{Type: v1.NodeExternalIP, Address: "2041:0000:140F::875B:131B"},
 		},
 	},
 	{


### PR DESCRIPTION
## Description

Allows to specify more than one address in k0s cloud provider.

Fixes #4853

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings