### PR TITLE
Detect --hostname-override flag in Autopilot for controller+worker nodes

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -556,6 +556,7 @@ func (c *command) start(ctx context.Context) error {
 
 	clusterComponents.Add(ctx, &controller.Autopilot{
 		K0sVars:            c.K0sVars,
+		KubeletExtraArgs:   c.KubeletExtraArgs,
 		AdminClientFactory: adminClientFactory,
 		EnableWorker:       c.EnableWorker,
 	})

--- a/inttest/ap-controllerworker/controllerworker_test.go
+++ b/inttest/ap-controllerworker/controllerworker_test.go
@@ -46,6 +46,10 @@ spec:
       peerAddress: %s
 `
 
+// TODO: Update this test after the https://github.com/k0sproject/k0s/pull/4860 is merged, backported and released.
+// 	Apply this commit to properly test controller+worker update process:
+//	 https://github.com/makhov/k0s/commit/bf702a829f958b04b7a6119ff03960e90100d4c9
+
 // SetupTest prepares the controller and filesystem, getting it into a consistent
 // state which we can run tests against.
 func (s *controllerworkerSuite) SetupTest() {

--- a/pkg/autopilot/common/hostname.go
+++ b/pkg/autopilot/common/hostname.go
@@ -17,6 +17,7 @@ package common
 import (
 	"os"
 
+	"github.com/k0sproject/k0s/internal/pkg/flags"
 	"github.com/k0sproject/k0s/pkg/node"
 )
 
@@ -29,4 +30,17 @@ const (
 // returns.
 func FindEffectiveHostname() (string, error) {
 	return node.GetNodename(os.Getenv(envAutopilotHostname))
+}
+
+func FindKubeletHostname(kubeletExtraArgs string) string {
+	defaultNodename, _ := node.GetNodename("")
+	if kubeletExtraArgs != "" {
+		extras := flags.Split(kubeletExtraArgs)
+		nodeName, ok := extras["--hostname-override"]
+		if ok {
+			return nodeName
+		}
+	}
+
+	return defaultNodename
 }

--- a/pkg/autopilot/controller/root/root.go
+++ b/pkg/autopilot/controller/root/root.go
@@ -24,6 +24,7 @@ type RootConfig struct {
 	InvocationID        string
 	KubeConfig          string
 	K0sDataDir          string
+	KubeletExtraArgs    string
 	Mode                string
 	ManagerPort         int
 	MetricsBindAddr     string

--- a/pkg/autopilot/controller/root_controller.go
+++ b/pkg/autopilot/controller/root_controller.go
@@ -75,7 +75,7 @@ func NewRootController(cfg aproot.RootConfig, logger *logrus.Entry, enableWorker
 	c.stopSubHandler = c.stopSubControllers
 	c.leaseWatcherCreator = NewLeaseWatcher
 	c.setupHandler = func(ctx context.Context, cf apcli.FactoryInterface) error {
-		setupController := NewSetupController(c.log, cf, cfg.K0sDataDir, enableWorker)
+		setupController := NewSetupController(c.log, cf, cfg.K0sDataDir, cfg.KubeletExtraArgs, enableWorker)
 		return setupController.Run(ctx)
 	}
 

--- a/pkg/autopilot/controller/setup.go
+++ b/pkg/autopilot/controller/setup.go
@@ -42,21 +42,23 @@ type SetupController interface {
 }
 
 type setupController struct {
-	log           *logrus.Entry
-	clientFactory apcli.FactoryInterface
-	k0sDataDir    string
-	enableWorker  bool
+	log              *logrus.Entry
+	clientFactory    apcli.FactoryInterface
+	k0sDataDir       string
+	enableWorker     bool
+	kubeletExtraArgs string
 }
 
 var _ SetupController = (*setupController)(nil)
 
 // NewSetupController creates a `SetupController`
-func NewSetupController(logger *logrus.Entry, cf apcli.FactoryInterface, k0sDataDir string, enableWorker bool) SetupController {
+func NewSetupController(logger *logrus.Entry, cf apcli.FactoryInterface, k0sDataDir, kubeletExtraArgs string, enableWorker bool) SetupController {
 	return &setupController{
-		log:           logger.WithField("controller", "setup"),
-		clientFactory: cf,
-		k0sDataDir:    k0sDataDir,
-		enableWorker:  enableWorker,
+		log:              logger.WithField("controller", "setup"),
+		clientFactory:    cf,
+		k0sDataDir:       k0sDataDir,
+		kubeletExtraArgs: kubeletExtraArgs,
+		enableWorker:     enableWorker,
 	}
 }
 
@@ -73,23 +75,28 @@ func (sc *setupController) Run(ctx context.Context) error {
 		}
 	}
 
-	hostname, err := apcomm.FindEffectiveHostname()
+	controlNodeName, err := apcomm.FindEffectiveHostname()
 	if err != nil {
 		return fmt.Errorf("unable to determine hostname for signal node setup: %w", err)
 	}
 
-	logger.Infof("Using effective hostname = '%v'", hostname)
+	kubeletNodeName := controlNodeName
+	if sc.enableWorker {
+		kubeletNodeName = apcomm.FindKubeletHostname(sc.kubeletExtraArgs)
+	}
+
+	logger.Infof("Using effective hostname = '%v', kubelet hostname = '%v'", controlNodeName, kubeletNodeName)
 
 	if err := retry.Do(func() error {
-		logger.Infof("Attempting to create controlnode '%s'", hostname)
-		if err := sc.createControlNode(ctx, sc.clientFactory, hostname); err != nil {
-			return fmt.Errorf("create controlnode '%s' attempt failed, retrying: %w", hostname, err)
+		logger.Infof("Attempting to create controlnode '%s'", controlNodeName)
+		if err := sc.createControlNode(ctx, sc.clientFactory, controlNodeName, kubeletNodeName); err != nil {
+			return fmt.Errorf("create controlnode '%s' attempt failed, retrying: %w", controlNodeName, err)
 		}
 
 		return nil
 
 	}); err != nil {
-		return fmt.Errorf("failed to create controlnode '%s' after max attempts: %w", hostname, err)
+		return fmt.Errorf("failed to create controlnode '%s' after max attempts: %w", controlNodeName, err)
 	}
 
 	return nil
@@ -113,7 +120,7 @@ func createNamespace(ctx context.Context, cf apcli.FactoryInterface, name string
 
 // createControlNode creates a new control node, ignoring errors if one already exists
 // for this physical host.
-func (sc *setupController) createControlNode(ctx context.Context, cf apcli.FactoryInterface, name string) error {
+func (sc *setupController) createControlNode(ctx context.Context, cf apcli.FactoryInterface, name, nodeName string) error {
 	logger := sc.log.WithField("component", "setup")
 	client, err := sc.clientFactory.GetAutopilotClient()
 	if err != nil {
@@ -140,7 +147,7 @@ func (sc *setupController) createControlNode(ctx context.Context, cf apcli.Facto
 				Name: name,
 				// Create the usual os and arch labels as this describes a controller node
 				Labels: map[string]string{
-					corev1.LabelHostname:   name,
+					corev1.LabelHostname:   nodeName,
 					corev1.LabelOSStable:   runtime.GOOS,
 					corev1.LabelArchStable: runtime.GOARCH,
 				},
@@ -159,7 +166,7 @@ func (sc *setupController) createControlNode(ctx context.Context, cf apcli.Facto
 		return err
 	}
 
-	addresses, err := getControlNodeAddresses(name)
+	addresses, err := getControlNodeAddresses(nodeName)
 	if err != nil {
 		return err
 	}

--- a/pkg/autopilot/controller/signal/k0s/cordon.go
+++ b/pkg/autopilot/controller/signal/k0s/cordon.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	autopilotv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	apsigpred "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common/predicate"
@@ -157,8 +158,19 @@ func (r *cordoning) drainNode(ctx context.Context, signalNode crcli.Object) erro
 			return fmt.Errorf("failed to cast signalNode to *corev1.Node")
 		}
 	} else {
+		nodeName := signalNode.GetName()
+		controlNode, ok := signalNode.(*autopilotv1beta2.ControlNode)
+		if ok {
+			for _, addr := range controlNode.Status.Addresses {
+				if addr.Type == corev1.NodeHostName {
+					nodeName = addr.Address
+					break
+				}
+			}
+		}
+
 		//otherwise get node from client
-		if err := r.client.Get(ctx, crcli.ObjectKey{Name: signalNode.GetName()}, node); err != nil {
+		if err := r.client.Get(ctx, crcli.ObjectKey{Name: nodeName}, node); err != nil {
 			return fmt.Errorf("failed to get node: %w", err)
 		}
 	}

--- a/pkg/component/controller/autopilot.go
+++ b/pkg/component/controller/autopilot.go
@@ -34,6 +34,7 @@ var _ manager.Component = (*Autopilot)(nil)
 
 type Autopilot struct {
 	K0sVars            *config.CfgVars
+	KubeletExtraArgs   string
 	AdminClientFactory kubernetes.ClientFactoryInterface
 	EnableWorker       bool
 }
@@ -54,6 +55,7 @@ func (a *Autopilot) Start(ctx context.Context) error {
 		InvocationID:        a.K0sVars.InvocationID,
 		KubeConfig:          a.K0sVars.AdminKubeConfigPath,
 		K0sDataDir:          a.K0sVars.DataDir,
+		KubeletExtraArgs:    a.KubeletExtraArgs,
 		Mode:                "controller",
 		ManagerPort:         8899,
 		MetricsBindAddr:     "0",


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #4857 

Detect kubernetes node name from `--hostname-override` flag in Autopilot for controller+worker nodes. 
Currently, if `--hostname-override` flag is used, Autopilot can't cordon the worker node, because names don't match.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings