### PR TITLE
fix(helm): error gets removed from chart cr on subsequent reconciles

### DIFF
--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -291,19 +291,20 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart helmv
 			return fmt.Errorf("can't reconcile installation for %q: %w", chart.GetName(), err)
 		}
 	} else {
-		if cr.chartNeedsUpgrade(chart) {
-			// update
-			chartRelease, err = cr.helm.UpgradeChart(ctx,
-				chart.Spec.ChartName,
-				chart.Spec.Version,
-				chart.Status.ReleaseName,
-				chart.Status.Namespace,
-				chart.Spec.YamlValues(),
-				timeout,
-			)
-			if err != nil {
-				return fmt.Errorf("can't reconcile upgrade for %q: %w", chart.GetName(), err)
-			}
+		if !cr.chartNeedsUpgrade(chart) {
+			return nil
+		}
+		// update
+		chartRelease, err = cr.helm.UpgradeChart(ctx,
+			chart.Spec.ChartName,
+			chart.Spec.Version,
+			chart.Status.ReleaseName,
+			chart.Status.Namespace,
+			chart.Spec.YamlValues(),
+			timeout,
+		)
+		if err != nil {
+			return fmt.Errorf("can't reconcile upgrade for %q: %w", chart.GetName(), err)
 		}
 	}
 	if err := apiretry.RetryOnConflict(apiretry.DefaultRetry, func() error {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When reconciliation happens but chartNeedsUpgrade evaluates to false the error from the previous upgrade attempt is removed from the chart cr status.

Fixes #4863 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

```
ethan@ethanm-ec-1:~/build/k0s$ sudo ./k0s kubectl apply -f ../../k0schart.yaml
chart.helm.k0sproject.io/k0s-addon-chart-docker-registry created
ethan@ethanm-ec-1:~/build/k0s$ sudo ./k0s kubectl -n registry get pvc
NAME              STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
docker-registry   Pending                                      local-path     <unset>                 10s
ethan@ethanm-ec-1:~/build/k0s$ sudo ./k0s kubectl -n registry get pvc
NAME              STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
docker-registry   Bound    pvc-555c7d4a-2c35-44cf-b728-64d61cd7749e   10Gi       RWO            local-path     <unset>                 14s
ethan@ethanm-ec-1:~/build/k0s$ sudo ./k0s kubectl -n registry get pod
NAME                               READY   STATUS    RESTARTS   AGE
docker-registry-7b76b786b9-v6s65   1/1     Running   0          16s
ethan@ethanm-ec-1:~/build/k0s$ export KUBECONFIG=/var/lib/k0s/pki/admin.conf
ethan@ethanm-ec-1:~/build/k0s$ sudo -E helm list -n registry
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /var/lib/k0s/pki/admin.conf
NAME           	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART                	APP VERSION
docker-registry	registry 	1       	2024-08-16 00:08:42.537994332 +0000 UTC	deployed	docker-registry-2.2.3	2.8.1
ethan@ethanm-ec-1:~/build/k0s$ sudo ./k0s kubectl -n kube-system get charts -oyaml
apiVersion: v1
items:
- apiVersion: helm.k0sproject.io/v1beta1
  kind: Chart
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"helm.k0sproject.io/v1beta1","kind":"Chart","metadata":{"annotations":{},"name":"k0s-addon-chart-docker-registry","namespace":"kube-system"},"spec":{"chartName":"/home/ethan/docker-registry-2.2.3.tgz","namespace":"registry","releaseName":"docker-registry","timeout":"0s","values":"image:\n  tag: 2.8.3\npersistence:\n  accessMode: ReadWriteOnce\n  enabled: true\n  size: 10Gi\n  storageClass: local-path\nreplicaCount: 1\nstorage: filesystem\n","version":"2.2.3"}}
    creationTimestamp: "2024-08-16T00:08:42Z"
    generation: 1
    name: k0s-addon-chart-docker-registry
    namespace: kube-system
    resourceVersion: "565"
    uid: b070af37-ddc9-42d8-b1f6-b7eb20cfd723
  spec:
    chartName: /home/ethan/docker-registry-2.2.3.tgz
    namespace: registry
    releaseName: docker-registry
    timeout: 0s
    values: |
      image:
        tag: 2.8.3
      persistence:
        accessMode: ReadWriteOnce
        enabled: true
        size: 10Gi
        storageClass: local-path
      replicaCount: 1
      storage: filesystem
    version: 2.2.3
  status:
    appVersion: 2.8.1
    namespace: registry
    releaseName: docker-registry
    revision: 1
    updated: 2024-08-16 00:08:59.042242009 +0000 UTC m=+65.203920179
    valuesHash: 431971fcb76d81ac462b7fe34639b4c043278ec4a24ecdf518962e3b4c099d1a
    version: 2.2.3
kind: List
metadata:
  resourceVersion: ""
ethan@ethanm-ec-1:~/build/k0s$ sudo ./k0s kubectl apply -f ../../upk0schart.yaml
chart.helm.k0sproject.io/k0s-addon-chart-docker-registry configured
ethan@ethanm-ec-1:~/build/k0s$ sudo -E helm list -n registry
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /var/lib/k0s/pki/admin.conf
NAME           	NAMESPACE	REVISION	UPDATED                               	STATUS	CHART                	APP VERSION
docker-registry	registry 	3       	2024-08-16 00:11:14.40263587 +0000 UTC	failed	docker-registry-2.2.3	2.8.1
ethan@ethanm-ec-1:~/build/k0s$ sudo ./k0s kubectl -n kube-system get charts -oyaml
apiVersion: v1
items:
- apiVersion: helm.k0sproject.io/v1beta1
  kind: Chart
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"helm.k0sproject.io/v1beta1","kind":"Chart","metadata":{"annotations":{},"name":"k0s-addon-chart-docker-registry","namespace":"kube-system"},"spec":{"chartName":"/home/ethan/docker-registry-2.2.3.tgz","namespace":"registry","releaseName":"docker-registry","timeout":"0s","values":"image:\n  tag: 2.8.3\npersistence:\n  accessMode: ReadWriteOnce\n  enabled: true\n  size: 10Gi\n  storageClass: local-path\nreplicaCount: 1\nstorage: filesystem\nextraEnvVars: []\n  - name: TESTING\n    value: \"testing\"\n","version":"2.2.3"}}
    creationTimestamp: "2024-08-16T00:08:42Z"
    generation: 2
    name: k0s-addon-chart-docker-registry
    namespace: kube-system
    resourceVersion: "707"
    uid: b070af37-ddc9-42d8-b1f6-b7eb20cfd723
  spec:
    chartName: /home/ethan/docker-registry-2.2.3.tgz
    namespace: registry
    releaseName: docker-registry
    timeout: 0s
    values: |
      image:
        tag: 2.8.3
      persistence:
        accessMode: ReadWriteOnce
        enabled: true
        size: 10Gi
        storageClass: local-path
      replicaCount: 1
      storage: filesystem
      extraEnvVars: []
        - name: TESTING
          value: "testing"
    version: 2.2.3
  status:
    appVersion: 2.8.1
    error: "can't upgrade loadedChart `docker-registry`: an error occurred while rolling
      back the release. original upgrade error: failed to replace object: PersistentVolumeClaim
      \"docker-registry\" is invalid: spec: Forbidden: spec is immutable after creation
      except resources.requests and volumeAttributesClassName for bound claims\n  core.PersistentVolumeClaimSpec{\n
      \ \tAccessModes:      {\"ReadWriteOnce\"},\n  \tSelector:         nil,\n  \tResources:
      \       {Requests: {s\"storage\": {i: {...}, s: \"10Gi\", Format: \"BinarySI\"}}},\n-
      \tVolumeName:       \"pvc-555c7d4a-2c35-44cf-b728-64d61cd7749e\",\n+ \tVolumeName:
      \      \"\",\n  \tStorageClassName: &\"local-path\",\n  \tVolumeMode:       &\"Filesystem\",\n
      \ \t... // 3 identical fields\n  }\n: failed to replace object: PersistentVolumeClaim
      \"docker-registry\" is invalid: spec: Forbidden: spec is immutable after creation
      except resources.requests and volumeAttributesClassName for bound claims\n  core.PersistentVolumeClaimSpec{\n
      \ \tAccessModes:      {\"ReadWriteOnce\"},\n  \tSelector:         nil,\n  \tResources:
      \       {Requests: {s\"storage\": {i: {...}, s: \"10Gi\", Format: \"BinarySI\"}}},\n-
      \tVolumeName:       \"pvc-555c7d4a-2c35-44cf-b728-64d61cd7749e\",\n+ \tVolumeName:
      \      \"\",\n  \tStorageClassName: &\"local-path\",\n  \tVolumeMode:       &\"Filesystem\",\n
      \ \t... // 3 identical fields\n  }\n"
    namespace: registry
    releaseName: docker-registry
    revision: 1
    updated: 2024-08-16 00:11:14.532659602 +0000 UTC m=+200.694337765
    valuesHash: f749a71a7f93817862fe979e7fffba021f591ebf8b5bd29d5e2fe23f67b6eecb
    version: 2.2.3
kind: List
metadata:
  resourceVersion: ""
```

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings