### PR TITLE
Don't treat kine data sources as URLs

### DIFF
--- a/pkg/apis/k0s/v1beta1/storage_test.go
+++ b/pkg/apis/k0s/v1beta1/storage_test.go
@@ -153,12 +153,12 @@ spec:
 	assert.Equal(t, KineStorageType, c.Spec.Storage.Type)
 	assert.NotNil(t, c.Spec.Storage.Kine)
 
-	expectedPath := "/var/lib/k0s/db/state.db"
+	expectedPath := "file:/var/lib/k0s/db/state.db"
 	if runtime.GOOS == "windows" {
-		expectedPath = "C:/var/lib/k0s/db/state.db"
+		expectedPath = "file:C:/var/lib/k0s/db/state.db"
 	}
 
-	assert.Equal(t, fmt.Sprintf("sqlite:%s?mode=rwc&_journal=WAL&cache=shared", expectedPath), c.Spec.Storage.Kine.DataSource)
+	assert.Equal(t, fmt.Sprintf("sqlite://%s?mode=rwc&_journal=WAL&cache=shared", expectedPath), c.Spec.Storage.Kine.DataSource)
 }
 
 type storageSuite struct {

--- a/pkg/backup/manager_unix.go
+++ b/pkg/backup/manager_unix.go
@@ -83,7 +83,7 @@ func (bm *Manager) discoverSteps(configFilePath string, nodeSpec *v1beta1.Cluste
 	if nodeSpec.Storage.Type == v1beta1.EtcdStorageType && !nodeSpec.Storage.Etcd.IsExternalClusterUsed() {
 		bm.Add(newEtcdStep(bm.tmpDir, vars.CertRootDir, vars.EtcdCertDir, nodeSpec.Storage.Etcd.PeerAddress, vars.EtcdDataDir))
 	} else if nodeSpec.Storage.Type == v1beta1.KineStorageType && strings.HasPrefix(nodeSpec.Storage.Kine.DataSource, "sqlite:") {
-		bm.Add(newSqliteStep(bm.tmpDir, nodeSpec.Storage.Kine.DataSource, vars.DataDir))
+		bm.Add(newSqliteStep(bm.tmpDir, nodeSpec.Storage.Kine.DataSource))
 	} else {
 		logrus.Warnf("only internal etcd and sqlite %s are supported. Other storage backends must be backed-up/restored manually.", action)
 	}

--- a/pkg/backup/sqlitedb_unix.go
+++ b/pkg/backup/sqlitedb_unix.go
@@ -20,7 +20,6 @@ package backup
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 
@@ -35,28 +34,23 @@ import (
 const kineBackup = "kine-state-backup.db"
 
 type sqliteStep struct {
-	dataSource string
-	tmpDir     string
+	dbPath string
+	tmpDir string
 }
 
-func newSqliteStep(tmpDir string, dataSource string) *sqliteStep {
+func newSqliteStep(tmpDir string, dbPath string) *sqliteStep {
 	return &sqliteStep{
-		tmpDir:     tmpDir,
-		dataSource: dataSource,
+		tmpDir: tmpDir,
+		dbPath: dbPath,
 	}
 }
 
 func (s *sqliteStep) Name() string {
-	dbPath, _ := s.getKineDBPath()
-	return fmt.Sprintf("sqlite db path %s", dbPath)
+	return fmt.Sprintf("sqlite db path %s", s.dbPath)
 }
 
 func (s *sqliteStep) Backup() (StepResult, error) {
-	dbPath, err := s.getKineDBPath()
-	if err != nil {
-		return StepResult{}, err
-	}
-	kineDB, err := db.Open(dbPath)
+	kineDB, err := db.Open(s.dbPath)
 	if err != nil {
 		return StepResult{}, err
 	}
@@ -80,27 +74,15 @@ func (s *sqliteStep) Restore(restoreFrom string, _ string) error {
 	if !file.Exists(snapshotPath) {
 		return fmt.Errorf("sqlite snapshot not found at %s", snapshotPath)
 	}
-	dbPath, err := s.getKineDBPath()
-	if err != nil {
-		return err
-	}
 
 	// make sure DB dir exists. if not, create it.
-	dbPathDir := filepath.Dir(dbPath)
-	if err = dir.Init(dbPathDir, constant.KineDBDirMode); err != nil {
+	dbPathDir := filepath.Dir(s.dbPath)
+	if err := dir.Init(dbPathDir, constant.KineDBDirMode); err != nil {
 		return err
 	}
-	logrus.Infof("restoring sqlite db to `%s`", dbPath)
-	if err := file.Copy(snapshotPath, dbPath); err != nil {
+	logrus.Infof("restoring sqlite db to `%s`", s.dbPath)
+	if err := file.Copy(snapshotPath, s.dbPath); err != nil {
 		logrus.Errorf("failed to restore snapshot from disk: %v", err)
 	}
 	return nil
-}
-
-func (s *sqliteStep) getKineDBPath() (string, error) {
-	u, err := url.Parse(s.dataSource)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse Kind datasource string: %w", err)
-	}
-	return u.Path, nil
 }

--- a/pkg/backup/sqlitedb_unix.go
+++ b/pkg/backup/sqlitedb_unix.go
@@ -37,14 +37,12 @@ const kineBackup = "kine-state-backup.db"
 type sqliteStep struct {
 	dataSource string
 	tmpDir     string
-	dataDir    string
 }
 
-func newSqliteStep(tmpDir string, dataSource string, dataDir string) *sqliteStep {
+func newSqliteStep(tmpDir string, dataSource string) *sqliteStep {
 	return &sqliteStep{
 		tmpDir:     tmpDir,
 		dataSource: dataSource,
-		dataDir:    dataDir,
 	}
 }
 

--- a/pkg/config/kine/datasource.go
+++ b/pkg/config/kine/datasource.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kine
+
+import (
+	"errors"
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+// Splits a kine data source string into the backend and DSN parts.
+//
+// Kine data sources are of the form "<backend>://<dsn>".
+// They look like URLs, but they aren't, so don't try to use [net/url.Parse].
+func SplitDataSource(dataSource string) (backend, dsn string, _ error) {
+	backend, dsn, ok := strings.Cut(dataSource, "://")
+
+	// Kine behaves weirdly if the infix isn't found or the backend is empty: It
+	// defaults to SQLite with an empty DSN, no matter what the data source is.
+	// Let's not duplicate this in k0s, but insist on something with an infix.
+
+	if !ok {
+		return "", "", errors.New("failed to find infix between driver and DSN")
+	}
+
+	switch backend {
+	case "":
+		return "", "", errors.New("no backend specified")
+	case "nats":
+		dsn = dataSource
+	case "http", "https":
+		backend = "etcd3"
+	}
+
+	return backend, dsn, nil
+}
+
+// Gets the file system path of the SQLite database file from an SQLite DSN.
+func GetSQLiteFilePath(workingDir, dsn string) (string, error) {
+	// The DSN is preprocessed by kine's SQLite Go database driver, and not
+	// passed to the SQLite library as is:
+	if pos := strings.IndexByte(dsn, '?'); pos >= 1 {
+		if !strings.HasPrefix(dsn, "file:") {
+			dsn = dsn[:pos]
+		}
+	}
+
+	// Now rely on the SQLite library's URI semantics.
+	//
+	// https://www.sqlite.org/c3ref/open.html
+	// https://www.sqlite.org/uri.html
+
+	// The DSN is treated as the file name if it's not a file URI.
+	fileName := dsn
+	uri, err := url.Parse(dsn)
+	if err == nil && uri.Scheme == "file" {
+		fileName = filepath.FromSlash(uri.Path)
+	}
+
+	switch fileName {
+	case "":
+		return "", errors.New("private temporary on-disk database")
+	case ":memory:":
+		return "", errors.New("in-memory database")
+	}
+
+	// Kine/SQLite should treat relative paths as relative to their working
+	// directory, which _should_ be k0s's data dir.
+	if !filepath.IsAbs(fileName) {
+		return filepath.Join(workingDir, dsn), nil
+	}
+
+	// Clean the file path. This is to be consistent with filepath.Join which
+	// cleans the path internally, too.
+	return filepath.Clean(fileName), nil
+}


### PR DESCRIPTION
## Description

They aren't (necessarily) valid URLs, hence `url.Parse` is inappropriate. Introuduce the `pkg/config/kine` package to provide some utility functions.

Fixes:
* #4867

Supersedes:
* #4868

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings