### PR TITLE
Add explicit names to all controller-runtime controllers

### DIFF
--- a/pkg/autopilot/controller/plans/init.go
+++ b/pkg/autopilot/controller/plans/init.go
@@ -108,6 +108,7 @@ func registerSchedulableStateController(logger *logrus.Entry, mgr crman.Manager,
 // controller-runtime.
 func registerPlanStateController(name string, logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, handler appc.PlanStateHandler, providers []appc.PlanCommandProvider) error {
 	return cr.NewControllerManagedBy(mgr).
+		Named("planstate-" + name).
 		For(&apv1beta2.Plan{}).
 		WithEventFilter(eventFilter).
 		Complete(

--- a/pkg/autopilot/controller/signal/airgap/download.go
+++ b/pkg/autopilot/controller/signal/airgap/download.go
@@ -37,16 +37,17 @@ type downloadManfiestBuilderAirgap struct {
 
 var _ apsigcomm.DownloadManifestBuilder = (*downloadManfiestBuilderAirgap)(nil)
 
-// registerDownloadController registers the 'downloading' controller to the
+// registerDownloading registers the 'airgap-downloading' controller to the
 // controller-runtime manager.
 //
 // This controller is only interested when autopilot signaling annotations have
 // moved to a `Downloading` status. At this point, it will attempt to download
 // the file provided in the update request.
-func registerDownloadController(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, k0sDataDir string) error {
-	logger.Infof("Registering airgap 'downloading' reconciler for '%s'", delegate.Name())
+func registerDownloading(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, k0sDataDir string) error {
+	logger.Infof("Registering 'airgap-downloading' reconciler for '%s'", delegate.Name())
 
 	return cr.NewControllerManagedBy(mgr).
+		Named("airgap-downloading").
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(

--- a/pkg/autopilot/controller/signal/airgap/init.go
+++ b/pkg/autopilot/controller/signal/airgap/init.go
@@ -42,11 +42,11 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 	}
 
 	if err := registerSignalController(logger, mgr, SignalControllerEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "signal")), delegate); err != nil {
-		return fmt.Errorf("unable to register airgap 'signal' controller: %w", err)
+		return fmt.Errorf("unable to register 'airgap-signal' controller: %w", err)
 	}
 
-	if err := registerDownloadController(logger, mgr, SignalControllerEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "airgap download")), delegate, k0sDataDir); err != nil {
-		return fmt.Errorf("unable to register airgap 'download' controller: %w", err)
+	if err := registerDownloading(logger, mgr, SignalControllerEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "airgap download")), delegate, k0sDataDir); err != nil {
+		return fmt.Errorf("unable to register 'airgap-downloading' controller: %w", err)
 	}
 
 	return nil

--- a/pkg/autopilot/controller/signal/airgap/signal.go
+++ b/pkg/autopilot/controller/signal/airgap/signal.go
@@ -56,16 +56,19 @@ func SignalControllerEventFilter(hostname string, handler apsigpred.ErrorHandler
 type signalControllerHandler struct {
 }
 
-// registerSignalController registers the airgap 'signal' controller to the controller-runtime manager.
+// registerSignalController registers the 'airgap-signal' controller to the
+// controller-runtime manager.
 //
-// This controller is only interested in changes to its own annotations, and is the main mechanism in
-// identifying incoming autopilot airgap signaling updates.
+// This controller is only interested in changes to its own annotations, and is
+// the main mechanism in identifying incoming autopilot airgap signaling
+// updates.
 func registerSignalController(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate) error {
 	logr := logger.WithFields(logrus.Fields{"updatetype": "airgap"})
 
-	logr.Infof("Registering 'signal' reconciler for '%s'", delegate.Name())
+	logr.Infof("Registering 'airgap-signal' reconciler for '%s'", delegate.Name())
 
 	return cr.NewControllerManagedBy(mgr).
+		Named("airgap-signal").
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(

--- a/pkg/autopilot/controller/signal/k0s/apply.go
+++ b/pkg/autopilot/controller/signal/k0s/apply.go
@@ -79,6 +79,7 @@ func registerApplyingUpdate(
 	logger.Infof("Registering 'applying-update' reconciler for '%s'", delegate.Name())
 
 	return cr.NewControllerManagedBy(mgr).
+		Named(delegate.Name() + "-applying-update").
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(

--- a/pkg/autopilot/controller/signal/k0s/cordon.go
+++ b/pkg/autopilot/controller/signal/k0s/cordon.go
@@ -81,6 +81,7 @@ func registerCordoning(logger *logrus.Entry, mgr crman.Manager, eventFilter crpr
 	}
 
 	return cr.NewControllerManagedBy(mgr).
+		Named(delegate.Name() + "-cordoning").
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(

--- a/pkg/autopilot/controller/signal/k0s/download.go
+++ b/pkg/autopilot/controller/signal/k0s/download.go
@@ -69,6 +69,7 @@ func registerDownloading(logger *logrus.Entry, mgr crman.Manager, eventFilter cr
 	logger.Infof("Registering k0s 'downloading' reconciler for '%s'", delegate.Name())
 
 	return cr.NewControllerManagedBy(mgr).
+		Named(delegate.Name() + "-downloading").
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(

--- a/pkg/autopilot/controller/signal/k0s/init.go
+++ b/pkg/autopilot/controller/signal/k0s/init.go
@@ -83,8 +83,8 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 		return fmt.Errorf("unable to register k0s 'restarted' controller: %w", err)
 	}
 
-	if err := registerUnCordoning(logger, mgr, unCordoningEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s uncordoning")), delegate); err != nil {
-		return fmt.Errorf("unable to register k0s 'uncordon' controller: %w", err)
+	if err := registerUncordoning(logger, mgr, unCordoningEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s uncordoning")), delegate); err != nil {
+		return fmt.Errorf("unable to register k0s 'uncordoning' controller: %w", err)
 	}
 
 	return nil

--- a/pkg/autopilot/controller/signal/k0s/restart_unix.go
+++ b/pkg/autopilot/controller/signal/k0s/restart_unix.go
@@ -70,6 +70,7 @@ func registerRestart(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred
 	logger.Infof("Registering 'restart' reconciler for '%s'", delegate.Name())
 
 	return cr.NewControllerManagedBy(mgr).
+		Named(delegate.Name() + "-restart").
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(

--- a/pkg/autopilot/controller/signal/k0s/restarted_unix.go
+++ b/pkg/autopilot/controller/signal/k0s/restarted_unix.go
@@ -64,6 +64,7 @@ func registerRestarted(logger *logrus.Entry, mgr crman.Manager, eventFilter crpr
 	logger.Infof("Registering 'restarted' reconciler for '%s'", delegate.Name())
 
 	return cr.NewControllerManagedBy(mgr).
+		Named(delegate.Name() + "-restarted").
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(

--- a/pkg/autopilot/controller/signal/k0s/signal.go
+++ b/pkg/autopilot/controller/signal/k0s/signal.go
@@ -77,6 +77,7 @@ func registerSignalController(logger *logrus.Entry, mgr crman.Manager, eventFilt
 	logr.Infof("Registering 'signal' reconciler for '%s'", delegate.Name())
 
 	return cr.NewControllerManagedBy(mgr).
+		Named(delegate.Name() + "-signal").
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(

--- a/pkg/autopilot/controller/signal/k0s/uncordon.go
+++ b/pkg/autopilot/controller/signal/k0s/uncordon.go
@@ -65,13 +65,13 @@ type uncordoning struct {
 	clientset *kubernetes.Clientset
 }
 
-// registerUnCordoning registers the 'uncordoning' controller to the
+// registerUncordoning registers the 'uncordoning' controller to the
 // controller-runtime manager.
 //
 // This controller is only interested when autopilot signaling annotations have
 // moved to a `Cordoning` status. At this point, it will attempt to cordong & drain
 // the node.
-func registerUnCordoning(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate) error {
+func registerUncordoning(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate) error {
 	logger.Infof("Registering 'uncordoning' reconciler for '%s'", delegate.Name())
 
 	// create the clientset
@@ -81,6 +81,7 @@ func registerUnCordoning(logger *logrus.Entry, mgr crman.Manager, eventFilter cr
 	}
 
 	return cr.NewControllerManagedBy(mgr).
+		Named(delegate.Name() + "-uncordoning").
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(

--- a/pkg/autopilot/controller/updates/update_controller.go
+++ b/pkg/autopilot/controller/updates/update_controller.go
@@ -41,6 +41,7 @@ type updateController struct {
 
 func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, clientFactory apcli.FactoryInterface, leaderMode bool, clusterID string) error {
 	return cr.NewControllerManagedBy(mgr).
+		Named("updater").
 		For(&apv1beta2.UpdateConfig{}).
 		Complete(
 			&updateController{

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -485,6 +485,7 @@ func (ec *ExtensionsController) instantiateManager(ctx context.Context) (crman.M
 
 	if err := builder.
 		ControllerManagedBy(mgr).
+		Named("chart").
 		For(&helmv1beta1.Chart{},
 			builder.WithPredicates(predicate.And(
 				predicate.GenerationChangedPredicate{},


### PR DESCRIPTION
## Description

New releases of controller-runtime will enforce unique names per controller, as the names become part of logs and metrics. Duplicate names will be very confusing. If no name is explicitly given, controller-runtime will fallback to generate a name based on the resource kind that's being managed by the controller, if any. Especially Autopilot registers mutliple controllers for the same kind, hence it will have overlapping controller names.

Add the "Named" call to all the places in which a controller is built.

This makes k0s compatible with new upstream versions of controller-runtime that are themselves compatible with Kubernetes 1.31, and a prerequisite for #4647.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings