### PR TITLE
etcd join workflow fix when the first attempt fails

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -168,7 +168,7 @@ func (c *command) start(ctx context.Context) error {
 
 	var joinClient *token.JoinClient
 
-	if (c.TokenArg != "" || c.TokenFile != "") && c.needToJoin() {
+	if (c.TokenArg != "" || c.TokenFile != "") && c.needToJoin(nodeConfig) {
 		var tokenData string
 		if c.TokenArg != "" {
 			tokenData = c.TokenArg
@@ -655,10 +655,13 @@ func (c *command) startWorker(ctx context.Context, profile string, nodeConfig *v
 }
 
 // If we've got CA in place we assume the node has already joined previously
-func (c *command) needToJoin() bool {
+func (c *command) needToJoin(nodeConfig *v1beta1.ClusterConfig) bool {
 	if file.Exists(filepath.Join(c.K0sVars.CertRootDir, "ca.key")) &&
 		file.Exists(filepath.Join(c.K0sVars.CertRootDir, "ca.crt")) {
 		return false
+	}
+	if nodeConfig.Spec.Storage.Type == v1beta1.EtcdStorageType && !nodeConfig.Spec.Storage.Etcd.IsExternalClusterUsed() {
+		return !file.Exists(filepath.Join(c.K0sVars.EtcdDataDir, "member", "snap", "db"))
 	}
 	return true
 }


### PR DESCRIPTION
## Description

Currently, if the first attempt to join etcd cluster fails (e.g. `/v1beta1/etcd/members` request returned 500), k0s won't try to join etcd again, because `needToJoin()` function only checks for the existence of the certificates.

This causes issues for k0smotron, where we spin up new machines in unpredictable order 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings