### PR TITLE
Introduce new leader election client

### DIFF
--- a/pkg/leaderelection/client.go
+++ b/pkg/leaderelection/client.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/k0sproject/k0s/pkg/k0scontext"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coordinationv1client "k8s.io/client-go/kubernetes/typed/coordination/v1"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+// Indicates if a leader election client has taken the lead or not.
+type Status bool
+
+const (
+	StatusPending Status = false
+	StatusLeading Status = true
+)
+
+// Returns a string representation suitable for logging.
+func (s Status) String() string {
+	if s {
+		return "leading"
+	}
+	return "pending"
+}
+
+// Configures a leader election client backed by a coordination/v1 Lease resource.
+type LeaseConfig struct {
+	// The Lease resource that's backing the leader election client.
+	Namespace, Name string
+
+	// The unique name identifying this client across all participants in the election.
+	Identity string
+
+	// The Kubernetes client used to manage the Lease resource.
+	Client coordinationv1client.LeasesGetter
+
+	internalConfig
+}
+
+// Implements [Config].
+func (c *LeaseConfig) buildLock() (resourcelock.Interface, error) {
+	if c.Namespace == "" {
+		return nil, fmt.Errorf("namespace may not be empty")
+	}
+	if c.Name == "" {
+		return nil, fmt.Errorf("name may not be empty")
+	}
+	if c.Client == nil {
+		return nil, fmt.Errorf("client may not be nil")
+	}
+
+	return &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Namespace: c.Namespace,
+			Name:      c.Name,
+		},
+		Client: c.Client,
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: c.Identity,
+		},
+	}, nil
+}
+
+// A client configuration to be used with [NewClient].
+//
+// See:
+//   - [LeaseConfig]
+type Config interface {
+	buildLock() (resourcelock.Interface, error)
+	internal() internalConfig
+}
+
+// Default durations for leader election.
+// Not publicly configurable at the moment.
+const (
+	defaultLeaseDuration = 60 * time.Second
+	defaultRenewDeadline = 15 * time.Second
+	defaultRetryPeriod   = 5 * time.Second
+)
+
+// Creates a new leader election client with the provided configuration.
+func NewClient(c Config) (*Client, error) {
+	lock, err := c.buildLock()
+	if err != nil {
+		return nil, err
+	}
+
+	ic := c.internal()
+	leaderElector, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		ReleaseOnCancel: true,
+		LeaseDuration:   defaultLeaseDuration,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) { k0scontext.Value[onStartedLeadingFunc](ctx)() },
+			OnStoppedLeading: func() { /* handled in runLeaderElectionRound */ },
+		},
+		RenewDeadline: cmp.Or(ic.renewDeadline, defaultRenewDeadline),
+		RetryPeriod:   cmp.Or(ic.retryPeriod, defaultRetryPeriod),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{leaderElector}, nil
+}
+
+// Internal, non-exposed leader election configuration settings.
+type internalConfig struct {
+	renewDeadline, retryPeriod time.Duration
+}
+
+// Implements [Config].
+func (c *internalConfig) internal() internalConfig { return *c }
+
+// A leader election client.
+type Client struct {
+	leaderElector *leaderelection.LeaderElector
+}
+
+// Executes the leader election process. The changed callback is called whenever
+// the status changes. It will be called sequentially, but not necessarily from
+// the same goroutine. Run returns when ctx is done.
+func (c *Client) Run(ctx context.Context, changed func(Status)) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			c.runLeaderElectionRound(ctx, changed)
+		}
+	}
+}
+
+// Performs a single round of leader election.
+// It returns after the lead got lost or when ctx is done.
+func (c *Client) runLeaderElectionRound(ctx context.Context, changed func(Status)) {
+	// The Kubernetes leader elector calls the OnStartedLeading callback
+	// concurrently in a goroutine. It doesn't wait for the callback to return
+	// when it calls OnStoppedLeading. As a result, both callbacks can
+	// interleave, and in pathological situations, OnStartedLeading can even be
+	// called _after_ OnStoppedLeading. Take this behavior into account here,
+	// and make sure that this round's callback is guaranteed not to be called
+	// at the same time, and that it always observes the correct order of leader
+	// election states (possibly none).
+
+	var changedCalled atomic.Bool
+	done := make(chan struct{})
+
+	leadTaken := func() {
+		defer close(done)
+		// Ensure that the leader elector hasn't returned yet.
+		if !changedCalled.Swap(true) {
+			changed(StatusLeading)
+		}
+	}
+
+	// This is an alternative implementation of the OnStoppedLeading callback.
+	// The callback doesn't have access to a context, so it can't get a value
+	// from it like it's done for OnStartedLeading. OnStoppedLeading is
+	// implemented via a defer call in the leader elector's Run method. This
+	// behavior can be implemented here as well.
+	defer func() {
+		// Wait for the StatusLeading callback to finish and call changed with
+		// StatusPending only if changed was called before.
+		if changedCalled.Swap(true) {
+			<-done
+			changed(StatusPending)
+		}
+	}()
+
+	// Run the leader elector with the appropriate callback.
+	c.leaderElector.Run(k0scontext.WithValue(ctx, onStartedLeadingFunc(leadTaken)))
+}
+
+// A helper type to pass the current leader election round's callback into the
+// leader elector's OnStartedLeading callback function.
+type onStartedLeadingFunc func()

--- a/pkg/leaderelection/client_test.go
+++ b/pkg/leaderelection/client_test.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	fakecoordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeaseConfig_Name(t *testing.T) {
+	client, err := NewClient(&LeaseConfig{
+		Namespace: "foo",
+		Identity:  "bar",
+		Client:    fake.NewSimpleClientset().CoordinationV1(),
+	})
+	assert.Nil(t, client)
+	assert.ErrorContains(t, err, "name may not be empty")
+}
+
+func TestLeaseConfig_Identity(t *testing.T) {
+	client, err := NewClient(&LeaseConfig{
+		Namespace: "foo",
+		Name:      "bar",
+		Client:    fake.NewSimpleClientset().CoordinationV1(),
+	})
+	assert.Nil(t, client)
+	assert.ErrorContains(t, err, "Lock identity is empty")
+}
+
+func TestLeaseConfig_Client(t *testing.T) {
+	client, err := NewClient(&LeaseConfig{
+		Namespace: "foo",
+		Name:      "bar",
+		Identity:  "baz",
+	})
+	assert.Nil(t, client)
+	assert.ErrorContains(t, err, "client may not be nil")
+}
+
+func TestClient_Reacquisition(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	ctx, cancel := context.WithCancel(context.TODO())
+	t.Cleanup(cancel)
+
+	givenLeaderElectorError := func() func(err error) {
+		var updateErr atomic.Pointer[error]
+		updateErr.Store(ptr.To[error](nil))
+		fakeClient.CoordinationV1().(*fakecoordinationv1.FakeCoordinationV1).PrependReactor("update", "leases", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			if errPtr := updateErr.Load(); *errPtr != nil {
+				return true, nil, *errPtr
+			}
+			return false, nil, nil
+		})
+
+		return func(err error) {
+			updateErr.Store(&err)
+		}
+	}()
+
+	observedCallbacks := 0
+	ct := &cancellingT{t, cancel}
+	callbacks := []func(Status){
+		func(status Status) {
+			assert.Equal(ct, StatusLeading, status, "Should take the lead when run")
+			if t.Failed() {
+				return
+			}
+			t.Log("Took the lead, disrupting leader election and waiting to loose the lead")
+			givenLeaderElectorError(errors.New("leader election disrupted by test case"))
+		},
+		func(status Status) {
+			assert.Equal(ct, StatusPending, status, "Should loose the lead when disrupted")
+			if t.Failed() {
+				return
+			}
+			t.Log("Lost the lead, restoring the leader election, and waiting to regain the lead")
+			givenLeaderElectorError(nil)
+		},
+		func(status Status) {
+			assert.Equal(ct, StatusLeading, status, "Should regain the lead")
+			if t.Failed() {
+				return
+			}
+			t.Log("Regained the lead after leader election was restored")
+			cancel()
+		},
+		func(status Status) {
+			assert.Equal(ct, StatusPending, status, "Should drop the lead when context is done")
+		},
+	}
+
+	underTest, err := NewClient(&LeaseConfig{
+		Namespace: "foo", Name: "bar", Identity: t.Name(),
+		Client: fakeClient.CoordinationV1(),
+		internalConfig: internalConfig{
+			renewDeadline: 10 * time.Millisecond,
+			retryPeriod:   5 * time.Millisecond,
+		},
+	})
+	require.NoError(t, err)
+
+	underTest.Run(ctx, func(status Status) {
+		assert.Less(ct, observedCallbacks, len(callbacks), "Callback called too often")
+		if t.Failed() {
+			return
+		}
+		callbacks[observedCallbacks](status)
+		observedCallbacks++
+	})
+
+	assert.Equal(t, len(callbacks), observedCallbacks, "Callback not called often enough")
+}
+
+func TestClient_LeadTakeover(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	ctx, cancel := context.WithCancel(context.TODO())
+	t.Cleanup(cancel)
+
+	// Create two leader election clients, Red and Black.
+	ctxRed, cancelRed := context.WithCancel(ctx)
+	red, err := NewClient(&LeaseConfig{
+		Namespace: "foo", Name: "bar", Identity: "Red",
+		Client: fakeClient.CoordinationV1(),
+		internalConfig: internalConfig{
+			renewDeadline: 10 * time.Millisecond,
+			retryPeriod:   5 * time.Millisecond,
+		},
+	})
+	require.NoError(t, err)
+	ctxBlack, cancelBlack := context.WithCancel(ctx)
+	black, err := NewClient(&LeaseConfig{
+		Namespace: "foo", Name: "bar", Identity: "Black",
+		Client: fakeClient.CoordinationV1(),
+		internalConfig: internalConfig{
+			renewDeadline: 10 * time.Millisecond,
+			retryPeriod:   5 * time.Millisecond,
+		},
+	})
+	require.NoError(t, err)
+
+	// Let Red and Black run concurrently. Red will take the lead first.
+	// Cancel Red's context and ensure that Black takes over the lead.
+	// Finally, cancel Black's context, so that the test terminates.
+
+	var observedCallbacks atomic.Uint32
+	ct := &cancellingT{t, cancel}
+	callbacks := []func(string, Status){
+		func(runner string, status Status) {
+			assert.Equal(ct, "Red", runner, "Red should take the lead first")
+			assert.Equal(ct, StatusLeading, status, "Red should take the lead first")
+			if t.Failed() {
+				return
+			}
+			t.Log("Red took the lead, cancelling Red's context")
+			cancelRed()
+		},
+		func(runner string, status Status) {
+			assert.Equal(ct, "Red", runner, "Red should drop the lead first")
+			assert.Equal(ct, StatusPending, status, "Red should drop the lead first")
+			if t.Failed() {
+				return
+			}
+			t.Log("Red dropped the lead")
+		},
+		func(runner string, status Status) {
+			assert.Equal(ct, "Black", runner, "Black should take the lead after Red")
+			assert.Equal(ct, StatusLeading, status, "Black should take the lead after Red")
+			if t.Failed() {
+				return
+			}
+			t.Log("Black took the lead, cancelling Black's context")
+			cancelBlack()
+		},
+		func(runner string, status Status) {
+			assert.Equal(ct, "Black", runner, "Black should finally drop the lead")
+			assert.Equal(ct, StatusPending, status, "Black should finally drop the lead")
+			if t.Failed() {
+				return
+			}
+			t.Log("Black dropped the lead")
+		},
+	}
+
+	// Pre-create the acquired lease for Red, so that there are no races when
+	// taking the lead by the two competing leader election client.
+	now := metav1.NewMicroTime(time.Now())
+	_, err = fakeClient.CoordinationV1().Leases("foo").Create(context.TODO(), &coordinationv1.Lease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Lease",
+			APIVersion: coordinationv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bar",
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity:       ptr.To("Red"),
+			AcquireTime:          &now,
+			RenewTime:            &now,
+			LeaseDurationSeconds: ptr.To(int32((1 * time.Hour).Seconds())), // block lease for a very long time
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Log("Pre-created acquired lease for Red")
+
+	// Run the two clients concurrently.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		red.Run(ctxRed, func(status Status) {
+			offset := observedCallbacks.Add(1) - 1
+			assert.Less(ct, int(offset), len(callbacks), "Callback called too often")
+			if t.Failed() {
+				return
+			}
+			callbacks[offset]("Red", status)
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		black.Run(ctxBlack, func(status Status) {
+			offset := observedCallbacks.Add(1) - 1
+			assert.Less(ct, int(offset), len(callbacks), "Callback called too often")
+			if t.Failed() {
+				return
+			}
+			callbacks[offset]("Black", status)
+		})
+	}()
+	wg.Wait()
+
+	assert.Equal(t, uint32(len(callbacks)), observedCallbacks.Load(), "Callback not called often enough")
+}
+
+// Small helper that cancels a context as soon as an error is reported.
+type cancellingT struct {
+	delegate assert.TestingT
+	cancel   context.CancelFunc
+}
+
+func (t *cancellingT) Errorf(format string, args ...any) {
+	t.delegate.Errorf(format, args...)
+	t.cancel()
+}

--- a/pkg/leaderelection/lease_pool.go
+++ b/pkg/leaderelection/lease_pool.go
@@ -150,9 +150,6 @@ func (p *LeasePool) Watch(ctx context.Context, opts ...WatchOpt) (*LeaseEvents, 
 	if err != nil {
 		return nil, err
 	}
-	if lec.WatchDog != nil {
-		lec.WatchDog.SetLeaderElection(le)
-	}
 
 	go func() {
 		for ctx.Err() == nil {


### PR DESCRIPTION
## Description


This is an alternative to the existing lease pool. Its main purpose is to better coordinate callback invocations and avoid the need for channels. Callers of the new client can still choose to send to channels in the callbacks, if necessary.

The new client also attempts to address some concurrency issues with the stock Kubernetes leader elector, which can call callbacks in unexpected ways.

Implement the existing `LeasePool` in terms of the new client. This allows for transitioning to the new interface piece by piece, instead replacing it all at once in a big changeset.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings