### PR TITLE
chore(lint): fix some linting complains

### DIFF
--- a/internal/pkg/iptablesutils/iptables_test.go
+++ b/internal/pkg/iptablesutils/iptables_test.go
@@ -18,6 +18,7 @@ package iptablesutils_test
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -214,5 +215,5 @@ func TestDetectHostIPTablesMode(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	logrus.SetLevel(logrus.DebugLevel)
-	m.Run()
+	os.Exit(m.Run())
 }

--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -61,7 +61,7 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 	s.T().Run("sysinfoSmoketest", func(t *testing.T) {
 		out, err := ssh.ExecWithOutput(s.Context(), fmt.Sprintf("%s sysinfo", s.K0sFullPath))
 		assert.NoError(t, err, "k0s sysinfo has non-zero exit code")
-		t.Logf(out)
+		t.Logf("%s", out)
 		assert.Regexp(t, "\nOperating system: Linux \\(pass\\)\n", out)
 		assert.Regexp(t, "\n  Linux kernel release: ", out)
 		assert.Regexp(t, "\n  CONFIG_CGROUPS: ", out)

--- a/pkg/apis/k0s/v1beta1/storage.go
+++ b/pkg/apis/k0s/v1beta1/storage.go
@@ -273,7 +273,7 @@ func (e *EtcdConfig) GetKeyFilePath(certDir string) string {
 func validateRequiredProperties(e *ExternalCluster) []error {
 	var errors []error
 
-	if e.Endpoints == nil || len(e.Endpoints) == 0 {
+	if len(e.Endpoints) == 0 {
 		errors = append(errors, fmt.Errorf("spec.storage.etcd.externalCluster.endpoints cannot be null or empty"))
 	} else if slices.Contains(e.Endpoints, "") {
 		errors = append(errors, fmt.Errorf("spec.storage.etcd.externalCluster.endpoints cannot contain empty strings"))


### PR DESCRIPTION


## Description

this addresses the following complains i found running the lint locally:

```
pkg/apis/k0s/v1beta1/storage.go:276:5: S1009: should omit nil check; len() for []string is defined as zero (gosimple)
        if e.Endpoints == nil || len(e.Endpoints) == 0 {
           ^
internal/pkg/iptablesutils/iptables_test.go:215:1: SA3000: TestMain should call os.Exit to set exit code (staticcheck)
func TestMain(m *testing.M) {
^
inttest/cli/cli_test.go:64:10: printf: non-constant format string in call to (*testing.common).Logf (govet)
                t.Logf(out)
                       ^
```

## Type of change

<!-- check the related options -->

- [x] Chore
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings