### PR TITLE
Concurrency safe client factory

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -561,7 +561,11 @@ func (c *command) start(ctx context.Context) error {
 		EnableWorker:       c.EnableWorker,
 	})
 
-	apClientFactory, err := apclient.NewClientFactory(adminClientFactory.GetRESTConfig())
+	restConfig, err := adminClientFactory.GetRESTConfig()
+	if err != nil {
+		return err
+	}
+	apClientFactory, err := apclient.NewClientFactory(restConfig)
 	if err != nil {
 		return err
 	}

--- a/internal/testutil/kube_client.go
+++ b/internal/testutil/kube_client.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testutil
 
 import (
-	"errors"
 	"reflect"
 	"strings"
 
@@ -99,10 +98,6 @@ func (f *FakeClientFactory) GetDiscoveryClient() (discovery.CachedDiscoveryInter
 
 func (f *FakeClientFactory) GetConfigClient() (k0sv1beta1.ClusterConfigInterface, error) {
 	return f.ConfigClient, nil
-}
-
-func (f *FakeClientFactory) GetRESTClient() (rest.Interface, error) {
-	return nil, errors.ErrUnsupported
 }
 
 func (f FakeClientFactory) GetRESTConfig() *rest.Config {

--- a/internal/testutil/kube_client.go
+++ b/internal/testutil/kube_client.go
@@ -105,7 +105,7 @@ func (f *FakeClientFactory) GetConfigClient() (k0sv1beta1.ClusterConfigInterface
 }
 
 func (f FakeClientFactory) GetRESTConfig() *rest.Config {
-	return &rest.Config{}
+	panic("GetRESTConfig not implemented for FakeClientFactory")
 }
 
 // Deprecated: Use [FakeClientFactory.GetK0sClient] instead.

--- a/internal/testutil/kube_client.go
+++ b/internal/testutil/kube_client.go
@@ -104,7 +104,7 @@ func (f *FakeClientFactory) GetConfigClient() (k0sv1beta1.ClusterConfigInterface
 	return f.K0sClient.K0sV1beta1().ClusterConfigs(constant.ClusterConfigNamespace), nil
 }
 
-func (f FakeClientFactory) GetRESTConfig() *rest.Config {
+func (f FakeClientFactory) GetRESTConfig() (*rest.Config, error) {
 	panic("GetRESTConfig not implemented for FakeClientFactory")
 }
 

--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -155,7 +155,11 @@ func (s *Stack) Apply(ctx context.Context, prune bool) error {
 
 // waitForCRD waits 5 seconds for a CRD to become established on a best-effort basis.
 func (s *Stack) waitForCRD(ctx context.Context, crdName string) {
-	client, err := extensionsclient.NewForConfig(s.Clients.GetRESTConfig())
+	config, err := s.Clients.GetRESTConfig()
+	if err != nil {
+		return
+	}
+	client, err := extensionsclient.NewForConfig(config)
 	if err != nil {
 		return
 	}

--- a/pkg/autopilot/checks/checks.go
+++ b/pkg/autopilot/checks/checks.go
@@ -66,7 +66,12 @@ func CanUpdate(ctx context.Context, log logrus.FieldLogger, clientFactory kubern
 			}
 
 			if metaClient == nil {
-				if metaClient, err = metadata.NewForConfig(clientFactory.GetRESTConfig()); err != nil {
+				restConfig, err := clientFactory.GetRESTConfig()
+				if err != nil {
+					return err
+				}
+
+				if metaClient, err = metadata.NewForConfig(restConfig); err != nil {
 					return err
 				}
 			}

--- a/pkg/autopilot/checks/checks.go
+++ b/pkg/autopilot/checks/checks.go
@@ -42,11 +42,7 @@ func CanUpdate(ctx context.Context, log logrus.FieldLogger, clientFactory kubern
 		}
 	}
 
-	metaClient, err := metadata.NewForConfig(clientFactory.GetRESTConfig())
-	if err != nil {
-		return err
-	}
-
+	var metaClient metadata.Interface
 	for _, r := range resources {
 		gv, err := schema.ParseGroupVersion(r.GroupVersion)
 		if err != nil {
@@ -67,6 +63,12 @@ func CanUpdate(ctx context.Context, log logrus.FieldLogger, clientFactory kubern
 			removedInVersion := removedInVersion(gv.WithKind(ar.Kind))
 			if removedInVersion == "" || semver.Compare(newVersion, removedInVersion) < 0 {
 				continue
+			}
+
+			if metaClient == nil {
+				if metaClient, err = metadata.NewForConfig(clientFactory.GetRESTConfig()); err != nil {
+					return err
+				}
 			}
 
 			metas, err := metaClient.Resource(gv.WithResource(ar.Name)).

--- a/pkg/component/controller/autopilot.go
+++ b/pkg/component/controller/autopilot.go
@@ -46,7 +46,11 @@ func (a *Autopilot) Init(ctx context.Context) error {
 func (a *Autopilot) Start(ctx context.Context) error {
 	log := logrus.WithFields(logrus.Fields{"component": "autopilot"})
 
-	autopilotClientFactory, err := apcli.NewClientFactory(a.AdminClientFactory.GetRESTConfig())
+	restConfig, err := a.AdminClientFactory.GetRESTConfig()
+	if err != nil {
+		return fmt.Errorf("creating autopilot client factory error: %w", err)
+	}
+	autopilotClientFactory, err := apcli.NewClientFactory(restConfig)
 	if err != nil {
 		return fmt.Errorf("creating autopilot client factory error: %w", err)
 	}

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -126,8 +126,10 @@ func (e *EtcdMemberReconciler) Stop() error {
 }
 
 func (e *EtcdMemberReconciler) waitForCRD(ctx context.Context) error {
-	rc := e.clientFactory.GetRESTConfig()
-
+	rc, err := e.clientFactory.GetRESTConfig()
+	if err != nil {
+		return err
+	}
 	ec, err := extclient.NewForConfig(rc)
 	if err != nil {
 		return err

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -38,7 +38,6 @@ type ClientFactoryInterface interface {
 	GetDynamicClient() (dynamic.Interface, error)
 	GetDiscoveryClient() (discovery.CachedDiscoveryInterface, error)
 	GetConfigClient() (cfgClient.ClusterConfigInterface, error)
-	GetRESTClient() (rest.Interface, error)
 	GetRESTConfig() *rest.Config
 	GetEtcdMemberClient() (etcdMemberClient.EtcdMemberInterface, error)
 }
@@ -193,14 +192,6 @@ func (c *ClientFactory) GetEtcdMemberClient() (etcdMemberClient.EtcdMemberInterf
 		return nil, err
 	}
 	return etcdMemberClient.EtcdMembers(), nil
-}
-
-func (c *ClientFactory) GetRESTClient() (rest.Interface, error) {
-	cs, ok := c.client.(*kubernetes.Clientset)
-	if !ok {
-		return nil, fmt.Errorf("error converting interface")
-	}
-	return cs.RESTClient(), nil
 }
 
 func (c *ClientFactory) GetRESTConfig() *rest.Config {

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -40,7 +40,7 @@ type ClientFactoryInterface interface {
 	GetDiscoveryClient() (discovery.CachedDiscoveryInterface, error)
 	GetK0sClient() (k0sclientset.Interface, error)
 	GetConfigClient() (cfgClient.ClusterConfigInterface, error) // Deprecated: Use [ClientFactoryInterface.GetK0sClient] instead.
-	GetRESTConfig() *rest.Config
+	GetRESTConfig() (*rest.Config, error)
 	GetEtcdMemberClient() (etcdMemberClient.EtcdMemberInterface, error) // Deprecated: Use [ClientFactoryInterface.GetK0sClient] instead.
 }
 
@@ -198,8 +198,12 @@ func (c *ClientFactory) GetEtcdMemberClient() (etcdMemberClient.EtcdMemberInterf
 	return k0sClient.EtcdV1beta1().EtcdMembers(), nil
 }
 
-func (c *ClientFactory) GetRESTConfig() *rest.Config {
-	return c.restConfig
+func (c *ClientFactory) GetRESTConfig() (*rest.Config, error) {
+	restConfig := c.restConfig
+	if restConfig == nil {
+		return nil, fmt.Errorf("REST config not yet initialized")
+	}
+	return restConfig, nil
 }
 
 // KubeconfigFromFile returns a [clientcmd.KubeconfigGetter] that tries to load


### PR DESCRIPTION
## Description

* Remove `GetRESTClient`
  This was accessing the client field without locking the mutex and was potentially missing initialization. The dynamic client is actually exposing its REST client, so that can be used instead.

* Use k0s's clientset in the k0s client factory
  Keep the old CRD specific versions for backwards compatibility.

* Lazy initialization for metadata client in Autopilot update checks
  This allows `FakeClientFactory.GetRESTConfig` method to panic without breaking tests. Code constructed with an empty rest.Config is not backed by a fake client at all, so it's better to have tests fail up front than to have strange errors when such constructed clients are actually used.

* Lazy initialization in client factory's `GetRESTClient`
  Previously, the `GetRESTClient` method was not synchronized and not concurrency safe. Callers could get a nil pointer under certain circumstances. Change this by adding mutexes and making it use lazy initialization like all other getters. This means that this method needs to be fallible.

* Introduce `LoadRESTConfig` function pointer
  This way, the way the REST config is loaded is up to the client factory users. The special "admin" settings are now part of the controller command, freeing the client factory from any particular way of loading and setting up the config.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings