### PR TITLE
Don't default to use shared-cache for kine SQLite databases

### DIFF
--- a/pkg/apis/k0s/v1beta1/storage.go
+++ b/pkg/apis/k0s/v1beta1/storage.go
@@ -187,7 +187,7 @@ func DefaultKineConfig(dataDir string) *KineConfig {
 			Scheme:   "file",
 			OmitHost: true,
 			Path:     filepath.ToSlash(filepath.Join(dataDir, "db", "state.db")),
-			RawQuery: "mode=rwc&_journal=WAL&cache=shared",
+			RawQuery: "mode=rwc&_journal=WAL",
 		}),
 	}
 }

--- a/pkg/apis/k0s/v1beta1/storage_test.go
+++ b/pkg/apis/k0s/v1beta1/storage_test.go
@@ -158,7 +158,7 @@ spec:
 		expectedPath = "file:C:/var/lib/k0s/db/state.db"
 	}
 
-	assert.Equal(t, fmt.Sprintf("sqlite://%s?mode=rwc&_journal=WAL&cache=shared", expectedPath), c.Spec.Storage.Kine.DataSource)
+	assert.Equal(t, fmt.Sprintf("sqlite://%s?mode=rwc&_journal=WAL", expectedPath), c.Spec.Storage.Kine.DataSource)
 }
 
 type storageSuite struct {


### PR DESCRIPTION
## Description

As per the [SQLite website](https://www.sqlite.org/sharedcache.html), the use of shared-cache is discouraged and most use cases are better served by using WALs, which k0s does anyway. Using shared-cache may yield to arbitrary kine errors of the form "database table is locked: kine" (not to confuse with "database is locked"), especially during heavy read/write concurrency, e.g. when the stack appliers do big syncs in parallel, while other API server operations are ongoing, as well. Some of those errors can be so grave that k0s is not able to finish bootstrapping.

I couldn't observe any obvious disadvantages by not using shared-cache so far.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings