### PR TITLE
Remove minReadySeconds from kube-router DaemonSet

### DIFF
--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -245,7 +245,6 @@ spec:
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: kube-router
-      minReadySeconds: 5
       initContainers:
         - name: install-cni-bins
           image: {{ .CNIInstallerImage }}


### PR DESCRIPTION
## Description

The `minReadySeconds` are a thing for `StatefulSets`. For `DaemonSets` there's no such field at all. Simply remove it as it has no effect, despite producing logs like 'unknown field "spec.template.spec.minReadySeconds"'.

Fixes:
* #4420

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings