### PR TITLE
Wait until containerd is reachable when starting

### DIFF
--- a/pkg/container/runtime/cri.go
+++ b/pkg/container/runtime/cri.go
@@ -32,6 +32,17 @@ type CRIRuntime struct {
 	criSocketPath string
 }
 
+func (cri *CRIRuntime) Ping(ctx context.Context) error {
+	client, conn, err := getRuntimeClient(cri.criSocketPath)
+	defer closeConnection(conn)
+	if err != nil {
+		return fmt.Errorf("failed to create CRI runtime client: %w", err)
+	}
+
+	_, err = client.Version(ctx, &pb.VersionRequest{})
+	return err
+}
+
 func (cri *CRIRuntime) ListContainers(ctx context.Context) ([]string, error) {
 	client, conn, err := getRuntimeClient(cri.criSocketPath)
 	defer closeConnection(conn)

--- a/pkg/container/runtime/runtime.go
+++ b/pkg/container/runtime/runtime.go
@@ -22,6 +22,7 @@ import (
 )
 
 type ContainerRuntime interface {
+	Ping(ctx context.Context) error
 	ListContainers(ctx context.Context) ([]string, error)
 	RemoveContainer(ctx context.Context, id string) error
 	StopContainer(ctx context.Context, id string) error


### PR DESCRIPTION
## Description

Kubelet will crash-loop if it can't connect to the container runtime. Wait for containerd to be reachable before returning from the containerd component's start method. This way, kubelet will be able to connect right away.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings