### PR TITLE
Remove bogus 'o' option which breaks newer curl from k0sctl download …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -601,7 +601,7 @@ jobs:
       - name: Create k0s Cluster using k0sctl
         run: |
           # download k0sctl
-          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo "https://github.com/k0sproject/k0sctl/releases/download/${K0SCTL_VERSION}/k0sctl-linux-x64" -o k0sctl
+          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo k0sctl "https://github.com/k0sproject/k0sctl/releases/download/${K0SCTL_VERSION}/k0sctl-linux-x64"
           chmod +x ./k0sctl
           ./k0sctl apply -c k0sctl.yaml
 


### PR DESCRIPTION
…step

## Description

The `curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo "https://github.com/k0sproject/k0sctl/releases/download/${K0SCTL_VERSION}/k0sctl-linux-x64" -o k0sctl` has `o` defined two times which seems to break newer curl:

```
curl: no URL specified!
curl: try 'curl --help' or 'curl --manual' for more information
```

So remove the "extra" `o` option

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings