### PR TITLE
Bump bootloose to v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,9 +25,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0
 	github.com/go-playground/validator/v10 v10.22.1
 	github.com/google/go-cmp v0.6.0
-	github.com/k0sproject/bootloose v0.7.2
-	github.com/k0sproject/dig v0.2.0
-	github.com/k0sproject/version v0.6.0
+	github.com/k0sproject/bootloose v0.9.0
 	github.com/kardianos/service v1.2.2
 	github.com/logrusorgru/aurora/v3 v3.0.0
 	github.com/mesosphere/toml-merge v0.2.0
@@ -83,6 +81,11 @@ require (
 )
 
 require (
+	github.com/k0sproject/dig v0.2.0
+	github.com/k0sproject/version v0.6.0
+)
+
+require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0 // indirect
@@ -123,7 +126,7 @@ require (
 	github.com/daviddengcn/go-colortext v1.0.0 // indirect
 	github.com/docker/cli v25.0.1+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
-	github.com/docker/docker v26.1.5+incompatible // indirect
+	github.com/docker/docker v27.0.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/docker/cli v25.0.1+incompatible h1:mFpqnrS6Hsm3v1k7Wa/BO23oz0k121MTbT
 github.com/docker/cli v25.0.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v26.1.5+incompatible h1:NEAxTwEjxV6VbBMBoGG3zPqbiJosIApZjxlbrG9q3/g=
-github.com/docker/docker v26.1.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v27.0.2+incompatible h1:mNhCtgXNV1fIRns102grG7rdzIsGGCq1OlOD0KunZos=
+github.com/docker/docker v27.0.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
@@ -353,8 +353,8 @@ github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/k0sproject/bootloose v0.7.2 h1:K3IRlP8WSBWuNqT7SN/L6nw3rYY+aMpfqylOQ2tksf4=
-github.com/k0sproject/bootloose v0.7.2/go.mod h1:BwIRhmv1ioCQsOeTa6qeSlBFzu5OTpINP9BIjVAXjEc=
+github.com/k0sproject/bootloose v0.9.0 h1:Ae45gF0jfS7ND6z1EotWs4qWAwqTRahvET91Y2+GMwo=
+github.com/k0sproject/bootloose v0.9.0/go.mod h1:4NkBMQoJ5ZZCGNWjiiEBOxn4ciEo1mBQVOmCYYglGmM=
 github.com/k0sproject/dig v0.2.0 h1:cNxEIl96g9kqSMfPSZLhpnZ0P8bWXKv08nxvsMHop5w=
 github.com/k0sproject/dig v0.2.0/go.mod h1:rBcqaQlJpcKdt2x/OE/lPvhGU50u/e95CSm5g/r4s78=
 github.com/k0sproject/version v0.6.0 h1:Wi8wu9j+H36+okIQA47o/YHbzNpKeIYj8IjGdJOdqsI=

--- a/inttest/common/bootloosesuite.go
+++ b/inttest/common/bootloosesuite.go
@@ -1172,7 +1172,7 @@ func (s *BootlooseSuite) initializeBootlooseClusterInDir(dir string) error {
 		Machines: []config.MachineReplicas{
 			{
 				Count: s.ControllerCount,
-				Spec: config.Machine{
+				Spec: &config.Machine{
 					Image:        s.BootLooseImage,
 					Name:         controllerNodeNameFormat,
 					Privileged:   true,
@@ -1182,7 +1182,7 @@ func (s *BootlooseSuite) initializeBootlooseClusterInDir(dir string) error {
 			},
 			{
 				Count: s.WorkerCount,
-				Spec: config.Machine{
+				Spec: &config.Machine{
 					Image:        s.BootLooseImage,
 					Name:         workerNodeNameFormat,
 					Privileged:   true,
@@ -1192,7 +1192,7 @@ func (s *BootlooseSuite) initializeBootlooseClusterInDir(dir string) error {
 			},
 			{
 				Count: s.K0smotronWorkerCount,
-				Spec: config.Machine{
+				Spec: &config.Machine{
 					Image:        s.BootLooseImage,
 					Name:         k0smotronNodeNameFormat,
 					Privileged:   true,
@@ -1205,7 +1205,7 @@ func (s *BootlooseSuite) initializeBootlooseClusterInDir(dir string) error {
 
 	if s.WithLB {
 		cfg.Machines = append(cfg.Machines, config.MachineReplicas{
-			Spec: config.Machine{
+			Spec: &config.Machine{
 				Name:         lbNodeNameFormat,
 				Image:        defaultBootLooseImage,
 				Privileged:   true,
@@ -1218,7 +1218,7 @@ func (s *BootlooseSuite) initializeBootlooseClusterInDir(dir string) error {
 
 	if s.WithExternalEtcd {
 		cfg.Machines = append(cfg.Machines, config.MachineReplicas{
-			Spec: config.Machine{
+			Spec: &config.Machine{
 				Name:         etcdNodeNameFormat,
 				Image:        defaultBootLooseImage,
 				Privileged:   true,
@@ -1230,7 +1230,7 @@ func (s *BootlooseSuite) initializeBootlooseClusterInDir(dir string) error {
 
 	if s.WithUpdateServer {
 		cfg.Machines = append(cfg.Machines, config.MachineReplicas{
-			Spec: config.Machine{
+			Spec: &config.Machine{
 				Name:       updateServerNodeNameFormat,
 				Image:      "update-server",
 				Privileged: true,


### PR DESCRIPTION
I don't know why dependabot isn't catching these, we're not ignoring them in the yaml.