### PR TITLE
[Backport release-1.30] Bump runc to 1.1.14

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -3,7 +3,7 @@ alpine_patch_version = $(alpine_version).2
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
 go_version = 1.22.6
 
-runc_version = 1.1.13
+runc_version = 1.1.14
 runc_buildimage = $(golang_buildimage)
 runc_build_go_tags = "seccomp"
 #runc_build_go_cgo_enabled =


### PR DESCRIPTION
Backport to `release-1.30`:
* #4967