### PR TITLE
[Backport release-1.28] Bump go to v1.22.7

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.18
 alpine_patch_version = $(alpine_version).4
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine3.19
-go_version = 1.22.6
+go_version = 1.22.7
 
 runc_version = 1.1.13
 runc_buildimage = $(golang_buildimage)


### PR DESCRIPTION
Backport to `release-1.28`:
* #4990

See:
* #4979