### PR TITLE
Disable grab download resume

### DIFF
--- a/pkg/autopilot/controller/signal/k0s/download.go
+++ b/pkg/autopilot/controller/signal/k0s/download.go
@@ -16,6 +16,8 @@ package k0s
 
 import (
 	"crypto/sha256"
+	"os"
+	"path/filepath"
 
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
@@ -88,6 +90,13 @@ func (b downloadManifestBuilderK0s) Build(signalNode crcli.Object, signalData ap
 			ExpectedHash: signalData.Command.K0sUpdate.Sha256,
 			Hasher:       sha256.New(),
 			DownloadDir:  b.k0sBinaryDir,
+			Filename:     filepath.Join(b.k0sBinaryDir, "k0s.tmp"),
+		},
+		// After the download is done, we need to rename the file to the correct name
+		AfterTransferSuccess: func() error {
+			src := filepath.Join(b.k0sBinaryDir, "k0s.tmp")
+			dst := filepath.Join(b.k0sBinaryDir, "k0s")
+			return os.Rename(src, dst)
 		},
 		SuccessState: Cordoning,
 	}

--- a/pkg/autopilot/download/downloader.go
+++ b/pkg/autopilot/download/downloader.go
@@ -34,6 +34,7 @@ type Config struct {
 	ExpectedHash string
 	Hasher       hash.Hash
 	DownloadDir  string
+	Filename     string
 }
 
 type downloader struct {
@@ -70,6 +71,15 @@ func (d *downloader) Download(ctx context.Context) error {
 		}
 
 		dlreq.SetChecksum(d.config.Hasher, expectedHash, true)
+	}
+
+	// We're never really resuming downloads, so disable this feature.
+	// This also allows to re-download the file if it's already present.
+	dlreq.NoResume = true
+
+	if d.config.Filename != "" {
+		d.logger.Infof("Setting filename to %s", d.config.Filename)
+		dlreq.Filename = d.config.Filename
 	}
 
 	client := grab.NewClient()


### PR DESCRIPTION
## Description

This is to mitigate cases like #4296

By default grab tries to resume the download if the file name determined from either the url or from content-type headers already exists. This makes things go side ways, if the existing file is smaller than the new one, the old content would still be there and only the "extra" new bytes would get written. I.e. the download would be "resumed". :facepalm:

This is probably not a fix for the root cause in #4296 as the only way I've been able to make grab fail with `bad content length` is by crafting a custom http server that maliciously borks `Content-Length` header.

This is a minimal possible fix that we can easily backport. @twz123 is already working on bigger refactoring of autopilot download functionality that gets rid of grab. Grab seems to bring more (bad) surprises than real benefits. In the end, we just download files and we should pretty much always just replace them. No need for full library dependecy for that.



<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test: I've tested the grab functionality manually to figure out this resume stuff
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings