### PR TITLE
Capture errors when creating new users in inttests

### DIFF
--- a/inttest/common/bootloosesuite.go
+++ b/inttest/common/bootloosesuite.go
@@ -653,16 +653,13 @@ func (s *BootlooseSuite) GetJoinToken(role string, extraArgs ...string) (string,
 	}
 	defer ssh.Disconnect()
 
-	tokenCmd := fmt.Sprintf("%s token create --role=%s %s 2>/dev/null", s.K0sFullPath, role, strings.Join(extraArgs, " "))
-	token, err := ssh.ExecWithOutput(s.Context(), tokenCmd)
-	if err != nil {
+	tokenCmd := fmt.Sprintf("%s token create --role=%s %s", s.K0sFullPath, role, strings.Join(extraArgs, " "))
+	var tokenBuf bytes.Buffer
+	if err := ssh.Exec(s.Context(), tokenCmd, SSHStreams{Out: &tokenBuf}); err != nil {
 		return "", fmt.Errorf("can't get join token: %w", err)
 	}
-	outputParts := strings.Split(token, "\n")
-	// in case of no k0s.conf given, there might be warnings on the first few lines
 
-	token = outputParts[len(outputParts)-1]
-	return token, nil
+	return string(bytes.TrimSpace(tokenBuf.Bytes())), nil
 }
 
 // ImportK0smotrtonImages imports


### PR DESCRIPTION
## Description

Remove error redirection. Instead, use separate buffers for stdout and stderr. This way, any errors during user creation will be properly reported.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings