### PR TITLE
Create the autopilot client before applying the plan

### DIFF
--- a/inttest/ap-airgap/airgap_test.go
+++ b/inttest/ap-airgap/airgap_test.go
@@ -142,6 +142,10 @@ spec:
 	)
 	s.Require().NoError(err)
 
+	client, err := s.AutopilotClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.NotEmpty(client)
+
 	manifestFile := "/tmp/happy.yaml"
 	s.PutFileTemplate(s.ControllerNode(0), manifestFile, planTemplate, nil)
 
@@ -150,10 +154,6 @@ spec:
 	out, err := s.RunCommandController(0, fmt.Sprintf("/usr/local/bin/k0s kubectl apply -f %s", manifestFile))
 	s.T().Logf("kubectl apply output: '%s'", out)
 	s.Require().NoError(err)
-
-	client, err := s.AutopilotClient(s.ControllerNode(0))
-	s.Require().NoError(err)
-	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
 	_, err = aptest.WaitForPlanState(ctx, client, apconst.AutopilotName, appc.PlanCompleted)

--- a/inttest/ap-controllerworker/controllerworker_test.go
+++ b/inttest/ap-controllerworker/controllerworker_test.go
@@ -114,6 +114,9 @@ func (s *controllerworkerSuite) SetupTest() {
 // TestApply applies a well-formed `plan` yaml, and asserts that
 // all of the correct values across different objects + controllers are correct.
 func (s *controllerworkerSuite) TestApply() {
+	client, err := s.AutopilotClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.NotEmpty(client)
 
 	planTemplate := `
 apiVersion: autopilot.k0sproject.io/v1beta2
@@ -148,10 +151,6 @@ spec:
 	out, err := s.RunCommandController(0, fmt.Sprintf("/usr/local/bin/k0s kubectl apply -f %s", manifestFile))
 	s.T().Logf("kubectl apply output: '%s'", out)
 	s.Require().NoError(err)
-
-	client, err := s.AutopilotClient(s.ControllerNode(0))
-	s.Require().NoError(err)
-	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
 	plan, err := aptest.WaitForPlanState(s.Context(), client, apconst.AutopilotName, appc.PlanCompleted)

--- a/inttest/ap-platformselect/platformselect_test.go
+++ b/inttest/ap-platformselect/platformselect_test.go
@@ -51,6 +51,10 @@ func (s *platformSelectSuite) SetupTest() {
 // TestApply applies a well-formed `plan` yaml that includes multiple
 // platform definitions, and asserts that the proper binary is downloaded.
 func (s *platformSelectSuite) TestApply() {
+	client, err := s.AutopilotClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.NotEmpty(client)
+
 	planTemplate := `
 apiVersion: autopilot.k0sproject.io/v1beta2
 kind: Plan
@@ -84,10 +88,6 @@ spec:
 	out, err := s.RunCommandController(0, fmt.Sprintf("/usr/local/bin/k0s kubectl apply -f %s", manifestFile))
 	s.T().Logf("kubectl apply output: '%s'", out)
 	s.Require().NoError(err)
-
-	client, err := s.AutopilotClient(s.ControllerNode(0))
-	s.Require().NoError(err)
-	s.NotEmpty(client)
 
 	// Its expected that if the wrong platform were to be downloaded, the update wouldn't be successful,
 	// as the binary would fail to run.

--- a/inttest/ap-quorum/quorum_test.go
+++ b/inttest/ap-quorum/quorum_test.go
@@ -77,6 +77,10 @@ func (s *quorumSuite) SetupTest() {
 // TestApply applies a well-formed `plan` yaml, and asserts that
 // all of the correct values across different objects + controllers are correct.
 func (s *quorumSuite) TestApply() {
+	client, err := s.AutopilotClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.NotEmpty(client)
+
 	planTemplate := `
 apiVersion: autopilot.k0sproject.io/v1beta2
 kind: Plan
@@ -108,10 +112,6 @@ spec:
 	out, err := s.RunCommandController(0, fmt.Sprintf("/usr/local/bin/k0s kubectl apply -f %s", manifestFile))
 	s.T().Logf("kubectl apply output: '%s'", out)
 	s.Require().NoError(err)
-
-	client, err := s.AutopilotClient(s.ControllerNode(0))
-	s.Require().NoError(err)
-	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
 	plan, err := aptest.WaitForPlanState(s.Context(), client, apconst.AutopilotName, appc.PlanCompleted)

--- a/inttest/ap-quorumsafety/quorumsafety_test.go
+++ b/inttest/ap-quorumsafety/quorumsafety_test.go
@@ -99,6 +99,10 @@ metadata:
 
 	// Create + populate the plan
 
+	client, err := s.AutopilotClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.NotEmpty(client)
+
 	planTemplate := `
 apiVersion: autopilot.k0sproject.io/v1beta2
 kind: Plan
@@ -130,10 +134,6 @@ spec:
 	out, err = s.RunCommandController(0, fmt.Sprintf("/usr/local/bin/k0s kubectl apply -f %s", manifestFile))
 	s.T().Logf("kubectl apply output (plan): '%s'", out)
 	s.Require().NoError(err)
-
-	client, err := s.AutopilotClient(s.ControllerNode(0))
-	s.Require().NoError(err)
-	s.NotEmpty(client)
 
 	// The plan should fail with "InconsistentTargets" due to autopilot detecting that `controller2`
 	// despite existing as a `ControlNode`, does not resolve.

--- a/inttest/ap-removedapis/removedapis_test.go
+++ b/inttest/ap-removedapis/removedapis_test.go
@@ -79,6 +79,10 @@ func (s *plansRemovedAPIsSuite) SetupTest() {
 // TestApply applies a well-formed `plan` yaml, and asserts that all of the correct values
 // across different objects are correct.
 func (s *plansRemovedAPIsSuite) TestApply() {
+	client, err := s.AutopilotClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.NotEmpty(client)
+
 	ctx := s.Context()
 
 	manifestFile := "/tmp/plan.yaml"
@@ -87,10 +91,6 @@ func (s *plansRemovedAPIsSuite) TestApply() {
 	out, err := s.RunCommandController(0, fmt.Sprintf("/usr/local/bin/k0s kubectl apply -f %s", manifestFile))
 	s.T().Logf("kubectl apply output: '%s'", out)
 	s.Require().NoError(err)
-
-	client, err := s.AutopilotClient(s.ControllerNode(0))
-	s.Require().NoError(err)
-	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
 	plan, err := aptest.WaitForPlanState(ctx, client, apconst.AutopilotName, appc.PlanWarning)

--- a/inttest/ap-selector/selector_test.go
+++ b/inttest/ap-selector/selector_test.go
@@ -126,16 +126,17 @@ spec:
 	s.Require().NoError(err)
 
 	// Save + apply the plan
+
+	apc, err := s.AutopilotClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.NotEmpty(apc)
+
 	manifestFile := "/tmp/plan.yaml"
 	s.PutFileTemplate(s.ControllerNode(0), manifestFile, planTemplate, nil)
 
 	out, err := s.RunCommandController(0, fmt.Sprintf("/usr/local/bin/k0s kubectl apply -f %s", manifestFile))
 	s.T().Logf("kubectl apply output: '%s'", out)
 	s.Require().NoError(err)
-
-	apc, err := s.AutopilotClient(s.ControllerNode(0))
-	s.Require().NoError(err)
-	s.NotEmpty(apc)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
 	plan, err := aptest.WaitForPlanState(s.Context(), apc, apconst.AutopilotName, appc.PlanCompleted)

--- a/inttest/ap-single/single_test.go
+++ b/inttest/ap-single/single_test.go
@@ -61,6 +61,10 @@ func (s *plansSingleControllerSuite) SetupTest() {
 // TestApply applies a well-formed `plan` yaml, and asserts that all of the correct values
 // across different objects are correct.
 func (s *plansSingleControllerSuite) TestApply() {
+	client, err := s.AutopilotClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.NotEmpty(client)
+
 	planTemplate := `
 apiVersion: autopilot.k0sproject.io/v1beta2
 kind: Plan
@@ -90,10 +94,6 @@ spec:
 	out, err := s.RunCommandController(0, fmt.Sprintf("/usr/local/bin/k0s kubectl apply -f %s", manifestFile))
 	s.T().Logf("kubectl apply output: '%s'", out)
 	s.Require().NoError(err)
-
-	client, err := s.AutopilotClient(s.ControllerNode(0))
-	s.Require().NoError(err)
-	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
 	plan, err := aptest.WaitForPlanState(s.Context(), client, apconst.AutopilotName, appc.PlanCompleted)

--- a/inttest/ap-updater-periodic/updater_test.go
+++ b/inttest/ap-updater-periodic/updater_test.go
@@ -105,6 +105,10 @@ func (s *plansSingleControllerSuite) getClusterID(kc kubernetes.Interface) strin
 // TestApply applies a well-formed `plan` yaml, and asserts that all of the correct values
 // across different objects are correct.
 func (s *plansSingleControllerSuite) TestApply() {
+	client, err := s.AutopilotClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.NotEmpty(client)
+
 	updaterConfig := `
 apiVersion: autopilot.k0sproject.io/v1beta2
 kind: UpdateConfig
@@ -144,10 +148,6 @@ spec:
 	out, err := s.RunCommandController(0, fmt.Sprintf("/usr/local/bin/k0s kubectl apply -f %s", manifestFile))
 	s.T().Logf("kubectl apply output: '%s'", out)
 	s.Require().NoError(err)
-
-	client, err := s.AutopilotClient(s.ControllerNode(0))
-	s.Require().NoError(err)
-	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
 	_, err = aptest.WaitForPlanState(s.Context(), client, apconst.AutopilotName, appc.PlanCompleted)

--- a/inttest/ap-updater/updater_test.go
+++ b/inttest/ap-updater/updater_test.go
@@ -56,6 +56,10 @@ func (s *plansSingleControllerSuite) SetupTest() {
 // TestApply applies a well-formed `plan` yaml, and asserts that all of the correct values
 // across different objects are correct.
 func (s *plansSingleControllerSuite) TestApply() {
+	client, err := s.AutopilotClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.NotEmpty(client)
+
 	updaterConfig := `
 apiVersion: autopilot.k0sproject.io/v1beta2
 kind: UpdateConfig
@@ -89,10 +93,6 @@ spec:
 	out, err := s.RunCommandController(0, fmt.Sprintf("/usr/local/bin/k0s kubectl apply -f %s", manifestFile))
 	s.T().Logf("kubectl apply output: '%s'", out)
 	s.Require().NoError(err)
-
-	client, err := s.AutopilotClient(s.ControllerNode(0))
-	s.Require().NoError(err)
-	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
 	_, err = aptest.WaitForPlanState(s.Context(), client, apconst.AutopilotName, appc.PlanCompleted)

--- a/inttest/kubeletcertrotate/kubeletcertrotate_test.go
+++ b/inttest/kubeletcertrotate/kubeletcertrotate_test.go
@@ -84,8 +84,12 @@ func (s *kubeletCertRotateSuite) SetupTest() {
 }
 
 func (s *kubeletCertRotateSuite) applyPlan(id string) {
+	client, err := s.AutopilotClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.NotEmpty(client)
+
 	// Ensure that a plan and yaml do not exist (safely)
-	_, err := s.RunCommandController(0, "/usr/local/bin/k0s kubectl delete plan autopilot | true")
+	_, err = s.RunCommandController(0, "/usr/local/bin/k0s kubectl delete plan autopilot | true")
 	s.Require().NoError(err)
 	_, err = s.RunCommandController(0, "rm -f /tmp/happy.yaml")
 	s.Require().NoError(err)
@@ -128,10 +132,6 @@ spec:
 	out, err := s.RunCommandController(0, fmt.Sprintf("/usr/local/bin/k0s kubectl apply -f %s", manifestFile))
 	s.T().Logf("kubectl apply output: '%s'", out)
 	s.Require().NoError(err)
-
-	client, err := s.AutopilotClient(s.ControllerNode(0))
-	s.Require().NoError(err)
-	s.NotEmpty(client)
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
 	plan, err := aptest.WaitForPlanState(s.Context(), client, apconst.AutopilotName, appc.PlanCompleted)


### PR DESCRIPTION
## Description

If it's done the other way round, it might happen that the k0s binary is being replaced by the autopilot update process, and cannot be executed.

This prevents errors like this:

> Process exited with status 126: "sh: /usr/local/bin/k0s: Permission denied"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings