### PR TITLE
Stale download cancellation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bombsimon/logrusr/v4 v4.1.0
 	github.com/carlmjohnson/requests v0.24.2
-	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/cilium/ebpf v0.16.0
 	github.com/cloudflare/cfssl v1.6.4
 	github.com/containerd/cgroups/v3 v3.0.3

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	golang.org/x/mod v0.21.0
 	golang.org/x/sync v0.8.0
 	golang.org/x/sys v0.25.0
+	golang.org/x/text v0.18.0
 	golang.org/x/tools v0.25.0
 	google.golang.org/grpc v1.67.0
 	helm.sh/helm/v3 v3.16.1
@@ -260,7 +261,6 @@ require (
 	golang.org/x/net v0.29.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/term v0.24.0 // indirect
-	golang.org/x/text v0.18.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,6 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXe
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/carlmjohnson/requests v0.24.2 h1:JDakhAmTIKL/qL/1P7Kkc2INGBJIkIFP6xUeUmPzLso=
 github.com/carlmjohnson/requests v0.24.2/go.mod h1:duYA/jDnyZ6f3xbcF5PpZ9N8clgopubP2nK5i6MVMhU=
-github.com/cavaliergopher/grab/v3 v3.0.1 h1:4z7TkBfmPjmLAAmkkAZNX/6QJ1nNFdv3SdIHXju0Fr4=
-github.com/cavaliergopher/grab/v3 v3.0.1/go.mod h1:1U/KNnD+Ft6JJiYoYBAimKH2XrYptb8Kl3DFGmsjpq4=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/internal/http/download.go
+++ b/internal/http/download.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/k0sproject/k0s/pkg/build"
+)
+
+type DownloadOption func(*downloadOptions)
+
+// Downloads the contents of the given URL. Writes the HTTP response body to writer.
+func Download(ctx context.Context, url string, target io.Writer, options ...DownloadOption) (err error) {
+	opts := downloadOptions{}
+	for _, opt := range options {
+		opt(&opts)
+	}
+
+	// Prepare the client and the request.
+	client := http.Client{
+		Transport: &http.Transport{
+			// This is a one-shot HTTP client which should release resources immediately.
+			DisableKeepAlives: true,
+		},
+	}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("invalid download request: %w", err)
+	}
+	req.Header.Set("User-Agent", "k0s/"+build.Version)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Execute the request.
+	resp, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		if cause := context.Cause(ctx); cause != nil && !errors.Is(err, cause) {
+			err = fmt.Errorf("%w (%w)", cause, err)
+		}
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bad status: %s", resp.Status)
+	}
+
+	if err := opts.detectRemoteFileName(resp); err != nil {
+		return err
+	}
+
+	// Run the actual data transfer.
+	if _, err := io.Copy(target, resp.Body); err != nil {
+		if cause := context.Cause(ctx); cause != nil && !errors.Is(err, cause) {
+			err = fmt.Errorf("%w (%w)", cause, err)
+		}
+
+		return fmt.Errorf("while downloading: %w", err)
+	}
+
+	return nil
+}
+
+type downloadOptions struct {
+	downloadFileNameOptions
+}

--- a/internal/http/download_test.go
+++ b/internal/http/download_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	internalhttp "github.com/k0sproject/k0s/internal/http"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownload_CancelRequest(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.TODO())
+	cancel(assert.AnError)
+
+	err := internalhttp.Download(ctx, "http://404.example.com", io.Discard)
+	assert.ErrorIs(t, err, assert.AnError)
+	if urlErr := (*url.Error)(nil); assert.ErrorAs(t, err, &urlErr) {
+		assert.Equal(t, "Get", urlErr.Op)
+		assert.Equal(t, "http://404.example.com", urlErr.URL)
+		assert.Equal(t, context.Canceled, urlErr.Err)
+	}
+}
+
+func TestDownload_NoContent(t *testing.T) {
+	baseURL := startFakeDownloadServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	err := internalhttp.Download(context.TODO(), baseURL, io.Discard)
+	assert.ErrorContains(t, err, "bad status: 204 No Content")
+}
+
+func TestDownload_ShortDownload(t *testing.T) {
+	baseURL := startFakeDownloadServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Length", "10")
+		_, err := w.Write([]byte("too short")) // this is only 9 bytes
+		assert.NoError(t, err)
+	}))
+
+	err := internalhttp.Download(context.TODO(), baseURL, io.Discard)
+	assert.ErrorContains(t, err, "while downloading: unexpected EOF")
+}
+
+func TestDownload_ExcessContentLength(t *testing.T) {
+	baseURL := startFakeDownloadServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Length", "4")
+		_, err := w.Write([]byte("yolo"))
+		assert.NoError(t, err)
+		// Excess content length
+		_, err = w.Write([]byte("<-stripped"))
+		assert.ErrorIs(t, err, http.ErrContentLength)
+	}))
+
+	var downloaded strings.Builder
+	err := internalhttp.Download(context.TODO(), baseURL, &downloaded)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "yolo", downloaded.String())
+}
+
+func TestDownload_RedirectLoop(t *testing.T) {
+	// The current implementation doesn't detect loops, but it stops after 10 redirects.
+
+	expectedRequests := uint32(10)
+	var requests atomic.Uint32
+	var baseURL string
+	baseURL = startFakeDownloadServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !assert.LessOrEqual(t, requests.Add(1), expectedRequests, "More requests than anticipated") {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+
+		// Produce redirect loops: /looper-0, /looper-1, /looper-2, /looper-0, ...
+		var seq uint8
+		if _, lastSeq, found := strings.Cut(r.URL.Path, "/looper-"); found {
+			if lastSeq, err := strconv.ParseUint(lastSeq, 10, 4); err == nil && lastSeq < 3 {
+				seq = uint8(lastSeq) + 1
+			}
+		}
+
+		http.Redirect(w, r, fmt.Sprintf("%s/looper-%d", baseURL, seq), http.StatusSeeOther)
+	}))
+
+	var downloaded strings.Builder
+	err := internalhttp.Download(context.TODO(), baseURL, &downloaded)
+
+	assert.Equal(t, expectedRequests, requests.Load())
+	assert.ErrorContains(t, err, "stopped after 10 redirects")
+}
+
+func startFakeDownloadServer(t *testing.T, handler http.Handler) string {
+	server := &http.Server{Addr: "localhost:0", Handler: handler}
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	serverError := make(chan error)
+	go func() {
+		defer close(serverError)
+		serverError <- server.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		err := server.Shutdown(context.Background())
+		if !assert.NoError(t, err, "Couldn't shutdown HTTP server") {
+			return
+		}
+
+		assert.ErrorIs(t, <-serverError, http.ErrServerClosed, "HTTP server terminated unexpectedly")
+	})
+
+	return (&url.URL{Scheme: "http", Host: listener.Addr().String()}).String()
+}

--- a/internal/http/filename.go
+++ b/internal/http/filename.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"errors"
+	"fmt"
+	"mime"
+	"net/http"
+	"path"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/unicode/norm"
+)
+
+// Stores the file name suggested by the server in the given pointer.
+// Requesting the suggested file name will cause the download to fail if the
+// file name detection fails.
+func StoreSuggestedRemoteFileNameInto(target *string) DownloadOption {
+	return func(opts *downloadOptions) {
+		opts.remoteFileNameTarget = target
+	}
+}
+
+type downloadFileNameOptions struct {
+	remoteFileNameTarget *string
+}
+
+func (o *downloadFileNameOptions) detectRemoteFileName(resp *http.Response) error {
+	if o.remoteFileNameTarget == nil {
+		return nil
+	}
+
+	name, err := fileNameFor(resp)
+	if err != nil {
+		return fmt.Errorf("failed to determine file name: %w", err)
+	}
+	*o.remoteFileNameTarget = name
+	return nil
+}
+
+func fileNameFor(resp *http.Response) (string, error) {
+	var hdrErr error
+	cd := resp.Header.Values("Content-Disposition")
+	switch len(cd) {
+	case 1:
+		fileName, hdrErr := fileNameFromContentDisposition(cd[0])
+		if hdrErr == nil {
+			return fileName, nil
+		}
+	case 0:
+		hdrErr = errors.New("none provided")
+	default:
+		hdrErr = errors.New("multiple headers")
+	}
+
+	fileName, pathErr := fileNameFromRequestPath(resp.Request.URL.Path)
+	if pathErr == nil {
+		return fileName, nil
+	}
+
+	return "", fmt.Errorf("Content-Disposition header failed (%w), request path failed (%w)", hdrErr, pathErr)
+}
+
+func fileNameFromContentDisposition(contentDisposition string) (string, error) {
+	// RFC 2183: The Content-Disposition Header Field
+	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#as_a_response_header_for_the_main_body
+
+	// The header values are in ISO-8859-1, but mime.ParseMediaType doesn't
+	// address any character encoding conversions. It will pass on all the bytes
+	// as-is. Every multi-byte character needs to be presented as percent
+	// escapes anyway, so convert the whole string from ISO-8859-1 to UTF-8.
+	utf8, err := charmap.ISO8859_1.NewDecoder().String(contentDisposition)
+	if err != nil { // Can this fail at all? ISO-8859-1 to UTF-8 should always be possible.
+		return "", err
+	}
+
+	_, params, err := mime.ParseMediaType(utf8)
+	if err != nil {
+		return "", err
+	}
+
+	// RFC 2183, section 2.3: The Filename Parameter
+	// The standard library's mime package takes care of the RFC 5987 syntax
+	// transparently, so all the star-suffixed params are folded into the
+	// canonical ones.
+	if fileName, ok := params["filename"]; ok {
+		return sanitizeFileName(fileName)
+	}
+
+	return "", fmt.Errorf("no filename parameter")
+}
+
+func fileNameFromRequestPath(requestPath string) (string, error) {
+	if requestPath == "" {
+		return "", fmt.Errorf("request path is empty")
+	}
+
+	fileName := path.Base(requestPath)
+	if fileName == "/" {
+		return "", fmt.Errorf("request path has no base")
+	}
+
+	return sanitizeFileName(fileName)
+}
+
+func sanitizeFileName(fileName string) (string, error) {
+
+	// https://www.w3.org/International/questions/qa-bidi-unicode-controls#basedirection
+	const (
+		lri = '\u2066' // LEFT-TO-RIGHT ISOLATE
+		rli = '\u2067' // RIGHT-TO-LEFT ISOLATE
+		fsi = '\u2068' // FIRST-STRONG ISOLATE
+		lre = '\u202a' // LEFT-TO-RIGHT EMBEDDING
+		rle = '\u202b' // RIGHT-TO-LEFT EMBEDDING
+		lro = '\u202d' // LEFT-TO-RIGHT OVERRIDE
+		rlo = '\u202e' // RIGHT-TO-LEFT OVERRIDE
+		pdi = '\u2069' // POP DIRECTIONAL ISOLATE
+		pdf = '\u202c' // POP DIRECTIONAL FORMATTING
+	)
+
+	// Perform unicode normalization to get path names in the operating system's
+	// preferred form. Linux and Windows usually prefer NFC, whereas macOS tends
+	// to prefer NFD. Since k0s doesn't run on macOS, it's supposedly fine to
+	// stick to NFC. See also below.
+	fileName = norm.NFC.String(fileName)
+
+	if len(fileName) > 255 {
+		return "", errors.New("too long")
+	}
+
+	switch fileName {
+	case "":
+		return "", errors.New("empty")
+	case ".":
+		return "", errors.New("dot")
+	case "..":
+		return "", errors.New("dotdot")
+	}
+
+	// https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+	if base, _, _ := strings.Cut(fileName, "."); len(base) < 6 {
+		switch strings.ToLower(base) {
+		case "con", "prn", "aux", "nul",
+			"com0", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
+			"lpt0", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+			"com¹", "com²", "com³", "lpt¹", "lpt²", "lpt³": // this line relies on NFC
+			return "", errors.New("reserved name")
+		}
+	}
+
+	// Now replace all the problematic characters.
+	var sanitized strings.Builder
+	for pos, size, len := 0, 0, len(fileName); pos < len; pos += size {
+		var (
+			ch    rune
+			valid bool
+		)
+
+		ch, size = utf8.DecodeRuneInString(fileName[pos:])
+		switch ch {
+		case '\\', '/': // path separators
+		case '<', '>', '|': // redirections and pipes are not safe for shells and are not allowed in Windows file names
+		case ':': // used to specify Windows drive letters and not allowed in Windows file names
+		case '"': // used to encapsulate file names in shells and not allowed in Windows file names
+		case '?', '*': // shell wildcards and not allowed in Windows file names
+			// all of the above get replaced
+
+		case lri, rli, fsi, lre, rle, lro, rlo, pdi, pdf:
+			// replace all text direction modifications
+			// https://www.freecodecamp.org/news/rtlo-in-hacking/
+
+		case utf8.RuneError:
+			if size == 1 { // "if the encoding is invalid, it returns (RuneError, 1)"
+				return "", fmt.Errorf("invalid UTF-8 at position %d: 0x%2x", pos, fileName[pos])
+			}
+			valid = true // It's fine otherwise.
+
+		default:
+			switch {
+			case unicode.Is(unicode.Other, ch): // control characters
+			case pos == 0 && unicode.IsSpace(ch): // leading space
+			case pos == len-1 && (ch == '.' || unicode.IsSpace(ch)): // trailing dot/space
+				// all of the above get replaced
+			default: // legit character
+				valid = true
+			}
+		}
+
+		if valid {
+			if sanitized.Len() > 0 {
+				sanitized.WriteRune(ch)
+			}
+		} else {
+			if sanitized.Len() < 1 {
+				sanitized.Grow(len)
+				sanitized.WriteString(fileName[:pos])
+			}
+			sanitized.WriteByte('_')
+		}
+	}
+
+	if sanitized.Len() > 0 {
+		fileName = sanitized.String()
+	}
+
+	return fileName, nil
+}

--- a/internal/http/filename_test.go
+++ b/internal/http/filename_test.go
@@ -1,0 +1,394 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path"
+	"testing"
+
+	internalhttp "github.com/k0sproject/k0s/internal/http"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDownload_ContentDisposition(t *testing.T) {
+	// Test cases taken from http://test.greenbytes.de/tech/tc2231/.
+	// Note that some of those are not passing as is, because mime.ParseMimeType
+	// is a bit lax on input validation. The outcomes will be overridden later on.
+	tests := map[string]*struct {
+		header   string // the Content-Disposition header to be sent by the server
+		fileName string // the expected file name
+	}{
+		// This should be equivalent to not including the header at all.
+		"inlonly": {`inline`, "inlonly"},
+
+		// This is invalid syntax, thus the header should be ignored.
+		"inlonlyquoted": {`"inline"`, "inlonlyquoted"},
+
+		// 'inline', specifying a filename of foo.html
+		// Some UAs use this filename in a subsequent "save" operation.
+		"inlwithasciifilename": {`inline; filename="foo.html"`, "foo.html"},
+
+		// Test cases which are not applicable here:
+		// - inlwithfnattach
+		// - inlwithasciifilenamepdf
+
+		// 'attachment' only
+		// UA should offer to download the resource.
+		"attonly": {`attachment`, "attonly"},
+
+		// 'attachment' only, using double quotes
+		// This is invalid syntax, thus the header should be ignored.
+		"attonlyquoted": {`"attachment"`, "attonlyquoted"},
+
+		// Test cases which are not applicable here:
+		// - attonly403
+
+		// 'ATTACHMENT' only
+		// UA should offer to download the resource.
+		"attonlyucase": {`ATTACHMENT`, "attonlyucase"},
+
+		// 'attachment', specifying a filename of foo.html
+		// UA should offer to download the resource as foo.html.
+		"attwithasciifilename": {`attachment; filename="foo.html"`, "foo.html"},
+
+		// 'attachment', specifying a filename of 0000000000111111111122222 (25 characters)
+		"attwithasciifilename25": {`attachment; filename="0000000000111111111122222"`, "0000000000111111111122222"},
+
+		// 'attachment', specifying a filename of 00000000001111111111222222222233333 (35 characters)
+		"attwithasciifilename35": {`attachment; filename="00000000001111111111222222222233333"`, "00000000001111111111222222222233333"},
+
+		// 'attachment', specifying a filename of f\oo.html (the first 'o' being escaped)
+		// UA should offer to download the resource as foo.html.
+		"attwithasciifnescapedchar": {`attachment; filename="f\oo.html"`, "foo.html"},
+
+		// 'attachment', specifying a filename of \"quoting\" tested.html (using double quotes around "quoting" to test... quoting)
+		// UA should offer to download the resource as something like '"quoting" tested.html'
+		// (stripping the quotes may be ok for security reasons, but getting confused by them is not).
+		"attwithasciifnescapedquote": {`attachment; filename="\"quoting\" tested.html"`, `_quoting_ tested.html`},
+
+		// 'attachment', specifying a filename of Here's a semicolon;.html - this checks for proper parsing for parameters.
+		"attwithquotedsemicolon": {`attachment; filename="Here's a semicolon;.html"`, "Here's a semicolon;.html"},
+
+		// 'attachment', specifying a filename of foo.html and an extension parameter "foo" which should be ignored (see Section 4.4 of RFC 6266.).
+		// UA should offer to download the resource as foo.html.
+		"attwithfilenameandextparam": {`attachment; foo="bar"; filename="foo.html"`, "foo.html"},
+
+		// 'attachment', specifying a filename of foo.html and an extension parameter "foo" which should be ignored (see Section 4.4 of RFC 6266.).
+		// In comparison to attwithfilenameandextparam, the extension parameter actually uses backslash-escapes.
+		// This tests whether the UA properly skips the parameter.
+		// UA should offer to download the resource as foo.html.
+		"attwithfilenameandextparamescaped": {`attachment; foo="\"\\";filename="foo.html"`, "foo.html"},
+
+		// 'attachment', specifying a filename of foo.html
+		// UA should offer to download the resource as foo.html.
+		"attwithasciifilenameucase": {`attachment; FILENAME="foo.html"`, "foo.html"},
+
+		// 'attachment', specifying a filename of foo.html using a token instead of a quoted-string (according to RFC 2045).
+		// Note that was invalid according to Section 19.5.1 of RFC 2616.
+		"attwithasciifilenamenq": {`attachment; filename=foo.html`, "foo.html"},
+
+		// 'attachment', specifying a filename of foo,bar.html using a comma despite using token syntax.
+		"attwithtokfncommanq": {`attachment; filename=foo,bar.html`, "attwithtokfncommanq"},
+
+		// 'attachment', specifying a filename of foo.html using a token instead of a quoted-string, and adding a trailing semicolon.
+		// The trailing semicolon makes the header field value syntactically
+		// incorrect, as no other parameter follows. Thus the header field
+		// should be ignored.
+		"attwithasciifilenamenqs": {`attachment; filename=foo.html ;`, "attwithasciifilenamenqs"},
+
+		//  'attachment', specifying a filename of foo, but including an empty parameter.
+		// The empty parameter makes the header field value syntactically
+		// incorrect, as no other parameter follows. Thus the header field
+		// should be ignored.
+		"attemptyparam": {`attachment; ;filename=foo`, "attemptyparam"},
+
+		// 'attachment', specifying a filename of foo bar.html without using quoting.
+		// This is invalid. "token" does not allow whitespace.
+		"attwithasciifilenamenqws": {`attachment; filename=foo bar.html`, "attwithasciifilenamenqws"},
+
+		// 'attachment', specifying a filename of 'foo.bar' using single quotes.
+		"attwithfntokensq": {`attachment; filename='foo.bar'`, "'foo.bar'"},
+
+		// 'attachment', specifying a filename of foo-ä.html, using UTF-8
+		// encoding. UA should offer to download the resource as "foo-Ã¤.html".
+		// Displaying "foo-ä.html" instead indicates that the UA tried to be
+		// smart by detecting something that happens to look like UTF-8.
+		"attwithutf8fnplain": {`attachment; filename="foo-ä.html"`, "foo-Ã¤.html"},
+
+		// 'attachment', specifying a filename of foo-%41.html
+		// UA should offer to download the resource as "foo-%41.html".
+		// Displaying "foo-A.html" instead would indicate that the UA has
+		// attempted to percent-decode the parameter.
+		"attwithfnrawpctenca": {`attachment; filename="foo-%41.html"`, "foo-%41.html"},
+
+		// 'attachment', specifying a filename of 50%.html
+		// UA should offer to download the resource as "50%.html". This tests
+		// how UAs that fails at attwithfnrawpctenca handle "%" characters that
+		// do not start a "% hexdig hexdig" sequence.
+		"attwithfnusingpct": {`attachment; filename="50%.html"`, "50%.html"},
+
+		// 'attachment', specifying a filename of foo-%41.html, using an escape character
+		// This tests whether adding an escape character inside a %xx sequence
+		// can be used to disable the non-conformant %xx-unescaping
+		"attwithfnrawpctencaq": {`attachment; filename="foo-%\41.html"`, "foo-%41.html"},
+
+		// 'attachment', specifying a name parameter of foo-%41.html.
+		// This test was added to observe the behavior of the (unspecified)
+		// treatment of "name" as synonym for "filename"; see Ned Freed's
+		// summary where this comes from in MIME messages. Should be treated as
+		// extension parameter, therefore almost any behavior is acceptable.
+		"attwithnamepct": {`attachment; name="foo-%41.html"`, "attwithnamepct"},
+
+		// 'attachment', specifying a filename parameter of ä-%41.html.
+		// This test was added to observe the behavior when non-ASCII characters
+		// and percent-hexdig sequences are combined.
+		"attwithfilenamepctandiso": {"attachment; filename=\"\xe4-%41.html\"", "ä-%41.html"},
+
+		// 'attachment', specifying a filename of foo-%c3%a4-%e2%82%ac.html, using raw percent encoded UTF-8 to represent foo-ä-€.html
+		// UA should offer to download the resource as
+		// "foo-%c3%a4-%e2%82%ac.html". Displaying "foo-ä-€.html" instead would
+		// indicate that the UA has attempted to percent-decode the parameter
+		// (using UTF-8). Displaying something else would indicate that the UA
+		// tried to percent-decode, but used a different encoding.
+		"attwithfnrawpctenclong": {`attachment; filename="foo-%c3%a4-%e2%82%ac.html"`, "foo-%c3%a4-%e2%82%ac.html"},
+
+		// 'attachment', specifying a filename of foo.html, with one blank space before the equals character.
+		// UA should offer to download the resource as "foo.html".
+		"attwithasciifilenamews1": {`attachment; filename ="foo.html"`, "foo.html"},
+
+		// 'attachment', specifying two filename parameters. This is invalid syntax.
+		"attwith2filenames": {`attachment; filename="foo.html"; filename="bar.html"`, "attwith2filenames"},
+
+		// 'attachment', specifying a filename of foo[1](2).html, but missing the quotes.
+		// Also, "[", "]", "(" and ")" are not allowed in the HTTP token production.
+		// This is invalid according to Section 19.5.1 of RFC 2616 and RFC 6266,
+		// so UAs should ignore it.
+		"attfnbrokentoken": {`attachment; filename=foo[1](2).html`, "attfnbrokentoken"},
+
+		// 'attachment', specifying a filename of foo-ä.html, using ISO-8859-1, but missing the quotes.
+		// This is invalid, as the umlaut is not a valid token character, so UAs
+		// should ignore it.
+		"attfnbrokentokeniso": {"attachment; filename=foo-\xe4.html", "attfnbrokentokeniso"},
+
+		// 'attachment', specifying a filename of foo-Ã¤.html (which happens to be foo-ä.html using UTF-8 encoding) but missing the quotes.
+		// This is invalid, as the umlaut is not a valid token character, so UAs
+		// should ignore it.
+		"attfnbrokentokenutf": {`attachment; filename=foo-ä.html`, "attfnbrokentokenutf"},
+
+		// Disposition type missing, filename specified.
+		// This is invalid, so UAs should ignore it.
+		"attmissingdisposition": {`filename=foo.html`, "attmissingdisposition"},
+
+		// Disposition type missing, filename specified after extension parameter.
+		// This is invalid, so UAs should ignore it.
+		"attmissingdisposition2": {`x=y; filename=foo.html`, "attmissingdisposition2"},
+
+		// Disposition type missing, filename "qux". Can it be more broken? (Probably)
+		// This is invalid, so UAs should ignore it.
+		"attmissingdisposition3": {`"foo; filename=bar;baz"; filename=qux`, "attmissingdisposition3"},
+
+		// Disposition type missing, two filenames specified separated by a comma
+		// This is syntactically equivalent to have two instances of the header with one filename parameter each.
+		// This is invalid, so UAs should ignore it.
+		"attmissingdisposition4": {`filename=foo.html, filename=bar.html`, "attmissingdisposition4"},
+
+		// Disposition type missing (but delimiter present), filename specified.
+		// This is invalid, so UAs should ignore it.
+		"emptydisposition": {`; filename=foo.html`, "emptydisposition"},
+
+		// Header field value starts with a colon.
+		// This is invalid, so UAs should ignore it.
+		"doublecolon": {`: inline; attachment; filename=foo.html`, "doublecolon"},
+
+		// Both disposition types specified.
+		// This is invalid, so UAs should ignore it.
+		"attandinline": {`inline; attachment; filename=foo.html`, "attandinline"},
+
+		// Both disposition types specified.
+		// This is invalid, so UAs should ignore it.
+		"attandinline2": {`attachment; inline; filename=foo.html`, "attandinline2"},
+
+		// 'attachment', specifying a filename parameter that is broken (quoted-string followed by more characters).
+		// This is invalid, so UAs should ignore it.
+		"attbrokenquotedfn": {`attachment; filename="foo.html".txt`, "attbrokenquotedfn"},
+
+		// 'attachment', specifying a filename parameter that is broken (missing ending double quote).
+		// This is invalid, so UAs should ignore it.
+		"attbrokenquotedfn2": {`attachment; filename="bar`, "attbrokenquotedfn2"},
+
+		// 'attachment', specifying a filename parameter that is broken (disallowed characters in token syntax).
+		// This is invalid, so UAs should ignore it.
+		"attbrokenquotedfn3": {`attachment; filename=foo"bar;baz"qux`, "attbrokenquotedfn3"},
+
+		// 'attachment', two comma-separated instances of the header field.
+		// As Content-Disposition doesn't use a list-style syntax, this is
+		// invalid syntax and, according to RFC 2616, Section 4.2, roughly
+		// equivalent to having two separate header field instances. This is
+		// invalid, so UAs should ignore it.
+		"attmultinstances": {`attachment; filename=foo.html, attachment; filename=bar.html`, "attmultinstances"},
+
+		// Uses two parameters, but the mandatory delimiter ";" is missing.
+		// This is invalid, so UAs should ignore it.
+		"attmissingdelim": {`attachment; foo=foo filename=bar`, "attmissingdelim"},
+
+		// Uses two parameters, but the mandatory delimiter ";" is missing.
+		// This is invalid, so UAs should ignore it.
+		"attmissingdelim2": {`attachment; filename=bar foo=foo`, "attmissingdelim2"},
+
+		// ";" missing between disposition type and filename parameter.
+		// This is invalid, so UAs should ignore it.
+		"attmissingdelim3": {`attachment filename=bar`, "attmissingdelim3"},
+
+		// filename parameter and disposition type reversed.
+		// This is invalid, so UAs should ignore it.
+		"attreversed": {`filename=foo.html; attachment`, "attreversed"},
+
+		// 'attachment', specifying an "xfilename" parameter.
+		// Should be treated as unnamed attachment.
+		"attconfusedparam": {`attachment; xfilename=foo.html`, "attconfusedparam"},
+
+		// 'attachment', specifying an absolute filename in the filesystem root.
+		// Either ignore the filename altogether, or discard the path information.
+		"attabspath": {`attachment; filename="/foo.html"`, "_foo.html"},
+
+		// 'attachment', specifying an absolute filename in the filesystem root.
+		// Either ignore the filename altogether, or discard the path
+		// information. Note that test results under Operating Systems other
+		// than Windows vary; apparently some UAs consider the backslash a
+		// legitimate filename character.
+		"attabspathwin": {`attachment; filename="\\foo.html"`, "_foo.html"},
+
+		// ... Leaving out the whole "Additional Parameters" section ...
+
+		// 'foobar' only
+		// This should be equivalent to using "attachment".
+		"dispext": {`foobar`, "dispext"},
+
+		// 'attachment', with no filename parameter
+		"dispextbadfn": {`attachment; example="filename=example.txt"`, "dispextbadfn"},
+
+		// 'attachment', specifying a filename of foo-ä.html, using RFC2231/5987 encoded ISO-8859-1
+		// UA should offer to download the resource as "foo-ä.html".
+		"attwithisofn2231iso": {`attachment; filename*=iso-8859-1''foo-%E4.html`, "foo-ä.html"},
+
+		// 'attachment', specifying a filename of foo-ä-€.html, using RFC2231/5987 encoded UTF-8
+		// UA should offer to download the resource as "foo-ä-€.html".
+		"attwithfn2231utf8": {`attachment; filename*=UTF-8''foo-%c3%a4-%e2%82%ac.html`, "foo-ä-€.html"},
+
+		// Behavior is undefined in RFC 2231, the charset part is missing, although UTF-8 was used.
+		"attwithfn2231noc": {`attachment; filename*=''foo-%c3%a4-%e2%82%ac.html`, "attwithfn2231noc"},
+
+		// 'attachment', specifying a filename of foo-ä.html, using RFC2231
+		// encoded UTF-8, but choosing the decomposed form (lowercase a plus
+		// COMBINING DIAERESIS) -- on a Windows target system, this should be
+		// translated to the preferred Unicode normal form (composed). UA should
+		// offer to download the resource as "foo-ä.html".
+		"attwithfn2231utf8comp": {`attachment; filename*=UTF-8''foo-a%cc%88.html`, "foo-ä.html"},
+
+		// 'attachment', specifying a filename of foo-ä-€.html, using RFC2231 encoded UTF-8, but declaring ISO-8859-1
+		// The octet %82 does not represent a valid ISO-8859-1 code point, so
+		// the UA should really ignore the parameter.
+		"attwithfn2231utf8-bad": {`attachment; filename*=iso-8859-1''foo-%c3%a4-%e2%82%ac.html`, "attwithfn2231utf8-bad"},
+
+		// 'attachment', specifying a filename of foo-ä.html, using RFC2231 encoded ISO-8859-1, but declaring UTF-8
+		// The octet %E4 does not represent a valid UTF-8 octet sequence, so the
+		// UA should really ignore the parameter.
+		"attwithfn2231iso-bad": {`attachment; filename*=utf-8''foo-%E4.html`, "attwithfn2231iso-bad"},
+
+		// 'attachment', specifying a filename of foo-ä.html, using RFC2231 encoded UTF-8, with whitespace before "*="
+		// The parameter is invalid, thus should be ignored.
+		"attwithfn2231ws1": {`attachment; filename *=UTF-8''foo-%c3%a4.html`, "attwithfn2231ws1"},
+
+		// 'attachment', specifying a filename of foo-ä.html, using RFC2231 encoded UTF-8, with whitespace after "*="
+		// UA should offer to download the resource as "foo-ä.html".
+		"attwithfn2231ws2": {`attachment; filename*= UTF-8''foo-%c3%a4.html`, "foo-ä.html"},
+
+		// 'attachment', specifying a filename of foo-ä.html, using RFC2231 encoded UTF-8, with whitespace inside "* ="
+		// UA should offer to download the resource as "foo-ä.html".
+		"attwithfn2231ws3": {`attachment; filename* =UTF-8''foo-%c3%a4.html`, "foo-ä.html"},
+
+		// 'attachment', specifying a filename of foo-ä.html, using RFC2231 encoded UTF-8, with double quotes around the parameter value.
+		// The parameter is invalid, thus should be ignored.
+		"attwithfn2231quot": {`attachment; filename*="UTF-8''foo-%c3%a4.html"`, "attwithfn2231quot"},
+
+		// 'attachment', specifying a filename of foo bar.html, using "filename*", but missing character encoding and language.
+		// The parameter is invalid, thus should be ignored.
+		"attwithfn2231quot2": {`attachment; filename*="foo%20bar.html"`, "attwithfn2231quot2"},
+
+		// 'attachment', specifying a filename of foo-ä.html, using RFC2231 encoded UTF-8, but a single quote is missing.
+		// The parameter is invalid, thus should be ignored.
+		"attwithfn2231singleqmissing": {`attachment; filename*=UTF-8'foo-%c3%a4.html`, "attwithfn2231singleqmissing"},
+
+		// 'attachment', specifying a filename of foo%, using RFC2231 encoded UTF-8, with a single "%" at the end.
+		// The parameter is invalid, thus should be ignored.
+		"attwithfn2231nbadpct1": {`attachment; filename*=UTF-8''foo%`, "attwithfn2231nbadpct1"},
+
+		// 'attachment', specifying a filename of f%oo.html, using RFC2231 encoded UTF-8, with a "%" not starting a percent-escape.
+		// The parameter is invalid, thus should be ignored.
+		"attwithfn2231nbadpct2": {`attachment; filename*=UTF-8''f%oo.html`, "attwithfn2231nbadpct2"},
+
+		// 'attachment', specifying a filename of A-%41.html, using RFC2231 encoded UTF-8.
+		"attwithfn2231dpct": {`attachment; filename*=UTF-8''A-%2541.html`, "A-%41.html"},
+
+		// 'attachment', specifying a filename of \foo.html, using RFC2231 encoded UTF-8.
+		"attwithfn2231abspathdisguised": {`attachment; filename*=UTF-8''%5cfoo.html`, "_foo.html"},
+
+		// RFC2231 Encoding: Continuations (optional)
+	}
+
+	// The mime.ParseMediaType implementation will fail for some of the above
+	// test cases, There's no way to fix that besides either fixing it upstream
+	// in the Go standard library or implementing the whole stuff by ourselves 🥴
+	// Here are the exceptions:
+
+	// This invalid header is simply accepted.
+	// This is in line with all the major browsers, it seems.
+	// http://test.greenbytes.de/tech/tc2231/#attwithasciifilenamenqs
+	tests["attwithasciifilenamenqs"].fileName = "foo.html"
+
+	// This invalid header is simply accepted.
+	// Browsers handle this differently ...
+	// http://test.greenbytes.de/tech/tc2231/#attwithfn2231quot
+	tests["attwithfn2231quot"].fileName = "foo-ä.html"
+
+	// mime.ParseMediaType only supports US-ASCII and UTF-8
+	// Doesn't look like that's changing anytime soon ... ¯\_(ツ)_/¯
+	tests["attwithisofn2231iso"].fileName = "attwithisofn2231iso"
+
+	// This kind of escape sequence is not recognized.
+	tests["attwithasciifnescapedchar"].fileName = "f_oo.html"
+	tests["attwithfnrawpctencaq"].fileName = "foo-%_41.html"
+
+	baseURL := startFakeDownloadServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Disposition", tests[path.Base(r.URL.Path)].header)
+	}))
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var fileName string
+			err := internalhttp.Download(context.TODO(), baseURL+"/"+name, io.Discard,
+				internalhttp.StoreSuggestedRemoteFileNameInto(&fileName),
+			)
+			assert.NoError(t, err)
+			assert.Equal(t, test.fileName, fileName)
+		})
+	}
+}

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io
+
+// An adapter to allow the use of an ordinary function as an [io.Writer].
+type WriterFunc func(p []byte) (int, error)
+
+// Write implements [io.Writer].
+func (f WriterFunc) Write(p []byte) (int, error) { return f(p) }

--- a/inttest/common/ssh.go
+++ b/inttest/common/ssh.go
@@ -29,6 +29,8 @@ import (
 	"sync"
 	"testing"
 
+	internalio "github.com/k0sproject/k0s/internal/io"
+
 	"github.com/mitchellh/go-homedir"
 	"golang.org/x/crypto/ssh"
 )
@@ -125,7 +127,7 @@ func (c *SSHConnection) ExecWithOutput(ctx context.Context, cmd string) (string,
 	errOnlyWriter, getErrOnlyBuffer := newWriterBuffer()
 	defer errOnlyWriter.Close()
 
-	combinedWriter := writerFunc(func(p []byte) (int, error) {
+	combinedWriter := internalio.WriterFunc(func(p []byte) (int, error) {
 		if n, err := errOnlyWriter.Write(p); err != nil {
 			return n, err
 		}
@@ -235,10 +237,6 @@ func (w *lockWriter) Close() error {
 
 	return nil
 }
-
-type writerFunc func(p []byte) (int, error)
-
-func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
 
 func trimOutput(output []byte) string {
 	if len(output) == 0 {

--- a/pkg/autopilot/controller/signal/common/download.go
+++ b/pkg/autopilot/controller/signal/common/download.go
@@ -81,7 +81,7 @@ func (r *downloadController) Reconcile(ctx context.Context, req cr.Request) (cr.
 
 	logger.Infof("Starting download of '%s'", manifest.URL)
 
-	httpdl := apdl.NewDownloader(manifest.Config, logger)
+	httpdl := apdl.NewDownloader(manifest.Config)
 	if err := httpdl.Download(ctx); err != nil {
 		logger.Errorf("Unable to download '%s': %v", manifest.URL, err)
 

--- a/pkg/autopilot/download/downloader.go
+++ b/pkg/autopilot/download/downloader.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cavaliergopher/grab/v3"
 	"github.com/k0sproject/k0s/pkg/build"
-	"github.com/sirupsen/logrus"
 )
 
 type Downloader interface {
@@ -38,16 +37,14 @@ type Config struct {
 
 type downloader struct {
 	config       Config
-	logger       *logrus.Entry
 	httpResponse *grab.Response
 }
 
 var _ Downloader = (*downloader)(nil)
 
-func NewDownloader(config Config, logger *logrus.Entry) Downloader {
+func NewDownloader(config Config) Downloader {
 	return &downloader{
 		config: config,
-		logger: logger.WithField("component", "downloader"),
 	}
 }
 

--- a/pkg/autopilot/download/downloader.go
+++ b/pkg/autopilot/download/downloader.go
@@ -36,8 +36,7 @@ type Config struct {
 }
 
 type downloader struct {
-	config       Config
-	httpResponse *grab.Response
+	config Config
 }
 
 var _ Downloader = (*downloader)(nil)
@@ -73,11 +72,11 @@ func (d *downloader) Download(ctx context.Context) error {
 	// Set user agent to mitigate 403 errors from GitHub
 	// See https://github.com/cavaliergopher/grab/issues/104
 	client.UserAgent = fmt.Sprintf("k0s/%s", build.Version)
-	d.httpResponse = client.Do(dlreq)
+	httpResponse := client.Do(dlreq)
 
 	select {
-	case <-d.httpResponse.Done:
-		return d.httpResponse.Err()
+	case <-httpResponse.Done:
+		return httpResponse.Err()
 
 	case <-ctx.Done():
 		return fmt.Errorf("download cancelled")

--- a/pkg/autopilot/download/downloader.go
+++ b/pkg/autopilot/download/downloader.go
@@ -23,6 +23,7 @@ import (
 	"hash"
 	"io"
 	"path/filepath"
+	"time"
 
 	internalhttp "github.com/k0sproject/k0s/internal/http"
 	"github.com/k0sproject/k0s/internal/pkg/file"
@@ -72,6 +73,12 @@ func (d *downloader) Download(ctx context.Context) (err error) {
 	}
 	defer func() { err = errors.Join(err, target.Close()) }()
 	targets = append(targets, target)
+
+	// Set a very long overall download timeout. This will ensure that the
+	// download will fail at some point, even if the remote server is
+	// artificially slow.
+	ctx, cancel := context.WithTimeout(ctx, 6*time.Hour)
+	defer cancel()
 
 	// Download from URL into targets.
 	var fileName string

--- a/pkg/k0scontext/context.go
+++ b/pkg/k0scontext/context.go
@@ -14,15 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package k0scontext provides utility functions for working with Go contexts
-// and specific keys for storing and retrieving k0s project-related
-// configuration data.
+// Package k0scontext provides various utilities for working with Go contexts.
 //
-// The package also includes functions for setting, retrieving, and checking the
-// presence of values associated with specific types. These functions simplify
-// context-based data management in a type-safe and ergonomic manner. Each
-// distinct type serves as a key for context values, removing the necessity for
-// an extra key constant. The type itself becomes the key.
+// This package also includes functions for setting, retrieving, and checking
+// the presence of values associated with specific types. These functions
+// simplify context-based data management in a type-safe and ergonomic way. Each
+// distinct type serves as a key for context values, so there is no need for
+// additional key constants. The type itself is the key.
 package k0scontext
 
 import (

--- a/pkg/k0scontext/timeout.go
+++ b/pkg/k0scontext/timeout.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k0scontext
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+// Returns a context that times out after a specified period of inactivity.
+// Calls to the keepAlive function will reset the timeout, ensuring that the
+// context will remain valid for as long as there is activity.
+func WithInactivityTimeout(ctx context.Context, timeout time.Duration) (_ context.Context, _ context.CancelCauseFunc, keepAlive func()) {
+	var lastActivity atomic.Pointer[time.Time]
+	keepAlive = func() {
+		now := time.Now()
+		lastActivity.Store(&now)
+	}
+
+	ctx, cancel := context.WithCancelCause(ctx)
+	keepAlive() // initialize the pointer
+
+	go func() {
+		for {
+			lastActivity := *lastActivity.Load()
+			remaining := time.Until(lastActivity.Add(timeout))
+
+			if remaining <= 0 {
+				cancel(&InactivityError{lastActivity, timeout})
+				return
+			}
+
+			select {
+			// Recalculate timeout to minimize drift.
+			case <-time.After(time.Until(lastActivity.Add(timeout))):
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return &inactivityContext{ctx}, cancel, keepAlive
+}
+
+// An error indicating that a context timed out due to inactivity.
+// Will identify as [context.DeadlineExceeded] when checked by [errors.Is].
+type InactivityError struct {
+	LastActivity time.Time
+	Timeout      time.Duration
+}
+
+func (e *InactivityError) Error() string {
+	return fmt.Sprint("timed out after ", e.Timeout, " of inactivity, last activity at ", e.LastActivity)
+}
+
+func (e *InactivityError) Is(err error) bool {
+	if err == context.DeadlineExceeded {
+		return true
+	}
+	_, ok := err.(*InactivityError)
+	return ok
+}
+
+// Translates causes of [*InactivityError] into [context.DeadlineExceeded].
+type inactivityContext struct {
+	context.Context
+}
+
+func (c *inactivityContext) Err() error {
+	err := context.Cause(c.Context)
+	if _, isTimeout := err.(*InactivityError); isTimeout { //nolint:errorlint
+		return context.DeadlineExceeded
+	}
+
+	return c.Context.Err()
+}

--- a/pkg/k0scontext/timeout_test.go
+++ b/pkg/k0scontext/timeout_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k0scontext_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/k0s/pkg/k0scontext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithInactivityTimeout_KeepAlive(t *testing.T) {
+	const (
+		jitter  = 25 * time.Millisecond // tolerable error for assertions
+		timeout = 10 * jitter           // inactivity timeout for the context
+		delay   = timeout / 2           // delay after which the timeout is kept alive once
+	)
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	t.Cleanup(cancel)
+
+	// Create a new context. The timeout is ticking ...
+	ctx, _, keepAlive := k0scontext.WithInactivityTimeout(ctx, timeout)
+
+	// Wait for some time, then keep the context alive once.
+	time.Sleep(delay)
+	start := time.Now()
+	keepAlive()
+	keptAlive := time.Now()
+
+	// Make sure the timeout has not expired.
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "Context already done, increase the jitter")
+	default:
+	}
+
+	// Now wait for the timeout to expire.
+	<-ctx.Done()
+	done := time.Now()
+
+	var inactivityErr *k0scontext.InactivityError
+	require.ErrorAs(t, context.Cause(ctx), &inactivityErr)
+	assert.Equal(t, timeout, inactivityErr.Timeout)
+	assert.WithinRange(t, inactivityErr.LastActivity, start, keptAlive)
+	assert.Less(t, keptAlive.Sub(start), jitter, "Touching took too long, increase the jitter")
+	assert.WithinRange(t, done,
+		// The earliest tolerable done time: The time just before the context
+		// was last kept alive, plus the timeout itself.
+		start.Add(timeout),
+		// The latest tolerable done time: The time just after the context was
+		// kept alive, plus the timeout itself, plus the jitter.
+		keptAlive.Add(timeout).Add(jitter),
+	)
+}
+
+func TestWithInactivityTimeout_Timeout(t *testing.T) {
+	ctx, cancel, _ := k0scontext.WithInactivityTimeout(context.TODO(), 0)
+	t.Cleanup(func() { cancel(nil) })
+
+	<-ctx.Done()
+	err, cause := ctx.Err(), context.Cause(ctx)
+
+	assert.Equal(t, context.DeadlineExceeded, err)
+	assert.ErrorIs(t, cause, context.DeadlineExceeded)
+	assert.ErrorContains(t, cause, "timed out after 0s of inactivity, last activity at ")
+}
+
+func TestWithInactivityTimeout_Cancel(t *testing.T) {
+	t.Run("Self", func(t *testing.T) {
+		ctx, cancel, _ := k0scontext.WithInactivityTimeout(context.TODO(), time.Hour)
+		t.Cleanup(func() { cancel(nil) })
+
+		cancel(assert.AnError)
+		<-ctx.Done()
+
+		assert.Equal(t, context.Canceled, ctx.Err())
+		assert.Equal(t, assert.AnError, context.Cause(ctx))
+	})
+
+	t.Run("Outer", func(t *testing.T) {
+		ctx, outerCancel := context.WithCancelCause(context.TODO())
+		t.Cleanup(func() { outerCancel(nil) })
+
+		ctx, cancel, _ := k0scontext.WithInactivityTimeout(ctx, time.Hour)
+		t.Cleanup(func() { cancel(nil) })
+
+		outerCancel(assert.AnError)
+		<-ctx.Done()
+
+		assert.Equal(t, context.Canceled, ctx.Err())
+		assert.Equal(t, assert.AnError, context.Cause(ctx))
+	})
+}


### PR DESCRIPTION
## Description

Cancel downloads whenever there's no data flowing for a certain amount of time. Add a very long overall timeout for Autopilot downloads. This will ensure that the download will fail at some point, even if the remote server is artificially slow.

Add `k0scontext.WithInactivityTimeout`, which returns a context that times out after a specified period of inactivity. It provides a "keep alive" mechanism to reset the timeout based on recent activity, ensuring that the context will remain valid for as long as there is activity. This is used to implement the cancellation of stale downloads.

Move the private `writerFunc` implementation from the integration tests into the regular code base. This adapter is useful from time to time.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings