### PR TITLE
Replace kubectl apply usage in inttests

### DIFF
--- a/inttest/ap-controllerworker/controllerworker_test.go
+++ b/inttest/ap-controllerworker/controllerworker_test.go
@@ -22,15 +22,15 @@ import (
 
 	"github.com/k0sproject/k0s/inttest/common"
 	aptest "github.com/k0sproject/k0s/inttest/common/autopilot"
-
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
+	k0sclientset "github.com/k0sproject/k0s/pkg/client/clientset"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
 
-	"github.com/stretchr/testify/suite"
-
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type controllerworkerSuite struct {
@@ -114,9 +114,10 @@ func (s *controllerworkerSuite) SetupTest() {
 // TestApply applies a well-formed `plan` yaml, and asserts that
 // all of the correct values across different objects + controllers are correct.
 func (s *controllerworkerSuite) TestApply() {
-	client, err := s.AutopilotClient(s.ControllerNode(0))
+	ctx := s.Context()
+
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
 	s.Require().NoError(err)
-	s.NotEmpty(client)
 
 	planTemplate := `
 apiVersion: autopilot.k0sproject.io/v1beta2
@@ -144,16 +145,15 @@ spec:
                   - controller2
                   - controller0
 `
-	ctx := s.Context()
-	manifestFile := "/tmp/happy.yaml"
-	s.PutFileTemplate(s.ControllerNode(0), manifestFile, planTemplate, nil)
 
-	out, err := s.RunCommandController(0, fmt.Sprintf("/usr/local/bin/k0s kubectl apply -f %s", manifestFile))
-	s.T().Logf("kubectl apply output: '%s'", out)
+	_, err = common.Create(ctx, restConfig, []byte(planTemplate))
 	s.Require().NoError(err)
+	s.T().Logf("Plan created")
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	plan, err := aptest.WaitForPlanState(s.Context(), client, apconst.AutopilotName, appc.PlanCompleted)
+	client, err := k0sclientset.NewForConfig(restConfig)
+	s.Require().NoError(err)
+	plan, err := aptest.WaitForPlanState(ctx, client, apconst.AutopilotName, appc.PlanCompleted)
 	s.Require().NoError(err)
 
 	s.Equal(1, len(plan.Status.Commands))

--- a/inttest/ap-updater-periodic/updater_test.go
+++ b/inttest/ap-updater-periodic/updater_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/k0sproject/k0s/inttest/common"
 	aptest "github.com/k0sproject/k0s/inttest/common/autopilot"
+	k0sclientset "github.com/k0sproject/k0s/pkg/client/clientset"
 
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
@@ -105,9 +106,10 @@ func (s *plansSingleControllerSuite) getClusterID(kc kubernetes.Interface) strin
 // TestApply applies a well-formed `plan` yaml, and asserts that all of the correct values
 // across different objects are correct.
 func (s *plansSingleControllerSuite) TestApply() {
-	client, err := s.AutopilotClient(s.ControllerNode(0))
+	ctx := s.Context()
+
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
 	s.Require().NoError(err)
-	s.NotEmpty(client)
 
 	updaterConfig := `
 apiVersion: autopilot.k0sproject.io/v1beta2
@@ -116,7 +118,7 @@ metadata:
   name: autopilot
 spec:
   channel: latest
-  updateServer: {{.Address}}
+  updateServer: http://` + s.GetUpdateServerIPAddress() + `
   upgradeStrategy:
     type: periodic
     periodic:
@@ -136,21 +138,14 @@ spec:
               selector: {}
 `
 
-	vars := struct {
-		Address string
-	}{
-		Address: fmt.Sprintf("http://%s", s.GetUpdateServerIPAddress()),
-	}
-
-	manifestFile := "/tmp/updateconfig.yaml"
-	s.PutFileTemplate(s.ControllerNode(0), manifestFile, updaterConfig, vars)
-
-	out, err := s.RunCommandController(0, fmt.Sprintf("/usr/local/bin/k0s kubectl apply -f %s", manifestFile))
-	s.T().Logf("kubectl apply output: '%s'", out)
+	_, err = common.Create(ctx, restConfig, []byte(updaterConfig))
 	s.Require().NoError(err)
+	s.T().Logf("Plan created")
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	_, err = aptest.WaitForPlanState(s.Context(), client, apconst.AutopilotName, appc.PlanCompleted)
+	client, err := k0sclientset.NewForConfig(restConfig)
+	s.Require().NoError(err)
+	_, err = aptest.WaitForPlanState(ctx, client, apconst.AutopilotName, appc.PlanCompleted)
 	s.Require().NoError(err)
 
 	kc, err := s.KubeClient(s.ControllerNode(0))

--- a/inttest/ap-updater/updater_test.go
+++ b/inttest/ap-updater/updater_test.go
@@ -15,12 +15,12 @@
 package updater
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/k0sproject/k0s/inttest/common"
 	aptest "github.com/k0sproject/k0s/inttest/common/autopilot"
+	k0sclientset "github.com/k0sproject/k0s/pkg/client/clientset"
 
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
@@ -56,9 +56,10 @@ func (s *plansSingleControllerSuite) SetupTest() {
 // TestApply applies a well-formed `plan` yaml, and asserts that all of the correct values
 // across different objects are correct.
 func (s *plansSingleControllerSuite) TestApply() {
-	client, err := s.AutopilotClient(s.ControllerNode(0))
+	ctx := s.Context()
+
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
 	s.Require().NoError(err)
-	s.NotEmpty(client)
 
 	updaterConfig := `
 apiVersion: autopilot.k0sproject.io/v1beta2
@@ -67,7 +68,7 @@ metadata:
   name: autopilot
 spec:
   channel: stable
-  updateServer: {{.Address}}
+  updateServer: http://` + s.GetUpdateServerIPAddress() + `
   upgradeStrategy:
     type: cron
     cron: "* * * * * *"
@@ -81,21 +82,14 @@ spec:
               selector: {}
 `
 
-	vars := struct {
-		Address string
-	}{
-		Address: fmt.Sprintf("http://%s", s.GetUpdateServerIPAddress()),
-	}
-
-	manifestFile := "/tmp/updateconfig.yaml"
-	s.PutFileTemplate(s.ControllerNode(0), manifestFile, updaterConfig, vars)
-
-	out, err := s.RunCommandController(0, fmt.Sprintf("/usr/local/bin/k0s kubectl apply -f %s", manifestFile))
-	s.T().Logf("kubectl apply output: '%s'", out)
+	_, err = common.Create(ctx, restConfig, []byte(updaterConfig))
 	s.Require().NoError(err)
+	s.T().Logf("UpdateConfig created")
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
-	_, err = aptest.WaitForPlanState(s.Context(), client, apconst.AutopilotName, appc.PlanCompleted)
+	client, err := k0sclientset.NewForConfig(restConfig)
+	s.Require().NoError(err)
+	_, err = aptest.WaitForPlanState(ctx, client, apconst.AutopilotName, appc.PlanCompleted)
 	s.Require().NoError(err)
 }
 


### PR DESCRIPTION
## Description

This removes SSH and "shelling out" from the equation, making the tests a bit more direct and hopefully improving error messages when things go south.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings