### PR TITLE
Call supportbundle binary directly

### DIFF
--- a/inttest/bootloose-alpine/root/usr/local/bin/troubleshoot-k0s-inttest.sh
+++ b/inttest/bootloose-alpine/root/usr/local/bin/troubleshoot-k0s-inttest.sh
@@ -11,7 +11,7 @@ export KUBECONFIG="$1/pki/admin.conf"
 
 bundleDir="$(mktemp -d)"
 trap 'rm -rf -- "$bundleDir"' INT EXIT
-kubectl supportbundle \
+kubectl-supportbundle \
   --debug \
   --interactive=false \
   --output="$bundleDir/support-bundle.tar.gz" \


### PR DESCRIPTION
## Description

Now that the kubectl binary is no longer part of the integration test Docker image, calling the supportbundle binary as a kubectl plugin no longer works.

See:
* #4993

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings