### PR TITLE
[Backport release-1.29] bug: disable oci bundle loader on byocri

### DIFF
--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -141,9 +141,9 @@ func (c *Command) Start(ctx context.Context) error {
 
 	if c.CriSocket == "" {
 		componentManager.Add(ctx, worker.NewContainerd(c.Logging["containerd"], c.K0sVars, workerConfig))
+		componentManager.Add(ctx, worker.NewOCIBundleReconciler(c.K0sVars))
 	}
 
-	componentManager.Add(ctx, worker.NewOCIBundleReconciler(c.K0sVars))
 	if c.WorkerProfile == "default" && runtime.GOOS == "windows" {
 		c.WorkerProfile = "default-windows"
 	}


### PR DESCRIPTION
Backport #5005 to `release-1.29`