### PR TITLE
feat: add support for basic auth, insecure tls and headers

### DIFF
--- a/internal/http/filename_test.go
+++ b/internal/http/filename_test.go
@@ -377,7 +377,7 @@ func TestDownload_ContentDisposition(t *testing.T) {
 	tests["attwithasciifnescapedchar"].fileName = "f_oo.html"
 	tests["attwithfnrawpctencaq"].fileName = "foo-%_41.html"
 
-	baseURL := startFakeDownloadServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	baseURL := startFakeDownloadServer(t, false, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Disposition", tests[path.Base(r.URL.Path)].header)
 	}))
 


### PR DESCRIPTION

## Description

add suport for basic auth, insecure tls and headers to the download package. this PR is part of an [adr](https://github.com/k0sproject/k0s/blob/main/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md) implementation that i plan to introduce gradually.


Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings