### PR TITLE
Applier manager improvements

### DIFF
--- a/pkg/applier/manager.go
+++ b/pkg/applier/manager.go
@@ -41,7 +41,6 @@ type Manager struct {
 	K0sVars           *config.CfgVars
 	KubeClientFactory kubeutil.ClientFactoryInterface
 
-	applier   Applier
 	bundleDir string
 	stop      func(reason string)
 	log       *logrus.Entry
@@ -65,8 +64,6 @@ func (m *Manager) Init(ctx context.Context) error {
 	}
 	m.log = logrus.WithField("component", constant.ApplierManagerComponentName)
 	m.bundleDir = m.K0sVars.ManifestsDir
-
-	m.applier = NewApplier(m.K0sVars.ManifestsDir, m.KubeClientFactory)
 
 	m.LeaderElector.AddAcquiredLeaseCallback(func() {
 		ctx, cancel := context.WithCancelCause(ctx)

--- a/pkg/applier/manager.go
+++ b/pkg/applier/manager.go
@@ -125,16 +125,10 @@ func (m *Manager) runWatchers(ctx context.Context) error {
 
 	for {
 		select {
-		case err, ok := <-watcher.Errors:
-			if !ok {
-				return err
-			}
+		case err := <-watcher.Errors:
+			log.WithError(err).Error("Watch error")
 
-			log.Warnf("watch error: %s", err.Error())
-		case event, ok := <-watcher.Events:
-			if !ok {
-				return nil
-			}
+		case event := <-watcher.Events:
 			switch event.Op {
 			case fsnotify.Create:
 				if dir.IsDirectory(event.Name) {

--- a/pkg/applier/manager_test.go
+++ b/pkg/applier/manager_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applier
+
+import (
+	"context"
+	"embed"
+	"os"
+	"path"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	kubeutil "github.com/k0sproject/k0s/internal/testutil"
+	"github.com/k0sproject/k0s/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
+)
+
+//go:embed testdata/manager_test/*
+var managerTestData embed.FS
+
+func TestManager(t *testing.T) {
+	ctx := context.Background()
+
+	dir := t.TempDir()
+
+	cfg := &config.CfgVars{
+		ManifestsDir: dir,
+	}
+
+	fakes := kubeutil.NewFakeClientFactory()
+
+	le := new(mockLeaderElector)
+
+	manager := &Manager{
+		K0sVars:           cfg,
+		KubeClientFactory: fakes,
+		LeaderElector:     le,
+	}
+
+	writeStack(t, dir, "testdata/manager_test/stack1")
+
+	err := manager.Init(ctx)
+	require.NoError(t, err)
+
+	err = manager.Start(ctx)
+	require.NoError(t, err)
+
+	le.activate()
+
+	// validate stack that already exists is applied
+
+	cmgv, _ := schema.ParseResourceArg("configmaps.v1.")
+	podgv, _ := schema.ParseResourceArg("pods.v1.")
+
+	waitForResource(t, fakes, *cmgv, "kube-system", "applier-test")
+	waitForResource(t, fakes, *podgv, "kube-system", "applier-test")
+
+	r, err := getResource(fakes, *cmgv, "kube-system", "applier-test")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "applier", r.GetLabels()["component"])
+	}
+	r, err = getResource(fakes, *podgv, "kube-system", "applier-test")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "Pod", r.GetKind())
+		assert.Equal(t, "applier", r.GetLabels()["component"])
+	}
+
+	// update the stack and verify the changes are applied
+
+	writeLabel(t, filepath.Join(dir, "stack1/pod.yaml"), "custom1", "test")
+
+	t.Log("waiting for pod to be updated")
+	waitFor(t, 100*time.Millisecond, 5*time.Second, func(ctx context.Context) (bool, error) {
+		r, err := getResource(fakes, *podgv, "kube-system", "applier-test")
+		if err != nil {
+			return false, nil
+		}
+		return r.GetLabels()["custom1"] == "test", nil
+	})
+
+	// lose and re-acquire leadership
+	le.deactivate()
+	le.activate()
+
+	// validate a new stack that is added is applied
+
+	writeStack(t, dir, "testdata/manager_test/stack2")
+
+	deployGV, _ := schema.ParseResourceArg("deployments.v1.apps")
+
+	waitForResource(t, fakes, *deployGV, "kube-system", "nginx")
+
+	r, err = getResource(fakes, *deployGV, "kube-system", "nginx")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "Deployment", r.GetKind())
+		assert.Equal(t, "applier", r.GetLabels()["component"])
+	}
+
+	// update the stack after the lease aquire and verify the changes are applied
+
+	writeLabel(t, filepath.Join(dir, "stack1/pod.yaml"), "custom2", "test")
+
+	t.Log("waiting for pod to be updated")
+	waitFor(t, 100*time.Millisecond, 5*time.Second, func(ctx context.Context) (bool, error) {
+		r, err := getResource(fakes, *podgv, "kube-system", "applier-test")
+		if err != nil {
+			return false, nil
+		}
+		return r.GetLabels()["custom2"] == "test", nil
+	})
+
+	// delete the stack and verify the resources are deleted
+
+	err = os.RemoveAll(filepath.Join(dir, "stack1"))
+	require.NoError(t, err)
+
+	t.Log("waiting for pod to be deleted")
+	waitFor(t, 100*time.Millisecond, 5*time.Second, func(ctx context.Context) (bool, error) {
+		_, err := getResource(fakes, *podgv, "kube-system", "applier-test")
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+func writeLabel(t *testing.T, file string, key string, value string) {
+	t.Helper()
+	contents, err := os.ReadFile(file)
+	require.NoError(t, err)
+	unst := map[interface{}]interface{}{}
+	err = yaml.Unmarshal(contents, &unst)
+	require.NoError(t, err)
+	unst["metadata"].(map[interface{}]interface{})["labels"].(map[interface{}]interface{})[key] = value
+	data, err := yaml.Marshal(unst)
+	require.NoError(t, err)
+	err = os.WriteFile(file, data, 0400)
+	require.NoError(t, err)
+}
+
+func waitForResource(t *testing.T, fakes *kubeutil.FakeClientFactory, gv schema.GroupVersionResource, namespace string, name string) {
+	t.Logf("waiting for resource %s/%s", gv.Resource, name)
+	waitFor(t, 100*time.Millisecond, 5*time.Second, func(ctx context.Context) (bool, error) {
+		_, err := getResource(fakes, gv, namespace, name)
+		if errors.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+func getResource(fakes *kubeutil.FakeClientFactory, gv schema.GroupVersionResource, namespace string, name string) (*unstructured.Unstructured, error) {
+	return fakes.DynamicClient.Resource(gv).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+}
+
+func waitFor(t *testing.T, interval, timeout time.Duration, fn wait.ConditionWithContextFunc) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, fn)
+	require.NoError(t, err)
+}
+
+func writeStack(t *testing.T, dst string, src string) {
+	dstStackDir := filepath.Join(dst, path.Base(src))
+	err := os.MkdirAll(dstStackDir, 0755)
+	require.NoError(t, err)
+	entries, err := managerTestData.ReadDir(src)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		data, err := managerTestData.ReadFile(path.Join(src, entry.Name()))
+		require.NoError(t, err)
+		dst := filepath.Join(dstStackDir, entry.Name())
+		t.Logf("writing file %s", dst)
+		err = os.WriteFile(dst, data, 0644)
+		require.NoError(t, err)
+	}
+}
+
+type mockLeaderElector struct {
+	mu       sync.Mutex
+	leader   bool
+	acquired []func()
+	lost     []func()
+}
+
+func (e *mockLeaderElector) activate() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.leader {
+		e.leader = true
+		for _, fn := range e.acquired {
+			fn()
+		}
+	}
+}
+
+func (e *mockLeaderElector) deactivate() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.leader {
+		e.leader = false
+		for _, fn := range e.lost {
+			fn()
+		}
+	}
+}
+
+func (e *mockLeaderElector) IsLeader() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.leader
+}
+
+func (e *mockLeaderElector) AddAcquiredLeaseCallback(fn func()) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.acquired = append(e.acquired, fn)
+	if e.leader {
+		fn()
+	}
+}
+
+func (e *mockLeaderElector) AddLostLeaseCallback(fn func()) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.lost = append(e.lost, fn)
+	if e.leader {
+		fn()
+	}
+}

--- a/pkg/applier/testdata/manager_test/stack1/configmap.yaml
+++ b/pkg/applier/testdata/manager_test/stack1/configmap.yaml
@@ -1,0 +1,9 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: applier-test
+  namespace: kube-system
+  labels:
+    component: applier
+data:
+  foo: bar

--- a/pkg/applier/testdata/manager_test/stack1/pod.yaml
+++ b/pkg/applier/testdata/manager_test/stack1/pod.yaml
@@ -1,0 +1,11 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: applier-test
+  namespace: kube-system
+  labels:
+    component: applier
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.15

--- a/pkg/applier/testdata/manager_test/stack2/deploy.yaml
+++ b/pkg/applier/testdata/manager_test/stack2/deploy.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: kube-system
+  labels:
+    component: applier
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+       app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: docker.io/nginx:1-alpine
+        resources:
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+        ports:
+          - containerPort: 80


### PR DESCRIPTION
## Description

* The stacks don't need to be stored in the manager struct
  The map is only ever used in the loop to create and remove stacks, so it doesn't need to be stored in the struct. This ensures that there can't be any racy concurrent accesses to it.

* Don't check for closed watch channels
  The only reason these channels get closed is if the watcher itself gets closed. This happens only when the method returns, which in turn only happens when the context is done. In this case, the loop has already exited without a select on a potentially closed channel. So the branches that checked for closed channels were effectively unreachable during runtime.

* Wait for goroutines to exit
  Rename cancelWatcher to stop and wait until the newly added stopped channel is closed. Also, add a stopped channel to each stack to do the same for each stack-specific goroutine.

* Restart watch loop on errors
  Exit the loop on error and restart it after a one-minute delay to allow it to recover in a new run. Also replace the bespoke retry loop for stacks with the Kubernetes client's wait package.

* Improve logging
  Cancel the contexts with a cause. Add this cause to the log statements when exiting loops. Rename bundlePath to bundleDir to reflect the fact that it is a directory, not a file.

* Remove unused applier field
  Seems to be a remnant from the past.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings