### PR TITLE
fix: chart crd forceUpgrade field should be nil by default

### DIFF
--- a/pkg/apis/helm/v1beta1/chart_types.go
+++ b/pkg/apis/helm/v1beta1/chart_types.go
@@ -34,7 +34,6 @@ type ChartSpec struct {
 	Namespace   string `json:"namespace,omitempty"`
 	Timeout     string `json:"timeout,omitempty"`
 	// ForceUpgrade when set to false, disables the use of the "--force" flag when upgrading the the chart (default: true).
-	// +kubebuilder:default=true
 	// +optional
 	ForceUpgrade *bool `json:"forceUpgrade,omitempty"`
 	Order        int   `json:"order,omitempty"`

--- a/pkg/apis/k0s/v1beta1/extensions.go
+++ b/pkg/apis/k0s/v1beta1/extensions.go
@@ -118,7 +118,6 @@ type Chart struct {
 	// +kubebuilder:validation:XIntOrString
 	Timeout BackwardCompatibleDuration `json:"timeout,omitempty"`
 	// ForceUpgrade when set to false, disables the use of the "--force" flag when upgrading the the chart (default: true).
-	// +kubebuilder:default=true
 	// +optional
 	ForceUpgrade *bool `json:"forceUpgrade,omitempty"`
 	Order        int   `json:"order,omitempty"`

--- a/static/_crds/helm/helm.k0sproject.io_charts.yaml
+++ b/static/_crds/helm/helm.k0sproject.io_charts.yaml
@@ -42,7 +42,6 @@ spec:
               chartName:
                 type: string
               forceUpgrade:
-                default: true
                 description: 'ForceUpgrade when set to false, disables the use of
                   the "--force" flag when upgrading the the chart (default: true).'
                 type: boolean

--- a/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
+++ b/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
@@ -106,7 +106,6 @@ spec:
                               minLength: 1
                               type: string
                             forceUpgrade:
-                              default: true
                               description: 'ForceUpgrade when set to false, disables
                                 the use of the "--force" flag when upgrading the the
                                 chart (default: true).'


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Even though the `forceUpgrade` field is a nil pointer, the k8s controller seems to be setting the field automatically in CRs that exist once the CRD is updated via a k0s upgrade. I believe this is because it defaults to true via the generated openapi spec.

```yaml
              forceUpgrade:
                default: true
                description: 'ForceUpgrade when set to false, disables the use of
                  the "--force" flag when upgrading the the chart (default: true).'
                type: boolean
```

This results in a backwards incompatible change for those importing the schema prior to this version.

```
W1001 20:21:35.308507       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: failed to list *v1beta1.ClusterConfig: json: unknown field "forceUpgrade"
```

```bash
$ curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.29.8+k0s.0 sh
$ sudo k0s install controller --single --config k0s.yaml --enable-dynamic-config
$ sudo k0s start
$ sudo k0s kubectl get clusterconfigs -A -oyaml
apiVersion: v1
items:
- apiVersion: k0s.k0sproject.io/v1beta1
  kind: ClusterConfig
  metadata:
    creationTimestamp: "2024-10-02T15:59:08Z"
    generation: 1
    name: k0s
    namespace: kube-system
    resourceVersion: "199"
    uid: 6b31fcff-9901-4545-bd4d-5c406052a7a4
  spec:
    extensions:
      helm:
        charts:
        - chartname: twuni/docker-registry
          name: docker-registry
          namespace: registry
          order: 0
          timeout: 0
          values: ""
          version: 2.2.3
        concurrencyLevel: 5
```

```bash
$ sudo k0s stop
$ curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.29.9+k0s.0 sh
$ sudo k0s start
$ sudo k0s kubectl get clusterconfigs -A -oyaml
apiVersion: v1
items:
- apiVersion: k0s.k0sproject.io/v1beta1
  kind: ClusterConfig
  metadata:
    creationTimestamp: "2024-10-02T15:59:08Z"
    generation: 1
    name: k0s
    namespace: kube-system
    resourceVersion: "199"
    uid: 6b31fcff-9901-4545-bd4d-5c406052a7a4
  spec:
    extensions:
      helm:
        charts:
        - chartname: twuni/docker-registry
          forceUpgrade: true
          name: docker-registry
          namespace: registry
          order: 0
          timeout: 0
          values: ""
          version: 2.2.3
        concurrencyLevel: 5
```

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

```bash
$ curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.29.8+k0s.0 sh
$ sudo k0s install controller --single --config k0s.yaml --enable-dynamic-config
$ sudo k0s start
$ sudo k0s kubectl get clusterconfigs -A -oyaml
apiVersion: v1
items:
- apiVersion: k0s.k0sproject.io/v1beta1
  kind: ClusterConfig
  metadata:
    creationTimestamp: "2024-10-02T15:59:08Z"
    generation: 1
    name: k0s
    namespace: kube-system
    resourceVersion: "199"
    uid: 6b31fcff-9901-4545-bd4d-5c406052a7a4
  spec:
    extensions:
      helm:
        charts:
        - chartname: twuni/docker-registry
          name: docker-registry
          namespace: registry
          order: 0
          timeout: 0
          values: ""
          version: 2.2.3
        concurrencyLevel: 5
```

```bash
$ sudo k0s stop
$ # Install custom build
$ sudo k0s start
$ sudo k0s kubectl get crd clusterconfigs.k0s.k0sproject.io -oyaml | grep forceUpgrade: -A 6
                            forceUpgrade:
                              description: 'ForceUpgrade when set to false, disables
                                the use of the "--force" flag when upgrading the the
                                chart (default: true).'
                              type: boolean
                            name:
                              type: string
$ sudo k0s kubectl get clusterconfigs -A -oyaml
apiVersion: v1
items:
- apiVersion: k0s.k0sproject.io/v1beta1
  kind: ClusterConfig
  metadata:
    creationTimestamp: "2024-10-02T16:05:16Z"
    generation: 1
    name: k0s
    namespace: kube-system
    resourceVersion: "199"
    uid: 4f079d8f-f8e2-4e92-b980-4d137b409c31
  spec:
    extensions:
      helm:
        charts:
        - chartname: twuni/docker-registry
          name: docker-registry
          namespace: registry
          order: 0
          timeout: 0
          values: ""
          version: 2.2.3
        concurrencyLevel: 5
```

To test for forward compatibility, install the latest k0s 1.30 release and see that it upgrades fine back to default: true.

```bash
$ sudo k0s stop
$ curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.30.5+k0s.0 sh
$ sudo k0s start
$ sudo k0s kubectl version
Client Version: v1.30.5
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
Server Version: v1.30.5+k0s
$ sudo k0s kubectl get clusterconfigs -A -oyaml
apiVersion: v1
items:
- apiVersion: k0s.k0sproject.io/v1beta1
  kind: ClusterConfig
  metadata:
    creationTimestamp: "2024-10-02T16:05:16Z"
    generation: 1
    name: k0s
    namespace: kube-system
    resourceVersion: "199"
    uid: 4f079d8f-f8e2-4e92-b980-4d137b409c31
  spec:
    extensions:
      helm:
        charts:
        - chartname: twuni/docker-registry
          forceUpgrade: true
          name: docker-registry
          namespace: registry
          order: 0
          timeout: 0
          values: ""
          version: 2.2.3
        concurrencyLevel: 5
```

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings