### PR TITLE
Run libseccomp tests in parallel

### DIFF
--- a/embedded-bins/runc/Dockerfile
+++ b/embedded-bins/runc/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILDIMAGE
 FROM $BUILDIMAGE AS build
 
 RUN apk add build-base git \
-	curl linux-headers gperf bash pkgconf
+	curl linux-headers gperf bash pkgconf cmd:tail
 
 ENV GOPATH=/go
 
@@ -10,11 +10,25 @@ ARG LIBSECCOMP_VERSION=2.5.5
 RUN curl --proto '=https' --tlsv1.2 -L https://github.com/seccomp/libseccomp/releases/download/v$LIBSECCOMP_VERSION/libseccomp-$LIBSECCOMP_VERSION.tar.gz \
 	| tar -C / -zx
 
-RUN cd /libseccomp-$LIBSECCOMP_VERSION && ./configure --sysconfdir=/etc --enable-static
+WORKDIR /libseccomp-$LIBSECCOMP_VERSION
+# tests: add basic support for running tests in parallel
+RUN curl -L https://github.com/seccomp/libseccomp/commit/2380f5788c692796f75e464c61aa877e5c4eb882.patch \
+	| git apply
+# tests: limit the number of bpf-sim-fuzz test iterations
+# https://github.com/seccomp/libseccomp/commit/5878cf2383ccedca3536f47155b13145809ae08e
+# the patch didnt apply due to commit touches .travis/
+# Use sed instead
+RUN sed -i -e 's/50$/5/' tests/*-sim-*.tests
 
-RUN make -j$(nproc) -C /libseccomp-$LIBSECCOMP_VERSION
-RUN make -j$(nproc) -C /libseccomp-$LIBSECCOMP_VERSION check
-RUN make -C /libseccomp-$LIBSECCOMP_VERSION install
+# tests: add support for the LIBSECCOMP_TSTCFG_JOBS env variable
+RUN curl -L https://github.com/seccomp/libseccomp/commit/4c19425fa69cfb4f7de5225d676a26ef0b442e28.patch \
+	| git apply
+RUN ./configure --sysconfdir=/etc --enable-static
+
+RUN make -j$(nproc)
+RUN make -j$(nproc) check-build
+RUN make -C tests check LIBSECCOMP_TSTCFG_JOBS=$(nproc)
+RUN make install
 
 ARG VERSION
 RUN mkdir -p $GOPATH/src/github.com/opencontainers/runc


### PR DESCRIPTION
Backport a commit that allows us to run the libseccomp tests in parallel. This lets us build runc image in 30-40 seconds instead of 4-5 minutes.

The bash script uses `tail` options that is not supported in busybox tail so pull in `tail` from coreutils.

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings