### PR TITLE
Let the ConfigSource be a regular component

### DIFF
--- a/pkg/component/controller/clusterconfig/configsource.go
+++ b/pkg/component/controller/clusterconfig/configsource.go
@@ -17,16 +17,13 @@ limitations under the License.
 package clusterconfig
 
 import (
-	"context"
-
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component/manager"
 )
 
 type ConfigSource interface {
-	// Release allows the config source to start sending config updates
-	Release(context.Context)
 	// ResultChan provides the result channel where config updates are pushed by the source on it is released
 	ResultChan() <-chan *v1beta1.ClusterConfig
-	// Stop stops sending config events
-	Stop()
+
+	manager.Component
 }


### PR DESCRIPTION
## Description

Replace the special `Release` method with the conventional `Start` method. This way, the `ConfigSource` can be added to the component manager as usual.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings