### PR TITLE
change cosign registry from GCR to GHCR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ sign-sbom: sbom/spdx.json
 	  -v "$(CURDIR):/k0s" \
 	  -v "$(CURDIR)/sbom:/out" \
 	  -e COSIGN_PASSWORD="$(COSIGN_PASSWORD)" \
-	  gcr.io/projectsigstore/cosign:v2.3.0 \
+	  ghcr.io/sigstore/cosign/cosign:v2.3.0 \
 	  sign-blob \
 	  --key /k0s/cosign.key \
 	  --tlog-upload=false \
@@ -329,6 +329,6 @@ sign-pub-key:
 	  -v "$(CURDIR):/k0s" \
 	  -v "$(CURDIR)/sbom:/out" \
 	  -e COSIGN_PASSWORD="$(COSIGN_PASSWORD)" \
-	  gcr.io/projectsigstore/cosign:v2.3.0 \
+	  ghcr.io/sigstore/cosign/cosign:v2.3.0 \
 	  public-key \
 	  --key /k0s/cosign.key --output-file /out/cosign.pub


### PR DESCRIPTION
## Description

This changes the Dockerfile to pull the cosign container image from GHCR instead of Google Cloud. This helps the Sigstore team manage their cloud spend (as GHCR is provided for free and Google Cloud Artifact Registry is not).

Note the container hash does not change and images are posted to both locations upon cosign's release process.