### PR TITLE
Remove extra colon from docs CPLB config example

### DIFF
--- a/docs/cplb.md
+++ b/docs/cplb.md
@@ -162,7 +162,7 @@ spec:
         network:
           controlPlaneLoadBalancing:
             enabled: true
-            type: Keepalived:
+            type: Keepalived
             keepalived:
               vrrpInstances:
               - virtualIPs: ["192.168.122.200/24"]

--- a/docs/cplb.md
+++ b/docs/cplb.md
@@ -92,7 +92,7 @@ spec:
               - ipAddress: "<External ip address>"
 ```
 
-Because this is a feature intended to configure the apiserver, CPLB noes not
+Because this is a feature intended to configure the apiserver, CPLB does not
 support dynamic configuration and in order to make changes you need to restart
 the k0s controllers to make changes.
 


### PR DESCRIPTION
## Description

Spotted this in https://github.com/k0sproject/k0sctl/issues/771 - there's an extra colon in the CPLB docs config example:

```yaml
        network:
          controlPlaneLoadBalancing:
            enabled: true
            type: Keepalived: # <--- here
            keepalived:
              vrrpInstances:
              - virtualIPs: ["192.168.122.200/24"]
                authPass: Example
              virtualServers:
              - ipAddress: "<External ip address>"
```

This PR removes it.

There was also `noes` instead of `does`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings