### PR TITLE
Allow line break HTML elements in Markdown files

### DIFF
--- a/.github/workflows/markdownlint-config.jsonc
+++ b/.github/workflows/markdownlint-config.jsonc
@@ -5,6 +5,11 @@
   "first-line-h1": false,
   "single-trailing-newline": false,
   "ol-prefix": "one_or_ordered",
+  "MD033": {
+    "allowed_elements": [
+      "br" // The br tag is more readable than two trailing spaces.
+    ]
+  },
   "MD055": false, // broken
   "MD056": false // broken
 }


### PR DESCRIPTION
## Description

The idiomatic way to add line breaks in Markdown files is to use two trailing spaces at the end of a line.

This poses some challenges:

* Hard to spot if there's no editor support for highlighting whitespace.
* Editors may remove them automatically, as whitespace at the end of a line is typically regarded as superfluous.

The `<br>` inline HTML element serves the same purpose, so let's make an exception for it.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings