### PR TITLE
Clarify custom CNI is not covered by k0s reset

### DIFF
--- a/docs/reset.md
+++ b/docs/reset.md
@@ -21,7 +21,7 @@ following:
   network interfaces or iptables rules set up specifically for cluster
   communication. This is done on a best effort basis. It's recommended that you
   reboot the host after a reset to ensure that there are no k0s remnants in the
-  host's network configuration.
+  host's network configuration. Custom CNI plugins are not cleaned up.
 * Registration with the host's init system: Reverts the registration done by
   `k0s install`. After a reset, k0s won't be automatically started when the host
   boots.


### PR DESCRIPTION
## Description

Someone reported k0s reset doesn't reset cilium CNI configuration, this is by design and I don't think we can achieve that reliably, so instead just document it.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings