### PR TITLE
ADR 1: Show how to use OCI registries via plain HTTP

### DIFF
--- a/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
+++ b/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
@@ -81,6 +81,16 @@ secretRef:
   name: artifacts-registry
 ```
 
+Example configuration for OCI using plain HTTP transport:
+
+```yaml
+url: oci+http://my.registry/binaries/k0s:v1.30.1+k0s.0
+sha256: e95603f167cce6e3cffef5594ef06785b3c1c00d3e27d8e4fc33824fe6c38a99
+secretRef:
+  namespace: kube-system
+  name: artifacts-registry
+```
+
 Example configuration for HTTPS:
 
 ```yaml


### PR DESCRIPTION
## Description

OCI registries use HTTPS by default. We forgot to specify how to turn this off, if desired.

Proposal: Use a custom URL scheme (`oci+http`) to turn this off and fall back to plain HTTP.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings