### PR TITLE
[Backport release-1.30] Applier manager improvements

### DIFF
--- a/pkg/applier/manager.go
+++ b/pkg/applier/manager.go
@@ -41,7 +41,6 @@ type Manager struct {
 	K0sVars           *config.CfgVars
 	KubeClientFactory kubeutil.ClientFactoryInterface
 
-	applier   Applier
 	bundleDir string
 	stop      func(reason string)
 	log       *logrus.Entry
@@ -65,8 +64,6 @@ func (m *Manager) Init(ctx context.Context) error {
 	}
 	m.log = logrus.WithField("component", constant.ApplierManagerComponentName)
 	m.bundleDir = m.K0sVars.ManifestsDir
-
-	m.applier = NewApplier(m.K0sVars.ManifestsDir, m.KubeClientFactory)
 
 	m.LeaderElector.AddAcquiredLeaseCallback(func() {
 		ctx, cancel := context.WithCancelCause(ctx)

--- a/pkg/applier/manager.go
+++ b/pkg/applier/manager.go
@@ -125,16 +125,10 @@ func (m *Manager) runWatchers(ctx context.Context) error {
 
 	for {
 		select {
-		case err, ok := <-watcher.Errors:
-			if !ok {
-				return err
-			}
+		case err := <-watcher.Errors:
+			log.WithError(err).Error("Watch error")
 
-			log.Warnf("watch error: %s", err.Error())
-		case event, ok := <-watcher.Events:
-			if !ok {
-				return nil
-			}
+		case event := <-watcher.Events:
 			switch event.Op {
 			case fsnotify.Create:
 				if dir.IsDirectory(event.Name) {


### PR DESCRIPTION
Backport to `release-1.30`:

* #5171
  Partially, without the test case (3502970a19ca94cdcf83623e4748240998c597d5). See https://github.com/k0sproject/k0s/pull/5062#issuecomment-2431294982.

See:

* #5062
* #5122