### PR TITLE
Fix etcd peer URL to support ipv6

### DIFF
--- a/pkg/apis/k0s/v1beta1/storage.go
+++ b/pkg/apis/k0s/v1beta1/storage.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -177,6 +178,15 @@ func (e *EtcdConfig) GetNodeName() (string, error) {
 	}
 
 	return os.Hostname()
+}
+
+// GetPeerURL returns the URL of PeerAddress
+func (e *EtcdConfig) GetPeerURL() string {
+	u := &url.URL{
+		Scheme: "https",
+		Host:   net.JoinHostPort(e.PeerAddress, "2380"),
+	}
+	return u.String()
 }
 
 // DefaultKineConfig creates KineConfig with sane defaults

--- a/pkg/backup/etcd_unix.go
+++ b/pkg/backup/etcd_unix.go
@@ -21,6 +21,8 @@ package backup
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -84,7 +86,11 @@ func (e etcdStep) Restore(restoreFrom, _ string) error {
 	if err != nil {
 		return err
 	}
-	peerURL := fmt.Sprintf("https://%s:2380", e.peerAddress)
+	u := &url.URL{
+		Scheme: "https",
+		Host:   net.JoinHostPort(e.peerAddress, "2380"),
+	}
+	peerURL := u.String()
 	restoreConfig := utilsnapshot.RestoreConfig{
 		SnapshotPath:   snapshotPath,
 		OutputDataDir:  e.etcdDataDir,

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -169,7 +169,7 @@ func (e *Etcd) Start(ctx context.Context) error {
 		name = hostName
 	}
 
-	peerURL := fmt.Sprintf("https://%s:2380", e.Config.PeerAddress)
+	peerURL := e.Config.GetPeerURL()
 
 	args := stringmap.StringMap{
 		"--data-dir":                    e.K0sVars.EtcdDataDir,

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"strconv"
 	"time"
 
@@ -177,9 +176,7 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context) error {
 		return err
 	}
 
-	peerURL := fmt.Sprintf("https://%s", net.JoinHostPort(e.etcdConfig.PeerAddress, "2380"))
-
-	memberID, err := etcdClient.GetPeerIDByAddress(ctx, peerURL)
+	memberID, err := etcdClient.GetPeerIDByAddress(ctx, e.etcdConfig.GetPeerURL())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
IPv6 URL need to have brackets [] around the ipv6 to separate it from the port. Eg https://[xx:yy:zz]:2380

Fix this by using net/url's String() formatter.

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #5180 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings