### PR TITLE
Don't try to compile CPLB on darwin

### DIFF
--- a/pkg/component/controller/cplb_linux.go
+++ b/pkg/component/controller/cplb_linux.go
@@ -1,5 +1,3 @@
-//go:build unix
-
 /*
 Copyright 2024 k0s authors
 

--- a/pkg/component/controller/cplb_other.go
+++ b/pkg/component/controller/cplb_other.go
@@ -1,3 +1,5 @@
+//go:build !linux
+
 /*
 Copyright 2024 k0s authors
 
@@ -19,6 +21,8 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
+	"runtime"
 
 	k0sAPI "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/config"
@@ -35,14 +39,14 @@ type Keepalived struct {
 	KubeConfigPath  string
 }
 
-func (k *Keepalived) Init(_ context.Context) error {
-	return errors.New("CPLB is not supported on Windows")
+func (k *Keepalived) Init(context.Context) error {
+	return fmt.Errorf("%w: CPLB is not supported on %s", errors.ErrUnsupported, runtime.GOOS)
 }
 
-func (k *Keepalived) Start(_ context.Context) error {
-	return errors.New("CPLB is not supported on Windows")
+func (k *Keepalived) Start(context.Context) error {
+	return fmt.Errorf("%w: CPLB is not supported on %s", errors.ErrUnsupported, runtime.GOOS)
 }
 
 func (k *Keepalived) Stop() error {
-	return errors.New("CPLB is not supported on Windows")
+	return fmt.Errorf("%w: CPLB is not supported on %s", errors.ErrUnsupported, runtime.GOOS)
 }


### PR DESCRIPTION
## Description

The unix build tag includes darwin, but CPLB only compiles on Linux. Use the linux build tag for the implementation instead, and use the current windows stub for anything that isn't linux.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings