### PR TITLE
Add support for setting kubelet root directory

### DIFF
--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -74,6 +74,7 @@ Flags:
       --k0s-cloud-provider-update-frequency duration   the frequency of k0s-cloud-provider node updates (default 2m0s)
       --kube-controller-manager-extra-args string      extra args for kube-controller-manager
       --kubelet-extra-args string                      extra args for kubelet
+      --kubelet-root-dir string                        Kubelet root directory for k0s
       --labels strings                                 Node labels, list of key=value pairs
   -l, --logging stringToString                         Logging Levels for the different components (default [containerd=info,etcd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1])
       --no-taints                                      disable default taints for controller node

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -72,6 +72,7 @@ Flags:
       --k0s-cloud-provider-update-frequency duration   the frequency of k0s-cloud-provider node updates (default 2m0s)
       --kube-controller-manager-extra-args string      extra args for kube-controller-manager
       --kubelet-extra-args string                      extra args for kubelet
+      --kubelet-root-dir string                        Kubelet root directory for k0s
       --labels strings                                 Node labels, list of key=value pairs
   -l, --logging stringToString                         Logging Levels for the different components (default [containerd=info,etcd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1])
       --no-taints                                      disable default taints for controller node

--- a/cmd/install/util.go
+++ b/cmd/install/util.go
@@ -40,7 +40,7 @@ func cmdFlagsToArgs(cmd *cobra.Command) ([]string, error) {
 			switch f.Name {
 			case "env", "force":
 				return
-			case "data-dir", "token-file", "config":
+			case "data-dir", "kubelet-root-dir", "token-file", "config":
 				if absVal, err := filepath.Abs(val); err != nil {
 					err = fmt.Errorf("failed to convert --%s=%s to an absolute path: %w", f.Name, val, err)
 					errs = append(errs, err)

--- a/inttest/kubeletcertrotate/kubeletcertrotate_test.go
+++ b/inttest/kubeletcertrotate/kubeletcertrotate_test.go
@@ -59,7 +59,7 @@ func (s *kubeletCertRotateSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	// Start the workers using the join token
-	s.Require().NoError(s.RunWorkersWithToken(workerJoinToken))
+	s.Require().NoError(s.RunWorkersWithToken(workerJoinToken, "--kubelet-root-dir=/var/lib/kubelet"))
 
 	client, err := s.KubeClient(s.ControllerNode(0))
 	s.Require().NoError(err)
@@ -74,7 +74,7 @@ func (s *kubeletCertRotateSuite) SetupTest() {
 	workerSSH, err := s.SSH(s.Context(), s.WorkerNode(0))
 	s.Require().NoError(err)
 	s.T().Log("waiting to see kubelet rotating the client cert before triggering Plan creation")
-	_, err = workerSSH.ExecWithOutput(s.Context(), "inotifywait --no-dereference /var/lib/k0s/kubelet/pki/kubelet-client-current.pem")
+	_, err = workerSSH.ExecWithOutput(s.Context(), "inotifywait --no-dereference /var/lib/kubelet/pki/kubelet-client-current.pem")
 	s.Require().NoError(err)
 	output, err := workerSSH.ExecWithOutput(s.Context(), "k0s status -ojson")
 	s.Require().NoError(err)

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -53,8 +53,9 @@ func NewConfig(debug bool, k0sVars *config.CfgVars, criSocketFlag string) (*Conf
 		},
 		&services{},
 		&directories{
-			dataDir: k0sVars.DataDir,
-			runDir:  k0sVars.RunDir,
+			dataDir:        k0sVars.DataDir,
+			kubeletRootDir: k0sVars.KubeletRootDir,
+			runDir:         k0sVars.RunDir,
 		},
 		&cni{},
 	}

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -63,7 +63,6 @@ type Kubelet struct {
 	ExtraArgs           string
 	DualStackEnabled    bool
 
-	rootDir    string
 	configPath string
 	supervisor supervisor.Supervisor
 }
@@ -84,10 +83,9 @@ func (k *Kubelet) Init(_ context.Context) error {
 		}
 	}
 
-	k.rootDir = filepath.Join(k.K0sVars.DataDir, "kubelet")
-	err := dir.Init(k.rootDir, constant.DataDirMode)
+	err := dir.Init(k.K0sVars.KubeletRootDir, constant.DataDirMode)
 	if err != nil {
-		return fmt.Errorf("failed to create %s: %w", k.rootDir, err)
+		return fmt.Errorf("failed to create %s: %w", k.K0sVars.KubeletRootDir, err)
 	}
 
 	runDir := filepath.Join(k.K0sVars.RunDir, "kubelet")
@@ -133,12 +131,12 @@ func (k *Kubelet) Start(ctx context.Context) error {
 
 	logrus.Info("Starting kubelet")
 	args := stringmap.StringMap{
-		"--root-dir":        k.rootDir,
+		"--root-dir":        k.K0sVars.KubeletRootDir,
 		"--config":          k.configPath,
 		"--kubeconfig":      k.Kubeconfig,
 		"--v":               k.LogLevel,
 		"--runtime-cgroups": "/system.slice/containerd.service",
-		"--cert-dir":        filepath.Join(k.rootDir, "pki"),
+		"--cert-dir":        filepath.Join(k.K0sVars.KubeletRootDir, "pki"),
 	}
 
 	if len(k.Labels) > 0 {

--- a/pkg/component/worker/utils.go
+++ b/pkg/component/worker/utils.go
@@ -144,7 +144,7 @@ func BootstrapKubeletKubeconfig(ctx context.Context, k0sVars *config.CfgVars, wo
 		return fmt.Errorf("wrong token type %s, expected type: kubelet-bootstrap", tokenType)
 	}
 
-	certDir := filepath.Join(k0sVars.DataDir, "kubelet", "pki")
+	certDir := filepath.Join(k0sVars.KubeletRootDir, "pki")
 	if err := dir.Init(certDir, constant.DataDirMode); err != nil {
 		return fmt.Errorf("failed to initialize kubelet certificate directory: %w", err)
 	}

--- a/pkg/config/cfgvars.go
+++ b/pkg/config/cfgvars.go
@@ -47,6 +47,7 @@ type CfgVars struct {
 	BinDir                     string              // location for all pki related binaries
 	CertRootDir                string              // CertRootDir defines the root location for all pki related artifacts
 	DataDir                    string              // Data directory containing k0s state
+	KubeletRootDir             string              // Root directory for kubelet
 	EtcdCertDir                string              // EtcdCertDir contains etcd certificates
 	EtcdDataDir                string              // EtcdDataDir contains etcd state
 	KineSocketPath             string              // The unix socket path for kine
@@ -105,6 +106,10 @@ func WithCommand(cmd command) CfgVarOption {
 			c.DataDir = f
 		}
 
+		if f, err := flags.GetString("kubelet-root-dir"); err == nil && f != "" {
+			c.KubeletRootDir = f
+		}
+
 		if f, err := flags.GetString("config"); err == nil && f != "" {
 			c.StartupConfigPath = f
 		}
@@ -137,6 +142,7 @@ func DefaultCfgVars() *CfgVars {
 // NewCfgVars returns a new CfgVars struct.
 func NewCfgVars(cobraCmd command, dirs ...string) (*CfgVars, error) {
 	var dataDir string
+	var kubeletRootDir string
 
 	if len(dirs) > 0 {
 		dataDir = dirs[0]
@@ -145,6 +151,9 @@ func NewCfgVars(cobraCmd command, dirs ...string) (*CfgVars, error) {
 	if cobraCmd != nil {
 		if val, err := cobraCmd.Flags().GetString("data-dir"); err == nil && val != "" {
 			dataDir = val
+		}
+		if val, err := cobraCmd.Flags().GetString("kubelet-root-dir"); err == nil && val != "" {
+			kubeletRootDir = val
 		}
 	}
 
@@ -156,6 +165,14 @@ func NewCfgVars(cobraCmd command, dirs ...string) (*CfgVars, error) {
 	dataDir, err := filepath.Abs(dataDir)
 	if err != nil {
 		return nil, fmt.Errorf("invalid datadir: %w", err)
+	}
+
+	if kubeletRootDir == "" {
+		kubeletRootDir = filepath.Join(dataDir, "kubelet")
+	}
+	kubeletRootDir, err = filepath.Abs(kubeletRootDir)
+	if err != nil {
+		return nil, fmt.Errorf("invalid kubeletRootDir: %w", err)
 	}
 
 	var runDir string
@@ -180,6 +197,7 @@ func NewCfgVars(cobraCmd command, dirs ...string) (*CfgVars, error) {
 		OCIBundleDir:               filepath.Join(dataDir, "images"),
 		CertRootDir:                certDir,
 		DataDir:                    dataDir,
+		KubeletRootDir:             kubeletRootDir,
 		EtcdCertDir:                filepath.Join(certDir, "etcd"),
 		EtcdDataDir:                filepath.Join(dataDir, "etcd"),
 		KineSocketPath:             filepath.Join(runDir, constant.KineSocket),

--- a/pkg/config/cfgvars.go
+++ b/pkg/config/cfgvars.go
@@ -107,7 +107,9 @@ func WithCommand(cmd command) CfgVarOption {
 		}
 
 		if f, err := flags.GetString("kubelet-root-dir"); err == nil && f != "" {
-			c.KubeletRootDir = f
+			if f, err := filepath.Abs(f); err == nil {
+				c.KubeletRootDir = f
+			}
 		}
 
 		if f, err := flags.GetString("config"); err == nil && f != "" {

--- a/pkg/config/cfgvars_test.go
+++ b/pkg/config/cfgvars_test.go
@@ -81,9 +81,12 @@ func TestWithCommand(t *testing.T) {
 	c := &CfgVars{}
 	WithCommand(fakeCmd)(c)
 
+	dir, err := filepath.Abs("/path/to/kubelet")
+	assert.NoError(t, err)
+
 	assert.Same(t, in, c.stdin)
 	assert.Equal(t, "/path/to/data", c.DataDir)
-	assert.Equal(t, "/path/to/kubelet", c.KubeletRootDir)
+	assert.Equal(t, dir, c.KubeletRootDir)
 	assert.Equal(t, "/path/to/config", c.StartupConfigPath)
 	assert.Equal(t, "/path/to/socket", c.StatusSocketPath)
 	assert.True(t, c.EnableDynamicConfig)

--- a/pkg/config/cfgvars_test.go
+++ b/pkg/config/cfgvars_test.go
@@ -19,6 +19,7 @@ package config
 import (
 	"bytes"
 	"io"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -62,6 +63,7 @@ func TestWithCommand(t *testing.T) {
 	fakeFlags := &FakeFlagSet{
 		values: map[string]any{
 			"data-dir":              "/path/to/data",
+			"kubelet-root-dir":      "/path/to/kubelet",
 			"config":                "/path/to/config",
 			"status-socket":         "/path/to/socket",
 			"enable-dynamic-config": true,
@@ -81,6 +83,7 @@ func TestWithCommand(t *testing.T) {
 
 	assert.Same(t, in, c.stdin)
 	assert.Equal(t, "/path/to/data", c.DataDir)
+	assert.Equal(t, "/path/to/kubelet", c.KubeletRootDir)
 	assert.Equal(t, "/path/to/config", c.StartupConfigPath)
 	assert.Equal(t, "/path/to/socket", c.StatusSocketPath)
 	assert.True(t, c.EnableDynamicConfig)
@@ -145,6 +148,45 @@ func TestNewCfgVars_DataDir(t *testing.T) {
 			c, err := NewCfgVars(tt.fakeCmd, tt.dirs...)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected.DataDir, c.DataDir)
+		})
+	}
+}
+
+func TestNewCfgVars_KubeletRootDir(t *testing.T) {
+	tests := []struct {
+		name     string
+		fakeCmd  command
+		dirs     []string
+		expected *CfgVars
+	}{
+		{
+			name:     "default kubelet root dir",
+			fakeCmd:  &FakeCommand{flagSet: &FakeFlagSet{}},
+			expected: &CfgVars{KubeletRootDir: filepath.Join(constant.DataDirDefault, "kubelet")},
+		},
+		{
+			name: "default kubelet root dir when datadir set",
+			fakeCmd: &FakeCommand{
+				flagSet: &FakeFlagSet{values: map[string]any{"data-dir": "/path/to/data"}},
+			},
+			expected: &CfgVars{KubeletRootDir: "/path/to/data/kubelet"},
+		},
+		{
+			name: "custom kubelet root dir",
+			fakeCmd: &FakeCommand{
+				flagSet: &FakeFlagSet{values: map[string]any{"kubelet-root-dir": "/path/to/kubelet"}},
+			},
+			expected: &CfgVars{KubeletRootDir: "/path/to/kubelet"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewCfgVars(tt.fakeCmd, tt.dirs...)
+			assert.NoError(t, err)
+			expected, err := filepath.Abs(tt.expected.KubeletRootDir)
+			assert.NoError(t, err)
+			assert.Equal(t, expected, c.KubeletRootDir)
 		})
 	}
 }

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -199,6 +199,7 @@ func GetPersistentFlagSet() *pflag.FlagSet {
 	flagset.BoolVarP(&Debug, "debug", "d", false, "Debug logging (default: false)")
 	flagset.BoolVarP(&Verbose, "verbose", "v", false, "Verbose logging (default: false)")
 	flagset.String("data-dir", constant.DataDirDefault, "Data Directory for k0s. DO NOT CHANGE for an existing setup, things will break!")
+	flagset.String("kubelet-root-dir", "", "Kubelet root directory for k0s")
 	flagset.StringVar(&StatusSocket, "status-socket", "", "Full file path to the socket file. (default: <rundir>/status.sock)")
 	flagset.StringVar(&DebugListenOn, "debugListenOn", ":6060", "Http listenOn for Debug pprof handler")
 	return flagset


### PR DESCRIPTION
## Description

 Storage drivers and others may hard code /var/lib/kubelet which
    conflicts with the k0s default /var/lib/k0s/kubelet. Allow users to
    override the kubelet root directory with --kubelet-root-dir similar to
    the way they can override --data-dir.

For backwards compatibility we keep the default to be `<datadir>/kubelet`.

Also fix unmounting when deleting directories in `k0s reset` while at it.

Fixes #1842
Fixes #4318

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings