### PR TITLE
[Backport release-1.29] Fix etcd peer URL to support ipv6

### DIFF
--- a/pkg/apis/k0s/v1beta1/storage.go
+++ b/pkg/apis/k0s/v1beta1/storage.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -159,6 +160,15 @@ func DefaultEtcdConfig() *EtcdConfig {
 		PeerAddress:     addr,
 		ExtraArgs:       make(map[string]string),
 	}
+}
+
+// GetPeerURL returns the URL of PeerAddress
+func (e *EtcdConfig) GetPeerURL() string {
+	u := &url.URL{
+		Scheme: "https",
+		Host:   net.JoinHostPort(e.PeerAddress, "2380"),
+	}
+	return u.String()
 }
 
 // DefaultKineConfig creates KineConfig with sane defaults

--- a/pkg/backup/etcd.go
+++ b/pkg/backup/etcd.go
@@ -21,6 +21,8 @@ package backup
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -84,7 +86,11 @@ func (e etcdStep) Restore(restoreFrom, _ string) error {
 	if err != nil {
 		return err
 	}
-	peerURL := fmt.Sprintf("https://%s:2380", e.peerAddress)
+	u := &url.URL{
+		Scheme: "https",
+		Host:   net.JoinHostPort(e.peerAddress, "2380"),
+	}
+	peerURL := u.String()
 	restoreConfig := utilsnapshot.RestoreConfig{
 		SnapshotPath:   snapshotPath,
 		OutputDataDir:  e.etcdDataDir,

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -155,7 +155,7 @@ func (e *Etcd) Start(ctx context.Context) error {
 		return err
 	}
 
-	peerURL := fmt.Sprintf("https://%s:2380", e.Config.PeerAddress)
+	peerURL := e.Config.GetPeerURL()
 
 	args := stringmap.StringMap{
 		"--data-dir":                    e.K0sVars.EtcdDataDir,


### PR DESCRIPTION
Backport to `release-1.29`:

* #5190

See:

* #5181
* #5180