### PR TITLE
Let cleanup steps hold their own data

### DIFF
--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -68,7 +68,7 @@ func (c *command) reset() error {
 	}
 
 	// Get Cleanup Config
-	cfg, err := cleanup.NewConfig(c.K0sVars, c.WorkerOptions.CriSocket)
+	cfg, err := cleanup.NewConfig(c.Debug, c.K0sVars, c.WorkerOptions.CriSocket)
 	if err != nil {
 		return fmt.Errorf("failed to configure cleanup: %w", err)
 	}

--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -68,7 +68,7 @@ func (c *command) reset() error {
 	}
 
 	// Get Cleanup Config
-	cfg, err := cleanup.NewConfig(c.K0sVars, c.CfgFile, c.WorkerOptions.CriSocket)
+	cfg, err := cleanup.NewConfig(c.K0sVars, c.WorkerOptions.CriSocket)
 	if err != nil {
 		return fmt.Errorf("failed to configure cleanup: %w", err)
 	}

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -66,10 +66,17 @@ func NewConfig(k0sVars *config.CfgVars, criSocketFlag string) (*Config, error) {
 }
 
 func (c *Config) Cleanup() error {
+	cfg, err := c.k0sVars.NodeConfig()
+	if err != nil {
+		logrus.Errorf("failed to get cluster setup: %v", err)
+	}
+
 	var errs []error
 	cleanupSteps := []Step{
 		&containers{Config: c},
-		&users{Config: c},
+		&users{
+			systemUsers: cfg.Spec.Install.SystemUsers,
+		},
 		&services{},
 		&directories{
 			dataDir: c.k0sVars.DataDir,

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -29,7 +29,6 @@ import (
 )
 
 type Config struct {
-	cfgFile          string
 	containerd       *containerdConfig
 	containerRuntime runtime.ContainerRuntime
 	dataDir          string
@@ -43,7 +42,7 @@ type containerdConfig struct {
 	socketPath string
 }
 
-func NewConfig(k0sVars *config.CfgVars, cfgFile string, criSocketFlag string) (*Config, error) {
+func NewConfig(k0sVars *config.CfgVars, criSocketFlag string) (*Config, error) {
 	runDir := "/run/k0s" // https://github.com/k0sproject/k0s/pull/591/commits/c3f932de85a0b209908ad39b817750efc4987395
 
 	var containerdCfg *containerdConfig
@@ -60,7 +59,6 @@ func NewConfig(k0sVars *config.CfgVars, cfgFile string, criSocketFlag string) (*
 	}
 
 	return &Config{
-		cfgFile:          cfgFile,
 		containerd:       containerdCfg,
 		containerRuntime: runtime.NewContainerRuntime(runtimeEndpoint),
 		dataDir:          k0sVars.DataDir,

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -71,7 +71,10 @@ func (c *Config) Cleanup() error {
 		&containers{Config: c},
 		&users{Config: c},
 		&services{},
-		&directories{Config: c},
+		&directories{
+			dataDir: c.k0sVars.DataDir,
+			runDir:  c.k0sVars.RunDir,
+		},
 		&cni{},
 	}
 

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -70,7 +70,7 @@ func (c *Config) Cleanup() error {
 	cleanupSteps := []Step{
 		&containers{Config: c},
 		&users{Config: c},
-		&services{Config: c},
+		&services{},
 		&directories{Config: c},
 		&cni{},
 	}

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -43,11 +43,9 @@ type containerdConfig struct {
 }
 
 func NewConfig(k0sVars *config.CfgVars, criSocketFlag string) (*Config, error) {
-	runDir := "/run/k0s" // https://github.com/k0sproject/k0s/pull/591/commits/c3f932de85a0b209908ad39b817750efc4987395
-
 	var containerdCfg *containerdConfig
 
-	runtimeEndpoint, err := worker.GetContainerRuntimeEndpoint(criSocketFlag, runDir)
+	runtimeEndpoint, err := worker.GetContainerRuntimeEndpoint(criSocketFlag, k0sVars.RunDir)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +60,7 @@ func NewConfig(k0sVars *config.CfgVars, criSocketFlag string) (*Config, error) {
 		containerd:       containerdCfg,
 		containerRuntime: runtime.NewContainerRuntime(runtimeEndpoint),
 		dataDir:          k0sVars.DataDir,
-		runDir:           runDir,
+		runDir:           k0sVars.DataDir,
 		k0sVars:          k0sVars,
 	}, nil
 }

--- a/pkg/cleanup/containers.go
+++ b/pkg/cleanup/containers.go
@@ -20,14 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
-	"time"
 
-	"github.com/k0sproject/k0s/internal/pkg/file"
+	"github.com/k0sproject/k0s/pkg/component/worker/containerd"
+	"github.com/k0sproject/k0s/pkg/container/runtime"
 
 	"github.com/avast/retry-go"
 	"github.com/sirupsen/logrus"
@@ -35,7 +32,8 @@ import (
 )
 
 type containers struct {
-	Config *Config
+	managedContainerd *containerd.Component
+	containerRuntime  runtime.ContainerRuntime
 }
 
 // Name returns the name of the step
@@ -46,23 +44,27 @@ func (c *containers) Name() string {
 // Run removes all the pods and mounts and stops containers afterwards
 // Run starts containerd if custom CRI is not configured
 func (c *containers) Run() error {
-	if !c.isCustomCriUsed() {
-		if err := c.startContainerd(); err != nil {
-			if errors.Is(err, fs.ErrNotExist) || errors.Is(err, exec.ErrNotFound) {
-				logrus.Debugf("containerd binary not found. Skipping container cleanup")
-				return nil
-			}
-			return fmt.Errorf("failed to start containerd: %w", err)
+	if c.managedContainerd != nil {
+		ctx := context.TODO()
+		if err := c.managedContainerd.Init(ctx); err != nil {
+			logrus.WithError(err).Warn("Failed to initialize containerd, skipping container cleanup")
+			return nil
 		}
+		if err := c.managedContainerd.Start(ctx); err != nil {
+			logrus.WithError(err).Warn("Failed to start containerd, skipping container cleanup")
+			return nil
+		}
+		defer func() {
+			if err := c.managedContainerd.Stop(); err != nil {
+				logrus.WithError(err).Warn("Failed to stop containerd")
+			}
+		}()
 	}
 
 	if err := c.stopAllContainers(); err != nil {
 		logrus.Debugf("error stopping containers: %v", err)
 	}
 
-	if !c.isCustomCriUsed() {
-		c.stopContainerd()
-	}
 	return nil
 }
 
@@ -91,48 +93,6 @@ func removeMount(path string) error {
 	return errors.Join(errs...)
 }
 
-func (c *containers) isCustomCriUsed() bool {
-	return c.Config.containerd == nil
-}
-
-func (c *containers) startContainerd() error {
-	logrus.Debugf("starting containerd")
-	args := []string{
-		"--root=" + filepath.Join(c.Config.dataDir, "containerd"),
-		"--state=" + filepath.Join(c.Config.runDir, "containerd"),
-		"--address=" + c.Config.containerd.socketPath,
-	}
-	if file.Exists("/etc/k0s/containerd.toml") {
-		args = append(args, "--config=/etc/k0s/containerd.toml")
-	}
-	cmd := exec.Command(c.Config.containerd.binPath, args...)
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-
-	c.Config.containerd.cmd = cmd
-	logrus.Debugf("started containerd successfully")
-
-	return nil
-}
-
-func (c *containers) stopContainerd() {
-	logrus.Debug("attempting to stop containerd")
-	logrus.Debugf("found containerd pid: %v", c.Config.containerd.cmd.Process.Pid)
-	if err := c.Config.containerd.cmd.Process.Signal(os.Interrupt); err != nil {
-		logrus.Errorf("failed to kill containerd: %v", err)
-	}
-	// if process, didn't exit, wait a few seconds and send SIGKILL
-	if c.Config.containerd.cmd.ProcessState.ExitCode() != -1 {
-		time.Sleep(5 * time.Second)
-
-		if err := c.Config.containerd.cmd.Process.Kill(); err != nil {
-			logrus.Errorf("failed to send SIGKILL to containerd: %v", err)
-		}
-	}
-	logrus.Debug("successfully stopped containerd")
-}
-
 func (c *containers) stopAllContainers() error {
 	var errs []error
 
@@ -141,7 +101,7 @@ func (c *containers) stopAllContainers() error {
 	err := retry.Do(func() error {
 		logrus.Debugf("trying to list all pods")
 		var err error
-		pods, err = c.Config.containerRuntime.ListContainers(ctx)
+		pods, err = c.containerRuntime.ListContainers(ctx)
 		if err != nil {
 			return err
 		}
@@ -158,7 +118,7 @@ func (c *containers) stopAllContainers() error {
 
 	for _, pod := range pods {
 		logrus.Debugf("stopping container: %v", pod)
-		err := c.Config.containerRuntime.StopContainer(ctx, pod)
+		err := c.containerRuntime.StopContainer(ctx, pod)
 		if err != nil {
 			if strings.Contains(err.Error(), "443: connect: connection refused") {
 				// on a single node instance, we will see "connection refused" error. this is to be expected
@@ -168,13 +128,13 @@ func (c *containers) stopAllContainers() error {
 				errs = append(errs, fmt.Errorf("failed to stop running pod %s: %w", pod, err))
 			}
 		}
-		err = c.Config.containerRuntime.RemoveContainer(ctx, pod)
+		err = c.containerRuntime.RemoveContainer(ctx, pod)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to remove pod %s: %w", pod, err))
 		}
 	}
 
-	pods, err = c.Config.containerRuntime.ListContainers(ctx)
+	pods, err = c.containerRuntime.ListContainers(ctx)
 	if err == nil && len(pods) == 0 {
 		logrus.Info("successfully removed k0s containers!")
 	}

--- a/pkg/cleanup/services.go
+++ b/pkg/cleanup/services.go
@@ -24,9 +24,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/install"
 )
 
-type services struct {
-	Config *Config
-}
+type services struct{}
 
 // Name returns the name of the step
 func (s *services) Name() string {

--- a/pkg/cleanup/users.go
+++ b/pkg/cleanup/users.go
@@ -17,12 +17,14 @@ limitations under the License.
 package cleanup
 
 import (
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/install"
+
 	"github.com/sirupsen/logrus"
 )
 
 type users struct {
-	Config *Config
+	systemUsers *k0sv1beta1.SystemUser
 }
 
 // Name returns the name of the step
@@ -32,11 +34,7 @@ func (u *users) Name() string {
 
 // Run removes all controller users that are present on the host
 func (u *users) Run() error {
-	cfg, err := u.Config.k0sVars.NodeConfig()
-	if err != nil {
-		logrus.Errorf("failed to get cluster setup: %v", err)
-	}
-	if err := install.DeleteControllerUsers(cfg.Spec.Install.SystemUsers); err != nil {
+	if err := install.DeleteControllerUsers(u.systemUsers); err != nil {
 		// don't fail, just notify on delete error
 		logrus.Warnf("failed to delete controller users: %v", err)
 	}


### PR DESCRIPTION
## Description

Let the cleanup steps hold their own data, instead of sharing the superset of required things via a pointer to Config. This makes the code structure a bit cleaner, so it is clear which step needs which configuration data.

Use the containerd component in the containers cleanup step to start the managed containerd, instead of the previous ad hoc approach.

Also, remove a hardcoded value for k0s's run directory along the way.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings