### PR TITLE
Correctly detect DNS address computation errors

### DIFF
--- a/pkg/apis/k0s/v1beta1/network_test.go
+++ b/pkg/apis/k0s/v1beta1/network_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"errors"
 	"testing"
 
 	"k8s.io/utils/ptr"
@@ -41,6 +42,19 @@ func (s *NetworkSuite) TestAddresses() {
 		dns, err := n.DNSAddress()
 		s.Require().NoError(err)
 		s.Equal("10.96.0.250", dns)
+	})
+	s.Run("DNS_service_cidr_too_narrow", func() {
+		n := Network{ServiceCIDR: "192.168.178.0/31"}
+		dns, err := n.DNSAddress()
+		s.Zero(dns)
+		s.ErrorContains(err, "failed to calculate DNS address: CIDR too narrow: 192.168.178.0/31")
+	})
+	s.Run("DNS_rejects_v6_service_cidr", func() {
+		n := Network{ServiceCIDR: "fd00:abcd:1234::/64"}
+		dns, err := n.DNSAddress()
+		s.Zero(dns)
+		s.ErrorIs(err, errors.ErrUnsupported)
+		s.ErrorContains(err, "unsupported operation: DNS address calculation for non-v4 CIDR: fd00:abcd:1234::/64")
 	})
 	s.Run("Internal_api_address_default", func() {
 		n := DefaultNetwork()


### PR DESCRIPTION
## Description

The existing code is unable to compute meaningful DNS addresses if the service CIDR doesn't describe a v4 network. Error out whenever the network IP is not a v4 address until it is clear how to properly compute the DNS address for a v6 network. Also, copy `address` by value so that changes to it don't change `ipnet` as well.

See https://github.com/k0sproject/k0s/pull/5223#discussion_r1838387251.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings