### PR TITLE
[Backport release-1.30] Bump Go to v1.22.9

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.19
 alpine_patch_version = $(alpine_version).2
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.22.8
+go_version = 1.22.9
 
 runc_version = 1.1.15
 runc_buildimage = $(golang_buildimage)


### PR DESCRIPTION
Backport to `release-1.30`:

* #5204