### PR TITLE
Remove stack when directory is renamed

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -298,7 +298,7 @@ func (c *command) start(ctx context.Context) error {
 
 	if !slices.Contains(c.DisableComponents, constant.ApplierManagerComponentName) {
 		nodeComponents.Add(ctx, &applier.Manager{
-			K0sVars:           c.K0sVars,
+			ManifestsDir:      c.K0sVars.ManifestsDir,
 			KubeClientFactory: adminClientFactory,
 			IgnoredStacks: []string{
 				controller.ClusterConfigStackName,

--- a/pkg/applier/manager.go
+++ b/pkg/applier/manager.go
@@ -29,7 +29,6 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/manager"
-	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 
@@ -41,7 +40,7 @@ import (
 
 // Manager is the Component interface wrapper for Applier
 type Manager struct {
-	K0sVars           *config.CfgVars
+	ManifestsDir      string
 	IgnoredStacks     []string
 	KubeClientFactory kubeutil.ClientFactoryInterface
 
@@ -62,12 +61,12 @@ type stack = struct {
 
 // Init initializes the Manager
 func (m *Manager) Init(ctx context.Context) error {
-	err := dir.Init(m.K0sVars.ManifestsDir, constant.ManifestsDirMode)
+	err := dir.Init(m.ManifestsDir, constant.ManifestsDirMode)
 	if err != nil {
-		return fmt.Errorf("failed to create manifest bundle dir %s: %w", m.K0sVars.ManifestsDir, err)
+		return fmt.Errorf("failed to create manifest bundle dir %s: %w", m.ManifestsDir, err)
 	}
 	m.log = logrus.WithField("component", constant.ApplierManagerComponentName)
-	m.bundleDir = m.K0sVars.ManifestsDir
+	m.bundleDir = m.ManifestsDir
 
 	m.LeaderElector.AddAcquiredLeaseCallback(func() {
 		ctx, cancel := context.WithCancelCause(ctx)

--- a/pkg/applier/manager.go
+++ b/pkg/applier/manager.go
@@ -150,7 +150,7 @@ func (m *Manager) runWatchers(ctx context.Context) {
 				if dir.IsDirectory(event.Name) {
 					m.createStack(ctx, stacks, event.Name)
 				}
-			case fsnotify.Remove:
+			case fsnotify.Remove, fsnotify.Rename:
 				m.removeStack(ctx, stacks, event.Name)
 			}
 

--- a/pkg/applier/manager_test.go
+++ b/pkg/applier/manager_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/internal/testutil"
 	"github.com/k0sproject/k0s/pkg/applier"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
@@ -157,6 +158,61 @@ data: {}
 	if assert.NoError(t, err) {
 		assert.Empty(t, configMaps.Items)
 	}
+}
+
+func TestManager_Rename(t *testing.T) {
+	cf := testutil.NewFakeClientFactory()
+	manifestsDir := t.TempDir()
+	leaderElector := leaderelector.Dummy{}
+
+	underTest := applier.Manager{
+		ManifestsDir:      manifestsDir,
+		KubeClientFactory: cf,
+		LeaderElector:     &leaderElector,
+	}
+
+	require.NoError(t, underTest.Init(context.TODO()))
+	require.NoError(t, underTest.Start(context.TODO()))
+	defer func() { assert.NoError(t, underTest.Stop()) }()
+	leaderElector.Leader = true
+	require.NoError(t, leaderElector.Start(context.TODO()))
+
+	theMap, err := yaml.Marshal(&map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap",
+		"metadata": map[string]any{"name": "the-map"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.Mkdir(filepath.Join(manifestsDir, "lorem"), 0755))
+	require.NoError(t, file.AtomicWithTarget(filepath.Join(manifestsDir, "lorem", "the-map.yaml")).Write(theMap))
+	t.Log("Waiting for stack to be applied")
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		configMaps, err := cf.Client.CoreV1().ConfigMaps(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+		if assert.NoError(t, err) && assert.Len(t, configMaps.Items, 1) {
+			cm := &configMaps.Items[0]
+			assert.Equal(t, "the-map", cm.Name)
+			assert.Subset(t, cm.Labels, map[string]string{"k0s.k0sproject.io/stack": "lorem"})
+		}
+	}, 20*time.Second, 350*time.Millisecond)
+
+	require.NoError(t, os.Rename(filepath.Join(manifestsDir, "lorem"), filepath.Join(manifestsDir, "ipsum")))
+	t.Log("Waiting for stack to be changed")
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		configMaps, err := cf.Client.CoreV1().ConfigMaps(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+		if assert.NoError(t, err) && assert.Len(t, configMaps.Items, 1) {
+			cm := &configMaps.Items[0]
+			assert.Equal(t, "the-map", cm.Name)
+			assert.Subset(t, cm.Labels, map[string]string{"k0s.k0sproject.io/stack": "ipsum"})
+		}
+	}, 20*time.Second, 350*time.Millisecond)
+
+	require.NoError(t, os.Rename(filepath.Join(manifestsDir, "ipsum"), filepath.Join(t.TempDir(), "moved-away")))
+	t.Log("Waiting for stack to be deleted")
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		configMaps, err := cf.Client.CoreV1().ConfigMaps(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+		if assert.NoError(t, err) {
+			assert.Empty(t, configMaps.Items)
+		}
+	}, 20*time.Second, 350*time.Millisecond)
 }
 
 //go:embed testdata/manager_test/*


### PR DESCRIPTION
## Description

A directory rename is signaled as a rename with the old name followed by a create with the new name. The applier manager didn't honor this, effectively running the old stack along with the new one.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings