### PR TITLE
feat: add output format flag to the k0s sysinfo command

### DIFF
--- a/cmd/sysinfo/sysinfo.go
+++ b/cmd/sysinfo/sysinfo.go
@@ -163,12 +163,12 @@ func (r *cliReporter) printf(format interface{}, args ...interface{}) error {
 }
 
 type Probe struct {
-	Path        []string
-	DisplayName string
-	Prop        string
-	Message     string
-	Category    ProbeCategory
-	Error       error
+	Path        []string      `json:"path"`
+	DisplayName string        `json:"displayName"`
+	Prop        string        `json:"prop"`
+	Message     string        `json:"message"`
+	Category    ProbeCategory `json:"category"`
+	Error       error         `json:"error"`
 }
 
 type ProbeCategory string

--- a/cmd/sysinfo/sysinfo.go
+++ b/cmd/sysinfo/sysinfo.go
@@ -17,7 +17,9 @@ limitations under the License.
 package sysinfo
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 
@@ -28,11 +30,13 @@ import (
 	"github.com/logrusorgru/aurora/v3"
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/term"
+	"sigs.k8s.io/yaml"
 )
 
 func NewSysinfoCmd() *cobra.Command {
 
 	var sysinfoSpec sysinfo.K0sSysinfoSpec
+	var outputFormat string
 
 	cmd := &cobra.Command{
 		Use:   "sysinfo",
@@ -43,18 +47,18 @@ func NewSysinfoCmd() *cobra.Command {
 			probes := sysinfoSpec.NewSysinfoProbes()
 			out := cmd.OutOrStdout()
 			cli := &cliReporter{
-				w:      out,
 				colors: aurora.NewAurora(term.IsTerminal(out)),
 			}
-
 			if err := probes.Probe(cli); err != nil {
+				return err
+			}
+			if err := cli.printResults(out, outputFormat); err != nil {
 				return err
 			}
 
 			if cli.failed {
 				return errors.New("sysinfo failed")
 			}
-
 			return nil
 		},
 	}
@@ -64,66 +68,155 @@ func NewSysinfoCmd() *cobra.Command {
 	flags.BoolVar(&sysinfoSpec.ControllerRoleEnabled, "controller", true, "Include controller-specific sysinfo")
 	flags.BoolVar(&sysinfoSpec.WorkerRoleEnabled, "worker", true, "Include worker-specific sysinfo")
 	flags.StringVar(&sysinfoSpec.DataDir, "data-dir", constant.DataDirDefault, "Data Directory for k0s")
+	flags.StringVarP(&outputFormat, "output", "o", "human", "Output format. Must be one of human|yaml|json")
 
 	return cmd
 }
 
 type cliReporter struct {
-	w      io.Writer
-	colors aurora.Aurora
-	failed bool
+	results []Probe
+	colors  aurora.Aurora
+	failed  bool
 }
 
+type Probe struct {
+	Path        []string
+	DisplayName string
+	Prop        string
+	Message     string
+	Category    ProbeCategory
+	Error       error
+}
+
+type ProbeCategory string
+
+const (
+	ProbeCategoryPass     ProbeCategory = "pass"
+	ProbeCategoryWarning  ProbeCategory = "warning"
+	ProbeCategoryRejected ProbeCategory = "rejected"
+	ProbeCategoryError    ProbeCategory = "error"
+)
+
 func (r *cliReporter) Pass(p probes.ProbeDesc, v probes.ProbedProp) error {
-	prop := propString(v)
-	return r.printf("%s%s%s%s\n",
-		indent(p),
-		r.colors.BrightWhite(p.DisplayName()+": "),
-		r.colors.Green(prop),
-		buildMsg(prop, "pass", ""),
-	)
+	r.results = append(r.results, Probe{
+		Path:        probePath(p),
+		DisplayName: p.DisplayName(),
+		Prop:        propString(v),
+		Category:    ProbeCategoryPass,
+	})
+	return nil
 }
 
 func (r *cliReporter) Warn(p probes.ProbeDesc, v probes.ProbedProp, msg string) error {
-	prop := propString(v)
-	return r.printf("%s%s%s%s\n",
-		indent(p),
-		r.colors.BrightWhite(p.DisplayName()+": "),
-		r.colors.Yellow(prop),
-		buildMsg(prop, "warning", msg))
+	r.results = append(r.results, Probe{
+		Path:        probePath(p),
+		DisplayName: p.DisplayName(),
+		Prop:        propString(v),
+		Message:     msg,
+		Category:    ProbeCategoryWarning,
+	})
+	return nil
 }
 
 func (r *cliReporter) Reject(p probes.ProbeDesc, v probes.ProbedProp, msg string) error {
 	r.failed = true
-	prop := propString(v)
-	return r.printf("%s%s%s%s\n",
-		indent(p),
-		r.colors.BrightWhite(p.DisplayName()+": "),
-		r.colors.Bold(r.colors.Red(prop)),
-		buildMsg(prop, "rejected", msg))
+	r.results = append(r.results, Probe{
+		Path:        probePath(p),
+		DisplayName: p.DisplayName(),
+		Prop:        propString(v),
+		Message:     msg,
+		Category:    ProbeCategoryRejected,
+	})
+	return nil
 }
 
 func (r *cliReporter) Error(p probes.ProbeDesc, err error) error {
 	r.failed = true
-
-	errStr := "error"
-	if err != nil {
-		e := err.Error()
-		if e != "" {
-			errStr = errStr + ": " + e
-		}
-	}
-
-	return r.printf("%s%s%s\n",
-		indent(p),
-		r.colors.BrightWhite(p.DisplayName()+": "),
-		r.colors.Bold(errStr).Red(),
-	)
+	r.results = append(r.results, Probe{
+		Path:        probePath(p),
+		DisplayName: p.DisplayName(),
+		Category:    ProbeCategoryError,
+		Error:       err,
+	})
+	return nil
 }
 
-func (r *cliReporter) printf(format interface{}, args ...interface{}) error {
-	_, err := io.WriteString(r.w, aurora.Sprintf(format, args...))
+func (r *cliReporter) printResults(w io.Writer, outputFormat string) error {
+	switch outputFormat {
+	case "human":
+		return r.printHuman(w)
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(r.results)
+	case "yaml":
+		b, err := yaml.Marshal(r.results)
+		if err != nil {
+			return err
+		}
+		_, err = io.WriteString(w, string(b))
+		return err
+	default:
+		return fmt.Errorf("unknown output format: %q", outputFormat)
+	}
+}
+
+func (r *cliReporter) printHuman(w io.Writer) error {
+	for _, p := range r.results {
+		if err := r.printOneHuman(w, p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *cliReporter) printOneHuman(w io.Writer, p Probe) error {
+	var out string
+	switch p.Category {
+	case ProbeCategoryPass:
+		out = aurora.Sprintf("%s%s%s%s\n",
+			indent(p.Path),
+			r.colors.BrightWhite(p.DisplayName+": "),
+			r.colors.Green(p.Prop),
+			buildMsg(p.Prop, string(p.Category), p.Message))
+	case ProbeCategoryWarning:
+		out = aurora.Sprintf("%s%s%s%s\n",
+			indent(p.Path),
+			r.colors.BrightWhite(p.DisplayName+": "),
+			r.colors.Yellow(p.Prop),
+			buildMsg(p.Prop, string(p.Category), p.Message))
+	case ProbeCategoryRejected:
+		out = aurora.Sprintf("%s%s%s%s\n",
+			indent(p.Path),
+			r.colors.BrightWhite(p.DisplayName+": "),
+			r.colors.Bold(r.colors.Red(p.Prop)),
+			buildMsg(p.Prop, string(p.Category), p.Message))
+	case ProbeCategoryError:
+		errStr := "error"
+		if p.Error != nil {
+			e := p.Error.Error()
+			if e != "" {
+				errStr = errStr + ": " + e
+			}
+		}
+
+		out = aurora.Sprintf("%s%s%s\n",
+			indent(p.Path),
+			r.colors.BrightWhite(p.DisplayName+": "),
+			r.colors.Bold(errStr).Red(),
+		)
+	default:
+		return fmt.Errorf("unknown probe category %q", p.Category)
+	}
+	_, err := io.WriteString(w, out)
 	return err
+}
+
+func probePath(p probes.ProbeDesc) []string {
+	if len(p.Path()) == 0 {
+		return nil
+	}
+	return p.Path()
 }
 
 func propString(p probes.ProbedProp) string {
@@ -134,13 +227,10 @@ func propString(p probes.ProbedProp) string {
 	return p.String()
 }
 
-func indent(p probes.ProbeDesc) string {
-	count := 0
-	if p != nil {
-		count = len(p.Path()) - 1
-		if count < 1 {
-			return ""
-		}
+func indent(path []string) string {
+	count := len(path) - 1
+	if count < 1 {
+		return ""
 	}
 
 	return strings.Repeat("  ", count)

--- a/cmd/sysinfo/sysinfo.go
+++ b/cmd/sysinfo/sysinfo.go
@@ -49,7 +49,7 @@ func NewSysinfoCmd() *cobra.Command {
 
 			var cli cliReporter
 			switch outputFormat {
-			case "human":
+			case "text":
 				cli = &humanReporter{
 					colors: aurora.NewAurora(term.IsTerminal(out)),
 				}
@@ -80,7 +80,7 @@ func NewSysinfoCmd() *cobra.Command {
 	flags.BoolVar(&sysinfoSpec.ControllerRoleEnabled, "controller", true, "Include controller-specific sysinfo")
 	flags.BoolVar(&sysinfoSpec.WorkerRoleEnabled, "worker", true, "Include worker-specific sysinfo")
 	flags.StringVar(&sysinfoSpec.DataDir, "data-dir", constant.DataDirDefault, "Data Directory for k0s")
-	flags.StringVarP(&outputFormat, "output", "o", "human", "Output format. Must be one of human|yaml|json")
+	flags.StringVarP(&outputFormat, "output", "o", "text", "Output format (valid values: text, json, yaml)")
 
 	return cmd
 }

--- a/cmd/sysinfo/sysinfo.go
+++ b/cmd/sysinfo/sysinfo.go
@@ -143,16 +143,18 @@ func collectAndPrint(probe probes.Probe, out io.Writer, marshal func(any) ([]byt
 	if err := probe.Probe(&c); err != nil {
 		return err
 	}
-	if c.failed {
-		return errors.New("sysinfo failed")
-	}
 	bytes, err := marshal(c.results)
 	if err != nil {
 		return err
 	}
-
 	_, err = out.Write(bytes)
-	return err
+	if err != nil {
+		return err
+	}
+	if c.failed {
+		return errors.New("sysinfo failed")
+	}
+	return nil
 }
 
 func (r *cliReporter) printf(format interface{}, args ...interface{}) error {

--- a/cmd/sysinfo/sysinfo_test.go
+++ b/cmd/sysinfo/sysinfo_test.go
@@ -60,14 +60,14 @@ func TestCliReporter_Pass(t *testing.T) {
 		},
 	} {
 		t.Run(data.name, func(t *testing.T) {
-			underTest := &cliReporter{
+			underTest := &humanReporter{
 				colors: aurora.NewAurora(true),
 			}
 			err := underTest.Pass(data.desc, data.prop)
 			assert.NoError(t, err)
 			assert.False(t, underTest.failed)
 			var buf strings.Builder
-			err = underTest.printHuman(&buf)
+			err = underTest.printResults(&buf)
 			assert.NoError(t, err)
 			result := buf.String()
 			t.Log(result)
@@ -111,14 +111,14 @@ func TestCliReporter_Warn(t *testing.T) {
 		},
 	} {
 		t.Run(data.name, func(t *testing.T) {
-			underTest := &cliReporter{
+			underTest := &humanReporter{
 				colors: aurora.NewAurora(true),
 			}
 			err := underTest.Warn(data.desc, data.prop, data.msg)
 			assert.NoError(t, err)
 			assert.False(t, underTest.failed)
 			var buf strings.Builder
-			err = underTest.printHuman(&buf)
+			err = underTest.printResults(&buf)
 			assert.NoError(t, err)
 			result := buf.String()
 			t.Log(result)
@@ -162,14 +162,14 @@ func TestCliReporter_Reject(t *testing.T) {
 		},
 	} {
 		t.Run(data.name, func(t *testing.T) {
-			underTest := &cliReporter{
+			underTest := &humanReporter{
 				colors: aurora.NewAurora(true),
 			}
 			err := underTest.Reject(data.desc, data.prop, data.msg)
 			assert.NoError(t, err)
 			assert.True(t, underTest.failed)
 			var buf strings.Builder
-			err = underTest.printHuman(&buf)
+			err = underTest.printResults(&buf)
 			assert.NoError(t, err)
 			result := buf.String()
 			t.Log(result)
@@ -202,14 +202,14 @@ func TestCliReporter_Error(t *testing.T) {
 		},
 	} {
 		t.Run(data.name, func(t *testing.T) {
-			underTest := &cliReporter{
+			underTest := &humanReporter{
 				colors: aurora.NewAurora(true),
 			}
 			err := underTest.Error(data.desc, data.err)
 			assert.NoError(t, err)
 			assert.True(t, underTest.failed)
 			var buf strings.Builder
-			err = underTest.printHuman(&buf)
+			err = underTest.printResults(&buf)
 			assert.NoError(t, err)
 			result := buf.String()
 			t.Log(result)
@@ -221,14 +221,14 @@ func TestCliReporter_Error(t *testing.T) {
 func TestCliReporter(t *testing.T) {
 	for _, data := range []struct {
 		name         string
-		probe        func(t *testing.T, cli *cliReporter)
+		probe        func(t *testing.T, cli cliReporter)
 		xpectResults []Probe
 		xpect        string
 		xpectFailed  bool
 	}{
 		{
 			"success",
-			func(t *testing.T, cli *cliReporter) {
+			func(t *testing.T, cli cliReporter) {
 				err := cli.Pass(&testDesc{"foo", probes.ProbePath{"bar"}}, testProp("baz"))
 				assert.NoError(t, err)
 				err = cli.Pass(&testDesc{"foo", probes.ProbePath{"bar", "baz"}}, testProp("qux"))
@@ -248,7 +248,7 @@ func TestCliReporter(t *testing.T) {
 		},
 		{
 			"has_reject",
-			func(t *testing.T, cli *cliReporter) {
+			func(t *testing.T, cli cliReporter) {
 				err := cli.Pass(&testDesc{"foo", probes.ProbePath{"bar"}}, testProp("baz"))
 				assert.NoError(t, err)
 				err = cli.Pass(&testDesc{"foo", probes.ProbePath{"bar", "baz"}}, testProp("qux"))
@@ -272,7 +272,7 @@ func TestCliReporter(t *testing.T) {
 		},
 		{
 			"has_error",
-			func(t *testing.T, cli *cliReporter) {
+			func(t *testing.T, cli cliReporter) {
 				err := cli.Pass(&testDesc{"foo", probes.ProbePath{"bar"}}, testProp("baz"))
 				assert.NoError(t, err)
 				err = cli.Pass(&testDesc{"foo", probes.ProbePath{"bar", "baz"}}, testProp("qux"))
@@ -296,13 +296,13 @@ func TestCliReporter(t *testing.T) {
 		},
 	} {
 		t.Run(data.name, func(t *testing.T) {
-			underTest := &cliReporter{
+			underTest := &humanReporter{
 				colors: aurora.NewAurora(true),
 			}
 			data.probe(t, underTest)
 			assert.Equal(t, data.xpectResults, underTest.results)
 			var buf strings.Builder
-			err := underTest.printResults(&buf, "human")
+			err := underTest.printResults(&buf)
 			assert.NoError(t, err)
 			result := buf.String()
 			assert.Equal(t, data.xpect, result)

--- a/cmd/sysinfo/sysinfo_test.go
+++ b/cmd/sysinfo/sysinfo_test.go
@@ -27,6 +27,13 @@ import (
 )
 
 func TestCliReporter_Pass(t *testing.T) {
+	var buf strings.Builder
+
+	underTest := &cliReporter{
+		w:      &buf,
+		colors: aurora.NewAurora(true),
+	}
+
 	for _, data := range []struct {
 		name  string
 		desc  probes.ProbeDesc
@@ -60,15 +67,10 @@ func TestCliReporter_Pass(t *testing.T) {
 		},
 	} {
 		t.Run(data.name, func(t *testing.T) {
-			underTest := &humanReporter{
-				colors: aurora.NewAurora(true),
-			}
+			buf.Reset()
 			err := underTest.Pass(data.desc, data.prop)
 			assert.NoError(t, err)
 			assert.False(t, underTest.failed)
-			var buf strings.Builder
-			err = underTest.printResults(&buf)
-			assert.NoError(t, err)
 			result := buf.String()
 			t.Log(result)
 			assert.Equal(t, data.xpect, result)
@@ -77,6 +79,13 @@ func TestCliReporter_Pass(t *testing.T) {
 }
 
 func TestCliReporter_Warn(t *testing.T) {
+	var buf strings.Builder
+
+	underTest := &cliReporter{
+		w:      &buf,
+		colors: aurora.NewAurora(true),
+	}
+
 	for _, data := range []struct {
 		name  string
 		desc  probes.ProbeDesc
@@ -111,15 +120,10 @@ func TestCliReporter_Warn(t *testing.T) {
 		},
 	} {
 		t.Run(data.name, func(t *testing.T) {
-			underTest := &humanReporter{
-				colors: aurora.NewAurora(true),
-			}
+			buf.Reset()
 			err := underTest.Warn(data.desc, data.prop, data.msg)
 			assert.NoError(t, err)
 			assert.False(t, underTest.failed)
-			var buf strings.Builder
-			err = underTest.printResults(&buf)
-			assert.NoError(t, err)
 			result := buf.String()
 			t.Log(result)
 			assert.Equal(t, data.xpect, result)
@@ -128,6 +132,13 @@ func TestCliReporter_Warn(t *testing.T) {
 }
 
 func TestCliReporter_Reject(t *testing.T) {
+	var buf strings.Builder
+
+	underTest := &cliReporter{
+		w:      &buf,
+		colors: aurora.NewAurora(true),
+	}
+
 	for _, data := range []struct {
 		name  string
 		desc  probes.ProbeDesc
@@ -162,15 +173,10 @@ func TestCliReporter_Reject(t *testing.T) {
 		},
 	} {
 		t.Run(data.name, func(t *testing.T) {
-			underTest := &humanReporter{
-				colors: aurora.NewAurora(true),
-			}
+			buf.Reset()
 			err := underTest.Reject(data.desc, data.prop, data.msg)
 			assert.NoError(t, err)
 			assert.True(t, underTest.failed)
-			var buf strings.Builder
-			err = underTest.printResults(&buf)
-			assert.NoError(t, err)
 			result := buf.String()
 			t.Log(result)
 			assert.Equal(t, data.xpect, result)
@@ -179,6 +185,13 @@ func TestCliReporter_Reject(t *testing.T) {
 }
 
 func TestCliReporter_Error(t *testing.T) {
+	var buf strings.Builder
+
+	underTest := &cliReporter{
+		w:      &buf,
+		colors: aurora.NewAurora(true),
+	}
+
 	for _, data := range []struct {
 		name  string
 		desc  probes.ProbeDesc
@@ -202,109 +215,12 @@ func TestCliReporter_Error(t *testing.T) {
 		},
 	} {
 		t.Run(data.name, func(t *testing.T) {
-			underTest := &humanReporter{
-				colors: aurora.NewAurora(true),
-			}
+			buf.Reset()
 			err := underTest.Error(data.desc, data.err)
 			assert.NoError(t, err)
 			assert.True(t, underTest.failed)
-			var buf strings.Builder
-			err = underTest.printResults(&buf)
-			assert.NoError(t, err)
 			result := buf.String()
 			t.Log(result)
-			assert.Equal(t, data.xpect, result)
-		})
-	}
-}
-
-func TestCliReporter(t *testing.T) {
-	for _, data := range []struct {
-		name         string
-		probe        func(t *testing.T, cli cliReporter)
-		xpectResults []Probe
-		xpect        string
-		xpectFailed  bool
-	}{
-		{
-			"success",
-			func(t *testing.T, cli cliReporter) {
-				err := cli.Pass(&testDesc{"foo", probes.ProbePath{"bar"}}, testProp("baz"))
-				assert.NoError(t, err)
-				err = cli.Pass(&testDesc{"foo", probes.ProbePath{"bar", "baz"}}, testProp("qux"))
-				assert.NoError(t, err)
-				err = cli.Warn(&testDesc{"foo", nil}, testProp("bar"), "baz")
-				assert.NoError(t, err)
-			},
-			[]Probe{
-				{Path: []string{"bar"}, DisplayName: "foo", Prop: "baz", Message: "", Category: "pass", Error: nil},
-				{Path: []string{"bar", "baz"}, DisplayName: "foo", Prop: "qux", Message: "", Category: "pass", Error: nil},
-				{Path: []string(nil), DisplayName: "foo", Prop: "bar", Message: "baz", Category: "warning", Error: nil},
-			},
-			("\x1b[97mfoo: \x1b[0m\x1b[32mbaz\x1b[0m (pass)\n" +
-				"  \x1b[97mfoo: \x1b[0m\x1b[32mqux\x1b[0m (pass)\n" +
-				"\x1b[97mfoo: \x1b[0m\x1b[33mbar\x1b[0m (warning: baz)\n"),
-			true,
-		},
-		{
-			"has_reject",
-			func(t *testing.T, cli cliReporter) {
-				err := cli.Pass(&testDesc{"foo", probes.ProbePath{"bar"}}, testProp("baz"))
-				assert.NoError(t, err)
-				err = cli.Pass(&testDesc{"foo", probes.ProbePath{"bar", "baz"}}, testProp("qux"))
-				assert.NoError(t, err)
-				err = cli.Warn(&testDesc{"foo", nil}, testProp("bar"), "baz")
-				assert.NoError(t, err)
-				err = cli.Reject(&testDesc{"foo", nil}, testProp("bar"), "baz")
-				assert.NoError(t, err)
-			},
-			[]Probe{
-				{Path: []string{"bar"}, DisplayName: "foo", Prop: "baz", Message: "", Category: "pass", Error: nil},
-				{Path: []string{"bar", "baz"}, DisplayName: "foo", Prop: "qux", Message: "", Category: "pass", Error: nil},
-				{Path: []string(nil), DisplayName: "foo", Prop: "bar", Message: "baz", Category: "warning", Error: nil},
-				{Path: []string(nil), DisplayName: "foo", Prop: "bar", Message: "baz", Category: "rejected", Error: nil},
-			},
-			("\x1b[97mfoo: \x1b[0m\x1b[32mbaz\x1b[0m (pass)\n" +
-				"  \x1b[97mfoo: \x1b[0m\x1b[32mqux\x1b[0m (pass)\n" +
-				"\x1b[97mfoo: \x1b[0m\x1b[33mbar\x1b[0m (warning: baz)\n" +
-				"\x1b[97mfoo: \x1b[0m\x1b[1;31mbar\x1b[0m (rejected: baz)\n"),
-			true,
-		},
-		{
-			"has_error",
-			func(t *testing.T, cli cliReporter) {
-				err := cli.Pass(&testDesc{"foo", probes.ProbePath{"bar"}}, testProp("baz"))
-				assert.NoError(t, err)
-				err = cli.Pass(&testDesc{"foo", probes.ProbePath{"bar", "baz"}}, testProp("qux"))
-				assert.NoError(t, err)
-				err = cli.Warn(&testDesc{"foo", nil}, testProp("bar"), "baz")
-				assert.NoError(t, err)
-				err = cli.Error(&testDesc{"foo", probes.ProbePath{}}, errors.New("bar"))
-				assert.NoError(t, err)
-			},
-			[]Probe{
-				{Path: []string{"bar"}, DisplayName: "foo", Prop: "baz", Message: "", Category: "pass", Error: nil},
-				{Path: []string{"bar", "baz"}, DisplayName: "foo", Prop: "qux", Message: "", Category: "pass", Error: nil},
-				{Path: []string(nil), DisplayName: "foo", Prop: "bar", Message: "baz", Category: "warning", Error: nil},
-				{Path: []string(nil), DisplayName: "foo", Prop: "", Message: "", Category: "error", Error: errors.New("bar")},
-			},
-			("\x1b[97mfoo: \x1b[0m\x1b[32mbaz\x1b[0m (pass)\n" +
-				"  \x1b[97mfoo: \x1b[0m\x1b[32mqux\x1b[0m (pass)\n" +
-				"\x1b[97mfoo: \x1b[0m\x1b[33mbar\x1b[0m (warning: baz)\n" +
-				"\x1b[97mfoo: \x1b[0m\x1b[1;31merror: bar\x1b[0m\n"),
-			true,
-		},
-	} {
-		t.Run(data.name, func(t *testing.T) {
-			underTest := &humanReporter{
-				colors: aurora.NewAurora(true),
-			}
-			data.probe(t, underTest)
-			assert.Equal(t, data.xpectResults, underTest.results)
-			var buf strings.Builder
-			err := underTest.printResults(&buf)
-			assert.NoError(t, err)
-			result := buf.String()
 			assert.Equal(t, data.xpect, result)
 		})
 	}
@@ -321,3 +237,77 @@ func (d *testDesc) DisplayName() string    { return d.name }
 type testProp string
 
 func (p testProp) String() string { return string(p) }
+
+func Test_resultsCollector(t *testing.T) {
+	for _, data := range []struct {
+		name         string
+		probe        func(t *testing.T, cli *resultsCollector)
+		xpectResults []Probe
+		xpectFailed  bool
+	}{
+		{
+			"success",
+			func(t *testing.T, cli *resultsCollector) {
+				err := cli.Pass(&testDesc{"foo", probes.ProbePath{"bar"}}, testProp("baz"))
+				assert.NoError(t, err)
+				err = cli.Pass(&testDesc{"foo", probes.ProbePath{"bar", "baz"}}, testProp("qux"))
+				assert.NoError(t, err)
+				err = cli.Warn(&testDesc{"foo", nil}, testProp("bar"), "baz")
+				assert.NoError(t, err)
+			},
+			[]Probe{
+				{Path: []string{"bar"}, DisplayName: "foo", Prop: "baz", Message: "", Category: "pass", Error: nil},
+				{Path: []string{"bar", "baz"}, DisplayName: "foo", Prop: "qux", Message: "", Category: "pass", Error: nil},
+				{Path: []string(nil), DisplayName: "foo", Prop: "bar", Message: "baz", Category: "warning", Error: nil},
+			},
+			false,
+		},
+		{
+			"has_reject",
+			func(t *testing.T, cli *resultsCollector) {
+				err := cli.Pass(&testDesc{"foo", probes.ProbePath{"bar"}}, testProp("baz"))
+				assert.NoError(t, err)
+				err = cli.Pass(&testDesc{"foo", probes.ProbePath{"bar", "baz"}}, testProp("qux"))
+				assert.NoError(t, err)
+				err = cli.Warn(&testDesc{"foo", nil}, testProp("bar"), "baz")
+				assert.NoError(t, err)
+				err = cli.Reject(&testDesc{"foo", nil}, testProp("bar"), "baz")
+				assert.NoError(t, err)
+			},
+			[]Probe{
+				{Path: []string{"bar"}, DisplayName: "foo", Prop: "baz", Message: "", Category: "pass", Error: nil},
+				{Path: []string{"bar", "baz"}, DisplayName: "foo", Prop: "qux", Message: "", Category: "pass", Error: nil},
+				{Path: []string(nil), DisplayName: "foo", Prop: "bar", Message: "baz", Category: "warning", Error: nil},
+				{Path: []string(nil), DisplayName: "foo", Prop: "bar", Message: "baz", Category: "rejected", Error: nil},
+			},
+			true,
+		},
+		{
+			"has_error",
+			func(t *testing.T, cli *resultsCollector) {
+				err := cli.Pass(&testDesc{"foo", probes.ProbePath{"bar"}}, testProp("baz"))
+				assert.NoError(t, err)
+				err = cli.Pass(&testDesc{"foo", probes.ProbePath{"bar", "baz"}}, testProp("qux"))
+				assert.NoError(t, err)
+				err = cli.Warn(&testDesc{"foo", nil}, testProp("bar"), "baz")
+				assert.NoError(t, err)
+				err = cli.Error(&testDesc{"foo", probes.ProbePath{}}, errors.New("bar"))
+				assert.NoError(t, err)
+			},
+			[]Probe{
+				{Path: []string{"bar"}, DisplayName: "foo", Prop: "baz", Message: "", Category: "pass", Error: nil},
+				{Path: []string{"bar", "baz"}, DisplayName: "foo", Prop: "qux", Message: "", Category: "pass", Error: nil},
+				{Path: []string(nil), DisplayName: "foo", Prop: "bar", Message: "baz", Category: "warning", Error: nil},
+				{Path: []string(nil), DisplayName: "foo", Prop: "", Message: "", Category: "error", Error: errors.New("bar")},
+			},
+			true,
+		},
+	} {
+		t.Run(data.name, func(t *testing.T) {
+			c := &resultsCollector{}
+			data.probe(t, c)
+			assert.Equal(t, data.xpectResults, c.results)
+			assert.Equal(t, data.xpectFailed, c.failed)
+		})
+	}
+}

--- a/cmd/sysinfo/sysinfo_test.go
+++ b/cmd/sysinfo/sysinfo_test.go
@@ -27,13 +27,6 @@ import (
 )
 
 func TestCliReporter_Pass(t *testing.T) {
-	var buf strings.Builder
-
-	underTest := &cliReporter{
-		w:      &buf,
-		colors: aurora.NewAurora(true),
-	}
-
 	for _, data := range []struct {
 		name  string
 		desc  probes.ProbeDesc
@@ -67,10 +60,15 @@ func TestCliReporter_Pass(t *testing.T) {
 		},
 	} {
 		t.Run(data.name, func(t *testing.T) {
-			buf.Reset()
+			underTest := &cliReporter{
+				colors: aurora.NewAurora(true),
+			}
 			err := underTest.Pass(data.desc, data.prop)
 			assert.NoError(t, err)
 			assert.False(t, underTest.failed)
+			var buf strings.Builder
+			err = underTest.printHuman(&buf)
+			assert.NoError(t, err)
 			result := buf.String()
 			t.Log(result)
 			assert.Equal(t, data.xpect, result)
@@ -79,13 +77,6 @@ func TestCliReporter_Pass(t *testing.T) {
 }
 
 func TestCliReporter_Warn(t *testing.T) {
-	var buf strings.Builder
-
-	underTest := &cliReporter{
-		w:      &buf,
-		colors: aurora.NewAurora(true),
-	}
-
 	for _, data := range []struct {
 		name  string
 		desc  probes.ProbeDesc
@@ -120,10 +111,15 @@ func TestCliReporter_Warn(t *testing.T) {
 		},
 	} {
 		t.Run(data.name, func(t *testing.T) {
-			buf.Reset()
+			underTest := &cliReporter{
+				colors: aurora.NewAurora(true),
+			}
 			err := underTest.Warn(data.desc, data.prop, data.msg)
 			assert.NoError(t, err)
 			assert.False(t, underTest.failed)
+			var buf strings.Builder
+			err = underTest.printHuman(&buf)
+			assert.NoError(t, err)
 			result := buf.String()
 			t.Log(result)
 			assert.Equal(t, data.xpect, result)
@@ -132,13 +128,6 @@ func TestCliReporter_Warn(t *testing.T) {
 }
 
 func TestCliReporter_Reject(t *testing.T) {
-	var buf strings.Builder
-
-	underTest := &cliReporter{
-		w:      &buf,
-		colors: aurora.NewAurora(true),
-	}
-
 	for _, data := range []struct {
 		name  string
 		desc  probes.ProbeDesc
@@ -173,10 +162,15 @@ func TestCliReporter_Reject(t *testing.T) {
 		},
 	} {
 		t.Run(data.name, func(t *testing.T) {
-			buf.Reset()
+			underTest := &cliReporter{
+				colors: aurora.NewAurora(true),
+			}
 			err := underTest.Reject(data.desc, data.prop, data.msg)
 			assert.NoError(t, err)
 			assert.True(t, underTest.failed)
+			var buf strings.Builder
+			err = underTest.printHuman(&buf)
+			assert.NoError(t, err)
 			result := buf.String()
 			t.Log(result)
 			assert.Equal(t, data.xpect, result)
@@ -185,13 +179,6 @@ func TestCliReporter_Reject(t *testing.T) {
 }
 
 func TestCliReporter_Error(t *testing.T) {
-	var buf strings.Builder
-
-	underTest := &cliReporter{
-		w:      &buf,
-		colors: aurora.NewAurora(true),
-	}
-
 	for _, data := range []struct {
 		name  string
 		desc  probes.ProbeDesc
@@ -215,12 +202,109 @@ func TestCliReporter_Error(t *testing.T) {
 		},
 	} {
 		t.Run(data.name, func(t *testing.T) {
-			buf.Reset()
+			underTest := &cliReporter{
+				colors: aurora.NewAurora(true),
+			}
 			err := underTest.Error(data.desc, data.err)
 			assert.NoError(t, err)
 			assert.True(t, underTest.failed)
+			var buf strings.Builder
+			err = underTest.printHuman(&buf)
+			assert.NoError(t, err)
 			result := buf.String()
 			t.Log(result)
+			assert.Equal(t, data.xpect, result)
+		})
+	}
+}
+
+func TestCliReporter(t *testing.T) {
+	for _, data := range []struct {
+		name         string
+		probe        func(t *testing.T, cli *cliReporter)
+		xpectResults []Probe
+		xpect        string
+		xpectFailed  bool
+	}{
+		{
+			"success",
+			func(t *testing.T, cli *cliReporter) {
+				err := cli.Pass(&testDesc{"foo", probes.ProbePath{"bar"}}, testProp("baz"))
+				assert.NoError(t, err)
+				err = cli.Pass(&testDesc{"foo", probes.ProbePath{"bar", "baz"}}, testProp("qux"))
+				assert.NoError(t, err)
+				err = cli.Warn(&testDesc{"foo", nil}, testProp("bar"), "baz")
+				assert.NoError(t, err)
+			},
+			[]Probe{
+				{Path: []string{"bar"}, DisplayName: "foo", Prop: "baz", Message: "", Category: "pass", Error: nil},
+				{Path: []string{"bar", "baz"}, DisplayName: "foo", Prop: "qux", Message: "", Category: "pass", Error: nil},
+				{Path: []string(nil), DisplayName: "foo", Prop: "bar", Message: "baz", Category: "warning", Error: nil},
+			},
+			("\x1b[97mfoo: \x1b[0m\x1b[32mbaz\x1b[0m (pass)\n" +
+				"  \x1b[97mfoo: \x1b[0m\x1b[32mqux\x1b[0m (pass)\n" +
+				"\x1b[97mfoo: \x1b[0m\x1b[33mbar\x1b[0m (warning: baz)\n"),
+			true,
+		},
+		{
+			"has_reject",
+			func(t *testing.T, cli *cliReporter) {
+				err := cli.Pass(&testDesc{"foo", probes.ProbePath{"bar"}}, testProp("baz"))
+				assert.NoError(t, err)
+				err = cli.Pass(&testDesc{"foo", probes.ProbePath{"bar", "baz"}}, testProp("qux"))
+				assert.NoError(t, err)
+				err = cli.Warn(&testDesc{"foo", nil}, testProp("bar"), "baz")
+				assert.NoError(t, err)
+				err = cli.Reject(&testDesc{"foo", nil}, testProp("bar"), "baz")
+				assert.NoError(t, err)
+			},
+			[]Probe{
+				{Path: []string{"bar"}, DisplayName: "foo", Prop: "baz", Message: "", Category: "pass", Error: nil},
+				{Path: []string{"bar", "baz"}, DisplayName: "foo", Prop: "qux", Message: "", Category: "pass", Error: nil},
+				{Path: []string(nil), DisplayName: "foo", Prop: "bar", Message: "baz", Category: "warning", Error: nil},
+				{Path: []string(nil), DisplayName: "foo", Prop: "bar", Message: "baz", Category: "rejected", Error: nil},
+			},
+			("\x1b[97mfoo: \x1b[0m\x1b[32mbaz\x1b[0m (pass)\n" +
+				"  \x1b[97mfoo: \x1b[0m\x1b[32mqux\x1b[0m (pass)\n" +
+				"\x1b[97mfoo: \x1b[0m\x1b[33mbar\x1b[0m (warning: baz)\n" +
+				"\x1b[97mfoo: \x1b[0m\x1b[1;31mbar\x1b[0m (rejected: baz)\n"),
+			true,
+		},
+		{
+			"has_error",
+			func(t *testing.T, cli *cliReporter) {
+				err := cli.Pass(&testDesc{"foo", probes.ProbePath{"bar"}}, testProp("baz"))
+				assert.NoError(t, err)
+				err = cli.Pass(&testDesc{"foo", probes.ProbePath{"bar", "baz"}}, testProp("qux"))
+				assert.NoError(t, err)
+				err = cli.Warn(&testDesc{"foo", nil}, testProp("bar"), "baz")
+				assert.NoError(t, err)
+				err = cli.Error(&testDesc{"foo", probes.ProbePath{}}, errors.New("bar"))
+				assert.NoError(t, err)
+			},
+			[]Probe{
+				{Path: []string{"bar"}, DisplayName: "foo", Prop: "baz", Message: "", Category: "pass", Error: nil},
+				{Path: []string{"bar", "baz"}, DisplayName: "foo", Prop: "qux", Message: "", Category: "pass", Error: nil},
+				{Path: []string(nil), DisplayName: "foo", Prop: "bar", Message: "baz", Category: "warning", Error: nil},
+				{Path: []string(nil), DisplayName: "foo", Prop: "", Message: "", Category: "error", Error: errors.New("bar")},
+			},
+			("\x1b[97mfoo: \x1b[0m\x1b[32mbaz\x1b[0m (pass)\n" +
+				"  \x1b[97mfoo: \x1b[0m\x1b[32mqux\x1b[0m (pass)\n" +
+				"\x1b[97mfoo: \x1b[0m\x1b[33mbar\x1b[0m (warning: baz)\n" +
+				"\x1b[97mfoo: \x1b[0m\x1b[1;31merror: bar\x1b[0m\n"),
+			true,
+		},
+	} {
+		t.Run(data.name, func(t *testing.T) {
+			underTest := &cliReporter{
+				colors: aurora.NewAurora(true),
+			}
+			data.probe(t, underTest)
+			assert.Equal(t, data.xpectResults, underTest.results)
+			var buf strings.Builder
+			err := underTest.printResults(&buf, "human")
+			assert.NoError(t, err)
+			result := buf.String()
 			assert.Equal(t, data.xpect, result)
 		})
 	}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds --output flag to the sysinfo command with formats human|yaml|json.

[sysinfo.json](https://github.com/user-attachments/files/17779571/sysinfo.json)

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings