### PR TITLE
CPLB userspace reverse proxy load balancer 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -109,3 +109,9 @@ issues:
     - linters:
         - staticcheck
       text: "^SA1019:"
+
+    # tcpproxy is copied from https://github.com/inetaf/tcpproxy/, as per
+    # Apache 2.0 license section 4 (Redistribution) we must keep the original header.
+    - path: "pkg/component/controller/cplb/tcpproxy/.*"
+      linters:
+        - goheader

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -148,11 +148,12 @@ func (c *Command) Start(ctx context.Context) error {
 		c.WorkerProfile = "default-windows"
 	}
 
-	componentManager.Add(ctx, &iptables.Component{
-		IPTablesMode: c.WorkerOptions.IPTablesMode,
-		BinDir:       c.K0sVars.BinDir,
-	})
-
+	if !c.DisableIPTables {
+		componentManager.Add(ctx, &iptables.Component{
+			IPTablesMode: c.WorkerOptions.IPTablesMode,
+			BinDir:       c.K0sVars.BinDir,
+		})
+	}
 	componentManager.Add(ctx,
 		&worker.Kubelet{
 			CRISocket:           c.CriSocket,

--- a/hack/copyright.sh
+++ b/hack/copyright.sh
@@ -45,6 +45,10 @@ has_date_copyright(){
 # Copyright notice aren't related to the date of the document.
 for i in $(find cmd hack internal inttest pkg static -type f -name '*.go' -not -name 'zz_generated*'); do
     case "$i" in
+    pkg/component/controller/cplb/tcpproxy/*)
+    # These files have a special copyright due to being copied
+    # from github.com/inetaf/tcpproxy
+    ;;
     pkg/client/clientset/*)
         if ! has_basic_copyright "$i"; then
           echo "ERROR: $i doesn't have a proper copyright notice" 1>&2

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -87,6 +87,9 @@ check-customports-dynamicconfig: TEST_PACKAGE=customports
 
 check-kubeletcertrotate: TIMEOUT=15m
 
+check-cplb-userspace-extaddr: export K0S_USE_EXTERNAL_ADDRESS=yes
+check-cplb-userspace-extaddr: TEST_PACKAGE=cplb-userspace
+
 check-dualstack-calico: export K0S_NETWORK=calico
 check-dualstack-calico: TEST_PACKAGE=dualstack
 

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -26,6 +26,7 @@ smoketests := \
 	check-containerdimports \
 	check-cplb-ipvs \
 	check-cplb-userspace \
+	check-cplb-userspace-extaddr \
 	check-ctr \
 	check-custom-cidrs \
 	check-customca \

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -24,7 +24,8 @@ smoketests := \
 	check-cnichange \
 	check-configchange \
 	check-containerdimports \
-	check-cplb \
+	check-cplb-ipvs \
+	check-cplb-userspace \
 	check-ctr \
 	check-custom-cidrs \
 	check-customca \

--- a/inttest/cplb-ipvs/cplbipvs_test.go
+++ b/inttest/cplb-ipvs/cplbipvs_test.go
@@ -1,0 +1,190 @@
+// Copyright 2024 k0s authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keepalived
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/k0s/inttest/common"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type cplbIPVSSuite struct {
+	common.BootlooseSuite
+}
+
+const haControllerConfig = `
+spec:
+  network:
+    controlPlaneLoadBalancing:
+      enabled: true
+      type: Keepalived
+      keepalived:
+        vrrpInstances:
+        - virtualIPs: ["%s/16"]
+          authPass: "123456"
+        virtualServers:
+        - ipAddress: %s
+    nodeLocalLoadBalancing:
+      enabled: true
+      type: EnvoyProxy
+`
+
+// SetupTest prepares the controller and filesystem, getting it into a consistent
+// state which we can run tests against.
+func (s *cplbIPVSSuite) TestK0sGetsUp() {
+	lb := s.getLBAddress()
+	ctx := s.Context()
+	var joinToken string
+
+	for idx := range s.BootlooseSuite.ControllerCount {
+		s.Require().NoError(s.WaitForSSH(s.ControllerNode(idx), 2*time.Minute, 1*time.Second))
+		s.PutFile(s.ControllerNode(idx), "/tmp/k0s.yaml", fmt.Sprintf(haControllerConfig, lb, lb))
+
+		// Note that the token is intentionally empty for the first controller
+		s.Require().NoError(s.InitController(idx, "--config=/tmp/k0s.yaml", "--disable-components=metrics-server", joinToken))
+		s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(idx)))
+
+		// With the primary controller running, create the join token for subsequent controllers.
+		if idx == 0 {
+			token, err := s.GetJoinToken("controller")
+			s.Require().NoError(err)
+			joinToken = token
+		}
+	}
+
+	// Final sanity -- ensure all nodes see each other according to etcd
+	for idx := range s.BootlooseSuite.ControllerCount {
+		s.Require().Len(s.GetMembers(idx), s.BootlooseSuite.ControllerCount)
+	}
+
+	// Create a worker join token
+	workerJoinToken, err := s.GetJoinToken("worker")
+	s.Require().NoError(err)
+
+	// Start the workers using the join token
+	s.Require().NoError(s.RunWorkersWithToken(workerJoinToken))
+
+	client, err := s.KubeClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+
+	s.Require().NoError(s.WaitForNodeReady(s.WorkerNode(0), client))
+
+	// Verify that all servers have the dummy interface
+	for idx := range s.BootlooseSuite.ControllerCount {
+		s.checkDummy(ctx, s.ControllerNode(idx), lb)
+	}
+
+	// Verify that only one controller has the VIP in eth0
+	count := 0
+	for idx := range s.BootlooseSuite.ControllerCount {
+		if s.hasVIP(ctx, s.ControllerNode(idx), lb) {
+			count++
+		}
+	}
+	s.Require().Equal(1, count, "Expected exactly one controller to have the VIP")
+
+	// Verify that the real servers are present in the ipvsadm output
+	for idx := range s.BootlooseSuite.ControllerCount {
+		s.validateRealServers(ctx, s.ControllerNode(idx), lb)
+	}
+}
+
+// getLBAddress returns the IP address of the controller 0 and it adds 100 to
+// the last octet unless it's bigger or equal to 154, in which case it
+// subtracts 100. Theoretically this could result in an invalid IP address.
+func (s *cplbIPVSSuite) getLBAddress() string {
+	ip := s.GetIPAddress(s.ControllerNode(0))
+	parts := strings.Split(ip, ".")
+	if len(parts) != 4 {
+		s.T().Fatalf("Invalid IP address: %q", ip)
+	}
+	lastOctet, err := strconv.Atoi(parts[3])
+	s.Require().NoErrorf(err, "Failed to convert last octet %q to int", parts[3])
+	if lastOctet >= 154 {
+		lastOctet -= 100
+	} else {
+		lastOctet += 100
+	}
+
+	return fmt.Sprintf("%s.%d", strings.Join(parts[:3], "."), lastOctet)
+}
+
+// validateRealServers checks that the real servers are present in the
+// ipvsadm output.
+func (s *cplbIPVSSuite) validateRealServers(ctx context.Context, node string, vip string) {
+	ssh, err := s.SSH(ctx, node)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	servers := []string{}
+	for i := range s.BootlooseSuite.ControllerCount {
+		servers = append(servers, s.GetIPAddress(s.ControllerNode(i)))
+	}
+
+	output, err := ssh.ExecWithOutput(ctx, "ipvsadm --save -n")
+	s.Require().NoError(err)
+
+	for _, server := range servers {
+		s.Require().Containsf(output, fmt.Sprintf("-a -t %s:6443 -r %s", vip, server), "Controller %s is missing a server in ipvsadm", node)
+	}
+
+}
+
+// checkDummy checks that the dummy interface is present on the given node and
+// that it has only the virtual IP address.
+func (s *cplbIPVSSuite) checkDummy(ctx context.Context, node string, vip string) {
+	ssh, err := s.SSH(ctx, node)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	output, err := ssh.ExecWithOutput(ctx, "ip --oneline addr show dummyvip0")
+	s.Require().NoError(err)
+
+	s.Require().Equal(0, strings.Count(output, "\n"), "Expected only one line of output")
+
+	expected := fmt.Sprintf("inet %s/32", vip)
+	s.Require().Contains(output, expected)
+}
+
+// hasVIP checks that the dummy interface is present on the given node and
+// that it has only the virtual IP address.
+func (s *cplbIPVSSuite) hasVIP(ctx context.Context, node string, vip string) bool {
+	ssh, err := s.SSH(ctx, node)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	output, err := ssh.ExecWithOutput(ctx, "ip --oneline addr show eth0")
+	s.Require().NoError(err)
+
+	return strings.Contains(output, fmt.Sprintf("inet %s/16", vip))
+}
+
+// TestKeepAlivedSuite runs the keepalived test suite. It verifies that the
+// virtual IP is working by joining a node to the cluster using the VIP.
+func TestCPLBIPVSSuite(t *testing.T) {
+	suite.Run(t, &cplbIPVSSuite{
+		common.BootlooseSuite{
+			ControllerCount: 3,
+			WorkerCount:     1,
+		},
+	})
+}

--- a/inttest/cplb-userspace/cplbuserspace_test.go
+++ b/inttest/cplb-userspace/cplbuserspace_test.go
@@ -23,12 +23,14 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/k0sproject/k0s/pkg/token"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -37,7 +39,7 @@ type CPLBUserSpaceSuite struct {
 	common.BootlooseSuite
 }
 
-const haControllerConfig = `
+const nllbControllerConfig = `
 spec:
   network:
     controlPlaneLoadBalancing:
@@ -52,19 +54,46 @@ spec:
       type: EnvoyProxy
 `
 
+const extAddrControllerConfig = `
+spec:
+  api:
+    externalAddress: %s
+  network:
+    provider: calico
+    controlPlaneLoadBalancing:
+      enabled: true
+      type: Keepalived
+      keepalived:
+        vrrpInstances:
+        - virtualIPs: ["%s/16"]
+          authPass: "123456"
+`
+
 // SetupTest prepares the controller and filesystem, getting it into a consistent
 // state which we can run tests against.
 func (s *CPLBUserSpaceSuite) TestK0sGetsUp() {
+	useExtAddr := os.Getenv("K0S_USE_EXTERNAL_ADDRESS") == "yes"
+	if useExtAddr {
+		s.T().Log("Using external address")
+	} else {
+		s.T().Log("Using CPLB + NLLB")
+	}
 	lb := s.getLBAddress()
 	ctx := s.Context()
 	var joinToken string
 
 	for idx := range s.BootlooseSuite.ControllerCount {
 		s.Require().NoError(s.WaitForSSH(s.ControllerNode(idx), 2*time.Minute, 1*time.Second))
-		s.PutFile(s.ControllerNode(idx), "/tmp/k0s.yaml", fmt.Sprintf(haControllerConfig, lb))
+		if useExtAddr {
+			s.PutFile(s.ControllerNode(idx), "/tmp/k0s.yaml", fmt.Sprintf(extAddrControllerConfig, lb, lb))
+			// Note that the token is intentionally empty for the first controller
+			s.Require().NoError(s.InitController(idx, "--config=/tmp/k0s.yaml", "--disable-components=endpoint-reconciler", "--enable-worker", joinToken))
+		} else {
+			s.PutFile(s.ControllerNode(idx), "/tmp/k0s.yaml", fmt.Sprintf(nllbControllerConfig, lb))
+			// Note that the token is intentionally empty for the first controller
+			s.Require().NoError(s.InitController(idx, "--config=/tmp/k0s.yaml", "--enable-worker", joinToken))
+		}
 
-		// Note that the token is intentionally empty for the first controller
-		s.Require().NoError(s.InitController(idx, "--config=/tmp/k0s.yaml", "--disable-components=metrics-server", "--enable-worker", joinToken))
 		s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(idx)))
 
 		// With the primary controller running, create the join token for subsequent controllers.
@@ -81,7 +110,7 @@ func (s *CPLBUserSpaceSuite) TestK0sGetsUp() {
 	}
 
 	// Create a worker join token
-	workerJoinToken, err := s.GetJoinToken("worker")
+	workerJoinToken, err := s.GetJoinToken(token.RoleWorker)
 	s.Require().NoError(err)
 
 	// Start the workers using the join token
@@ -111,11 +140,16 @@ func (s *CPLBUserSpaceSuite) TestK0sGetsUp() {
 
 	// Verify that controller+worker nodes are working normally.
 	s.T().Log("waiting to see CNI pods ready")
-	s.Require().NoError(common.WaitForKubeRouterReady(s.Context(), client), "kube router did not start")
+	if useExtAddr {
+		s.Require().NoError(common.WaitForDaemonSet(ctx, client, "calico-node", "kube-system"), "calico-node did not start")
+	} else {
+		s.Require().NoError(common.WaitForKubeRouterReady(ctx, client), "kube router did not start")
+	}
+
 	s.T().Log("waiting to see konnectivity-agent pods ready")
-	s.Require().NoError(common.WaitForDaemonSet(s.Context(), client, "konnectivity-agent", "kube-system"), "konnectivity-agent did not start")
+	s.Require().NoError(common.WaitForDaemonSet(ctx, client, "konnectivity-agent", "kube-system"), "konnectivity-agent did not start")
 	s.T().Log("waiting to get logs from pods")
-	s.Require().NoError(common.WaitForPodLogs(s.Context(), client, "kube-system"))
+	s.Require().NoError(common.WaitForPodLogs(ctx, client, "kube-system"))
 
 	s.T().Log("Testing that the load balancer is actually balancing the load")
 	// Other stuff may be querying the controller, running the HTTPS request 15 times
@@ -123,7 +157,7 @@ func (s *CPLBUserSpaceSuite) TestK0sGetsUp() {
 	signatures := make(map[string]int)
 	url := url.URL{Scheme: "https", Host: net.JoinHostPort(lb, strconv.Itoa(6443))}
 	for range 15 {
-		signature, err := getServerCertSignature(url.String())
+		signature, err := getServerCertSignature(ctx, url.String())
 		s.Require().NoError(err)
 		signatures[signature] = 1
 	}
@@ -134,21 +168,22 @@ func (s *CPLBUserSpaceSuite) TestK0sGetsUp() {
 // getLBAddress returns the IP address of the controller 0 and it adds 100 to
 // the last octet unless it's bigger or equal to 154, in which case it
 // subtracts 100. Theoretically this could result in an invalid IP address.
+// This is so that get a virtual IP in the same subnet as the controller.
 func (s *CPLBUserSpaceSuite) getLBAddress() string {
 	ip := s.GetIPAddress(s.ControllerNode(0))
-	parts := strings.Split(ip, ".")
-	if len(parts) != 4 {
-		s.T().Fatalf("Invalid IP address: %q", ip)
-	}
-	lastOctet, err := strconv.Atoi(parts[3])
-	s.Require().NoErrorf(err, "Failed to convert last octet %q to int", parts[3])
-	if lastOctet >= 154 {
-		lastOctet -= 100
-	} else {
-		lastOctet += 100
+	addr := net.ParseIP(ip)
+	ipv4 := addr.To4()
+	if ipv4 == nil {
+		s.T().Fatalf("This test doesn't support IPv6: %q", ip)
 	}
 
-	return fmt.Sprintf("%s.%d", strings.Join(parts[:3], "."), lastOctet)
+	if ipv4[3] >= 154 {
+		ipv4[3] -= 100
+	} else {
+		ipv4[3] += 100
+	}
+
+	return ipv4.String()
 }
 
 // checkDummy checks that the dummy interface isn't present in the node.
@@ -157,8 +192,7 @@ func (s *CPLBUserSpaceSuite) checkDummy(ctx context.Context, node string) {
 	s.Require().NoError(err)
 	defer ssh.Disconnect()
 
-	_, err = ssh.ExecWithOutput(ctx, "ip --oneline addr show dummyvip0")
-	s.Require().Error(err)
+	s.Require().Error(ssh.Exec(ctx, "ip --oneline addr show dummyvip0", common.SSHStreams{}))
 }
 
 // hasVIP checks that the dummy interface is present on the given node and
@@ -175,7 +209,7 @@ func (s *CPLBUserSpaceSuite) hasVIP(ctx context.Context, node string, vip string
 }
 
 // getServerCertSignature connects to the given HTTPS URL and returns the server certificate signature.
-func getServerCertSignature(url string) (string, error) {
+func getServerCertSignature(ctx context.Context, url string) (string, error) {
 	// Create a custom HTTP client with a custom TLS configuration
 	client := &http.Client{
 		Transport: &http.Transport{
@@ -184,13 +218,25 @@ func getServerCertSignature(url string) (string, error) {
 			},
 		},
 	}
+	defer client.CloseIdleConnections()
 
 	// Make a request to the URL
-	resp, err := client.Get(url)
+
+	// Make a request to the URL with the context
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
+
+	if err != nil {
+		return "", err
+	}
 
 	// Get the TLS connection state
 	connState := resp.TLS
@@ -199,7 +245,7 @@ func getServerCertSignature(url string) (string, error) {
 	}
 
 	// Get the server certificate
-	if len(connState.PeerCertificates) == 0 {
+	if len(connState.PeerCertificates) != 1 {
 		return "", errors.New("no server certificate found")
 	}
 	cert := connState.PeerCertificates[0]

--- a/inttest/cplb-userspace/cplbuserspace_test.go
+++ b/inttest/cplb-userspace/cplbuserspace_test.go
@@ -154,15 +154,16 @@ func (s *CPLBUserSpaceSuite) TestK0sGetsUp() {
 	s.T().Log("Testing that the load balancer is actually balancing the load")
 	// Other stuff may be querying the controller, running the HTTPS request 15 times
 	// should be more than we need.
+	attempt := 0
 	signatures := make(map[string]int)
 	url := url.URL{Scheme: "https", Host: net.JoinHostPort(lb, strconv.Itoa(6443))}
-	for range 15 {
+	for len(signatures) < 3 {
 		signature, err := getServerCertSignature(ctx, url.String())
 		s.Require().NoError(err)
 		signatures[signature] = 1
+		attempt++
+		s.Require().LessOrEqual(attempt, 15, "Failed to get a signature from all controllers")
 	}
-
-	s.Require().Len(signatures, 3, "Expected 3 different signatures, got %d", len(signatures))
 }
 
 // getLBAddress returns the IP address of the controller 0 and it adds 100 to

--- a/inttest/customports/customports_test.go
+++ b/inttest/customports/customports_test.go
@@ -131,7 +131,7 @@ func (s *customPortsSuite) TestControllerJoinsWithCustomPort() {
 	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see CNI pods ready")
-	s.Require().NoError(common.WaitForKubeRouterReady(s.Context(), kc), "calico did not start")
+	s.Require().NoError(common.WaitForKubeRouterReady(s.Context(), kc), "kube-router did not start")
 	s.T().Log("waiting to see konnectivity-agent pods ready")
 	s.Require().NoError(common.WaitForDaemonSet(s.Context(), kc, "konnectivity-agent", "kube-system"), "konnectivity-agent did not start")
 

--- a/pkg/apis/k0s/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types.go
@@ -366,7 +366,7 @@ func (s *ClusterSpec) Validate() (errs []error) {
 	}
 
 	if s.Network != nil && s.Network.ControlPlaneLoadBalancing != nil {
-		for _, err := range s.Network.ControlPlaneLoadBalancing.Validate(s.API.ExternalAddress) {
+		for _, err := range s.Network.ControlPlaneLoadBalancing.Validate() {
 			errs = append(errs, fmt.Errorf("controlPlaneLoadBalancing: %w", err))
 		}
 	}

--- a/pkg/apis/k0s/v1beta1/cplb.go
+++ b/pkg/apis/k0s/v1beta1/cplb.go
@@ -277,7 +277,7 @@ func (k *KeepalivedSpec) validateVirtualServers() []error {
 }
 
 // Validate validates the ControlPlaneLoadBalancingSpec
-func (c *ControlPlaneLoadBalancingSpec) Validate(externalAddress string) (errs []error) {
+func (c *ControlPlaneLoadBalancingSpec) Validate() (errs []error) {
 	if c == nil {
 		return nil
 	}
@@ -290,11 +290,11 @@ func (c *ControlPlaneLoadBalancingSpec) Validate(externalAddress string) (errs [
 		errs = append(errs, fmt.Errorf("unsupported CPLB type: %s. Only allowed value: %s", c.Type, CPLBTypeKeepalived))
 	}
 
-	return append(errs, c.Keepalived.Validate(externalAddress)...)
+	return append(errs, c.Keepalived.Validate()...)
 }
 
 // Validate validates the KeepalivedSpec
-func (k *KeepalivedSpec) Validate(externalAddress string) (errs []error) {
+func (k *KeepalivedSpec) Validate() (errs []error) {
 	if k == nil {
 		return nil
 	}
@@ -305,11 +305,6 @@ func (k *KeepalivedSpec) Validate(externalAddress string) (errs []error) {
 		k.UserSpaceProxyPort = 6444
 	} else if k.UserSpaceProxyPort < 1 || k.UserSpaceProxyPort > 65535 {
 		errs = append(errs, errors.New("UserSpaceProxyPort must be in the range of 1-65535"))
-	}
-
-	// CPLB reconciler relies in watching kubernetes.default.svc endpoints
-	if externalAddress != "" && len(k.VirtualServers) > 0 {
-		errs = append(errs, errors.New(".spec.api.externalAddress and virtual servers cannot be used together"))
 	}
 
 	return errs

--- a/pkg/component/controller/cplb/cplb_linux.go
+++ b/pkg/component/controller/cplb/cplb_linux.go
@@ -22,8 +22,11 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os/exec"
 	"path/filepath"
 	"slices"
+	"strconv"
+	"strings"
 	"syscall"
 	"text/template"
 	"time"
@@ -32,11 +35,17 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/users"
 	k0sAPI "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/assets"
+	"github.com/k0sproject/k0s/pkg/component/controller/cplb/tcpproxy"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/supervisor"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+)
+
+const (
+	iptablesCommandAppend = "-A"
+	iptablesCommandDelete = "-D"
 )
 
 // Keepalived is the controller for the keepalived process in the control plane load balancing
@@ -55,6 +64,7 @@ type Keepalived struct {
 	reconciler       *CPLBReconciler
 	updateCh         chan struct{}
 	reconcilerDone   chan struct{}
+	proxy            tcpproxy.Proxy
 }
 
 // Init extracts the needed binaries and creates the directories
@@ -83,13 +93,14 @@ func (k *Keepalived) Start(_ context.Context) error {
 		return nil
 	}
 
-	if len(k.Config.VRRPInstances) > 0 {
+	// We only need the dummy interface when using IPVS.
+	if len(k.Config.VirtualServers) > 0 {
 		if err := k.configureDummy(); err != nil {
 			return fmt.Errorf("failed to configure dummy interface: %w", err)
 		}
 	}
 
-	if len(k.Config.VirtualServers) > 0 {
+	if len(k.Config.VRRPInstances) > 0 || len(k.Config.VirtualServers) > 0 {
 		k.log.Info("Starting CPLB reconciler")
 		updateCh := make(chan struct{}, 1)
 		k.reconciler = NewCPLBReconciler(k.KubeConfigPath, updateCh)
@@ -140,7 +151,14 @@ func (k *Keepalived) Start(_ context.Context) error {
 		k.reconcilerDone = reconcilerDone
 		go func() {
 			defer close(reconcilerDone)
-			k.watchReconcilerUpdates()
+			if len(k.Config.VirtualServers) > 0 {
+				k.watchReconcilerUpdatesKeepalived()
+			} else {
+
+				if err := k.watchReconcilerUpdatesReverseProxy(); err != nil {
+					k.log.WithError(err).Error("failed to watch reconciler updates")
+				}
+			}
 		}()
 	}
 	return k.supervisor.Supervise()
@@ -150,29 +168,37 @@ func (k *Keepalived) Start(_ context.Context) error {
 // k0s controller is stopped, it can still reach the other APIservers on the VIP
 func (k *Keepalived) Stop() error {
 	if k.reconciler != nil {
-		k.log.Infof("Stopping cplb-reconciler")
+		k.log.Info("Stopping cplb-reconciler")
 		k.reconciler.Stop()
 		close(k.updateCh)
 		<-k.reconcilerDone
 	}
 
-	k.log.Infof("Stopping keepalived")
+	k.log.Info("Stopping keepalived")
 	k.supervisor.Stop()
 
-	k.log.Infof("Deleting dummy interface")
-	link, err := netlink.LinkByName(dummyLinkName)
-	if err != nil {
-		if errors.As(err, &netlink.LinkNotFoundError{}) {
-			return nil
+	if len(k.Config.VirtualServers) > 0 {
+		k.log.Info("Deleting dummy interface")
+		link, err := netlink.LinkByName(dummyLinkName)
+		if err != nil {
+			if errors.As(err, &netlink.LinkNotFoundError{}) {
+				return nil
+			}
+			k.log.Errorf("failed to get link by name %s. Attempting to delete it anyway: %v", dummyLinkName, err)
+			link = &netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: dummyLinkName,
+				},
+			}
 		}
-		k.log.Errorf("failed to get link by name %s. Attempting to delete it anyway: %v", dummyLinkName, err)
-		link = &netlink.Dummy{
-			LinkAttrs: netlink.LinkAttrs{
-				Name: dummyLinkName,
-			},
-		}
+		return netlink.LinkDel(link)
 	}
-	return netlink.LinkDel(link)
+	if err := k.proxy.Close(); err != nil {
+		return fmt.Errorf("failed to close proxy: %w", err)
+	}
+
+	// Only clean iptables rules if we are using the userspace reverse proxy
+	return k.redirectToProxyIPTables(iptablesCommandDelete)
 }
 
 // configureDummy creates the dummy interface and sets the virtual IPs on it.
@@ -321,7 +347,69 @@ func (k *Keepalived) generateKeepalivedTemplate() error {
 	return nil
 }
 
-func (k *Keepalived) watchReconcilerUpdates() {
+func (k *Keepalived) watchReconcilerUpdatesReverseProxy() error {
+	k.proxy = tcpproxy.Proxy{}
+	// We don't know how long until we get the first update, so initially we
+	// forward everything to localhost
+	k.proxy.AddRoute(fmt.Sprintf(":%d", k.Config.UserSpaceProxyPort), tcpproxy.To(fmt.Sprintf("127.0.0.1:%d", k.APIPort)))
+
+	if err := k.proxy.Start(); err != nil {
+		return fmt.Errorf("failed to start proxy: %w", err)
+	}
+
+	fmt.Println("Waiting for updateCh")
+	<-k.updateCh
+	k.setProxyRoutes()
+
+	// Do not create the iptables rules until we have the first update and the
+	// proxy is running
+	if err := k.redirectToProxyIPTables(iptablesCommandAppend); err != nil {
+		k.log.Fatal(err)
+	}
+
+	for range k.updateCh {
+		k.setProxyRoutes()
+	}
+	return nil
+}
+
+func (k *Keepalived) setProxyRoutes() {
+	routes := []tcpproxy.Target{}
+	for _, addr := range k.reconciler.GetIPs() {
+		routes = append(routes, tcpproxy.To(fmt.Sprintf("%s:%d", addr, k.APIPort)))
+	}
+
+	k.proxy.SetRoutes(fmt.Sprintf(":%d", k.Config.UserSpaceProxyPort), routes)
+}
+
+func (k *Keepalived) redirectToProxyIPTables(op string) error {
+	for _, vrrp := range k.Config.VRRPInstances {
+		for _, vipCIDR := range vrrp.VirtualIPs {
+			vip := strings.Split(vipCIDR, "/")[0]
+
+			cmdArgs := []string{
+				"-t", "nat", op, "PREROUTING", "-p", "tcp",
+				"-d", vip, "--dport", strconv.Itoa(k.APIPort),
+				"-j", "REDIRECT", "--to-port", strconv.Itoa(k.Config.UserSpaceProxyPort),
+			}
+
+			if op == iptablesCommandAppend {
+				k.log.Infof("Adding iptables rule to redirect %s", vip)
+			} else if op == iptablesCommandDelete {
+				k.log.Infof("Deleting iptables rule to redirect %s", vip)
+			}
+
+			cmd := exec.Command(filepath.Join(k.K0sVars.BinDir, "iptables"), cmdArgs...)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("failed to execute iptables command: %w, output: %s", err, output)
+			}
+		}
+	}
+	return nil
+}
+
+func (k *Keepalived) watchReconcilerUpdatesKeepalived() {
 	// Wait for the supervisor to start keepalived before
 	// watching for endpoint changes
 	process := k.supervisor.GetProcess()
@@ -385,9 +473,9 @@ vrrp_instance k0s-vip-{{$i}} {
         auth_pass {{ $instance.AuthPass }}
     }
     virtual_ipaddress {
-	    {{ range $instance.VirtualIPs }}
-		{{ . }}
-		{{ end }}
+        {{ range $instance.VirtualIPs }}
+        {{ . }}
+        {{ end }}
     }
 }
 {{ end }}

--- a/pkg/component/controller/cplb/tcpproxy/tcpproxy.go
+++ b/pkg/component/controller/cplb/tcpproxy/tcpproxy.go
@@ -1,0 +1,492 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Modifications made by Mirantis Inc., 2024.
+// Copyright 2017 Google Inc.
+//
+// Copyright 2024 Mirantis, Inc.
+
+// Package tcpproxy lets users build TCP proxies
+
+package tcpproxy
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"time"
+)
+
+// Proxy is a proxy. Its zero value is a valid proxy that does
+// nothing. Call methods to add routes before calling Start or Run.
+//
+// The order that routes are added in matters; each is matched in the order
+// registered.
+type Proxy struct {
+	configs map[string]*config // ip:port => config
+
+	lns        []net.Listener
+	donec      chan struct{} // closed before err
+	err        error         // any error from listening
+	routesChan chan route
+
+	// ListenFunc optionally specifies an alternate listen
+	// function. If nil, net.Dial is used.
+	// The provided net is always "tcp".
+	ListenFunc func(net, laddr string) (net.Listener, error)
+}
+
+// Matcher reports whether hostname matches the Matcher's criteria.
+type Matcher func(ctx context.Context, hostname string) bool
+
+// config contains the proxying state for one listener.
+type config struct {
+	routes []route
+}
+
+// A route matches a connection to a target.
+type route interface {
+	// match examines the initial bytes of a connection, looking for a
+	// match. If a match is found, match returns a non-nil Target to
+	// which the stream should be proxied. match returns nil if the
+	// connection doesn't match.
+	//
+	// match must not consume bytes from the given bufio.Reader, it
+	// can only Peek.
+	//
+	// If an sni or host header was parsed successfully, that will be
+	// returned as the second parameter.
+	match(*bufio.Reader) (Target, string)
+}
+
+func (p *Proxy) netListen() func(net, laddr string) (net.Listener, error) {
+	if p.ListenFunc != nil {
+		return p.ListenFunc
+	}
+	return net.Listen
+}
+
+func (p *Proxy) configFor(ipPort string) *config {
+	if p.configs == nil {
+		p.configs = make(map[string]*config)
+	}
+	if p.configs[ipPort] == nil {
+		p.configs[ipPort] = &config{}
+	}
+	return p.configs[ipPort]
+}
+
+func (p *Proxy) addRoute(ipPort string, r route) {
+	cfg := p.configFor(ipPort)
+	cfg.routes = append(cfg.routes, r)
+}
+
+// AddRoute appends an always-matching route to the ipPort listener,
+// directing any connection to dest.
+//
+// This is generally used as either the only rule (for simple TCP
+// proxies), or as the final fallback rule for an ipPort.
+//
+// The ipPort is any valid net.Listen TCP address.
+func (p *Proxy) AddRoute(ipPort string, dest Target) {
+	p.addRoute(ipPort, fixedTarget{dest})
+}
+
+func (p *Proxy) setRoutes(ipPort string, targets []Target) {
+	var routes []route
+	for _, target := range targets {
+		routes = append(routes, fixedTarget{target})
+	}
+
+	cfg := p.configFor(ipPort)
+	cfg.routes = routes
+}
+
+// SetRoutes replaces routes for the ipPort.
+//
+// It's possible that the old routes are still used once after this
+// function is called. If an empty slice is passed, the routes are
+// preserved in order to avoid an infinite loop.
+func (p *Proxy) SetRoutes(ipPort string, targets []Target) {
+	if len(targets) == 0 {
+		return
+	}
+	p.setRoutes(ipPort, targets)
+}
+
+type fixedTarget struct {
+	t Target
+}
+
+func (m fixedTarget) match(*bufio.Reader) (Target, string) { return m.t, "" }
+
+// Run is calls Start, and then Wait.
+//
+// It blocks until there's an error. The return value is always
+// non-nil.
+func (p *Proxy) Run() error {
+	if err := p.Start(); err != nil {
+		return err
+	}
+	return p.Wait()
+}
+
+// Wait waits for the Proxy to finish running. Currently this can only
+// happen if a Listener is closed, or Close is called on the proxy.
+//
+// It is only valid to call Wait after a successful call to Start.
+func (p *Proxy) Wait() error {
+	<-p.donec
+	return p.err
+}
+
+// Close closes all the proxy's self-opened listeners.
+func (p *Proxy) Close() error {
+	for _, c := range p.lns {
+		c.Close()
+	}
+	return nil
+}
+
+// Start creates a TCP listener for each unique ipPort from the
+// previously created routes and starts the proxy. It returns any
+// error from starting listeners.
+//
+// If it returns a non-nil error, any successfully opened listeners
+// are closed.
+func (p *Proxy) Start() error {
+	if p.donec != nil {
+		return errors.New("already started")
+	}
+	p.donec = make(chan struct{})
+	errc := make(chan error, len(p.configs))
+	p.lns = make([]net.Listener, 0, len(p.configs))
+	for ipPort, config := range p.configs {
+		ln, err := p.netListen()("tcp", ipPort)
+		if err != nil {
+			p.Close()
+			return err
+		}
+		p.lns = append(p.lns, ln)
+		p.routesChan = make(chan route)
+		go p.serveListener(errc, ln, config)
+	}
+	go p.awaitFirstError(errc)
+	return nil
+}
+
+func (p *Proxy) awaitFirstError(errc <-chan error) {
+	p.err = <-errc
+	close(p.donec)
+}
+
+func (p *Proxy) serveListener(ret chan<- error, ln net.Listener, cfg *config) {
+	go p.roundRobin(cfg)
+	for {
+		c, err := ln.Accept()
+		if err != nil {
+			ret <- err
+			return
+		}
+		go p.serveConn(c)
+	}
+}
+
+// serveConn runs in its own goroutine and matches c against routes.
+// It returns whether it matched purely for testing.
+func (p *Proxy) serveConn(c net.Conn) bool {
+	br := bufio.NewReader(c)
+	for route := range p.routesChan {
+		if target, hostName := route.match(br); target != nil {
+			if n := br.Buffered(); n > 0 {
+				peeked, _ := br.Peek(br.Buffered())
+				c = &Conn{
+					HostName: hostName,
+					Peeked:   peeked,
+					Conn:     c,
+				}
+			}
+			target.HandleConn(c)
+			return true
+		}
+	}
+	// TODO: hook for this?
+	log.Printf("tcpproxy: no routes matched conn %v/%v; closing", c.RemoteAddr().String(), c.LocalAddr().String())
+	c.Close()
+	return false
+}
+
+// roundRobin writes to a channel the next route to use.
+func (p *Proxy) roundRobin(cfg *config) {
+	for {
+		for _, route := range cfg.routes {
+			p.routesChan <- route
+		}
+	}
+}
+
+// Conn is an incoming connection that has had some bytes read from it
+// to determine how to route the connection. The Read method stitches
+// the peeked bytes and unread bytes back together.
+type Conn struct {
+	// HostName is the hostname field that was sent to the request router.
+	// In the case of TLS, this is the SNI header, in the case of HTTPHost
+	// route, it will be the host header.  In the case of a fixed
+	// route, i.e. those created with AddRoute(), this will always be
+	// empty. This can be useful in the case where further routing decisions
+	// need to be made in the Target impementation.
+	HostName string
+
+	// Peeked are the bytes that have been read from Conn for the
+	// purposes of route matching, but have not yet been consumed
+	// by Read calls. It set to nil by Read when fully consumed.
+	Peeked []byte
+
+	// Conn is the underlying connection.
+	// It can be type asserted against *net.TCPConn or other types
+	// as needed. It should not be read from directly unless
+	// Peeked is nil.
+	net.Conn
+}
+
+func (c *Conn) Read(p []byte) (n int, err error) {
+	if len(c.Peeked) > 0 {
+		n = copy(p, c.Peeked)
+		c.Peeked = c.Peeked[n:]
+		if len(c.Peeked) == 0 {
+			c.Peeked = nil
+		}
+		return n, nil
+	}
+	return c.Conn.Read(p)
+}
+
+// Target is what an incoming matched connection is sent to.
+type Target interface {
+	// HandleConn is called when an incoming connection is
+	// matched. After the call to HandleConn, the tcpproxy
+	// package never touches the conn again. Implementations are
+	// responsible for closing the connection when needed.
+	//
+	// The concrete type of conn will be of type *Conn if any
+	// bytes have been consumed for the purposes of route
+	// matching.
+	HandleConn(net.Conn)
+}
+
+// To is shorthand way of writing &tcpproxy.DialProxy{Addr: addr}.
+func To(addr string) *DialProxy {
+	return &DialProxy{Addr: addr}
+}
+
+// DialProxy implements Target by dialing a new connection to Addr
+// and then proxying data back and forth.
+//
+// The To func is a shorthand way of creating a DialProxy.
+type DialProxy struct {
+	// Addr is the TCP address to proxy to.
+	Addr string
+
+	// KeepAlivePeriod sets the period between TCP keep alives.
+	// If zero, a default is used. To disable, use a negative number.
+	// The keep-alive is used for both the client connection and
+	KeepAlivePeriod time.Duration
+
+	// DialTimeout optionally specifies a dial timeout.
+	// If zero, a default is used.
+	// If negative, the timeout is disabled.
+	DialTimeout time.Duration
+
+	// DialContext optionally specifies an alternate dial function
+	// for TCP targets. If nil, the standard
+	// net.Dialer.DialContext method is used.
+	DialContext func(ctx context.Context, network, address string) (net.Conn, error)
+
+	// OnDialError optionally specifies an alternate way to handle errors dialing Addr.
+	// If nil, the error is logged and src is closed.
+	// If non-nil, src is not closed automatically.
+	OnDialError func(src net.Conn, dstDialErr error)
+
+	// ProxyProtocolVersion optionally specifies the version of
+	// HAProxy's PROXY protocol to use. The PROXY protocol provides
+	// connection metadata to the DialProxy target, via a header
+	// inserted ahead of the client's traffic. The DialProxy target
+	// must explicitly support and expect the PROXY header; there is
+	// no graceful downgrade.
+	// If zero, no PROXY header is sent. Currently, version 1 is supported.
+	ProxyProtocolVersion int
+}
+
+// UnderlyingConn returns c.Conn if c of type *Conn,
+// otherwise it returns c.
+func UnderlyingConn(c net.Conn) net.Conn {
+	if wrap, ok := c.(*Conn); ok {
+		return wrap.Conn
+	}
+	return c
+}
+
+func tcpConn(c net.Conn) (t *net.TCPConn, ok bool) {
+	if c, ok := UnderlyingConn(c).(*net.TCPConn); ok {
+		return c, ok
+	}
+	if c, ok := c.(*net.TCPConn); ok {
+		return c, ok
+	}
+	return nil, false
+}
+
+func goCloseConn(c net.Conn) { go c.Close() }
+
+func closeRead(c net.Conn) {
+	if c, ok := tcpConn(c); ok {
+		_ = c.CloseRead()
+	}
+}
+
+func closeWrite(c net.Conn) {
+	if c, ok := tcpConn(c); ok {
+		_ = c.CloseWrite()
+	}
+}
+
+// HandleConn implements the Target interface.
+func (dp *DialProxy) HandleConn(src net.Conn) {
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	if dp.DialTimeout >= 0 {
+		ctx, cancel = context.WithTimeout(ctx, dp.dialTimeout())
+	}
+	dst, err := dp.dialContext()(ctx, "tcp", dp.Addr)
+	if cancel != nil {
+		cancel()
+	}
+	if err != nil {
+		dp.onDialError()(src, err)
+		return
+	}
+	defer goCloseConn(dst)
+
+	if err = dp.sendProxyHeader(dst, src); err != nil {
+		dp.onDialError()(src, err)
+		return
+	}
+	defer goCloseConn(src)
+
+	if ka := dp.keepAlivePeriod(); ka > 0 {
+		for _, c := range []net.Conn{src, dst} {
+			if c, ok := tcpConn(c); ok {
+				_ = c.SetKeepAlive(true)
+				_ = c.SetKeepAlivePeriod(ka)
+			}
+		}
+	}
+
+	errc := make(chan error, 2)
+	go proxyCopy(errc, src, dst)
+	go proxyCopy(errc, dst, src)
+	<-errc
+	<-errc
+}
+
+func (dp *DialProxy) sendProxyHeader(w io.Writer, src net.Conn) error {
+	switch dp.ProxyProtocolVersion {
+	case 0:
+		return nil
+	case 1:
+		var srcAddr, dstAddr *net.TCPAddr
+		if a, ok := src.RemoteAddr().(*net.TCPAddr); ok {
+			srcAddr = a
+		}
+		if a, ok := src.LocalAddr().(*net.TCPAddr); ok {
+			dstAddr = a
+		}
+
+		if srcAddr == nil || dstAddr == nil {
+			_, err := io.WriteString(w, "PROXY UNKNOWN\r\n")
+			return err
+		}
+
+		family := "TCP4"
+		if srcAddr.IP.To4() == nil {
+			family = "TCP6"
+		}
+		_, err := fmt.Fprintf(w, "PROXY %s %s %s %d %d\r\n", family, srcAddr.IP, dstAddr.IP, srcAddr.Port, dstAddr.Port)
+		return err
+	default:
+		return fmt.Errorf("PROXY protocol version %d not supported", dp.ProxyProtocolVersion)
+	}
+}
+
+// proxyCopy is the function that copies bytes around.
+// It's a named function instead of a func literal so users get
+// named goroutines in debug goroutine stack dumps.
+func proxyCopy(errc chan<- error, dst, src net.Conn) {
+	defer closeRead(src)
+	defer closeWrite(dst)
+
+	// Before we unwrap src and/or dst, copy any buffered data.
+	if wc, ok := src.(*Conn); ok && len(wc.Peeked) > 0 {
+		if _, err := dst.Write(wc.Peeked); err != nil {
+			errc <- err
+			return
+		}
+		wc.Peeked = nil
+	}
+
+	// Unwrap the src and dst from *Conn to *net.TCPConn so Go
+	// 1.11's splice optimization kicks in.
+	src = UnderlyingConn(src)
+	dst = UnderlyingConn(dst)
+
+	_, err := io.Copy(dst, src)
+	errc <- err
+}
+
+func (dp *DialProxy) keepAlivePeriod() time.Duration {
+	if dp.KeepAlivePeriod != 0 {
+		return dp.KeepAlivePeriod
+	}
+	return time.Minute
+}
+
+func (dp *DialProxy) dialTimeout() time.Duration {
+	if dp.DialTimeout > 0 {
+		return dp.DialTimeout
+	}
+	return 10 * time.Second
+}
+
+var defaultDialer = new(net.Dialer)
+
+func (dp *DialProxy) dialContext() func(ctx context.Context, network, address string) (net.Conn, error) {
+	if dp.DialContext != nil {
+		return dp.DialContext
+	}
+	return defaultDialer.DialContext
+}
+
+func (dp *DialProxy) onDialError() func(src net.Conn, dstDialErr error) {
+	if dp.OnDialError != nil {
+		return dp.OnDialError
+	}
+	return func(src net.Conn, dstDialErr error) {
+		log.Printf("tcpproxy: for incoming conn %v, error dialing %q: %v", src.RemoteAddr().String(), dp.Addr, dstDialErr)
+		src.Close()
+	}
+}

--- a/pkg/component/controller/cplb/tcpproxy/tcpproxy_test.go
+++ b/pkg/component/controller/cplb/tcpproxy/tcpproxy_test.go
@@ -75,7 +75,7 @@ func TestBufferedClose(t *testing.T) {
 	defer back.Close()
 
 	p := testProxy(t, front)
-	p.AddRoute(testFrontAddr, To(back.Addr().String()))
+	p.SetRoutes(testFrontAddr, []Route{To(back.Addr().String())})
 	if err := p.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestProxyAlwaysMatch(t *testing.T) {
 	defer back.Close()
 
 	p := testProxy(t, front)
-	p.AddRoute(testFrontAddr, To(back.Addr().String()))
+	p.setRoutes(testFrontAddr, []Route{To(back.Addr().String())})
 	if err := p.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -149,10 +149,10 @@ func TestProxyPROXYOut(t *testing.T) {
 	defer back.Close()
 
 	p := testProxy(t, front)
-	p.AddRoute(testFrontAddr, &DialProxy{
+	p.SetRoutes(testFrontAddr, []Route{{
 		Addr:                 back.Addr().String(),
 		ProxyProtocolVersion: 1,
-	})
+	}})
 	if err := p.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -185,7 +185,7 @@ func TestSetRoutes(t *testing.T) {
 
 	var p Proxy
 	ipPort := ":8080"
-	p.AddRoute(ipPort, To("127.0.0.2:8080"))
+	p.setRoutes(ipPort, []Route{To("127.0.0.2:8080")})
 	cfg := p.configFor(ipPort)
 
 	expectedAddrsList := [][]string{
@@ -203,21 +203,21 @@ func TestSetRoutes(t *testing.T) {
 	}
 }
 
-func stringsToTargets(s []string) []Target {
-	targets := make([]Target, len(s))
+func stringsToTargets(s []string) []Route {
+	targets := make([]Route, len(s))
 	for i, v := range s {
 		targets[i] = To(v)
 	}
 
 	return targets
 }
-func equalRoutes(routes []route, expectedAddrs []string) bool {
+func equalRoutes(routes []Route, expectedAddrs []string) bool {
 	if len(routes) != len(expectedAddrs) {
 		return false
 	}
 
 	for i := range routes {
-		addr := routes[i].(fixedTarget).t.(*DialProxy).Addr
+		addr := routes[i].Addr
 		if addr != expectedAddrs[i] {
 			return false
 		}

--- a/pkg/component/controller/cplb/tcpproxy/tcpproxy_test.go
+++ b/pkg/component/controller/cplb/tcpproxy/tcpproxy_test.go
@@ -1,0 +1,226 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Modifications made by Mirantis Inc., 2024.
+// Copyright 2017 Google Inc.
+//
+// Copyright 2024 Mirantis, Inc.
+
+package tcpproxy
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"testing"
+)
+
+func TestProxyStartNone(t *testing.T) {
+	var p Proxy
+	if err := p.Start(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newLocalListener(t *testing.T) net.Listener {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		ln, err = net.Listen("tcp", "[::1]:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return ln
+}
+
+const testFrontAddr = "1.2.3.4:567"
+
+func testListenFunc(t *testing.T, ln net.Listener) func(network, laddr string) (net.Listener, error) {
+	return func(network, laddr string) (net.Listener, error) {
+		if network != "tcp" {
+			t.Errorf("got Listen call with network %q, not tcp", network)
+			return nil, errors.New("invalid network")
+		}
+		if laddr != testFrontAddr {
+			t.Fatalf("got Listen call with laddr %q, want %q", laddr, testFrontAddr)
+			panic("bogus address")
+		}
+		return ln, nil
+	}
+}
+
+func testProxy(t *testing.T, front net.Listener) *Proxy {
+	return &Proxy{
+		ListenFunc: testListenFunc(t, front),
+	}
+}
+
+func TestBufferedClose(t *testing.T) {
+	front := newLocalListener(t)
+	defer front.Close()
+	back := newLocalListener(t)
+	defer back.Close()
+
+	p := testProxy(t, front)
+	p.AddRoute(testFrontAddr, To(back.Addr().String()))
+	if err := p.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	toFront, err := net.Dial("tcp", front.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer toFront.Close()
+
+	fromProxy, err := back.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fromProxy.Close()
+	const msg = "message"
+	if _, err := io.WriteString(toFront, msg); err != nil {
+		t.Fatal(err)
+	}
+	// actively close toFront, the write should still make to the back.
+	toFront.Close()
+
+	buf := make([]byte, len(msg))
+	if _, err := io.ReadFull(fromProxy, buf); err != nil {
+		t.Fatal(err)
+	}
+	if string(buf) != msg {
+		t.Fatalf("got %q; want %q", buf, msg)
+	}
+}
+
+func TestProxyAlwaysMatch(t *testing.T) {
+	front := newLocalListener(t)
+	defer front.Close()
+	back := newLocalListener(t)
+	defer back.Close()
+
+	p := testProxy(t, front)
+	p.AddRoute(testFrontAddr, To(back.Addr().String()))
+	if err := p.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	toFront, err := net.Dial("tcp", front.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer toFront.Close()
+
+	fromProxy, err := back.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fromProxy.Close()
+	const msg = "message"
+	_, _ = io.WriteString(toFront, msg)
+
+	buf := make([]byte, len(msg))
+	if _, err := io.ReadFull(fromProxy, buf); err != nil {
+		t.Fatal(err)
+	}
+	if string(buf) != msg {
+		t.Fatalf("got %q; want %q", buf, msg)
+	}
+}
+
+func TestProxyPROXYOut(t *testing.T) {
+	front := newLocalListener(t)
+	defer front.Close()
+	back := newLocalListener(t)
+	defer back.Close()
+
+	p := testProxy(t, front)
+	p.AddRoute(testFrontAddr, &DialProxy{
+		Addr:                 back.Addr().String(),
+		ProxyProtocolVersion: 1,
+	})
+	if err := p.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	toFront, err := net.Dial("tcp", front.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _ = io.WriteString(toFront, "foo")
+	toFront.Close()
+
+	fromProxy, err := back.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bs, err := ioutil.ReadAll(fromProxy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := fmt.Sprintf("PROXY TCP4 %s %s %d %d\r\nfoo", toFront.LocalAddr().(*net.TCPAddr).IP, toFront.RemoteAddr().(*net.TCPAddr).IP, toFront.LocalAddr().(*net.TCPAddr).Port, toFront.RemoteAddr().(*net.TCPAddr).Port)
+	if string(bs) != want {
+		t.Fatalf("got %q; want %q", bs, want)
+	}
+}
+
+func TestSetRoutes(t *testing.T) {
+
+	var p Proxy
+	ipPort := ":8080"
+	p.AddRoute(ipPort, To("127.0.0.2:8080"))
+	cfg := p.configFor(ipPort)
+
+	expectedAddrsList := [][]string{
+		{"127.0.0.1:80"},
+		{"127.0.0.1:80", "127.0.0.1:443"},
+		{},
+		{"127.0.0.1:80"},
+	}
+
+	for _, expectedAddrs := range expectedAddrsList {
+		p.setRoutes(ipPort, stringsToTargets(expectedAddrs))
+		if !equalRoutes(cfg.routes, expectedAddrs) {
+			t.Fatalf("got %v; want %v", cfg.routes, expectedAddrs)
+		}
+	}
+}
+
+func stringsToTargets(s []string) []Target {
+	targets := make([]Target, len(s))
+	for i, v := range s {
+		targets[i] = To(v)
+	}
+
+	return targets
+}
+func equalRoutes(routes []route, expectedAddrs []string) bool {
+	if len(routes) != len(expectedAddrs) {
+		return false
+	}
+
+	for i := range routes {
+		addr := routes[i].(fixedTarget).t.(*DialProxy).Addr
+		if addr != expectedAddrs[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -85,6 +85,7 @@ type WorkerOptions struct {
 	TokenArg         string
 	WorkerProfile    string
 	IPTablesMode     string
+	DisableIPTables  bool
 }
 
 func (o *ControllerOptions) Normalize() error {

--- a/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
+++ b/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
@@ -508,6 +508,15 @@ spec:
                           Keepalived contains configuration options related to the "Keepalived" type
                           of load balancing.
                         properties:
+                          userSpaceProxyBindPort:
+                            default: 6444
+                            description: |-
+                              UserspaceProxyPort is the port where the userspace proxy will bind
+                              to. This port is only exposed on the localhost interface and is only
+                              used internally. Defaults to 6444.
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
                           virtualServers:
                             description: |-
                               Configuration options related to the virtual servers. This is an array


### PR DESCRIPTION
## Description

Implement userspace CPLB reverse proxy load balancer.

Due to the keepalived virtualservers using IPVS for the load balancing, we simply couldn't make it work on some environments and needed to implement a userspace reverse proxy.

Fixes #4700 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings