### PR TITLE
Move CPLB into its own package

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -44,6 +44,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/certificate"
 	"github.com/k0sproject/k0s/pkg/component/controller"
 	"github.com/k0sproject/k0s/pkg/component/controller/clusterconfig"
+	"github.com/k0sproject/k0s/pkg/component/controller/cplb"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/controller/workerconfig"
 	"github.com/k0sproject/k0s/pkg/component/manager"
@@ -237,14 +238,14 @@ func (c *command) start(ctx context.Context) error {
 	// Assume a single active controller during startup
 	numActiveControllers := value.NewLatest[uint](1)
 
-	if cplb := nodeConfig.Spec.Network.ControlPlaneLoadBalancing; cplb != nil && cplb.Enabled {
+	if cplbCfg := nodeConfig.Spec.Network.ControlPlaneLoadBalancing; cplbCfg != nil && cplbCfg.Enabled {
 		if c.SingleNode {
 			return errors.New("control plane load balancing cannot be used in a single-node cluster")
 		}
 
-		nodeComponents.Add(ctx, &controller.Keepalived{
+		nodeComponents.Add(ctx, &cplb.Keepalived{
 			K0sVars:         c.K0sVars,
-			Config:          cplb.Keepalived,
+			Config:          cplbCfg.Keepalived,
 			DetailedLogging: c.Debug,
 			LogConfig:       c.Debug,
 			KubeConfigPath:  c.K0sVars.AdminKubeConfigPath,

--- a/pkg/component/controller/cplb/cplb_linux.go
+++ b/pkg/component/controller/cplb/cplb_linux.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package cplb
 
 import (
 	"bufio"

--- a/pkg/component/controller/cplb/cplb_other.go
+++ b/pkg/component/controller/cplb/cplb_other.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package cplb
 
 import (
 	"context"

--- a/pkg/component/controller/cplb/cplb_reconciler.go
+++ b/pkg/component/controller/cplb/cplb_reconciler.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package cplb
 
 import (
 	"context"

--- a/pkg/component/controller/cplb/cplb_reconciler_test.go
+++ b/pkg/component/controller/cplb/cplb_reconciler_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package cplb
 
 import (
 	"testing"


### PR DESCRIPTION
## Description

Move CPLB into its own package. This is part of the efforts to add the userspace reverse proxy, since https://github.com/k0sproject/k0s/pull/5279. Because it's far too large this will help with the review. Also I intend to merge this quickly to prevent merge conflicts to some extent.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings