### PR TITLE
Fix link to adopters in the project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,14 @@ We currently have a monthly office hours call on the last Tuesday of the month.
 
 To see the call details in your local timezone, check out [https://dateful.com/eventlink/2735919704](https://dateful.com/eventlink/2735919704).
 
+<!-- End Join the Community -->
 ### Adopters
 
-k0s is used in numerous cases and environments. The range we've seen it being adopted ranges from very small far edge deployments to big data center deployments. Please add your use case to [adopters] list.
+k0s is used across diverse environments, from small-scale far-edge deployments
+to large data centers. Share your use case and add yourself to the list of
+[adopters].
 
-[adopters]: docs/adopters.md
-<!-- End Join the Community -->
+[adopters]: ADOPTERS.md
 
 <!-- Start Motivation -->
 ## Motivation

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,15 @@ Before that mishap we had 4776 stargazers, making k0s one of the most popular Ku
     end="<!-- End Join the Community -->"
 %}
 
+<!-- Copied over from "Join the Community" because rewriting the link won't work here. -->
+### Adopters
+
+k0s is used across diverse environments, from small-scale far-edge deployments
+to large data centers. Share your use case and add yourself to the list of
+[adopters].
+
+[adopters]: adopters.md
+
 ## Commercial Support
 
 [Mirantis](https://www.mirantis.com/software/k0s/) offers technical support, professional services and training for k0s. The support subscriptions include, for example, prioritized support (Phone, Web, Email) and access to verified extensions on top of your k0s cluster.


### PR DESCRIPTION
## Description

After moving the adopters file to the project root, the link in the project README pointed to the include file for mkdocs. Fix this by making it point to the real thing again. Since rewriting the link doesn't really work when using it as an include, duplicate this little paragraph in both READMES.

Fixes:

* #5262

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings