### PR TITLE
Don't check for dynamic config when listing images

### DIFF
--- a/cmd/airgap/listimages.go
+++ b/cmd/airgap/listimages.go
@@ -17,7 +17,6 @@ limitations under the License.
 package airgap
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/k0sproject/k0s/pkg/airgap"
@@ -37,10 +36,6 @@ func NewAirgapListImagesCmd() *cobra.Command {
 			opts, err := config.GetCmdOpts(cmd)
 			if err != nil {
 				return err
-			}
-
-			if opts.EnableDynamicConfig {
-				return errors.New("dynamic config is not supported for airgap list-images")
 			}
 
 			clusterConfig, err := opts.K0sVars.NodeConfig()


### PR DESCRIPTION
## Description

There's no `--enable-dynamic-config` flag for `k0s airgap list-images`:

```console
$ k0s airgap list-images --enable-dynamic-config
Error: unknown flag: --enable-dynamic-config
```

Fixes: 1e5e6b6e5 ("Disable airgap list-images for dynamic config")

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings