### PR TITLE
Honor IO errors in list-images sub-command

### DIFF
--- a/cmd/airgap/listimages.go
+++ b/cmd/airgap/listimages.go
@@ -48,8 +48,11 @@ func NewAirgapListImagesCmd() *cobra.Command {
 				return fmt.Errorf("failed to get config: %w", err)
 			}
 
+			out := cmd.OutOrStdout()
 			for _, uri := range airgap.GetImageURIs(clusterConfig.Spec, all) {
-				fmt.Fprintln(cmd.OutOrStdout(), uri)
+				if _, err := fmt.Fprintln(out, uri); err != nil {
+					return err
+				}
 			}
 			return nil
 		},


### PR DESCRIPTION
## Description

Previously, the sub-command did not interrupt the loop and returned successfully, even when it encountered IO errors while writing to standard out.

Use `strings.Builder` instead of `bytes.Buffer`: The out and err streams are always treated as strings for better readability, so it's more idiomatic to use `strings.Builder` for them. Replace `intoLines` with `strings.Split`, as `strings.Builder` doesn't implement `io.Reader,` which eliminates another helper function on the fly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings