### PR TITLE
Reject unknown sub-commands for k0s airgap

### DIFF
--- a/cmd/airgap/airgap.go
+++ b/cmd/airgap/airgap.go
@@ -26,6 +26,8 @@ func NewAirgapCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "airgap",
 		Short: "Manage airgap setup",
+		Args:  cobra.NoArgs,
+		Run:   func(*cobra.Command, []string) { /* Enforce arg validation. */ },
 	}
 
 	cmd.AddCommand(NewAirgapListImagesCmd())

--- a/cmd/airgap/airgap_test.go
+++ b/cmd/airgap/airgap_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package airgap_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"testing/iotest"
+
+	"github.com/k0sproject/k0s/cmd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAirgapCmd_RejectsUnknownCommands(t *testing.T) {
+	var stdout, stderr strings.Builder
+	underTest := cmd.NewRootCmd()
+	underTest.SetArgs([]string{"airgap", "bogus"})
+	underTest.SetIn(iotest.ErrReader(errors.New("unexpected read from standard input")))
+	underTest.SetOut(&stdout)
+	underTest.SetErr(&stderr)
+
+	msg := `unknown command "bogus" for "k0s airgap"`
+	assert.ErrorContains(t, underTest.Execute(), msg)
+	assert.Equal(t, "Error: "+msg+"\n", stderr.String())
+	assert.Empty(t, stdout.String())
+}

--- a/cmd/airgap/listimages.go
+++ b/cmd/airgap/listimages.go
@@ -32,6 +32,7 @@ func NewAirgapListImagesCmd() *cobra.Command {
 		Use:     "list-images",
 		Short:   "List image names and version needed for air-gap install",
 		Example: `k0s airgap list-images`,
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts, err := config.GetCmdOpts(cmd)
 			if err != nil {


### PR DESCRIPTION
## Description

Cobra has the property of not reporting any unrecognized sub-commands and simply displaying the help page for any command that doesn't have a run function set. Overwrite this for k0s's airgap sub-command.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings