### PR TITLE
Tweak and document disabling Docker build integration

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -151,19 +151,13 @@ jobs:
         run: |
           cat <<EOF >>"$GITHUB_ENV"
           TARGET_OS=${{ matrix.target-os }}
-          GO=go
-          GO_ENV=
-          GOCACHE=$GITHUB_WORKSPACE/build/cache/go/build
-          GOMODCACHE=$GITHUB_WORKSPACE/build/cache/go/mod
+          DOCKER=
           UNITTEST_EXTRA_ARGS=BUILD_GO_LDFLAGS_EXTRA=
           EOF
 
           echo ::group::Build Environment
           cat -- "$GITHUB_ENV"
           echo ::endgroup::
-
-          mkdir -p build/cache
-          make --touch .k0sbuild.docker-image.k0s
 
       - name: Prepare build environment
         run: .github/workflows/prepare-build-env.sh

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,13 @@ K0S_GO_BUILD_CACHE ?= build/cache
 GO_SRCS := $(shell find . -type f -name '*.go' -not -path './$(K0S_GO_BUILD_CACHE)/*' -not -path './inttest/*' -not -name '*_test.go' -not -name 'zz_generated*')
 GO_CHECK_UNIT_DIRS := . ./cmd/... ./pkg/... ./internal/... ./static/... ./hack/...
 
-DOCKER = docker
+DOCKER ?= docker
 # EMBEDDED_BINS_BUILDMODE can be either:
 #   docker	builds the binaries in docker
 #   none	does not embed any binaries
 
-ifeq ($(DOCKER),false)
+# Disable Docker build integration if DOCKER is set to the empty string.
+ifeq ($(DOCKER),)
   EMBEDDED_BINS_BUILDMODE ?= none
   K0S_BUILD_IMAGE_FILE =
   GO ?= go
@@ -35,6 +36,7 @@ else
   K0S_BUILD_IMAGE_FILE = .k0sbuild.docker-image.k0s
   GO ?= $(GO_ENV) go
 endif
+
 # k0s runs on linux even if it's built on mac or windows
 TARGET_OS ?= linux
 BUILD_UID ?= $(shell id -u)

--- a/Makefile
+++ b/Makefile
@@ -22,20 +22,33 @@ GO_SRCS := $(shell find . -type f -name '*.go' -not -path './$(K0S_GO_BUILD_CACH
 GO_CHECK_UNIT_DIRS := . ./cmd/... ./pkg/... ./internal/... ./static/... ./hack/...
 
 DOCKER ?= docker
+# Disable Docker build integration if DOCKER is set to the empty string.
+ifeq ($(DOCKER),)
+  GO_ENV_REQUISITES ?=
+  GO_ENV ?= PATH=$(abspath $(K0S_GO_BUILD_CACHE))/go/bin:"$$PATH" \
+    GOBIN="$(abspath $(K0S_GO_BUILD_CACHE))/go/bin" \
+    GOCACHE="$(abspath $(K0S_GO_BUILD_CACHE))/go/build" \
+    GOMODCACHE="$(abspath $(K0S_GO_BUILD_CACHE))/go/mod"
+  GO ?= $(GO_ENV) go
+else
+  GO_ENV_REQUISITES ?= .k0sbuild.docker-image.k0s
+  GO_ENV ?= $(DOCKER) run --rm \
+    -v '$(realpath $(K0S_GO_BUILD_CACHE))':/run/k0s-build \
+    -v '$(CURDIR)':/go/src/github.com/k0sproject/k0s \
+    -w /go/src/github.com/k0sproject/k0s \
+    -e GOOS \
+    -e CGO_ENABLED \
+    -e CGO_CFLAGS \
+    -e GOARCH \
+    --user $(BUILD_UID):$(BUILD_GID) \
+    -- '$(shell cat .k0sbuild.docker-image.k0s)'
+  GO ?= $(GO_ENV) go
+endif
+
 # EMBEDDED_BINS_BUILDMODE can be either:
 #   docker	builds the binaries in docker
 #   none	does not embed any binaries
-
-# Disable Docker build integration if DOCKER is set to the empty string.
-ifeq ($(DOCKER),)
-  EMBEDDED_BINS_BUILDMODE ?= none
-  K0S_BUILD_IMAGE_FILE =
-  GO ?= go
-else
-  EMBEDDED_BINS_BUILDMODE ?= docker
-  K0S_BUILD_IMAGE_FILE = .k0sbuild.docker-image.k0s
-  GO ?= $(GO_ENV) go
-endif
+EMBEDDED_BINS_BUILDMODE ?= docker
 
 # k0s runs on linux even if it's built on mac or windows
 TARGET_OS ?= linux
@@ -81,17 +94,6 @@ endif
 LD_FLAGS += $(BUILD_GO_LDFLAGS_EXTRA)
 
 GOLANG_IMAGE ?= $(golang_buildimage)
-K0S_GO_BUILD_CACHE_VOLUME_PATH=$(realpath $(K0S_GO_BUILD_CACHE))
-GO_ENV ?= $(DOCKER) run --rm \
-	-v '$(K0S_GO_BUILD_CACHE_VOLUME_PATH)':/run/k0s-build \
-	-v '$(CURDIR)':/go/src/github.com/k0sproject/k0s \
-	-w /go/src/github.com/k0sproject/k0s \
-	-e GOOS \
-	-e CGO_ENABLED \
-	-e CGO_CFLAGS \
-	-e GOARCH \
-	--user $(BUILD_UID):$(BUILD_GID) \
-	-- '$(shell cat $(K0S_BUILD_IMAGE_FILE))'
 
 # https://www.gnu.org/software/make/manual/make.html#index-spaces_002c-in-variable-values
 nullstring :=
@@ -114,12 +116,12 @@ all: k0s k0s.exe
 $(K0S_GO_BUILD_CACHE):
 	mkdir -p -- '$@'
 
-$(K0S_BUILD_IMAGE_FILE): build/Dockerfile embedded-bins/Makefile.variables | $(K0S_GO_BUILD_CACHE)
+.k0sbuild.docker-image.k0s: build/Dockerfile embedded-bins/Makefile.variables | $(K0S_GO_BUILD_CACHE)
 	$(DOCKER) build --progress=plain --iidfile '$@' \
 	  --build-arg BUILDIMAGE=$(GOLANG_IMAGE) \
-	  -t $(patsubst .%,%,$(K0S_BUILD_IMAGE_FILE)) - <build/Dockerfile
+	  -t k0sbuild.docker-image.k0s - <build/Dockerfile
 
-go.sum: go.mod $(K0S_BUILD_IMAGE_FILE)
+go.sum: go.mod $(GO_ENV_REQUISITES)
 	$(GO) mod tidy && touch -c -- '$@'
 
 # List of all the custom APIs that k0s defines.
@@ -132,7 +134,7 @@ $(foreach gv,$(api_group_versions),$(eval $(foreach t,$(api_group_version_target
 # Run controller-gen for each API group version.
 controller_gen_targets := $(foreach gv,$(api_group_versions),pkg/apis/$(gv)/.controller-gen.stamp)
 codegen_targets := $(controller_gen_targets)
-$(controller_gen_targets): $(K0S_BUILD_IMAGE_FILE) hack/tools/boilerplate.go.txt hack/tools/Makefile.variables
+$(controller_gen_targets): $(GO_ENV_REQUISITES) hack/tools/boilerplate.go.txt hack/tools/Makefile.variables
 	rm -rf 'static/_crds/$(dir $(@:pkg/apis/%/.controller-gen.stamp=%))'
 	gendir="$$(mktemp -d .controller-gen.tmp.XXXXXX)" \
 	  && trap "rm -rf -- $$gendir" INT EXIT \
@@ -146,7 +148,7 @@ $(controller_gen_targets): $(K0S_BUILD_IMAGE_FILE) hack/tools/boilerplate.go.txt
 # Run register-gen for each API group version.
 register_gen_targets := $(foreach gv,$(api_group_versions),pkg/apis/$(gv)/zz_generated.register.go)
 codegen_targets += $(register_gen_targets)
-$(register_gen_targets): $(K0S_BUILD_IMAGE_FILE) hack/tools/boilerplate.go.txt embedded-bins/Makefile.variables
+$(register_gen_targets): $(GO_ENV_REQUISITES) hack/tools/boilerplate.go.txt embedded-bins/Makefile.variables
 	CGO_ENABLED=0 $(GO) run k8s.io/code-generator/cmd/register-gen@v$(kubernetes_version:1.%=0.%) \
 	  --go-header-file=hack/tools/boilerplate.go.txt \
 	  --output-file='_$(notdir $@).tmp' \
@@ -161,7 +163,7 @@ $(register_gen_targets): $(K0S_BUILD_IMAGE_FILE) hack/tools/boilerplate.go.txt e
 clientset_input_dirs := $(foreach gv,$(api_group_versions),pkg/apis/$(gv))
 codegen_targets += pkg/client/clientset/.client-gen.stamp
 pkg/client/clientset/.client-gen.stamp: $(shell find $(clientset_input_dirs) -type f -name '*.go' -not -name '*_test.go' -not -name 'zz_generated*')
-pkg/client/clientset/.client-gen.stamp: $(K0S_BUILD_IMAGE_FILE) hack/tools/boilerplate.go.txt embedded-bins/Makefile.variables
+pkg/client/clientset/.client-gen.stamp: $(GO_ENV_REQUISITES) hack/tools/boilerplate.go.txt embedded-bins/Makefile.variables
 	gendir="$$(mktemp -d .client-gen.tmp.XXXXXX)" \
 	  && trap "rm -rf -- $$gendir" INT EXIT \
 	  && CGO_ENABLED=0 $(GO) run k8s.io/code-generator/cmd/client-gen@v$(kubernetes_version:1.%=0.%) \
@@ -182,7 +184,7 @@ codegen_targets += pkg/assets/zz_generated_offsets_$(TARGET_OS).go
 zz_os = $(patsubst pkg/assets/zz_generated_offsets_%.go,%,$@)
 pkg/assets/zz_generated_offsets_linux.go: .bins.linux.stamp
 pkg/assets/zz_generated_offsets_windows.go: .bins.windows.stamp
-pkg/assets/zz_generated_offsets_linux.go pkg/assets/zz_generated_offsets_windows.go: $(K0S_BUILD_IMAGE_FILE) go.sum
+pkg/assets/zz_generated_offsets_linux.go pkg/assets/zz_generated_offsets_windows.go: $(GO_ENV_REQUISITES) go.sum
 	GOOS=${GOHOSTOS} $(GO) run -tags=hack hack/gen-bindata/cmd/main.go -o bindata_$(zz_os) -pkg assets \
 	     -gofile pkg/assets/zz_generated_offsets_$(zz_os).go \
 	     -prefix embedded-bins/staging/$(zz_os)/ embedded-bins/staging/$(zz_os)/bin
@@ -190,12 +192,11 @@ endif
 
 k0s: TARGET_OS = linux
 k0s: BUILD_GO_CGO_ENABLED = 1
-k0s: $(K0S_BUILD_IMAGE_FILE)
 
 k0s.exe: TARGET_OS = windows
 k0s.exe: BUILD_GO_CGO_ENABLED = 0
 
-k0s.exe k0s: go.sum $(codegen_targets) $(GO_SRCS) $(shell find static/manifests/calico static/manifests/windows -type f)
+k0s.exe k0s: $(GO_ENV_REQUISITES) go.sum $(codegen_targets) $(GO_SRCS) $(shell find static/manifests/calico static/manifests/windows -type f)
 	rm -f -- '$@'
 	CGO_ENABLED=$(BUILD_GO_CGO_ENABLED) CGO_CFLAGS='$(BUILD_CGO_CFLAGS)' GOOS=$(TARGET_OS) $(GO) build $(BUILD_GO_FLAGS) -ldflags='$(LD_FLAGS)' -o '$@' main.go
 ifneq ($(EMBEDDED_BINS_BUILDMODE),none)
@@ -225,14 +226,14 @@ lint-copyright:
 
 .PHONY: lint-go
 lint-go: GOLANGCI_LINT_FLAGS ?=
-lint-go: $(K0S_BUILD_IMAGE_FILE) go.sum bindata
+lint-go: $(GO_ENV_REQUISITES) go.sum bindata
 	CGO_ENABLED=0 $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v$(golangci-lint_version)
 	CGO_CFLAGS='$(BUILD_CGO_CFLAGS)' $(GO_ENV) golangci-lint run --verbose --build-tags=$(subst $(space),$(comma),$(BUILD_GO_TAGS)) $(GOLANGCI_LINT_FLAGS) $(GO_LINT_DIRS)
 
 .PHONY: lint
 lint: lint-copyright lint-go
 
-airgap-images.txt: k0s $(K0S_BUILD_IMAGE_FILE)
+airgap-images.txt: k0s $(GO_ENV_REQUISITES)
 	$(GO_ENV) ./k0s airgap list-images --all > '$@'
 
 airgap-image-bundle-linux-amd64.tar: TARGET_PLATFORM := linux/amd64
@@ -265,7 +266,7 @@ else
 check-unit: GO_TEST_RACE ?= -race
 endif
 check-unit: BUILD_GO_TAGS += hack
-check-unit: $(K0S_BUILD_IMAGE_FILE) go.sum bindata
+check-unit: $(GO_ENV_REQUISITES) go.sum bindata
 	CGO_CFLAGS='$(BUILD_CGO_CFLAGS)' $(GO) test -tags=$(subst $(space),$(comma),$(BUILD_GO_TAGS)) $(GO_TEST_RACE) -ldflags='$(LD_FLAGS)' `$(GO) list -tags=$(subst $(space),$(comma),$(BUILD_GO_TAGS)) $(GO_CHECK_UNIT_DIRS)`
 
 .PHONY: clean-gocache
@@ -274,7 +275,7 @@ clean-gocache:
 	rm -rf -- '$(K0S_GO_BUILD_CACHE)/go'
 
 .PHONY: clean-docker-image
-clean-docker-image: IID_FILES = $(K0S_BUILD_IMAGE_FILE)
+clean-docker-image: IID_FILES = .k0sbuild.docker-image.k0s
 clean-docker-image:
 	$(clean-iid-files)
 

--- a/README.md
+++ b/README.md
@@ -138,23 +138,34 @@ The requirements for building k0s from source are as follows:
 All of the compilation steps are performed inside Docker containers, no
 installation of Go is required.
 
-The k0s binary can be built in two different ways:
+The k0s binary can be built in different ways:
 
 The "k0s" way, self-contained, all binaries compiled from source, statically
-linked and embedded:
+linked, including embedded binaries:
 
 ```shell
 make
 ```
 
-The "package maintainer" way, without any embedded binaries (requires that the
-required binaries are provided separately at runtime):
+The "package maintainer" way, without building and embedding the required
+binaries. This assumes necessary binaries are provided separately at runtime:
 
 ```shell
 make EMBEDDED_BINS_BUILDMODE=none
 ```
 
-The embedded binaries can be built on their own:
+Docker build integration is enabled by default. However, in environments without
+Docker, you can use the Go toolchain installed on the host system to build k0s
+without embedding binaries. Note that static linking is not possible with
+glibc-based toolchains:
+
+```shell
+make DOCKER='' EMBEDDED_BINS_BUILDMODE=none BUILD_GO_LDFLAGS_EXTRA=''
+```
+
+Note that the k0s build system does not currently support building the embedded
+binaries without Docker. However, the embedded binaries can be built
+independently using Docker:
 
 ```shell
 make -C embedded-bins


### PR DESCRIPTION
## Description

Don't default `EMBEDDED_BINS_BUILDMODE` to none when disabling Docker integration. This makes it clear that the binaries can't be built without it, at the moment. Inline the `K0S_BUILD_IMAGE_FILE` variable and replace it with the more generic `GO_ENV_REQUISITES`. Use the empty string to disable Docker integration: The previous sentinel value of "false" may have given the impression that "true" is the correct value to enable Docker build integration. Also, "false" is actually an executable provided by coreutils. An empty string can never point to a potentially executable file, and won't give the impression that DOCKER is some sort of boolean variable.

Document the new build variables in the README. 

Follow-up to:

* #5096

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings