### PR TITLE
Make calls to mktemp more portable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,12 +10,12 @@
 /k0s.exe.code
 /pkg/assets/zz_generated_offsets*.go
 .*.stamp
-.tmp
+*.tmp
+*.tmp.*
 .terraform
 .idea
 *.tfstate*
 aws_private.pem
-out.json
 .vscode
 .k0sbuild.docker-image.*
 docs/cli

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ controller_gen_targets := $(foreach gv,$(api_group_versions),pkg/apis/$(gv)/.con
 codegen_targets := $(controller_gen_targets)
 $(controller_gen_targets): $(K0S_BUILD_IMAGE_FILE) hack/tools/boilerplate.go.txt hack/tools/Makefile.variables
 	rm -rf 'static/_crds/$(dir $(@:pkg/apis/%/.controller-gen.stamp=%))'
-	gendir="$$(mktemp -d .controller-gen.XXXXXX.tmp)" \
+	gendir="$$(mktemp -d .controller-gen.tmp.XXXXXX)" \
 	  && trap "rm -rf -- $$gendir" INT EXIT \
 	  && CGO_ENABLED=0 $(GO) run sigs.k8s.io/controller-tools/cmd/controller-gen@v$(controller-gen_version) \
 	    paths="./$(dir $@)..." \
@@ -160,7 +160,7 @@ clientset_input_dirs := $(foreach gv,$(api_group_versions),pkg/apis/$(gv))
 codegen_targets += pkg/client/clientset/.client-gen.stamp
 pkg/client/clientset/.client-gen.stamp: $(shell find $(clientset_input_dirs) -type f -name '*.go' -not -name '*_test.go' -not -name 'zz_generated*')
 pkg/client/clientset/.client-gen.stamp: $(K0S_BUILD_IMAGE_FILE) hack/tools/boilerplate.go.txt embedded-bins/Makefile.variables
-	gendir="$$(mktemp -d .client-gen.XXXXXX.tmp)" \
+	gendir="$$(mktemp -d .client-gen.tmp.XXXXXX)" \
 	  && trap "rm -rf -- $$gendir" INT EXIT \
 	  && CGO_ENABLED=0 $(GO) run k8s.io/code-generator/cmd/client-gen@v$(kubernetes_version:1.%=0.%) \
 	    --go-header-file=hack/tools/boilerplate.go.txt \

--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -65,7 +65,7 @@ $(bindir)/kubelet.exe $(bindir)/kube-proxy.exe: .container.kubernetes.windows
 $(bindir)/containerd.exe $(bindir)/containerd-shim-runhcs-v1.exe: .container.containerd.windows
 
 $(addprefix $(bindir)/, $(bins)): | $(bindir)
-	tardir=$$(mktemp -d -- '.$(notdir $@).XXXXXX.tmp') \
+	tardir=$$(mktemp -d -- '.$(notdir $@).tmp.XXXXXX') \
 	  && trap "rm -rf -- $$tardir" INT EXIT \
 	  && docker export "$$(cat $<)" \
 	  | tar -C "$$tardir" -x bin/$(notdir $@) \


### PR DESCRIPTION
## Description

`mktemp` does not necessarily support the `XXXXXX` placeholder in the middle of the template string, so move all placeholder occurrences in template strings to the end. Adjust the gitignore file accordingly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings