### PR TITLE
Move hard-coded cgroup settings into worker profiles

### DIFF
--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -504,11 +504,12 @@ func (r *Reconciler) buildConfigMaps(snapshot *snapshot) ([]*corev1.ConfigMap, e
 	workerProfiles := make(map[string]*workerconfig.Profile)
 
 	workerProfile := r.buildProfile(snapshot)
-	workerProfile.KubeletConfiguration.CgroupsPerQOS = ptr.To(true)
 	workerProfiles["default"] = workerProfile
 
 	workerProfile = r.buildProfile(snapshot)
 	workerProfile.KubeletConfiguration.CgroupsPerQOS = ptr.To(false)
+	workerProfile.KubeletConfiguration.KubeReservedCgroup = ""
+	workerProfile.KubeletConfiguration.KubeletCgroups = ""
 	workerProfiles["default-windows"] = workerProfile
 
 	for _, profile := range snapshot.profiles {
@@ -597,6 +598,8 @@ func (r *Reconciler) buildProfile(snapshot *snapshot) *workerconfig.Profile {
 			},
 			ClusterDNS:         []string{r.clusterDNSIP.String()},
 			ClusterDomain:      r.clusterDomain,
+			KubeReservedCgroup: "system.slice",
+			KubeletCgroups:     "/system.slice/containerd.service",
 			TLSMinVersion:      "VersionTLS12",
 			TLSCipherSuites:    cipherSuites,
 			FailSwapOn:         ptr.To(false),

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -42,7 +42,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
-	"k8s.io/utils/ptr"
 
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
@@ -241,13 +240,6 @@ func (k *Kubelet) writeKubeletConfig() error {
 			taints = append(taints, parsedTaint)
 		}
 		config.RegisterWithTaints = taints
-	}
-
-	// cgroup related things (Linux only)
-	if runtime.GOOS == "linux" {
-		config.KubeReservedCgroup = "system.slice"
-		config.KubeletCgroups = "/system.slice/containerd.service"
-		config.CgroupsPerQOS = ptr.To(true)
 	}
 
 	configBytes, err := yaml.Marshal(config)


### PR DESCRIPTION
## Description

This makes them overridable. Also, don't set `cgroupsPerQOS` to true, which is the default anyway.

See:

* #4319
* #4954
* #4234

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings