### PR TITLE
Remove redundant logrus.SetOutput(stderr) statements

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"time"
 
-	k0slog "github.com/k0sproject/k0s/internal/pkg/log"
+	internallog "github.com/k0sproject/k0s/internal/pkg/log"
 	mw "github.com/k0sproject/k0s/internal/pkg/middleware"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/config"
@@ -56,7 +56,7 @@ func NewAPICmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			logrus.SetOutput(cmd.OutOrStdout())
-			k0slog.SetInfoLevel()
+			internallog.SetInfoLevel()
 			return config.CallParentPersistentPreRun(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/backup/backup_unix.go
+++ b/cmd/backup/backup_unix.go
@@ -43,10 +43,6 @@ func NewBackupCmd() *cobra.Command {
 		Use:   "backup",
 		Short: "Back-Up k0s configuration. Must be run as root (or with sudo)",
 		Args:  cobra.NoArgs,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			// ensure logs don't mess up output
-			logrus.SetOutput(cmd.ErrOrStderr())
-		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			opts, err := config.GetCmdOpts(cmd)
 			if err != nil {

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -34,7 +34,7 @@ import (
 	workercmd "github.com/k0sproject/k0s/cmd/worker"
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/file"
-	k0slog "github.com/k0sproject/k0s/internal/pkg/log"
+	internallog "github.com/k0sproject/k0s/internal/pkg/log"
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo"
 	"github.com/k0sproject/k0s/internal/sync/value"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
@@ -83,7 +83,7 @@ func NewControllerCmd() *cobra.Command {
 		Args: cobra.MaximumNArgs(1),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			logrus.SetOutput(cmd.OutOrStdout())
-			k0slog.SetInfoLevel()
+			internallog.SetInfoLevel()
 			return config.CallParentPersistentPreRun(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/etcd/list.go
+++ b/cmd/etcd/list.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/etcd"
-	"github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 )
@@ -32,10 +31,6 @@ func etcdListCmd() *cobra.Command {
 		Use:   "member-list",
 		Short: "List etcd cluster members (JSON encoded)",
 		Args:  cobra.NoArgs,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			// ensure logs don't mess up the output
-			logrus.SetOutput(cmd.ErrOrStderr())
-		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			opts, err := config.GetCmdOpts(cmd)
 			if err != nil {

--- a/cmd/kubeconfig/admin.go
+++ b/cmd/kubeconfig/admin.go
@@ -26,7 +26,6 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -39,10 +38,6 @@ func kubeConfigAdminCmd() *cobra.Command {
 	$ export KUBECONFIG=~/.kube/config
 	$ kubectl get nodes`,
 		Args: cobra.NoArgs,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			// ensure logs don't mess up the output
-			logrus.SetOutput(cmd.ErrOrStderr())
-		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			opts, err := config.GetCmdOpts(cmd)
 			if err != nil {

--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -46,10 +45,6 @@ Note: A certificate once signed cannot be revoked for a particular user`,
 
 	optionally add groups:
 	$ k0s kubeconfig create username --groups [groups]`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			// ensure logs don't mess up the output
-			logrus.SetOutput(cmd.ErrOrStderr())
-		},
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			username := args[0]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,7 +42,7 @@ import (
 	"github.com/k0sproject/k0s/cmd/validate"
 	"github.com/k0sproject/k0s/cmd/version"
 	"github.com/k0sproject/k0s/cmd/worker"
-	k0slog "github.com/k0sproject/k0s/internal/pkg/log"
+	internallog "github.com/k0sproject/k0s/internal/pkg/log"
 	"github.com/k0sproject/k0s/pkg/build"
 	"github.com/k0sproject/k0s/pkg/config"
 
@@ -61,12 +61,12 @@ func NewRootCmd() *cobra.Command {
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if config.Verbose {
-				k0slog.SetInfoLevel()
+				internallog.SetInfoLevel()
 			}
 
 			if config.Debug {
 				// TODO: check if it actually works and is not overwritten by something else
-				k0slog.SetDebugLevel()
+				internallog.SetDebugLevel()
 
 				go func() {
 					log := logrus.WithField("debug_server", config.DebugListenOn)

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -25,7 +25,7 @@ import (
 	"runtime"
 	"syscall"
 
-	k0slog "github.com/k0sproject/k0s/internal/pkg/log"
+	internallog "github.com/k0sproject/k0s/internal/pkg/log"
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo"
 	"github.com/k0sproject/k0s/pkg/build"
 	"github.com/k0sproject/k0s/pkg/component/iptables"
@@ -61,7 +61,7 @@ func NewWorkerCmd() *cobra.Command {
 		Args: cobra.MaximumNArgs(1),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			logrus.SetOutput(cmd.OutOrStdout())
-			k0slog.SetInfoLevel()
+			internallog.SetInfoLevel()
 			return config.CallParentPersistentPreRun(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/main.go
+++ b/main.go
@@ -23,13 +23,13 @@ import (
 	"strings"
 
 	"github.com/k0sproject/k0s/cmd"
-	k0slog "github.com/k0sproject/k0s/internal/pkg/log"
+	internallog "github.com/k0sproject/k0s/internal/pkg/log"
 )
 
 //go:generate make codegen
 
 func init() {
-	k0slog.InitLogging()
+	internallog.InitLogging()
 }
 
 func main() {


### PR DESCRIPTION
## Description

Logrus writes to stderr by default, and k0s doesn't change this in its initialization process. Only the few long-running sub-commands change this to stdout themselves.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings