### PR TITLE
Compile UnmountLazy just for Linux

### DIFF
--- a/pkg/cleanup/unmount_linux.go
+++ b/pkg/cleanup/unmount_linux.go
@@ -16,8 +16,10 @@ limitations under the License.
 
 package cleanup
 
-import "fmt"
+import (
+	"golang.org/x/sys/unix"
+)
 
 func UnmountLazy(path string) error {
-	return fmt.Errorf("lazy unmount is not supported on Windows for path: %s", path)
+	return unix.Unmount(path, unix.MNT_DETACH)
 }

--- a/pkg/cleanup/unmount_other.go
+++ b/pkg/cleanup/unmount_other.go
@@ -1,4 +1,4 @@
-//go:build unix
+//go:build !linux
 
 /*
 Copyright 2024 k0s authors
@@ -19,9 +19,11 @@ limitations under the License.
 package cleanup
 
 import (
-	"golang.org/x/sys/unix"
+	"errors"
+	"fmt"
+	"runtime"
 )
 
-func UnmountLazy(path string) error {
-	return unix.Unmount(path, unix.MNT_DETACH)
+func UnmountLazy(string) error {
+	return fmt.Errorf("%w on %s", errors.ErrUnsupported, runtime.GOOS)
 }


### PR DESCRIPTION
## Description

`MNT_DETACH` is defined for Linux only, hence change the build tag from unix to linux and provide a fallback for everything non-Linux.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings