### PR TITLE
Some small improvements to inttests

### DIFF
--- a/inttest/containerdimports/containerd_imports_test.go
+++ b/inttest/containerdimports/containerd_imports_test.go
@@ -38,17 +38,16 @@ func (s *ContainerdImportsSuite) TestK0sGetsUp() {
 	s.Require().NoError(err)
 	defer ssh.Disconnect()
 
-	s.NoError(s.InitController(0))
+	s.Require().NoError(s.InitController(0))
 
-	s.NoError(s.RunWorkers())
+	s.Require().NoError(s.RunWorkers())
 
 	kc, err := s.KubeClient(s.ControllerNode(0))
 	if err != nil {
 		s.FailNow("failed to obtain Kubernetes client", err)
 	}
 
-	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
-	s.NoError(err)
+	s.Require().NoError(s.WaitForNodeReady(s.WorkerNode(0), kc))
 
 	s.AssertSomeKubeSystemPods(kc)
 


### PR DESCRIPTION
## Description

Only use stdout when fetching the kubeconfig in `GetKubeConfig`. This make the command work even when it logs something to stderr.

When `clientcmd.RESTConfigFromKubeConfig` failed, the error was checked too late, resulting in a panic.

Be fail-fast on some bootstrap errors in one inttest.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings