### PR TITLE
Ensure iface.FirstPublicAddress isn't a secondary IP

### DIFF
--- a/internal/pkg/iface/iface.go
+++ b/internal/pkg/iface/iface.go
@@ -82,19 +82,20 @@ func FirstPublicAddress() (string, error) {
 		case strings.HasPrefix(i.Name, "cali"):
 			continue
 		}
-		addresses, err := i.Addrs()
+
+		addresses, err := interfaceAddrs(i)
 		if err != nil {
-			logrus.Warnf("failed to get addresses for interface %s: %s", i.Name, err.Error())
+			logrus.WithError(err).Warn("Skipping network interface ", i.Name)
 			continue
 		}
-		for _, a := range addresses {
+		for a := range addresses {
 			// check the address type and skip if loopback
-			if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-				if ipnet.IP.To4() != nil {
-					return ipnet.IP.String(), nil
+			if a != nil && !a.IP.IsLoopback() {
+				if a.IP.To4() != nil {
+					return a.IP.String(), nil
 				}
-				if ipnet.IP.To16() != nil && ipv6addr == "" {
-					ipv6addr = ipnet.IP.String()
+				if a.IP.To16() != nil && ipv6addr == "" {
+					ipv6addr = a.IP.String()
 				}
 			}
 		}

--- a/internal/pkg/iface/iface_linux.go
+++ b/internal/pkg/iface/iface_linux.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package iface
+
+import (
+	"fmt"
+	"iter"
+	"net"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+func interfaceAddrs(i net.Interface) (iter.Seq[*net.IPNet], error) {
+	link, err := netlink.LinkByName(i.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get link by name: %w", err)
+	}
+
+	addresses, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list IP addresses: %w", err)
+	}
+
+	return func(yield func(*net.IPNet) bool) {
+		for _, a := range addresses {
+			// skip secondary addresses. This is to avoid returning VIPs as the public address
+			// https://github.com/k0sproject/k0s/issues/4664
+			if a.Flags&unix.IFA_F_SECONDARY != 0 {
+				continue
+			}
+
+			if a.IPNet != nil {
+				if !yield(a.IPNet) {
+					return
+				}
+			}
+		}
+	}, nil
+}

--- a/internal/pkg/iface/iface_other.go
+++ b/internal/pkg/iface/iface_other.go
@@ -1,0 +1,42 @@
+//go:build !linux
+
+/*
+Copyright 2025 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package iface
+
+import (
+	"fmt"
+	"iter"
+	"net"
+)
+
+func interfaceAddrs(i net.Interface) (iter.Seq[*net.IPNet], error) {
+	addresses, err := i.Addrs()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list interface addresses: %w", err)
+	}
+
+	return func(yield func(*net.IPNet) bool) {
+		for _, a := range addresses {
+			if ipnet, ok := a.(*net.IPNet); ok && ipnet != nil {
+				if !yield(ipnet) {
+					return
+				}
+			}
+		}
+	}, nil
+}


### PR DESCRIPTION
## Description

This fixes only the automatic address detection for etcd. If a user configures them manually it doesn't attempt to prevent the error.

Fixes #4664

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings