### PR TITLE
Remove some unused Autopilot constants

### DIFF
--- a/pkg/autopilot/constant/static.go
+++ b/pkg/autopilot/constant/static.go
@@ -17,12 +17,7 @@ package constant
 const (
 	AutopilotName                      = "autopilot"
 	AutopilotNamespace                 = "k0s-autopilot"
-	AutopilotConfigName                = AutopilotName
-	K0sBinaryDir                       = "/usr/local/bin"
 	K0sTempFilename                    = "k0s.tmp"
-	K0sDefaultDataDir                  = "/var/lib/k0s"
-	K0sManifestSubDir                  = "manifests"
-	K0sImagesDir                       = "images"
 	K0SControlNodeModeAnnotation       = "autopilot.k0sproject.io/mode"
 	K0SControlNodeModeController       = "controller"
 	K0SControlNodeModeControllerWorker = "controller+worker"

--- a/pkg/autopilot/controller/signal/airgap/download.go
+++ b/pkg/autopilot/controller/signal/airgap/download.go
@@ -18,7 +18,6 @@ import (
 	"crypto/sha256"
 	"path"
 
-	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	apsigcomm "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common"
 	apdl "github.com/k0sproject/k0s/pkg/autopilot/download"
@@ -63,7 +62,7 @@ func (b downloadManfiestBuilderAirgap) Build(signalNode crcli.Object, signalData
 			URL:          signalData.Command.AirgapUpdate.URL,
 			ExpectedHash: signalData.Command.AirgapUpdate.Sha256,
 			Hasher:       sha256.New(),
-			DownloadDir:  path.Join(b.k0sDataDir, apconst.K0sImagesDir),
+			DownloadDir:  path.Join(b.k0sDataDir, "images"),
 		},
 		SuccessState: apsigcomm.Completed,
 	}


### PR DESCRIPTION
## Description

... and inline one constant that's used only once.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings