### PR TITLE
Clean up cfgvars error handling and tests

### DIFF
--- a/pkg/config/cfgvars.go
+++ b/pkg/config/cfgvars.go
@@ -174,7 +174,7 @@ func NewCfgVars(cobraCmd command, dirs ...string) (*CfgVars, error) {
 	}
 	kubeletRootDir, err = filepath.Abs(kubeletRootDir)
 	if err != nil {
-		return nil, fmt.Errorf("invalid kubeletRootDir: %w", err)
+		return nil, err
 	}
 
 	var runDir string

--- a/pkg/config/cfgvars_test.go
+++ b/pkg/config/cfgvars_test.go
@@ -82,7 +82,7 @@ func TestWithCommand(t *testing.T) {
 	WithCommand(fakeCmd)(c)
 
 	dir, err := filepath.Abs("/path/to/kubelet")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Same(t, in, c.stdin)
 	assert.Equal(t, "/path/to/data", c.DataDir)
@@ -149,7 +149,7 @@ func TestNewCfgVars_DataDir(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c, err := NewCfgVars(tt.fakeCmd, tt.dirs...)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected.DataDir, c.DataDir)
 		})
 	}
@@ -186,9 +186,9 @@ func TestNewCfgVars_KubeletRootDir(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c, err := NewCfgVars(tt.fakeCmd, tt.dirs...)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			expected, err := filepath.Abs(tt.expected.KubeletRootDir)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expected, c.KubeletRootDir)
 		})
 	}


### PR DESCRIPTION
Use requires instead of assert when there is no point in testing the next.

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings