### PR TITLE
Show help again for non-leaf subcommands

### DIFF
--- a/cmd/airgap/airgap.go
+++ b/cmd/airgap/airgap.go
@@ -17,9 +17,10 @@ limitations under the License.
 package airgap
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/k0sproject/k0s/pkg/config"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func NewAirgapCmd() *cobra.Command {
@@ -27,7 +28,7 @@ func NewAirgapCmd() *cobra.Command {
 		Use:   "airgap",
 		Short: "Manage airgap setup",
 		Args:  cobra.NoArgs,
-		Run:   func(*cobra.Command, []string) { /* Enforce arg validation. */ },
+		RunE:  func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
 	}
 
 	cmd.AddCommand(NewAirgapListImagesCmd())

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func NewConfigCmd() *cobra.Command {
@@ -25,7 +26,7 @@ func NewConfigCmd() *cobra.Command {
 		Use:   "config",
 		Short: "Configuration related sub-commands",
 		Args:  cobra.NoArgs,
-		Run:   func(*cobra.Command, []string) { /* Enforce arg validation. */ },
+		RunE:  func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
 	}
 	cmd.AddCommand(NewCreateCmd())
 	cmd.AddCommand(NewEditCmd())

--- a/cmd/etcd/etcd.go
+++ b/cmd/etcd/etcd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/config"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func NewEtcdCmd() *cobra.Command {
@@ -52,7 +53,7 @@ func NewEtcdCmd() *cobra.Command {
 			}
 			return nil
 		},
-		Run: func(*cobra.Command, []string) { /* Enforce arg validation. */ },
+		RunE: func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
 	}
 	cmd.AddCommand(etcdLeaveCmd())
 	cmd.AddCommand(etcdListCmd())

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -25,6 +25,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/install"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type command config.CLIOptions
@@ -41,7 +42,7 @@ func NewInstallCmd() *cobra.Command {
 		Use:   "install",
 		Short: "Install k0s on a brand-new system. Must be run as root (or with sudo)",
 		Args:  cobra.NoArgs,
-		Run:   func(*cobra.Command, []string) { /* Enforce arg validation. */ },
+		RunE:  func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
 	}
 
 	cmd.AddCommand(installControllerCmd(&installFlags))

--- a/cmd/kubeconfig/kubeconfig.go
+++ b/cmd/kubeconfig/kubeconfig.go
@@ -20,6 +20,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/config"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func NewKubeConfigCmd() *cobra.Command {
@@ -27,7 +28,7 @@ func NewKubeConfigCmd() *cobra.Command {
 		Use:   "kubeconfig [command]",
 		Short: "Create a kubeconfig file for a specified user",
 		Args:  cobra.NoArgs,
-		Run:   func(*cobra.Command, []string) { /* Enforce arg validation. */ },
+		RunE:  func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
 	}
 	cmd.AddCommand(kubeconfigCreateCmd())
 	cmd.AddCommand(kubeConfigAdminCmd())

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -22,6 +22,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/token"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func NewTokenCmd() *cobra.Command {
@@ -29,7 +30,7 @@ func NewTokenCmd() *cobra.Command {
 		Use:   "token",
 		Short: "Manage join tokens",
 		Args:  cobra.NoArgs,
-		Run:   func(*cobra.Command, []string) { /* Enforce arg validation. */ },
+		RunE:  func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
 	}
 
 	cmd.AddCommand(tokenCreateCmd())


### PR DESCRIPTION
## Description

Adding a run function to enable argument validation also disabled the default behavior of displaying the help text. Restore this by explicitly returning the "help requested" error.

Fixes:

* #5382

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings