### PR TITLE
Remove legacy runtime config migration

### DIFF
--- a/pkg/config/runtime_test.go
+++ b/pkg/config/runtime_test.go
@@ -24,38 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLoadRuntimeConfig_Legacy(t *testing.T) {
-	tmpfile, err := os.CreateTemp("", "runtime-config")
-	assert.NoError(t, err)
-	defer os.Remove(tmpfile.Name())
-
-	// prepare k0sVars
-	k0sVars := &CfgVars{
-		DataDir:           "/var/lib/k0s-custom",
-		RuntimeConfigPath: tmpfile.Name(),
-	}
-
-	content := []byte(`apiVersion: k0s.k0sproject.io/v1beta1
-kind: ClusterConfig
-metadata:
-  name: k0s
-spec:
-  api:
-    address: 10.2.3.4
-`)
-	err = os.WriteFile(k0sVars.RuntimeConfigPath, content, 0644)
-	assert.NoError(t, err)
-
-	spec, err := LoadRuntimeConfig(k0sVars)
-	assert.NoError(t, err)
-	assert.NotNil(t, spec)
-	assert.Equal(t, "/var/lib/k0s-custom", spec.K0sVars.DataDir)
-	assert.Equal(t, os.Getpid(), spec.Pid)
-	assert.NotNil(t, spec.NodeConfig)
-	assert.NotNil(t, spec.NodeConfig.Spec.API)
-	assert.Equal(t, "10.2.3.4", spec.NodeConfig.Spec.API.Address)
-}
-
 func TestLoadRuntimeConfig_K0sNotRunning(t *testing.T) {
 	// create a temporary file for runtime config
 	tmpfile, err := os.CreateTemp("", "runtime-config")


### PR DESCRIPTION
## Description

The legacy config has been replaced for quite some releases already. So this migration code is no longer required.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings