### PR TITLE
Let API subcommand accept the runtime config via stdin

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -165,7 +165,7 @@ func (c *command) start(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize runtime config: %w", err)
 	}
 	defer func() {
-		if err := rtc.Cleanup(); err != nil {
+		if err := rtc.Spec.Cleanup(); err != nil {
 			logrus.WithError(err).Warn("Failed to cleanup runtime config")
 		}
 	}()
@@ -329,10 +329,7 @@ func (c *command) start(ctx context.Context) error {
 	}
 
 	if !c.SingleNode && !slices.Contains(c.DisableComponents, constant.ControlAPIComponentName) {
-		nodeComponents.Add(ctx, &controller.K0SControlAPI{
-			ConfigPath: c.CfgFile,
-			K0sVars:    c.K0sVars,
-		})
+		nodeComponents.Add(ctx, &controller.K0SControlAPI{RuntimeConfig: rtc})
 	}
 
 	if !slices.Contains(c.DisableComponents, constant.CsrApproverComponentName) {

--- a/pkg/config/runtime_test.go
+++ b/pkg/config/runtime_test.go
@@ -70,15 +70,16 @@ func TestNewRuntimeConfig(t *testing.T) {
 	}
 
 	// create a new runtime config and check if it's valid
-	spec, err := NewRuntimeConfig(k0sVars)
+	cfg, err := NewRuntimeConfig(k0sVars)
+	spec := cfg.Spec
 	assert.NoError(t, err)
 	assert.NotNil(t, spec)
 	assert.Same(t, k0sVars, spec.K0sVars)
 	assert.Equal(t, os.Getpid(), spec.Pid)
 	assert.NotNil(t, spec.NodeConfig)
-	cfg, err := spec.K0sVars.NodeConfig()
+	nodeConfig, err := spec.K0sVars.NodeConfig()
 	assert.NoError(t, err)
-	assert.Equal(t, "10.0.0.1", cfg.Spec.API.Address)
+	assert.Equal(t, "10.0.0.1", nodeConfig.Spec.API.Address)
 	assert.FileExists(t, rtConfigPath)
 
 	// try to create a new runtime config when one is already active and check if it returns an error

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -44,6 +45,7 @@ type Supervisor struct {
 	BinPath        string
 	RunDir         string
 	DataDir        string
+	Stdin          func() io.Reader
 	Args           []string
 	PidFile        string
 	UID            int
@@ -174,6 +176,9 @@ func (s *Supervisor) Supervise() error {
 				s.cmd = exec.Command(s.BinPath, s.Args...)
 				s.cmd.Dir = s.DataDir
 				s.cmd.Env = getEnv(s.DataDir, s.Name, s.KeepEnvPrefix)
+				if s.Stdin != nil {
+					s.cmd.Stdin = s.Stdin()
+				}
 
 				// detach from the process group so children don't
 				// get signals sent directly to parent.


### PR DESCRIPTION
## Description

The API subcommand is not designed to run as a standalone process. Rather, it's intended to be executed under the supervision of a k0s controller. Therefore, the usual way of loading the configuration is inappropriate. Instead, have this subcommand accept the runtime configuration via stdin. This will prevent a false fallback to a generated default configuration, as well as loading the configuration from a possibly existing default configuration file that has nothing to do with the one used by the supervising process.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings