### PR TITLE
Only use persistent flags if appropriate

### DIFF
--- a/cmd/airgap/airgap.go
+++ b/cmd/airgap/airgap.go
@@ -31,8 +31,16 @@ func NewAirgapCmd() *cobra.Command {
 		RunE:  func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
 	}
 
+	var deprecatedFlags pflag.FlagSet
+	deprecatedFlags.AddFlagSet(config.GetPersistentFlagSet())
+	deprecatedFlags.AddFlagSet(config.FileInputFlag())
+	deprecatedFlags.VisitAll(func(f *pflag.Flag) {
+		f.Hidden = true
+		f.Deprecated = "it has no effect and will be removed in a future release"
+		cmd.PersistentFlags().AddFlag(f)
+	})
+
 	cmd.AddCommand(NewAirgapListImagesCmd())
-	cmd.PersistentFlags().AddFlagSet(config.FileInputFlag())
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+
 	return cmd
 }

--- a/cmd/airgap/listimages.go
+++ b/cmd/airgap/listimages.go
@@ -53,8 +53,11 @@ func NewAirgapListImagesCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().AddFlagSet(config.FileInputFlag())
-	cmd.Flags().BoolVar(&all, "all", false, "include all images, even if they are not used in the current configuration")
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.AddFlagSet(config.FileInputFlag())
+	flags.BoolVar(&all, "all", false, "include all images, even if they are not used in the current configuration")
+
 	return cmd
 }

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -67,7 +67,9 @@ func NewAPICmd() *cobra.Command {
 			return (&command{CLIOptions: opts}).start()
 		},
 	}
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+
+	cmd.Flags().AddFlagSet(config.GetPersistentFlagSet())
+
 	return cmd
 }
 

--- a/cmd/backup/backup_unix.go
+++ b/cmd/backup/backup_unix.go
@@ -59,8 +59,11 @@ func NewBackupCmd() *cobra.Command {
 			return c.backup(savePath, cmd.OutOrStdout())
 		},
 	}
-	cmd.Flags().StringVar(&savePath, "save-path", "", "destination directory path for backup assets, use '-' for stdout")
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.StringVar(&savePath, "save-path", "", "destination directory path for backup assets, use '-' for stdout")
+
 	return cmd
 }
 

--- a/cmd/config/create.go
+++ b/cmd/config/create.go
@@ -55,7 +55,10 @@ func NewCreateCmd() *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().BoolVar(&includeImages, "include-images", false, "include the default images in the output")
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.BoolVar(&includeImages, "include-images", false, "include the default images in the output")
+
 	return cmd
 }

--- a/cmd/config/edit.go
+++ b/cmd/config/edit.go
@@ -31,6 +31,8 @@ func NewEditCmd() *cobra.Command {
 			return reExecKubectl(cmd, "-n", "kube-system", "edit", "clusterconfig", "k0s")
 		},
 	}
-	cmd.PersistentFlags().AddFlagSet(config.GetKubeCtlFlagSet())
+
+	cmd.Flags().AddFlagSet(config.GetKubeCtlFlagSet())
+
 	return cmd
 }

--- a/cmd/config/status.go
+++ b/cmd/config/status.go
@@ -38,7 +38,10 @@ func NewStatusCmd() *cobra.Command {
 			return reExecKubectl(cmd, args...)
 		},
 	}
-	cmd.PersistentFlags().AddFlagSet(config.GetKubeCtlFlagSet())
-	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format. Must be one of yaml|json")
+
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetKubeCtlFlagSet())
+	flags.StringVarP(&outputFormat, "output", "o", "", "Output format. Must be one of yaml|json")
+
 	return cmd
 }

--- a/cmd/config/validate.go
+++ b/cmd/config/validate.go
@@ -62,8 +62,10 @@ func NewValidateCmd() *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
-	cmd.Flags().AddFlagSet(config.FileInputFlag())
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.AddFlagSet(config.FileInputFlag())
 	_ = cmd.MarkFlagRequired("config")
+
 	return cmd
 }

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -121,11 +121,12 @@ func NewControllerCmd() *cobra.Command {
 		},
 	}
 
-	// append flags
-	cmd.Flags().BoolVar(&ignorePreFlightChecks, "ignore-pre-flight-checks", false, "continue even if pre-flight checks fail")
-	cmd.Flags().AddFlagSet(config.GetPersistentFlagSet())
-	cmd.PersistentFlags().AddFlagSet(config.GetControllerFlags())
-	cmd.PersistentFlags().AddFlagSet(config.GetWorkerFlags())
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.AddFlagSet(config.GetControllerFlags())
+	flags.AddFlagSet(config.GetWorkerFlags())
+	flags.BoolVar(&ignorePreFlightChecks, "ignore-pre-flight-checks", false, "continue even if pre-flight checks fail")
+
 	return cmd
 }
 

--- a/cmd/etcd/etcd.go
+++ b/cmd/etcd/etcd.go
@@ -55,8 +55,11 @@ func NewEtcdCmd() *cobra.Command {
 		},
 		RunE: func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
 	}
+
+	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+
 	cmd.AddCommand(etcdLeaveCmd())
 	cmd.AddCommand(etcdListCmd())
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+
 	return cmd
 }

--- a/cmd/etcd/leave.go
+++ b/cmd/etcd/leave.go
@@ -86,13 +86,14 @@ func etcdLeaveCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().AddFlag(&pflag.Flag{
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.AddFlag(&pflag.Flag{
 		Name:  "peer-address",
 		Usage: "etcd peer address to remove (default <this node's peer address>)",
 		Value: (*ipOrDNSName)(&peerAddressArg),
 	})
 
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	return cmd
 }
 

--- a/cmd/etcd/list.go
+++ b/cmd/etcd/list.go
@@ -52,6 +52,8 @@ func etcdListCmd() *cobra.Command {
 			return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]interface{}{"members": members})
 		},
 	}
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+
+	cmd.Flags().AddFlagSet(config.GetPersistentFlagSet())
+
 	return cmd
 }

--- a/cmd/install/controller.go
+++ b/cmd/install/controller.go
@@ -81,9 +81,11 @@ With the controller subcommand you can setup a single node cluster by running:
 			return nil
 		},
 	}
-	// append flags
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
-	cmd.Flags().AddFlagSet(config.GetControllerFlags())
-	cmd.Flags().AddFlagSet(config.GetWorkerFlags())
+
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.AddFlagSet(config.GetControllerFlags())
+	flags.AddFlagSet(config.GetWorkerFlags())
+
 	return cmd
 }

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -18,7 +18,6 @@ package install
 
 import (
 	"github.com/k0sproject/k0s/pkg/config"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -38,11 +37,17 @@ func NewInstallCmd() *cobra.Command {
 		RunE:  func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
 	}
 
+	pflags := cmd.PersistentFlags()
+	config.GetPersistentFlagSet().VisitAll(func(f *pflag.Flag) {
+		f.Hidden = true
+		f.Deprecated = "it has no effect and will be removed in a future release"
+		pflags.AddFlag(f)
+	})
+	pflags.BoolVar(&installFlags.force, "force", false, "force init script creation")
+	pflags.StringArrayVarP(&installFlags.envVars, "env", "e", nil, "set environment variable")
+
 	cmd.AddCommand(installWorkerCmd(&installFlags))
 	addPlatformSpecificCommands(cmd, &installFlags)
 
-	cmd.PersistentFlags().BoolVar(&installFlags.force, "force", false, "force init script creation")
-	cmd.PersistentFlags().StringArrayVarP(&installFlags.envVars, "env", "e", nil, "set environment variable")
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	return cmd
 }

--- a/cmd/install/worker.go
+++ b/cmd/install/worker.go
@@ -55,9 +55,10 @@ Windows flags like "--api-server", "--cidr-range" and "--cluster-dns" will be ig
 			return nil
 		},
 	}
-	// append flags
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
-	cmd.PersistentFlags().AddFlagSet(config.GetWorkerFlags())
+
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.AddFlagSet(config.GetWorkerFlags())
 
 	return cmd
 }

--- a/cmd/kubeconfig/admin.go
+++ b/cmd/kubeconfig/admin.go
@@ -82,6 +82,8 @@ func kubeConfigAdminCmd() *cobra.Command {
 			return err
 		},
 	}
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+
+	cmd.Flags().AddFlagSet(config.GetPersistentFlagSet())
+
 	return cmd
 }

--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -72,9 +72,11 @@ Note: A certificate once signed cannot be revoked for a particular user`,
 		},
 	}
 
-	cmd.Flags().AddFlagSet(config.FileInputFlag())
-	cmd.Flags().StringVar(&groups, "groups", "", "Specify groups")
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.AddFlagSet(config.FileInputFlag())
+	flags.StringVar(&groups, "groups", "", "Specify groups")
+
 	return cmd
 }
 

--- a/cmd/kubeconfig/kubeconfig.go
+++ b/cmd/kubeconfig/kubeconfig.go
@@ -30,8 +30,15 @@ func NewKubeConfigCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE:  func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
 	}
+
+	config.GetPersistentFlagSet().VisitAll(func(f *pflag.Flag) {
+		f.Hidden = true
+		f.Deprecated = "it has no effect and will be removed in a future release"
+		cmd.PersistentFlags().AddFlag(f)
+	})
+
 	cmd.AddCommand(kubeconfigCreateCmd())
 	cmd.AddCommand(kubeConfigAdminCmd())
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+
 	return cmd
 }

--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -47,9 +47,9 @@ func NewResetCmd() *cobra.Command {
 			return c.reset()
 		},
 	}
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 
 	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
 	flags.AddFlagSet(config.GetCriSocketFlag())
 	flags.AddFlagSet(config.FileInputFlag())
 	flags.String("kubelet-root-dir", "", "Kubelet root directory for k0s")

--- a/cmd/restore/restore_unix.go
+++ b/cmd/restore/restore_unix.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -62,13 +61,7 @@ func NewRestoreCmd() *cobra.Command {
 		},
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		logrus.Fatal("failed to get local path")
-	}
-
-	restoredConfigPathDescription := fmt.Sprintf("Specify desired name and full path for the restored k0s.yaml file (default: %s/k0s_<archive timestamp>.yaml", cwd)
-	cmd.Flags().StringVar(&restoredConfigPath, "config-out", "", restoredConfigPathDescription)
+	cmd.Flags().StringVar(&restoredConfigPath, "config-out", "", "Specify desired name and full path for the restored k0s.yaml file (default: k0s_<archive timestamp>.yaml")
 	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
 	return cmd
 }
@@ -113,11 +106,5 @@ func defaultConfigFileOutputPath(archivePath string) string {
 	f := filepath.Base(archivePath)
 	nameWithoutExt := strings.Split(f, ".")[0]
 	fName := strings.TrimPrefix(nameWithoutExt, "k0s_backup_")
-	restoredFileName := fmt.Sprintf("k0s_%s.yaml", fName)
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		return ""
-	}
-	return path.Join(cwd, restoredFileName)
+	return fmt.Sprintf("k0s_%s.yaml", fName)
 }

--- a/cmd/restore/restore_unix.go
+++ b/cmd/restore/restore_unix.go
@@ -61,8 +61,10 @@ func NewRestoreCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&restoredConfigPath, "config-out", "", "Specify desired name and full path for the restored k0s.yaml file (default: k0s_<archive timestamp>.yaml")
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.StringVar(&restoredConfigPath, "config-out", "", "Specify desired name and full path for the restored k0s.yaml file (default: k0s_<archive timestamp>.yaml")
+
 	return cmd
 }
 

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -32,6 +32,7 @@ import (
 
 func NewStatusCmd() *cobra.Command {
 	var output string
+
 	cmd := &cobra.Command{
 		Use:     "status",
 		Short:   "Get k0s instance status information",
@@ -56,14 +57,18 @@ func NewStatusCmd() *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&output, "out", "o", "", "sets type of output to json or yaml")
 	cmd.PersistentFlags().String("status-socket", "", "Full file path to the socket file. (default: <rundir>/status.sock)")
+
 	cmd.AddCommand(NewStatusSubCmdComponents())
+
+	cmd.Flags().StringVarP(&output, "out", "o", "", "sets type of output to json or yaml")
+
 	return cmd
 }
 
 func NewStatusSubCmdComponents() *cobra.Command {
 	var maxCount int
+
 	cmd := &cobra.Command{
 		Use:     "components",
 		Short:   "Get k0s instance component status information",
@@ -87,9 +92,15 @@ func NewStatusSubCmdComponents() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().IntVar(&maxCount, "max-count", 1, "how many latest probes to show")
-	return cmd
 
+	flags := cmd.Flags()
+	flags.IntVar(&maxCount, "max-count", 1, "how many latest probes to show")
+	flags.StringP("out", "o", "", "")
+	outFlag := flags.Lookup("out")
+	outFlag.Hidden = true
+	outFlag.Deprecated = "it has no effect and will be removed in a future release"
+
+	return cmd
 }
 
 func printStatus(w io.Writer, status *status.K0sStatus, output string) {

--- a/cmd/token/create.go
+++ b/cmd/token/create.go
@@ -98,11 +98,12 @@ k0s token create --role worker --expiry 10m  //sets expiration time to 10 minute
 			return nil
 		},
 	}
-	// append flags
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
-	cmd.Flags().StringVar(&tokenExpiry, "expiry", "0s", "Expiration time of the token. Format 1.5h, 2h45m or 300ms.")
-	cmd.Flags().StringVar(&createTokenRole, "role", "worker", "Either worker or controller")
-	cmd.Flags().BoolVar(&waitCreate, "wait", false, "wait forever (default false)")
+
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.StringVar(&tokenExpiry, "expiry", "0s", "Expiration time of the token. Format 1.5h, 2h45m or 300ms.")
+	flags.StringVar(&createTokenRole, "role", "worker", "Either worker or controller")
+	flags.BoolVar(&waitCreate, "wait", false, "wait forever (default false)")
 
 	return cmd
 }

--- a/cmd/token/invalidate.go
+++ b/cmd/token/invalidate.go
@@ -51,6 +51,8 @@ func tokenInvalidateCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+
+	cmd.Flags().AddFlagSet(config.GetPersistentFlagSet())
+
 	return cmd
 }

--- a/cmd/token/list.go
+++ b/cmd/token/list.go
@@ -78,7 +78,10 @@ func tokenListCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&listTokenRole, "role", "", "Either worker, controller or empty for all roles")
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.StringVar(&listTokenRole, "role", "", "Either worker, controller or empty for all roles")
+
 	return cmd
 }

--- a/cmd/token/preshared.go
+++ b/cmd/token/preshared.go
@@ -78,12 +78,15 @@ func preSharedCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&certPath, "cert", "", "path to the CA certificate file")
-	cmd.Flags().StringVar(&joinURL, "url", "", "url of the api server to join")
-	cmd.Flags().StringVar(&preSharedRole, "role", "worker", "token role. valid values: worker, controller. Default: worker")
-	cmd.Flags().StringVar(&outDir, "out", ".", "path to the output directory. Default: current dir")
-	cmd.Flags().DurationVar(&validity, "valid", 0, "how long token is valid, in Go duration format")
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
+
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.StringVar(&certPath, "cert", "", "path to the CA certificate file")
+	flags.StringVar(&joinURL, "url", "", "url of the api server to join")
+	flags.StringVar(&preSharedRole, "role", "worker", "token role. valid values: worker, controller. Default: worker")
+	flags.StringVar(&outDir, "out", ".", "path to the output directory. Default: current dir")
+	flags.DurationVar(&validity, "valid", 0, "how long token is valid, in Go duration format")
+
 	return cmd
 }
 

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -51,9 +51,10 @@ func NewVersionCmd() *cobra.Command {
 		},
 	}
 
-	// append flags
-	cmd.PersistentFlags().BoolVarP(&all, "all", "a", false, "use to print all k0s version info")
-	cmd.PersistentFlags().BoolVarP(&isJsn, "json", "j", false, "use to print all k0s version info in json")
+	flags := cmd.Flags()
+	flags.BoolVarP(&all, "all", "a", false, "use to print all k0s version info")
+	flags.BoolVarP(&isJsn, "json", "j", false, "use to print all k0s version info in json")
+
 	return cmd
 }
 

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -93,10 +93,11 @@ func NewWorkerCmd() *cobra.Command {
 		},
 	}
 
-	// append flags
-	cmd.Flags().BoolVar(&ignorePreFlightChecks, "ignore-pre-flight-checks", false, "continue even if pre-flight checks fail")
-	cmd.PersistentFlags().AddFlagSet(config.GetPersistentFlagSet())
-	cmd.PersistentFlags().AddFlagSet(config.GetWorkerFlags())
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.AddFlagSet(config.GetWorkerFlags())
+	flags.BoolVar(&ignorePreFlightChecks, "ignore-pre-flight-checks", false, "continue even if pre-flight checks fail")
+
 	return cmd
 }
 


### PR DESCRIPTION
## Description

These flags are used for shared functionality based on Cobra's "persistent" functions. In k0s, however, the distinction was never that clear. Persistent flags were mostly used by accident, sometimes to share flag definitions between subcommands, even if the persistent functions didn't use those flags.

Identify most (all?) of these cases and use flags instead of persistent flags. Deprecate and hide the unused persistent flags, so that they can eventually be removed.

Also remove the cwd prefixing for the restored config file in `k0s restore`. Relative paths are automatically resolved based on the current working directory. No need to do this manually.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings