### PR TITLE
Use localhost in admin kubeconfig again, if possible

### DIFF
--- a/cmd/controller/certificates.go
+++ b/cmd/controller/certificates.go
@@ -24,7 +24,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/internal/pkg/users"
@@ -67,8 +66,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 	}
 	c.CACert = string(cert)
 	// Changing the URL here also requires changes in the "k0s kubeconfig admin" subcommand.
-	apiAddress := net.JoinHostPort(c.ClusterSpec.API.Address, strconv.Itoa(c.ClusterSpec.API.Port))
-	kubeConfigAPIUrl := (&url.URL{Scheme: "https", Host: apiAddress}).String()
+	kubeConfigAPIUrl := c.ClusterSpec.API.LocalURL()
 
 	apiServerUID, err := users.LookupUID(constant.ApiserverUser)
 	if err != nil {
@@ -289,7 +287,7 @@ func detectLocalIPs(ctx context.Context) ([]string, error) {
 	return localIPs, nil
 }
 
-func kubeConfig(dest, url, caCert, clientCert, clientKey string, ownerID int) error {
+func kubeConfig(dest string, url *url.URL, caCert, clientCert, clientKey string, ownerID int) error {
 	// We always overwrite the kubeconfigs as the certs might be regenerated at startup
 	const (
 		clusterName = "local"
@@ -300,7 +298,7 @@ func kubeConfig(dest, url, caCert, clientCert, clientKey string, ownerID int) er
 	kubeconfig, err := clientcmd.Write(clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{clusterName: {
 			// The server URL is replaced in the "k0s kubeconfig admin" subcommand.
-			Server:                   url,
+			Server:                   url.String(),
 			CertificateAuthorityData: []byte(caCert),
 		}},
 		Contexts: map[string]*clientcmdapi.Context{contextName: {

--- a/cmd/kubeconfig/admin.go
+++ b/cmd/kubeconfig/admin.go
@@ -65,7 +65,7 @@ func kubeConfigAdminCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			internalURL := fmt.Sprintf("https://localhost:%d", nodeConfig.Spec.API.Port)
+			internalURL := nodeConfig.Spec.API.LocalURL().String()
 			externalURL := nodeConfig.Spec.API.APIAddressURL()
 			for _, c := range adminConfig.Clusters {
 				if c.Server == internalURL {

--- a/pkg/apis/k0s/v1beta1/api.go
+++ b/pkg/apis/k0s/v1beta1/api.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/url"
 	"strconv"
@@ -70,6 +71,17 @@ func DefaultAPISpec() *APISpec {
 	a.setDefaults()
 	a.SANs, _ = iface.AllAddresses()
 	return a
+}
+
+func (a *APISpec) LocalURL() *url.URL {
+	var host string
+	if a.OnlyBindToAddress {
+		host = net.JoinHostPort(a.Address, strconv.Itoa(a.Port))
+	} else {
+		host = fmt.Sprintf("localhost:%d", a.Port)
+	}
+
+	return &url.URL{Scheme: "https", Host: host}
 }
 
 // APIAddress ...


### PR DESCRIPTION
## Description

If the API server is binding to all addresses, it's better to use the loopback interface to communicate with the API server locally. This avoids e.g. weird HTTP proxy problems.

See:

* https://github.com/k0sproject/k0s/issues/5350#issuecomment-2580777985
* #3824

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings