### PR TITLE
Fix invalid configuration in `gitops-flux.md`

### DIFF
--- a/docs/examples/gitops-flux.md
+++ b/docs/examples/gitops-flux.md
@@ -101,16 +101,16 @@ Create the following YAML file (simple-web-server-with-nodeport.yaml) into the s
     selector:
       matchLabels:
         app: web
-      template:
-        metadata:
-          labels:
-            app: web
-        spec:
-          containers:
-          - name: httpd
-            image: httpd:2.4.53-alpine
-            ports:
-            - containerPort: 80
+    template:
+      metadata:
+        labels:
+          app: web
+      spec:
+        containers:
+        - name: httpd
+          image: httpd:2.4.53-alpine
+          ports:
+          - containerPort: 80
   ---
   apiVersion: v1
   kind: Service


### PR DESCRIPTION
## Description

I was getting this error due to an invalid configuration. This PR fixes it.

```
 Deployment.apps "web-server" is invalid: [spec.template.metadata.labels: Invalid value: map[string]string(nil): selector does not match template labels, spec.template.spec.containers: Required value]
```


## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ x My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings