### PR TITLE
Don't cache the node config in the CfgVars struct

### DIFF
--- a/pkg/config/cfgvars.go
+++ b/pkg/config/cfgvars.go
@@ -65,20 +65,6 @@ type CfgVars struct {
 	nodeConfig *v1beta1.ClusterConfig
 }
 
-func (c *CfgVars) DeepCopy() *CfgVars {
-	if c == nil {
-		return nil
-	}
-	// Make a copy of the original struct, this works because all the fields are
-	// primitive types
-	copy := *c
-
-	copy.nodeConfig = c.nodeConfig.DeepCopy()
-
-	// Return the copied struct
-	return &copy
-}
-
 type CfgVarOption func(*CfgVars)
 
 // Command represents cobra.Command

--- a/pkg/config/cfgvars.go
+++ b/pkg/config/cfgvars.go
@@ -61,8 +61,7 @@ type CfgVars struct {
 	HelmRepositoryCache  string
 	HelmRepositoryConfig string
 
-	stdin      io.Reader
-	nodeConfig *v1beta1.ClusterConfig
+	stdin io.Reader
 }
 
 type CfgVarOption func(*CfgVars)
@@ -107,10 +106,6 @@ func WithCommand(cmd command) CfgVarOption {
 			c.DefaultStorageType = v1beta1.EtcdStorageType
 		}
 	}
-}
-
-func (c *CfgVars) SetNodeConfig(cfg *v1beta1.ClusterConfig) {
-	c.nodeConfig = cfg
 }
 
 func DefaultCfgVars() *CfgVars {
@@ -219,10 +214,6 @@ func (c *CfgVars) defaultStorageSpec() *v1beta1.StorageSpec {
 var defaultConfigPath = constant.K0sConfigPathDefault
 
 func (c *CfgVars) NodeConfig() (*v1beta1.ClusterConfig, error) {
-	if c.nodeConfig != nil {
-		return c.nodeConfig, nil
-	}
-
 	if c.StartupConfigPath == "" {
 		return nil, errors.New("config path is not set")
 	}
@@ -259,8 +250,6 @@ func (c *CfgVars) NodeConfig() (*v1beta1.ClusterConfig, error) {
 	if nodeConfig.Spec.Storage.Type == v1beta1.KineStorageType && nodeConfig.Spec.Storage.Kine == nil {
 		nodeConfig.Spec.Storage.Kine = v1beta1.DefaultKineConfig(c.DataDir)
 	}
-
-	c.nodeConfig = nodeConfig
 
 	return nodeConfig, nil
 }

--- a/pkg/config/cfgvars_test.go
+++ b/pkg/config/cfgvars_test.go
@@ -222,10 +222,10 @@ func TestNodeConfig_Stdin(t *testing.T) {
 	require.NoError(t, err)
 
 	nodeConfig, err := underTest.NodeConfig()
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "calico", nodeConfig.Spec.Network.Provider)
 
-	nodeConfig2, err := underTest.NodeConfig()
-	require.NoError(t, err)
-	assert.Same(t, nodeConfig, nodeConfig2)
+	nodeConfig, err = underTest.NodeConfig()
+	assert.ErrorContains(t, err, "stdin already grabbed")
+	assert.Nil(t, nodeConfig)
 }

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -302,7 +302,7 @@ func GetCmdOpts(cobraCmd command) (*CLIOptions, error) {
 	}
 
 	// if a runtime config can be loaded, use it to override the k0sVars
-	if rtc, err := LoadRuntimeConfig(k0sVars); err == nil {
+	if rtc, err := LoadRuntimeConfig(k0sVars.RuntimeConfigPath); err == nil {
 		k0sVars = rtc.K0sVars
 	}
 

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -107,11 +107,6 @@ func NewRuntimeConfig(k0sVars *CfgVars) (*RuntimeConfigSpec, error) {
 		return nil, fmt.Errorf("load node config: %w", err)
 	}
 
-	vars := k0sVars.DeepCopy()
-
-	// don't persist the startup config path in the runtime config
-	vars.StartupConfigPath = ""
-
 	cfg := &RuntimeConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			CreationTimestamp: metav1.Now(),

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -59,8 +59,8 @@ type RuntimeConfigSpec struct {
 	Pid        int                    `json:"pid"`
 }
 
-func LoadRuntimeConfig(k0sVars *CfgVars) (*RuntimeConfigSpec, error) {
-	content, err := os.ReadFile(k0sVars.RuntimeConfigPath)
+func LoadRuntimeConfig(path string) (*RuntimeConfigSpec, error) {
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func LoadRuntimeConfig(k0sVars *CfgVars) (*RuntimeConfigSpec, error) {
 }
 
 func NewRuntimeConfig(k0sVars *CfgVars) (*RuntimeConfigSpec, error) {
-	if _, err := LoadRuntimeConfig(k0sVars); err == nil {
+	if _, err := LoadRuntimeConfig(k0sVars.RuntimeConfigPath); err == nil {
 		return nil, ErrK0sAlreadyRunning
 	}
 


### PR DESCRIPTION
## Description

The node config should be read at most once and then reused. Caching the config in this way shouldn't be necessary.

On the way:
* Use only the path as parameter to `LoadRuntimeConfig`. This is the only information needed. Passing just the path instead
of the full `CfgVars` struct makes it easier to reason about what is happening.
* Remove unused `vars` variable and `DeepCopy`. The `vars` variable was never read, and the `DeepCopy` method was used just to initialize it. Remove both. The original intent was probably not to list the `StartupConfigPath` in the file written to disk, but since that never worked as intended and there were no problems with it, I think it's okay to leave things as they are.
* Restructure `NewRuntimeConfig` test. Use a real config file instead of mocking out the config file loading
using the private `nodeConfig` field. Verify that the folder for the runtime config file is created, if it doesn't exist.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings