### PR TITLE
[Backport release-1.31] Use localhost in admin kubeconfig again, if possible

### DIFF
--- a/cmd/kubeconfig/admin.go
+++ b/cmd/kubeconfig/admin.go
@@ -69,7 +69,7 @@ func kubeConfigAdminCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			internalURL := fmt.Sprintf("https://localhost:%d", nodeConfig.Spec.API.Port)
+			internalURL := nodeConfig.Spec.API.LocalURL().String()
 			externalURL := nodeConfig.Spec.API.APIAddressURL()
 			for _, c := range adminConfig.Clusters {
 				if c.Server == internalURL {

--- a/pkg/apis/k0s/v1beta1/api.go
+++ b/pkg/apis/k0s/v1beta1/api.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/url"
+	"strconv"
 
 	"github.com/k0sproject/k0s/internal/pkg/iface"
 	"github.com/k0sproject/k0s/internal/pkg/stringslice"
@@ -69,6 +71,17 @@ func DefaultAPISpec() *APISpec {
 	a.setDefaults()
 	a.SANs, _ = iface.AllAddresses()
 	return a
+}
+
+func (a *APISpec) LocalURL() *url.URL {
+	var host string
+	if a.OnlyBindToAddress {
+		host = net.JoinHostPort(a.Address, strconv.Itoa(a.Port))
+	} else {
+		host = fmt.Sprintf("localhost:%d", a.Port)
+	}
+
+	return &url.URL{Scheme: "https", Host: host}
 }
 
 // APIAddress ...


### PR DESCRIPTION
Backport to `release-1.31`:

* #5426