### PR TITLE
Always treat an etcd backend as joinable

### DIFF
--- a/pkg/apis/k0s/v1beta1/storage_test.go
+++ b/pkg/apis/k0s/v1beta1/storage_test.go
@@ -52,7 +52,7 @@ func TestStorageSpec_IsJoinable(t *testing.T) {
 					PeerAddress: "",
 				},
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "kine-sqlite",


### PR DESCRIPTION
## Description

Controllers will always be able to connect to an etcd backend, either by joining as a managed etcd node, or by simply connecting to an external cluster over the network. Add some comments about whether a backend is considered joinable or not to both the etcd and kine storage types.

Fixes:

* #4311

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings