### PR TITLE
Use full patch version for go directives in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k0sproject/k0s
 
-go 1.23
+go 1.23.0
 
 // k0s
 require (

--- a/hack/tool/go.mod
+++ b/hack/tool/go.mod
@@ -1,6 +1,6 @@
 module tool
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/hashicorp/terraform-exec v0.21.0


### PR DESCRIPTION
## Description

It turns out that since Go 1.21, in which Go started using fully qualified versions and not omitting zeros (i.e. "1.21.0" instead of just "1.21"), just stating the minor version without the patch version is actually considered a development version of Go. Who would have thought? The correct way to use the Go directive is to set it to "go 1.23.0".

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings