### PR TITLE
Load node configuration only once

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -160,7 +160,7 @@ func (c *command) start(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize dir: %w", err)
 	}
 
-	rtc, err := config.NewRuntimeConfig(c.K0sVars)
+	rtc, err := config.NewRuntimeConfig(c.K0sVars, nodeConfig)
 	if err != nil {
 		return fmt.Errorf("failed to initialize runtime config: %w", err)
 	}

--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -76,7 +76,7 @@ func (c *command) reset() error {
 	}
 
 	// Get Cleanup Config
-	cfg, err := cleanup.NewConfig(c.Debug, c.K0sVars, c.WorkerOptions.CriSocket)
+	cfg, err := cleanup.NewConfig(c.Debug, c.K0sVars, nodeCfg.Spec.Install.SystemUsers, c.WorkerOptions.CriSocket)
 	if err != nil {
 		return fmt.Errorf("failed to configure cleanup: %w", err)
 	}

--- a/cmd/token/create.go
+++ b/cmd/token/create.go
@@ -61,6 +61,11 @@ k0s token create --role worker --expiry 10m  //sets expiration time to 10 minute
 				return err
 			}
 
+			nodeConfig, err := opts.K0sVars.NodeConfig()
+			if err != nil {
+				return err
+			}
+
 			var bootstrapToken string
 			// we will retry every second for two minutes and then error
 			err = retry.OnError(wait.Backoff{
@@ -80,11 +85,6 @@ k0s token create --role worker --expiry 10m  //sets expiration time to 10 minute
 				}
 				if err = ensureTokenCreationAcceptable(createTokenRole, statusInfo); err != nil {
 					waitCreate = false
-					return err
-				}
-
-				nodeConfig, err := opts.K0sVars.NodeConfig()
-				if err != nil {
 					return err
 				}
 

--- a/pkg/backup/manager_unix.go
+++ b/pkg/backup/manager_unix.go
@@ -164,7 +164,7 @@ func (bm *Manager) RunRestore(archivePath string, k0sVars *config.CfgVars, desir
 		return fmt.Errorf("failed to unpack backup archive `%s`: %w", archivePath, err)
 	}
 	defer os.RemoveAll(bm.tmpDir)
-	cfg, err := bm.getConfigForRestore(k0sVars)
+	cfg, err := bm.getConfigForRestore()
 	if err != nil {
 		return fmt.Errorf("failed to parse backed-up configuration file, check the backup archive: %w", err)
 	}
@@ -180,11 +180,16 @@ func (bm *Manager) RunRestore(archivePath string, k0sVars *config.CfgVars, desir
 	return nil
 }
 
-func (bm Manager) getConfigForRestore(k0sVars *config.CfgVars) (*v1beta1.ClusterConfig, error) {
+func (bm Manager) getConfigForRestore() (*v1beta1.ClusterConfig, error) {
 	configFromBackup := path.Join(bm.tmpDir, "k0s.yaml")
 	logrus.Debugf("Using k0s.yaml from: %s", configFromBackup)
 
-	cfg, err := k0sVars.NodeConfig()
+	bytes, err := os.ReadFile(configFromBackup)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := v1beta1.ConfigFromString(string(bytes))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -37,12 +37,7 @@ type Config struct {
 	cleanupSteps []Step
 }
 
-func NewConfig(debug bool, k0sVars *config.CfgVars, criSocketFlag string) (*Config, error) {
-	cfg, err := k0sVars.NodeConfig()
-	if err != nil {
-		logrus.Errorf("failed to get cluster setup: %v", err)
-	}
-
+func NewConfig(debug bool, k0sVars *config.CfgVars, systemUsers *k0sv1beta1.SystemUser, criSocketFlag string) (*Config, error) {
 	containers, err := newContainersStep(debug, k0sVars, criSocketFlag)
 	if err != nil {
 		return nil, err
@@ -50,9 +45,7 @@ func NewConfig(debug bool, k0sVars *config.CfgVars, criSocketFlag string) (*Conf
 
 	cleanupSteps := []Step{
 		containers,
-		&users{
-			systemUsers: cfg.Spec.Install.SystemUsers,
-		},
+		&users{systemUsers: systemUsers},
 		&services{},
 		&directories{
 			dataDir:        k0sVars.DataDir,

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -107,14 +107,9 @@ func ParseRuntimeConfig(content []byte) (*RuntimeConfig, error) {
 	return &config, nil
 }
 
-func NewRuntimeConfig(k0sVars *CfgVars) (*RuntimeConfig, error) {
+func NewRuntimeConfig(k0sVars *CfgVars, nodeConfig *v1beta1.ClusterConfig) (*RuntimeConfig, error) {
 	if _, err := LoadRuntimeConfig(k0sVars.RuntimeConfigPath); err == nil {
 		return nil, ErrK0sAlreadyRunning
-	}
-
-	nodeConfig, err := k0sVars.NodeConfig()
-	if err != nil {
-		return nil, fmt.Errorf("load node config: %w", err)
 	}
 
 	cfg := &RuntimeConfig{

--- a/pkg/config/runtime_test.go
+++ b/pkg/config/runtime_test.go
@@ -69,21 +69,23 @@ func TestNewRuntimeConfig(t *testing.T) {
 		DataDir:           tempDir,
 	}
 
+	// Check if the node config can be loaded properly
+	nodeConfig, err := k0sVars.NodeConfig()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "10.0.0.1", nodeConfig.Spec.API.Address)
+	}
+
 	// create a new runtime config and check if it's valid
-	cfg, err := NewRuntimeConfig(k0sVars)
-	spec := cfg.Spec
-	assert.NoError(t, err)
-	assert.NotNil(t, spec)
-	assert.Same(t, k0sVars, spec.K0sVars)
-	assert.Equal(t, os.Getpid(), spec.Pid)
-	assert.NotNil(t, spec.NodeConfig)
-	nodeConfig, err := spec.K0sVars.NodeConfig()
-	assert.NoError(t, err)
-	assert.Equal(t, "10.0.0.1", nodeConfig.Spec.API.Address)
+	cfg, err := NewRuntimeConfig(k0sVars, nodeConfig)
+	if assert.NoError(t, err) && assert.NotNil(t, cfg) && assert.NotNil(t, cfg.Spec) {
+		assert.Same(t, k0sVars, cfg.Spec.K0sVars)
+		assert.Same(t, nodeConfig, cfg.Spec.NodeConfig)
+		assert.Equal(t, os.Getpid(), cfg.Spec.Pid)
+	}
 	assert.FileExists(t, rtConfigPath)
 
 	// try to create a new runtime config when one is already active and check if it returns an error
-	_, err = NewRuntimeConfig(k0sVars)
+	_, err = NewRuntimeConfig(k0sVars, nil)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrK0sAlreadyRunning)
 }


### PR DESCRIPTION
## Description


* Don't load node configuration twice in `k0s backup`, `k0s token create` and `k0s reset`.
* Don't reload node config when reconciling CoreDNS.  
  Changing the node configuration requires a restart of k0s, so it's okay to get the required values from the node configuration once when creating the component.
* Read restore configuration from right location  
  Load the configuration from the saved k0s.yaml backup file instead of using the configuration of the current k0s process.
* Don't load node config implicitly when creating the runtime config  
  Rely on the fact that the caller has already loaded it and require it as an additional parameter.

Follow-up to:

* #5433

Fixes:
* #1409 (78ed374d8)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings