### PR TITLE
Airgap image bundle verification in GH Action step

### DIFF
--- a/.github/workflows/build-airgap-image-bundle.yml
+++ b/.github/workflows/build-airgap-image-bundle.yml
@@ -61,6 +61,8 @@ jobs:
           mkdir -p "embedded-bins/staging/$TARGET_OS/bin"
           make --touch airgap-images.txt
           make "airgap-image-bundle-$TARGET_OS-$TARGET_ARCH.tar"
+          tar tf "airgap-image-bundle-$TARGET_OS-$TARGET_ARCH.tar" >/dev/null
+          sha256sum "airgap-image-bundle-$TARGET_OS-$TARGET_ARCH.tar"
 
       - name: "Upload :: Airgap image bundle"
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description

Test the resulting tar archive and compute its SHA-256 digest to verify the integrity of the created airgap image bundle.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings