### PR TITLE
Bump go 1.23.5

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.21
 alpine_patch_version = $(alpine_version).0
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.23.4
+go_version = 1.23.5
 
 runc_version = 1.2.3
 runc_buildimage = $(golang_buildimage)


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/sSaUhLA-2SI/m/Y9wOnjSUDgAJ
https://go.dev/doc/devel/release#go1.23.5
https://github.com/golang/go/issues?q=milestone%3AGo1.23.5+label%3ACherryPickApproved