### PR TITLE
Prevent creating empty airgap images on failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ lint-go: $(GO_ENV_REQUISITES) go.sum bindata
 lint: lint-copyright lint-go
 
 airgap-images.txt: k0s $(GO_ENV_REQUISITES)
-	$(GO_ENV) ./k0s airgap list-images --all > '$@'
+	$(GO_ENV) ./k0s airgap list-images --all > '$@.tmp' && mv '$@.tmp' '$@'
 
 airgap-image-bundle-linux-amd64.tar: TARGET_PLATFORM := linux/amd64
 airgap-image-bundle-linux-arm64.tar: TARGET_PLATFORM := linux/arm64
@@ -248,7 +248,8 @@ airgap-image-bundle-linux-arm64.tar \
 airgap-image-bundle-linux-arm.tar: .k0sbuild.image-bundler.stamp airgap-images.txt
 	$(DOCKER) run --rm -i --privileged \
 	  -e TARGET_PLATFORM='$(TARGET_PLATFORM)' \
-	  '$(shell cat .k0sbuild.image-bundler.stamp)' < airgap-images.txt > '$@'
+	  '$(shell cat .k0sbuild.image-bundler.stamp)' < airgap-images.txt > '$@.tmp' \
+	  && mv '$@.tmp' '$@'
 
 .k0sbuild.image-bundler.stamp: hack/image-bundler/* embedded-bins/Makefile.variables
 	$(DOCKER) build --progress=plain --iidfile '$@' \


### PR DESCRIPTION
Do the redirection to a tempfile and only move it to the make taget on success so we don't end up with empty airgap-images.txt or airgap-image-bundle-* on failure.

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings