### PR TITLE
GitHub Actions cache optimizations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+go.mod text eol=lf
+go.sum text eol=lf

--- a/.github/workflows/build-k0s.yml
+++ b/.github/workflows/build-k0s.yml
@@ -80,9 +80,9 @@ jobs:
       - name: "Cache :: GOMODCACHE"
         uses: actions/cache@v4
         with:
-          key: build-k0s-${{ inputs.target-os }}-${{ inputs.target-arch }}-gomodcache-${{ hashFiles('go.sum') }}
-          path: |
-            build/cache/go/mod
+          key: build-k0s-gomodcache-${{ hashFiles('go.sum') }}
+          path: build/cache/go/mod
+          enableCrossOsArchive: true
 
       - name: "Build :: k0s"
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -182,8 +182,8 @@ jobs:
         uses: actions/cache@v4
         with:
           key: unittests-k0s-gomodcache-${{ hashFiles('go.sum') }}
-          path: |
-            build/cache/go/mod
+          path: build/cache/go/mod
+          enableCrossOsArchive: true
 
       - name: Run unit tests
         run: make check-unit $UNITTEST_EXTRA_ARGS

--- a/.github/workflows/pr-closed.yaml
+++ b/.github/workflows/pr-closed.yaml
@@ -1,0 +1,33 @@
+name: Pull request closed
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  # Based on https://github.com/actions/cache/blob/v4.2.0/tips-and-workarounds.md#force-deletion-of-caches-overriding-default-cache-eviction-policy
+  cleanup-actions-caches:
+    name: Cleanup GitHub Actions caches
+    runs-on: ubuntu-latest
+    permissions:
+      # `actions:write` permission is required to delete caches
+      #   See also: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id
+      actions: write
+      contents: read
+
+    steps:
+      - name: Cleanup
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_REPO: "${{ github.repository }}"
+          BRANCH: "refs/pull/${{ github.event.pull_request.number }}/merge"
+        run: |
+          set -euo pipefail
+          gh api -X GET /repos/{owner}/{repo}/actions/caches -f ref="$BRANCH" --paginate -q '.actions_caches[] | "\(.id) \(.key)"' | {
+            fail=0
+            while read -r id key; do
+              echo Deleting cache with ID $id: $key
+              gh api -X DELETE /repos/{owner}/{repo}/actions/caches/"$id" || fail=1
+            done
+            [ $fail -eq 0 ]
+          }


### PR DESCRIPTION
## Description

When a pull request is closed, clean up up the GitHub Actions caches associated with it.

Optimize Go's mod cache usage across GH Actions. In order to be able to share caches between operating systems, you have
to set enableCrossOsArchive to true, and the cache paths have to be identical (which was already the case). Also make sure that go.mod/go.sum files always use LF line endings, even on Windows. Otherwise the cache keys would be different.

See: https://github.com/actions/cache/blob/v4.2.0/tips-and-workarounds.md#cross-os-cache

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings