### PR TITLE
Compress k0s binary using UPX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ else
   GO ?= $(GO_ENV) go
 endif
 
+UPX ?= upx
+UPX_OPTS ?= -1
+
 # EMBEDDED_BINS_BUILDMODE can be either:
 #   docker	builds the binaries in docker
 #   none	does not embed any binaries
@@ -203,6 +206,9 @@ k0s.exe: BUILD_GO_CGO_ENABLED = 0
 k0s.exe k0s: $(GO_ENV_REQUISITES) go.sum $(codegen_targets) $(GO_SRCS) $(shell find static/manifests/calico static/manifests/windows -type f)
 	rm -f -- '$@'
 	CGO_ENABLED=$(BUILD_GO_CGO_ENABLED) CGO_CFLAGS='$(BUILD_CGO_CFLAGS)' GOOS=$(TARGET_OS) $(GO) build $(BUILD_GO_FLAGS) -ldflags='$(LD_FLAGS)' -o '$@' main.go
+ifneq ($(UPX),)
+	$(GO_ENV) $(UPX) $(UPX_OPTS) -- '$@'
+endif
 ifneq ($(EMBEDDED_BINS_BUILDMODE),none)
 	cat -- bindata_$(TARGET_OS) >>$@
 endif

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,7 +9,7 @@ RUN set -ex; \
   arm*) binutils=binutils-gold ;; \
     *)    binutils=binutils ;; \
   esac; \
-  apk add --no-cache make gcc musl-dev "$binutils"
+  apk add --no-cache make gcc musl-dev "$binutils" upx
 
 ENV \
   HOME="/run/k0s-build" \


### PR DESCRIPTION
## Description

Make this configurable via Make variables.

This is a PoC based on #5468, to see if it is generally possible and to have something to tinker with. CI seems to be passing. The size reduction is about 25% for the linux-amd64 executable, and over 30% for the windows-amd64 executable.

I did some highly scientific ^^ benchmarks using `time ./k0s` on my machine, to compare startup times of the compressed and uncompressed versions of the executable. For me, compression added around 420 ms of startup latency.

See:

* #5468

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings