### PR TITLE
Update flowcontrol entries in removed APIs

### DIFF
--- a/pkg/autopilot/checks/removedapis.go
+++ b/pkg/autopilot/checks/removedapis.go
@@ -43,7 +43,7 @@ func removedInVersion(candidate schema.GroupVersionKind) string {
 }
 
 // Sorted array of removed APIs.
-var removedGVKs = [59]removedAPI{
+var removedGVKs = [65]removedAPI{
 	{"admissionregistration.k8s.io", "v1beta1", "MutatingWebhookConfiguration", "v1.22.0"},
 	{"admissionregistration.k8s.io", "v1beta1", "ValidatingWebhookConfiguration", "v1.22.0"},
 	{"apiextensions.k8s.io", "v1beta1", "CustomResourceDefinition", "v1.22.0"},
@@ -73,6 +73,12 @@ var removedGVKs = [59]removedAPI{
 	{"extensions", "v1beta1", "PodSecurityPolicy", "v1.16.0"},
 	{"extensions", "v1beta1", "ReplicaSet", "v1.16.0"},
 	{"flowcontrol.apiserver.k8s.io", "v1beta1", "FlowControl", "v1.26.0"},
+	{"flowcontrol.apiserver.k8s.io", "v1beta1", "FlowSchema", "v1.26.0"},
+	{"flowcontrol.apiserver.k8s.io", "v1beta1", "PriorityLevelConfiguration", "v1.26.0"},
+	{"flowcontrol.apiserver.k8s.io", "v1beta2", "FlowSchema", "v1.29.0"},
+	{"flowcontrol.apiserver.k8s.io", "v1beta2", "PriorityLevelConfiguration", "v1.29.0"},
+	{"flowcontrol.apiserver.k8s.io", "v1beta3", "FlowSchema", "v1.32.0"},
+	{"flowcontrol.apiserver.k8s.io", "v1beta3", "PriorityLevelConfiguration", "v1.32.0"},
 	{"k0s.k0sproject.example.com", "v1beta1", "RemovedCRD", "v99.99.99"}, // This is a test entry
 	{"networking.k8s.io", "v1beta1", "Ingress", "v1.22.0"},
 	{"networking.k8s.io", "v1beta1", "IngressClass", "v1.22.0"},


### PR DESCRIPTION
## Description

Added missing entries in 1.26, 1.29 and 1.32

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#flowcontrol-resources-v132

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings