### PR TITLE
Sleep 5 secs after airgap image bundle creation

### DIFF
--- a/hack/image-bundler/bundler.sh
+++ b/hack/image-bundler/bundler.sh
@@ -34,4 +34,6 @@ done
 
 echo Exporting images ... >&2
 ctr images export --platform "$TARGET_PLATFORM" -- - "$@"
-echo Images exported. >&2
+echo Images exported. Waiting 5 secs ...>&2
+sleep 5
+echo Good bye. >&2


### PR DESCRIPTION
## Description

Airgap image bundle files are sometimes truncated. This is supposedly due to some standard input buffers in Docker that don't get flushed properly when the container gets shut down.

Fix it in the silly way of letting the container run for a few more seconds, so there's time to flush everything. This is a simple but blunt solution, since writing the bundle to files inside the container means that the Makefile has to deal with mounting and file ownership and permissions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings