### PR TITLE
Allow to override k0sctl version in OS tests matrix

### DIFF
--- a/.github/workflows/ostests-matrix.yaml
+++ b/.github/workflows/ostests-matrix.yaml
@@ -8,6 +8,9 @@ on:
       k0s-version:
         type: string
         description: The k0s version to test. Will build k0s from source if empty.
+      k0sctl-version:
+        type: string
+        description: The k0sctl version to use when bootstrapping test clusters.
       e2e-concurrency-level:
         type: number
         description: The number of tests that may be run concurrently.
@@ -81,6 +84,7 @@ jobs:
     uses: ./.github/workflows/ostests-e2e.yaml
     with:
       k0s-version: ${{ inputs.k0s-version }}
+      k0sctl-version: ${{ inputs.k0sctl-version }}
       e2e-concurrency-level: ${{ fromJSON(inputs.e2e-concurrency-level) }} # infamous GH workflows bug that looses type information (actions/runner#2206)
       e2e-focus: ${{ inputs.e2e-focus }}
       os: ${{ matrix.os }}


### PR DESCRIPTION
## Description

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings