### PR TITLE
Revert "Remove default-config and validate sub-commands"

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ import (
 	"github.com/k0sproject/k0s/cmd/stop"
 	"github.com/k0sproject/k0s/cmd/sysinfo"
 	"github.com/k0sproject/k0s/cmd/token"
+	"github.com/k0sproject/k0s/cmd/validate"
 	"github.com/k0sproject/k0s/cmd/version"
 	"github.com/k0sproject/k0s/cmd/worker"
 	internallog "github.com/k0sproject/k0s/internal/pkg/log"
@@ -86,10 +87,12 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(stop.NewStopCmd())
 	cmd.AddCommand(sysinfo.NewSysinfoCmd())
 	cmd.AddCommand(token.NewTokenCmd())
+	cmd.AddCommand(validate.NewValidateCmd()) // hidden+deprecated
 	cmd.AddCommand(version.NewVersionCmd())
 	cmd.AddCommand(worker.NewWorkerCmd())
 
 	cmd.AddCommand(newCompletionCmd())
+	cmd.AddCommand(newDefaultConfigCmd()) // hidden+deprecated
 	cmd.AddCommand(newDocsCmd())
 
 	addPlatformSpecificCommands(cmd)
@@ -119,6 +122,14 @@ func newDocsCmd() *cobra.Command {
 			return errors.New("invalid format")
 		},
 	}
+}
+
+func newDefaultConfigCmd() *cobra.Command {
+	cmd := configcmd.NewCreateCmd()
+	cmd.Hidden = true
+	cmd.Deprecated = "use 'k0s config create' instead"
+	cmd.Use = "default-config"
+	return cmd
 }
 
 func newCompletionCmd() *cobra.Command {

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2025 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validate
+
+import (
+	configcmd "github.com/k0sproject/k0s/cmd/config"
+
+	"github.com/spf13/cobra"
+)
+
+// TODO deprecated, remove when appropriate
+func NewValidateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:        "validate",
+		Short:      "Validation related sub-commands",
+		Hidden:     true,
+		Deprecated: "use 'k0s config validate' instead",
+	}
+	cmd.AddCommand(newConfigCmd())
+	return cmd
+}
+
+func newConfigCmd() *cobra.Command {
+	cmd := configcmd.NewValidateCmd()
+	cmd.Use = "config"
+	cmd.Deprecated = "use 'k0s config validate' instead"
+	cmd.Hidden = false
+	return cmd
+}


### PR DESCRIPTION
Reverts k0sproject/k0s#5376

There's a bug in k0sproject/version that causes k0sctl's version-based detection to make false assumptions about the supported sub-commands in k0s. That needs to be addressed first before we can remove these deprecated commands for realz.