### PR TITLE
Don't use join tokens to bootstrap embedded kubelet

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -748,8 +748,8 @@ func joinController(ctx context.Context, tokenArg string, certRootDir string) (*
 		return nil, fmt.Errorf("failed to create join client: %w", err)
 	}
 
-	if joinClient.JoinTokenType() != "controller-bootstrap" {
-		return nil, fmt.Errorf("wrong token type %s, expected type: controller-bootstrap", joinClient.JoinTokenType())
+	if actual := joinClient.JoinTokenType(); actual != token.ControllerTokenAuthName {
+		return nil, fmt.Errorf("wrong token type %s, expected type: %s", actual, token.ControllerTokenAuthName)
 	}
 
 	logrus.Info("Joining existing cluster via ", joinClient.Address())

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -748,10 +748,6 @@ func joinController(ctx context.Context, tokenArg string, certRootDir string) (*
 		return nil, fmt.Errorf("failed to create join client: %w", err)
 	}
 
-	if actual := joinClient.JoinTokenType(); actual != token.ControllerTokenAuthName {
-		return nil, fmt.Errorf("wrong token type %s, expected type: %s", actual, token.ControllerTokenAuthName)
-	}
-
 	logrus.Info("Joining existing cluster via ", joinClient.Address())
 
 	var caData v1beta1.CaResponse

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -32,7 +32,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/avast/retry-go"
 	workercmd "github.com/k0sproject/k0s/cmd/worker"
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/file"
@@ -62,11 +61,14 @@ import (
 	"github.com/k0sproject/k0s/pkg/performance"
 	"github.com/k0sproject/k0s/pkg/telemetry"
 	"github.com/k0sproject/k0s/pkg/token"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
+
 	"k8s.io/apimachinery/pkg/fields"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
+
+	"github.com/avast/retry-go"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 type command config.CLIOptions
@@ -636,7 +638,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions) er
 
 	if controllerMode.WorkloadsEnabled() {
 		perfTimer.Checkpoint("starting-worker")
-		if err := c.startWorker(ctx, nodeName, kubeletExtraArgs, flags, nodeConfig); err != nil {
+		if err := c.startWorker(ctx, nodeName, kubeletExtraArgs, flags); err != nil {
 			logrus.WithError(err).Error("Failed to start controller worker")
 		} else {
 			perfTimer.Checkpoint("started-worker")
@@ -655,48 +657,18 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions) er
 	return nil
 }
 
-func (c *command) startWorker(ctx context.Context, nodeName apitypes.NodeName, kubeletExtraArgs stringmap.StringMap, opts *config.ControllerOptions, nodeConfig *v1beta1.ClusterConfig) error {
-	var bootstrapConfig string
-	if !file.Exists(c.K0sVars.KubeletAuthConfigPath) {
-		// wait for controller to start up
-		err := retry.Do(func() error {
-			if !file.Exists(c.K0sVars.AdminKubeConfigPath) {
-				return fmt.Errorf("file does not exist: %s", c.K0sVars.AdminKubeConfigPath)
-			}
-			return nil
-		}, retry.Context(ctx))
-		if err != nil {
-			return err
-		}
-
-		err = retry.Do(func() error {
-			// five minutes here are coming from maximum theoretical duration of kubelet bootstrap process
-			// we use retry.Do with 10 attempts, back-off delay and delay duration 500 ms which gives us
-			// 225 seconds here
-			tokenAge := time.Second * 225
-			cfg, err := token.CreateKubeletBootstrapToken(ctx, nodeConfig.Spec.API, c.K0sVars, token.RoleWorker, tokenAge)
-			if err != nil {
-				return err
-			}
-			bootstrapConfig = cfg
-			return nil
-		}, retry.Context(ctx))
-		if err != nil {
-			return err
-		}
-	}
+func (c *command) startWorker(ctx context.Context, nodeName apitypes.NodeName, kubeletExtraArgs stringmap.StringMap, opts *config.ControllerOptions) error {
 	// Cast and make a copy of the controller command so it can use the same
 	// opts to start the worker. Needs to be a copy so the original token and
 	// possibly other args won't get messed up.
 	wc := workercmd.Command(*(*config.CLIOptions)(c))
-	wc.TokenArg = bootstrapConfig
 	wc.Labels = append(wc.Labels, fields.OneTermEqualSelector(constant.K0SNodeRoleLabel, "control-plane").String())
 	if opts.Mode() == config.ControllerPlusWorkerMode && !opts.NoTaints {
 		key := path.Join(constant.NodeRoleLabelNamespace, "master")
 		taint := fields.OneTermEqualSelector(key, ":NoSchedule")
 		wc.Taints = append(wc.Taints, taint.String())
 	}
-	return wc.Start(ctx, nodeName, kubeletExtraArgs, (*embeddingController)(opts))
+	return wc.Start(ctx, nodeName, kubeletExtraArgs, kubernetes.KubeconfigFromFile(c.K0sVars.AdminKubeConfigPath), (*embeddingController)(opts))
 }
 
 type embeddingController config.ControllerOptions

--- a/cmd/token/preshared.go
+++ b/cmd/token/preshared.go
@@ -120,10 +120,10 @@ func createKubeConfig(tok *bootstraptokenv1.BootstrapTokenString, role, joinURL,
 
 	var userName string
 	switch role {
-	case "worker":
-		userName = "kubelet-bootstrap"
-	case "controller":
-		userName = "controller-bootstrap"
+	case token.RoleWorker:
+		userName = token.WorkerTokenAuthName
+	case token.RoleController:
+		userName = token.ControllerTokenAuthName
 	default:
 		return fmt.Errorf("unknown role: %s", role)
 	}

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -147,8 +147,8 @@ func GetNodeName(opts *config.WorkerOptions) (apitypes.NodeName, stringmap.Strin
 
 // Start starts the worker components based on the given [config.CLIOptions].
 func (c *Command) Start(ctx context.Context, nodeName apitypes.NodeName, kubeletExtraArgs stringmap.StringMap, controller EmbeddingController) error {
-	if err := worker.BootstrapKubeletKubeconfig(ctx, c.K0sVars, nodeName, &c.WorkerOptions); err != nil {
-		return err
+	if err := worker.BootstrapKubeletClientConfig(ctx, c.K0sVars, nodeName, &c.WorkerOptions); err != nil {
+		return fmt.Errorf("failed to bootstrap kubelet client configuration: %w", err)
 	}
 
 	kubeletKubeconfigPath := c.K0sVars.KubeletAuthConfigPath

--- a/pkg/component/worker/utils.go
+++ b/pkg/component/worker/utils.go
@@ -142,11 +142,6 @@ func BootstrapKubeletKubeconfig(ctx context.Context, k0sVars *config.CfgVars, no
 		return fmt.Errorf("wrong token type %s, expected type: %s", actual, token.WorkerTokenAuthName)
 	}
 
-	certDir := filepath.Join(k0sVars.KubeletRootDir, "pki")
-	if err := dir.Init(certDir, constant.DataDirMode); err != nil {
-		return fmt.Errorf("failed to initialize kubelet certificate directory: %w", err)
-	}
-
 	logrus.Infof("Bootstrapping kubelet client configuration using %s as node name", nodeName)
 
 	if err := retry.Do(
@@ -155,7 +150,7 @@ func BootstrapKubeletKubeconfig(ctx context.Context, k0sVars *config.CfgVars, no
 				ctx,
 				k0sVars.KubeletAuthConfigPath,
 				bootstrapKubeconfigPath,
-				certDir,
+				filepath.Join(k0sVars.KubeletRootDir, "pki"),
 				nodeName,
 			)
 		},

--- a/pkg/component/worker/utils.go
+++ b/pkg/component/worker/utils.go
@@ -138,8 +138,8 @@ func BootstrapKubeletKubeconfig(ctx context.Context, k0sVars *config.CfgVars, no
 		}
 	}
 
-	if tokenType := token.GetTokenType(bootstrapKubeconfig); tokenType != "kubelet-bootstrap" {
-		return fmt.Errorf("wrong token type %s, expected type: kubelet-bootstrap", tokenType)
+	if actual := token.GetTokenType(bootstrapKubeconfig); actual != token.WorkerTokenAuthName {
+		return fmt.Errorf("wrong token type %s, expected type: %s", actual, token.WorkerTokenAuthName)
 	}
 
 	certDir := filepath.Join(k0sVars.KubeletRootDir, "pki")

--- a/pkg/token/joinclient.go
+++ b/pkg/token/joinclient.go
@@ -33,9 +33,8 @@ import (
 
 // JoinClient is the client we can use to call k0s join APIs
 type JoinClient struct {
-	joinTokenType string
-	joinAddress   string
-	restClient    *rest.RESTClient
+	joinAddress string
+	restClient  *rest.RESTClient
 }
 
 // JoinClientFromToken creates a new join api client from a token
@@ -50,6 +49,10 @@ func JoinClientFromToken(encodedToken string) (*JoinClient, error) {
 		return nil, err
 	}
 
+	if actual := GetTokenType(kubeconfig); actual != ControllerTokenAuthName {
+		return nil, fmt.Errorf("wrong token type %s, expected type: %s", actual, ControllerTokenAuthName)
+	}
+
 	restConfig, err := kubernetes.ClientConfig(func() (*api.Config, error) { return kubeconfig, nil })
 	if err != nil {
 		return nil, err
@@ -62,18 +65,13 @@ func JoinClientFromToken(encodedToken string) (*JoinClient, error) {
 	}
 
 	return &JoinClient{
-		joinAddress:   restConfig.Host,
-		joinTokenType: GetTokenType(kubeconfig),
-		restClient:    restClient,
+		joinAddress: restConfig.Host,
+		restClient:  restClient,
 	}, nil
 }
 
 func (j *JoinClient) Address() string {
 	return j.joinAddress
-}
-
-func (j *JoinClient) JoinTokenType() string {
-	return j.joinTokenType
 }
 
 // GetCA calls the CA sync API

--- a/pkg/token/joinclient_test.go
+++ b/pkg/token/joinclient_test.go
@@ -50,7 +50,7 @@ func TestJoinClient_GetCA(t *testing.T) {
 	})
 
 	joinURL.Path = "/some/sub/path"
-	kubeconfig, err := token.GenerateKubeconfig(joinURL.String(), certData, t.Name(), &bootstraptokenv1.BootstrapTokenString{ID: "the-id", Secret: "the-secret"})
+	kubeconfig, err := token.GenerateKubeconfig(joinURL.String(), certData, token.ControllerTokenAuthName, &bootstraptokenv1.BootstrapTokenString{ID: "the-id", Secret: "the-secret"})
 	require.NoError(t, err)
 	tok, err := token.JoinEncode(bytes.NewReader(kubeconfig))
 	require.NoError(t, err)
@@ -85,7 +85,7 @@ func TestJoinClient_JoinEtcd(t *testing.T) {
 	})
 
 	joinURL.Path = "/some/sub/path"
-	kubeconfig, err := token.GenerateKubeconfig(joinURL.String(), certData, t.Name(), &bootstraptokenv1.BootstrapTokenString{ID: "the-id", Secret: "the-secret"})
+	kubeconfig, err := token.GenerateKubeconfig(joinURL.String(), certData, token.ControllerTokenAuthName, &bootstraptokenv1.BootstrapTokenString{ID: "the-id", Secret: "the-secret"})
 	require.NoError(t, err)
 	tok, err := token.JoinEncode(bytes.NewReader(kubeconfig))
 	require.NoError(t, err)
@@ -126,7 +126,7 @@ func TestJoinClient_Cancellation(t *testing.T) {
 				<-req.Context().Done()              // block forever
 			})
 
-			kubeconfig, err := token.GenerateKubeconfig(joinURL.String(), certData, "", &bootstraptokenv1.BootstrapTokenString{})
+			kubeconfig, err := token.GenerateKubeconfig(joinURL.String(), certData, token.ControllerTokenAuthName, &bootstraptokenv1.BootstrapTokenString{})
 			require.NoError(t, err)
 			tok, err := token.JoinEncode(bytes.NewReader(kubeconfig))
 			require.NoError(t, err)

--- a/pkg/token/kubeconfig.go
+++ b/pkg/token/kubeconfig.go
@@ -37,6 +37,11 @@ const (
 	RoleWorker     = "worker"
 )
 
+const (
+	ControllerTokenAuthName = "controller-bootstrap"
+	WorkerTokenAuthName     = "kubelet-bootstrap"
+)
+
 // CreateKubeletBootstrapToken creates a new k0s bootstrap token.
 func CreateKubeletBootstrapToken(ctx context.Context, api *v1beta1.APISpec, k0sVars *config.CfgVars, role string, expiry time.Duration) (string, error) {
 	userName, joinURL, err := loadUserAndJoinURL(api, role)
@@ -84,9 +89,9 @@ func GenerateKubeconfig(joinURL string, caCert []byte, userName string, token *b
 func loadUserAndJoinURL(api *v1beta1.APISpec, role string) (string, string, error) {
 	switch role {
 	case RoleController:
-		return "controller-bootstrap", api.K0sControlPlaneAPIAddress(), nil
+		return ControllerTokenAuthName, api.K0sControlPlaneAPIAddress(), nil
 	case RoleWorker:
-		return "kubelet-bootstrap", api.APIAddressURL(), nil
+		return WorkerTokenAuthName, api.APIAddressURL(), nil
 	default:
 		return "", "", fmt.Errorf("unsupported role %q; supported roles are %q and %q", role, RoleController, RoleWorker)
 	}


### PR DESCRIPTION
## Description

When a controller bootstraps its embedded kubelet, it doesn't have to use a join token at all. Instead, it can just bootstrap the kubelet configuration using its own admin kubeconfig.

Add a new KubeconfigGetter argument to the worker start method. If running from a controller, this will simply point to the admin kubeconfig. When running as a standalone worker, this will actually be backed by the join token, if any.

Extract kubelet's CA from its kubeconfig, instead of doing it once during the bootstrapping process. This eliminates the need for another persistent flle in k0s's data directory, allows the use of arbitrary kubelet bootstrap kubeconfigs (as long as they're valid), and removes a potential panic for bootstrap kubeconfigs that don't have a cluster called "k0s".

Improve logging during kubelet config bootstrapping: Use a structured logger, remove "kubelet" from log and error messages, as that's now obvious from the context.

Remove the explicit initialization of the kubelet cert directory. This will be handled by the upstream client config loading code just fine.

Remove the join client's token type. It has to be always of type controller-bootstrap. Integrate that check into the join client creation function instead.

Introduce constants for join token auth names.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings