### PR TITLE
Share node name detection between controller and worker

### DIFF
--- a/pkg/autopilot/common/hostname.go
+++ b/pkg/autopilot/common/hostname.go
@@ -29,11 +29,12 @@ const (
 // for an AUTOPILOT_HOSTNAME environment variable, falling back to whatever the OS
 // returns.
 func FindEffectiveHostname() (string, error) {
-	return node.GetNodename(os.Getenv(envAutopilotHostname))
+	nodeName, err := node.GetNodeName(os.Getenv(envAutopilotHostname))
+	return string(nodeName), err
 }
 
 func FindKubeletHostname(kubeletExtraArgs string) string {
-	defaultNodename, _ := node.GetNodename("")
+	defaultNodename, _ := node.GetNodeName("")
 	if kubeletExtraArgs != "" {
 		extras := flags.Split(kubeletExtraArgs)
 		nodeName, ok := extras["--hostname-override"]
@@ -42,5 +43,5 @@ func FindKubeletHostname(kubeletExtraArgs string) string {
 		}
 	}
 
-	return defaultNodename
+	return string(defaultNodename)
 }

--- a/pkg/node/nodename.go
+++ b/pkg/node/nodename.go
@@ -20,18 +20,19 @@ import (
 	"context"
 	"fmt"
 
+	apitypes "k8s.io/apimachinery/pkg/types"
 	nodeutil "k8s.io/component-helpers/node/util"
 )
 
-// GetNodename returns the node name for the node taking OS, cloud provider and override into account
-func GetNodename(override string) (string, error) {
-	return getNodename(context.TODO(), override)
+// GetNodeName returns the node name for the node taking OS, cloud provider and override into account
+func GetNodeName(override string) (apitypes.NodeName, error) {
+	return getNodeName(context.TODO(), override)
 }
 
-func getNodename(ctx context.Context, override string) (string, error) {
+func getNodeName(ctx context.Context, override string) (apitypes.NodeName, error) {
 	if override == "" {
 		var err error
-		override, err = defaultNodenameOverride(ctx)
+		override, err = defaultNodeNameOverride(ctx)
 		if err != nil {
 			return "", err
 		}
@@ -40,5 +41,5 @@ func getNodename(ctx context.Context, override string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to determine node name: %w", err)
 	}
-	return nodeName, nil
+	return apitypes.NodeName(nodeName), nil
 }

--- a/pkg/node/nodename_other.go
+++ b/pkg/node/nodename_other.go
@@ -22,6 +22,6 @@ import (
 	"context"
 )
 
-func defaultNodenameOverride(context.Context) (string, error) {
+func defaultNodeNameOverride(context.Context) (string, error) {
 	return "", nil // no default override
 }

--- a/pkg/node/nodename_test.go
+++ b/pkg/node/nodename_test.go
@@ -20,16 +20,18 @@ import (
 	"runtime"
 	"testing"
 
+	apitypes "k8s.io/apimachinery/pkg/types"
+	nodeutil "k8s.io/component-helpers/node/util"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	nodeutil "k8s.io/component-helpers/node/util"
 )
 
-func TestGetNodename(t *testing.T) {
+func TestGetNodeName(t *testing.T) {
 	t.Run("should_always_return_override_if_given", func(t *testing.T) {
-		name, err := GetNodename("override")
+		name, err := GetNodeName("override")
 		if assert.NoError(t, err) {
-			assert.Equal(t, "override", name)
+			assert.Equal(t, apitypes.NodeName("override"), name)
 		}
 	})
 
@@ -38,9 +40,9 @@ func TestGetNodename(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("should_call_kubernetes_hostname_helper_on_linux", func(t *testing.T) {
-			name, err := GetNodename("")
+			name, err := GetNodeName("")
 			if assert.NoError(t, err) {
-				assert.Equal(t, kubeHostname, name)
+				assert.Equal(t, apitypes.NodeName(kubeHostname), name)
 			}
 		})
 	}

--- a/pkg/node/nodename_windows.go
+++ b/pkg/node/nodename_windows.go
@@ -28,7 +28,7 @@ import (
 // A URL that may be retrieved to determine the nodename.
 type nodenameURL string
 
-func defaultNodenameOverride(ctx context.Context) (string, error) {
+func defaultNodeNameOverride(ctx context.Context) (string, error) {
 	// we need to check if we have EC2 dns name available
 	url := k0scontext.ValueOr[nodenameURL](ctx, "http://169.254.169.254/latest/meta-data/local-hostname")
 

--- a/pkg/node/nodename_windows_test.go
+++ b/pkg/node/nodename_windows_test.go
@@ -24,29 +24,32 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/pkg/k0scontext"
+
+	apitypes "k8s.io/apimachinery/pkg/types"
+	nodeutil "k8s.io/component-helpers/node/util"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	nodeutil "k8s.io/component-helpers/node/util"
 )
 
-func TestGetNodenameWindows(t *testing.T) {
+func TestGetNodeNameWindows(t *testing.T) {
 	kubeHostname, err := nodeutil.GetHostname("")
 	require.NoError(t, err)
 	baseURL := startFakeMetadataServer(t)
 
 	t.Run("no_metadata_service_available", func(t *testing.T) {
 		ctx := k0scontext.WithValue(context.TODO(), nodenameURL(baseURL))
-		name, err := getNodename(ctx, "")
+		name, err := getNodeName(ctx, "")
 		if assert.NoError(t, err) {
-			assert.Equal(t, kubeHostname, name)
+			assert.Equal(t, apitypes.NodeName(kubeHostname), name)
 		}
 	})
 
 	t.Run("metadata_service_is_available", func(t *testing.T) {
 		ctx := k0scontext.WithValue(context.TODO(), nodenameURL(baseURL+"/latest/meta-data/local-hostname"))
-		name, err := getNodename(ctx, "")
+		name, err := getNodeName(ctx, "")
 		if assert.NoError(t, err) {
-			assert.Equal(t, "some-hostname from aws_metadata", name)
+			assert.Equal(t, apitypes.NodeName("some-hostname from aws_metadata"), name)
 		}
 	})
 }


### PR DESCRIPTION
## Description

The controller uses the node name solely when counting the number of active controllers. Albeit it's not super-important to match the actual worker node name in any case, it is probably a good practice and avoids weird edge cases.

Use the Kubernetes API machinery's `NodeName` newtype to "tag" the node name in a type safe manner, i.e. so that it can't be mixed with other arbitrary strings.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings