### PR TITLE
Disable leader election in single-controller clusters

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -242,6 +242,9 @@ func (c *command) start(ctx context.Context) error {
 	logrus.Infof("using storage backend %s", nodeConfig.Spec.Storage.Type)
 	nodeComponents.Add(ctx, storageBackend)
 
+	// Will the cluster support multiple controllers, or just a single one?
+	singleController := c.SingleNode || !nodeConfig.Spec.Storage.IsJoinable()
+
 	// Assume a single active controller during startup
 	numActiveControllers := value.NewLatest[uint](1)
 
@@ -300,7 +303,7 @@ func (c *command) start(ctx context.Context) error {
 		return fmt.Errorf("failed to determine node name: %w", err)
 	}
 
-	if !c.SingleNode {
+	if !singleController {
 		nodeComponents.Add(ctx, &controller.K0sControllersLeaseCounter{
 			NodeName:              nodeName,
 			InvocationID:          c.K0sVars.InvocationID,
@@ -316,12 +319,12 @@ func (c *command) start(ctx context.Context) error {
 	}
 
 	// One leader elector per controller
-	if !c.SingleNode {
+	if singleController {
+		leaderElector = &leaderelector.Dummy{Leader: true}
+	} else {
 		// The name used to be hardcoded in the component itself
 		// At some point we need to rename this.
 		leaderElector = leaderelector.NewLeasePool(c.K0sVars.InvocationID, adminClientFactory, "k0s-endpoint-reconciler")
-	} else {
-		leaderElector = &leaderelector.Dummy{Leader: true}
 	}
 	nodeComponents.Add(ctx, leaderElector)
 
@@ -560,9 +563,9 @@ func (c *command) start(ctx context.Context) error {
 
 	if !slices.Contains(c.DisableComponents, constant.KubeSchedulerComponentName) {
 		clusterComponents.Add(ctx, &controller.Scheduler{
-			LogLevel:   c.LogLevels.KubeScheduler,
-			K0sVars:    c.K0sVars,
-			SingleNode: c.SingleNode,
+			LogLevel:              c.LogLevels.KubeScheduler,
+			K0sVars:               c.K0sVars,
+			DisableLeaderElection: singleController,
 		})
 	}
 
@@ -570,7 +573,7 @@ func (c *command) start(ctx context.Context) error {
 		clusterComponents.Add(ctx, &controller.Manager{
 			LogLevel:              c.LogLevels.KubeControllerManager,
 			K0sVars:               c.K0sVars,
-			SingleNode:            c.SingleNode,
+			DisableLeaderElection: singleController,
 			ServiceClusterIPRange: nodeConfig.Spec.Network.BuildServiceCIDR(nodeConfig.Spec.API.Address),
 			ExtraArgs:             c.KubeControllerManagerExtraArgs,
 		})
@@ -590,7 +593,7 @@ func (c *command) start(ctx context.Context) error {
 		K0sVars:            c.K0sVars,
 		KubeletExtraArgs:   c.KubeletExtraArgs,
 		AdminClientFactory: adminClientFactory,
-		EnableWorker:       c.EnableWorker,
+		Workloads:          c.EnableWorker,
 	})
 
 	restConfig, err := adminClientFactory.GetRESTConfig()

--- a/pkg/component/controller/autopilot.go
+++ b/pkg/component/controller/autopilot.go
@@ -38,7 +38,7 @@ type Autopilot struct {
 	K0sVars            *config.CfgVars
 	KubeletExtraArgs   string
 	AdminClientFactory kubernetes.ClientFactoryInterface
-	EnableWorker       bool
+	Workloads          bool
 }
 
 func (a *Autopilot) Init(ctx context.Context) error {
@@ -66,7 +66,7 @@ func (a *Autopilot) Start(ctx context.Context) error {
 		ManagerPort:         8899,
 		MetricsBindAddr:     "0",
 		HealthProbeBindAddr: "0",
-	}, logrus.WithFields(logrus.Fields{"component": "autopilot"}), a.EnableWorker, a.AdminClientFactory, autopilotClientFactory)
+	}, logrus.WithFields(logrus.Fields{"component": "autopilot"}), a.Workloads, a.AdminClientFactory, autopilotClientFactory)
 	if err != nil {
 		return fmt.Errorf("failed to create autopilot controller: %w", err)
 	}

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -41,7 +41,7 @@ import (
 type Manager struct {
 	K0sVars               *config.CfgVars
 	LogLevel              string
-	SingleNode            bool
+	DisableLeaderElection bool
 	ServiceClusterIPRange string
 	ExtraArgs             string
 
@@ -132,7 +132,7 @@ func (a *Manager) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterCon
 			args[name] = value
 		}
 	}
-	if a.SingleNode {
+	if a.DisableLeaderElection {
 		args["leader-elect"] = "false"
 	}
 

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -35,13 +35,13 @@ import (
 
 // Scheduler implement the component interface to run kube scheduler
 type Scheduler struct {
-	gid            int
-	K0sVars        *config.CfgVars
-	LogLevel       string
-	SingleNode     bool
-	supervisor     *supervisor.Supervisor
-	uid            int
-	previousConfig stringmap.StringMap
+	gid                   int
+	K0sVars               *config.CfgVars
+	LogLevel              string
+	DisableLeaderElection bool
+	supervisor            *supervisor.Supervisor
+	uid                   int
+	previousConfig        stringmap.StringMap
 }
 
 var _ manager.Component = (*Scheduler)(nil)
@@ -95,7 +95,7 @@ func (a *Scheduler) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterC
 		}
 		args[name] = value
 	}
-	if a.SingleNode {
+	if a.DisableLeaderElection {
 		args["leader-elect"] = "false"
 	}
 	args = clusterConfig.Spec.FeatureGates.BuildArgs(args, kubeSchedulerComponentName)


### PR DESCRIPTION
## Description

Leader election has only been disabled for single node clusters. However, it can also be disabled if there's no chance of ever joining another controller because the underlying storage is embedded.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings