### PR TITLE
Apply the bootstraprbac stack directly

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -323,6 +323,7 @@ func (c *command) start(ctx context.Context) error {
 			KubeClientFactory: adminClientFactory,
 			IgnoredStacks: []string{
 				controller.ClusterConfigStackName,
+				controller.SystemRBACStackName,
 			},
 			LeaderElector: leaderElector,
 		})
@@ -533,8 +534,8 @@ func (c *command) start(ctx context.Context) error {
 		clusterComponents.Add(ctx, reconciler)
 	}
 
-	if !slices.Contains(c.DisableComponents, constant.SystemRbacComponentName) {
-		clusterComponents.Add(ctx, controller.NewSystemRBAC(c.K0sVars.ManifestsDir))
+	if !slices.Contains(c.DisableComponents, constant.SystemRBACComponentName) {
+		clusterComponents.Add(ctx, &controller.SystemRBAC{Clients: adminClientFactory})
 	}
 
 	if !slices.Contains(c.DisableComponents, constant.NodeRoleComponentName) {

--- a/pkg/component/controller/systemrbac.go
+++ b/pkg/component/controller/systemrbac.go
@@ -17,37 +17,75 @@ limitations under the License.
 package controller
 
 import (
+	"bytes"
+	"cmp"
 	"context"
 	_ "embed"
-	"path"
-	"path/filepath"
+	"fmt"
 
-	"github.com/k0sproject/k0s/internal/pkg/dir"
-	"github.com/k0sproject/k0s/internal/pkg/file"
+	"github.com/k0sproject/k0s/pkg/applier"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/constant"
+	"github.com/k0sproject/k0s/pkg/kubernetes"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/cli-runtime/pkg/resource"
+
+	"github.com/avast/retry-go"
+	"github.com/sirupsen/logrus"
 )
+
+const SystemRBACStackName = "bootstraprbac"
 
 // SystemRBAC implements system RBAC reconciler
 type SystemRBAC struct {
-	manifestDir string
+	Clients kubernetes.ClientFactoryInterface
 }
 
 var _ manager.Component = (*SystemRBAC)(nil)
 
-// NewSystemRBAC creates new system level RBAC reconciler
-func NewSystemRBAC(manifestDir string) *SystemRBAC {
-	return &SystemRBAC{manifestDir}
-}
-
-// Writes the bootstrap RBAC manifests into the manifests folder.
-func (s *SystemRBAC) Init(context.Context) error {
-	rbacDir := path.Join(s.manifestDir, "bootstraprbac")
-	if err := dir.Init(rbacDir, constant.ManifestsDirMode); err != nil {
+// Applies the system RBAC manifests to the cluster.
+func (s *SystemRBAC) Init(ctx context.Context) error {
+	infos, err := resource.NewLocalBuilder().
+		Unstructured().
+		Stream(bytes.NewReader(systemRBAC), SystemRBACStackName).
+		Flatten().
+		Do().
+		Infos()
+	if err != nil {
 		return err
 	}
 
-	return file.WriteContentAtomically(filepath.Join(rbacDir, "bootstrap-rbac.yaml"), systemRBAC, 0644)
+	resources := make([]*unstructured.Unstructured, len(infos))
+	for i := range infos {
+		resources[i] = infos[i].Object.(*unstructured.Unstructured)
+	}
+
+	var lastErr error
+	if err := retry.Do(
+		func() error {
+			stack := applier.Stack{
+				Name:      SystemRBACStackName,
+				Resources: resources,
+				Clients:   s.Clients,
+			}
+			lastErr := stack.Apply(ctx, true)
+			return lastErr
+		},
+		retry.Context(ctx),
+		retry.LastErrorOnly(true),
+		retry.OnRetry(func(attempt uint, err error) {
+			logrus.WithFields(logrus.Fields{
+				"component": constant.SystemRBACComponentName,
+				"stack":     SystemRBACStackName,
+				"attempt":   attempt + 1,
+			}).WithError(err).Debug("Failed to apply stack, retrying after backoff")
+		}),
+	); err != nil {
+		return fmt.Errorf("failed to apply system RBAC stack: %w", cmp.Or(lastErr, err))
+	}
+
+	return nil
 }
 
 func (s *SystemRBAC) Start(context.Context) error { return nil }

--- a/pkg/component/controller/systemrbac.yaml
+++ b/pkg/component/controller/systemrbac.yaml
@@ -1,0 +1,66 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubelet-bootstrap
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node-bootstrapper
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-autoapprove-bootstrap
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:nodeclient
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-autoapprove-certificate-rotation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:selfnodeclient
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:nodes:autopilot
+rules:
+  - apiGroups: ["autopilot.k0sproject.io"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["nodes", "pods", "pods/eviction", "namespaces"]
+    verbs: ["*"]
+  - apiGroups: ["apps"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:nodes:autopilot
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:nodes:autopilot
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:nodes

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -262,7 +262,7 @@ var availableComponents = []string{
 	constant.MetricsServerComponentName,
 	constant.NetworkProviderComponentName,
 	constant.NodeRoleComponentName,
-	constant.SystemRbacComponentName,
+	constant.SystemRBACComponentName,
 	constant.WindowsNodeComponentName,
 	constant.WorkerConfigComponentName,
 }

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -118,7 +118,7 @@ const (
 	WorkerConfigComponentName          = "worker-config"
 	MetricsServerComponentName         = "metrics-server"
 	NetworkProviderComponentName       = "network-provider"
-	SystemRbacComponentName            = "system-rbac"
+	SystemRBACComponentName            = "system-rbac"
 	NodeRoleComponentName              = "node-role"
 	WindowsNodeComponentName           = "windows-node"
 	AutopilotComponentName             = "autopilot"


### PR DESCRIPTION
## Description

Don't write the manifests to disk, just use them directly in the `Init` method as a standalone stack. Flag the stack name as ignored in the applier manager. Move the const manifest content to a separate file and use go:embed to retrieve it. As there's no templating involved, remove the template writer and use the embedded data directly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings