### PR TITLE
Wait for autpoilot CRDs before starting Autopilot worker component

### DIFF
--- a/pkg/autopilot/controller/root_worker.go
+++ b/pkg/autopilot/controller/root_worker.go
@@ -8,7 +8,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"time"
 
 	apcli "github.com/k0sproject/k0s/pkg/autopilot/client"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
@@ -16,11 +15,8 @@ import (
 	"github.com/k0sproject/k0s/pkg/autopilot/controller/signal"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	k8sretry "k8s.io/client-go/util/retry"
-	"k8s.io/utils/ptr"
+
 	cr "sigs.k8s.io/controller-runtime"
-	crconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	crman "sigs.k8s.io/controller-runtime/pkg/manager"
 	crmetricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	crwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -32,8 +28,6 @@ type rootWorker struct {
 	cfg           aproot.RootConfig
 	log           *logrus.Entry
 	clientFactory apcli.FactoryInterface
-
-	initialized bool
 }
 
 var _ aproot.Root = (*rootWorker)(nil)
@@ -54,16 +48,6 @@ func (w *rootWorker) Run(ctx context.Context) error {
 
 	managerOpts := crman.Options{
 		Scheme: scheme,
-		Controller: crconfig.Controller{
-			// If this controller is already initialized, this means that all
-			// controller-runtime controllers have already been successfully
-			// registered to another manager. However, controller-runtime
-			// maintains a global checklist of controller names and doesn't
-			// currently provide a way to unregister names from discarded
-			// managers. So it's necessary to suppress the global name check
-			// whenever things retried.
-			SkipNameValidation: ptr.To(w.initialized),
-		},
 		WebhookServer: crwebhook.NewServer(crwebhook.Options{
 			Port: w.cfg.ManagerPort,
 		}),
@@ -73,51 +57,34 @@ func (w *rootWorker) Run(ctx context.Context) error {
 		HealthProbeBindAddress: w.cfg.HealthProbeBindAddr,
 	}
 
-	// In some cases, we need to wait on the worker side until controller deploys all autopilot CRDs
-	var attempt uint
-	return k8sretry.OnError(wait.Backoff{
-		Steps:    120,
-		Duration: 1 * time.Second,
-		Factor:   1.0,
-		Jitter:   0.1,
-	}, func(err error) bool {
-		attempt++
-		logger := logger.WithError(err).WithField("attempt", attempt)
-		logger.Debug("Failed to run controller manager, retrying after backoff")
-		return true
-	}, func() error {
-		clusterID, err := w.getClusterID(ctx)
-		if err != nil {
-			return err
-		}
+	clusterID, err := w.getClusterID(ctx)
+	if err != nil {
+		return err
+	}
 
-		restConfig, err := w.clientFactory.GetRESTConfig()
-		if err != nil {
-			return err
-		}
+	restConfig, err := w.clientFactory.GetRESTConfig()
+	if err != nil {
+		return err
+	}
 
-		mgr, err := cr.NewManager(restConfig, managerOpts)
-		if err != nil {
-			return fmt.Errorf("failed to create controller manager: %w", err)
-		}
+	mgr, err := cr.NewManager(restConfig, managerOpts)
+	if err != nil {
+		return fmt.Errorf("failed to create controller manager: %w", err)
+	}
 
-		if err := RegisterIndexers(ctx, mgr, "worker"); err != nil {
-			return fmt.Errorf("unable to register indexers: %w", err)
-		}
+	if err := RegisterIndexers(ctx, mgr, "worker"); err != nil {
+		return fmt.Errorf("unable to register indexers: %w", err)
+	}
 
-		if err := signal.RegisterControllers(ctx, logger, mgr, apdel.NodeControllerDelegate(), w.cfg.K0sDataDir, clusterID); err != nil {
-			return fmt.Errorf("unable to register signal controllers: %w", err)
-		}
+	if err := signal.RegisterControllers(ctx, logger, mgr, apdel.NodeControllerDelegate(), w.cfg.K0sDataDir, clusterID); err != nil {
+		return fmt.Errorf("unable to register signal controllers: %w", err)
+	}
 
-		// All the controller-runtime controllers have been registered.
-		w.initialized = true
-
-		// The controller-runtime start blocks until the context is canceled.
-		if err := mgr.Start(ctx); err != nil {
-			return fmt.Errorf("unable to run controller-runtime manager for workers: %w", err)
-		}
-		return nil
-	})
+	// The controller-runtime start blocks until the context is canceled.
+	if err := mgr.Start(ctx); err != nil {
+		return fmt.Errorf("unable to run controller-runtime manager for workers: %w", err)
+	}
+	return nil
 }
 
 func (w *rootWorker) getClusterID(ctx context.Context) (string, error) {

--- a/pkg/component/controller/systemrbac-ap.yaml
+++ b/pkg/component/controller/systemrbac-ap.yaml
@@ -30,6 +30,10 @@ rules:
   - apiGroups: [autopilot.k0sproject.io]
     resources: [plans]
     verbs: [get, list, watch]
+  # Autopilot waits until the Autopilot CRDs appeared.
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [get, list, watch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/component/worker/autopilot.go
+++ b/pkg/component/worker/autopilot.go
@@ -6,26 +6,28 @@
 package worker
 
 import (
+	"cmp"
 	"context"
-	"errors"
 	"fmt"
+	"slices"
 	"time"
 
+	autopilotv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
 	apcli "github.com/k0sproject/k0s/pkg/autopilot/client"
 	apcont "github.com/k0sproject/k0s/pkg/autopilot/controller"
 	aproot "github.com/k0sproject/k0s/pkg/autopilot/controller/root"
+	k0sscheme "github.com/k0sproject/k0s/pkg/client/clientset/scheme"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/kubernetes"
-	"github.com/sirupsen/logrus"
+	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
 
-	"k8s.io/apimachinery/pkg/util/wait"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
-)
 
-const (
-	defaultPollDuration = 5 * time.Second
-	defaultPollTimeout  = 5 * time.Minute
+	"github.com/avast/retry-go"
+	"github.com/sirupsen/logrus"
 )
 
 var _ manager.Component = (*Autopilot)(nil)
@@ -33,6 +35,8 @@ var _ manager.Component = (*Autopilot)(nil)
 type Autopilot struct {
 	K0sVars     *config.CfgVars
 	CertManager *CertificateManager
+
+	clientFactory apcli.FactoryInterface
 }
 
 func (a *Autopilot) Init(ctx context.Context) error {
@@ -40,39 +44,44 @@ func (a *Autopilot) Init(ctx context.Context) error {
 }
 
 func (a *Autopilot) Start(ctx context.Context) error {
-	log := logrus.WithFields(logrus.Fields{"component": "autopilot"})
+	log := logrus.WithField("component", "autopilot")
 
-	// Wait 5 mins till we see kubelet auth config in place
-	timeout, cancel := context.WithTimeout(ctx, defaultPollTimeout)
-	defer cancel()
-
-	var restConfig *rest.Config
-	// wait.PollUntilWithContext passes it is own ctx argument as a ctx to the given function
-	// Poll until the kubelet config can be loaded successfully, as this is the access to the kube api
-	// needed by autopilot.
-	if err := wait.PollUntilWithContext(timeout, defaultPollDuration, func(ctx context.Context) (done bool, err error) {
-		log.Debugf("Attempting to load autopilot client config")
-		if restConfig, err = a.CertManager.GetRestConfig(ctx); err != nil {
-			log.WithError(err).Warnf("Failed to load autopilot client config, retrying in %v", defaultPollDuration)
-			return false, nil
-		}
-
-		return true, nil
-	}); err != nil {
-		return fmt.Errorf("unable to create autopilot client: %w", err)
+	kinds, err := getAutopilotKinds()
+	if err != nil {
+		return err
 	}
 
-	// Without the config, there is nothing that we can do.
+	var lastErr error
+	if err := retry.Do(
+		func() (err error) {
+			defer func() { lastErr = err }()
 
-	if restConfig == nil {
-		return errors.New("unable to create an autopilot client -- timed out")
+			restConfig, err := a.CertManager.GetRestConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			a.clientFactory = &apcli.ClientFactory{ClientFactoryInterface: &kubernetes.ClientFactory{
+				LoadRESTConfig: func() (*rest.Config, error) { return restConfig, nil },
+			}}
+
+			// We need to wait until all autopilot CRDs are established.
+			kinds := slices.Clone(kinds) // take a copy to avoid side effects
+			if err := waitUntilCRDsEstablished(ctx, a.clientFactory, kinds); err != nil {
+				return fmt.Errorf("while waiting for Autopilot CRDs %v to become established: %w", kinds, err)
+			}
+
+			return nil
+		},
+		retry.Context(ctx),
+		retry.LastErrorOnly(true),
+		retry.OnRetry(func(attempt uint, err error) {
+			log.WithField("attempt", attempt+1).WithError(err).Debug("Retrying after backoff")
+		}),
+	); err != nil {
+		return fmt.Errorf("failed to initialize autopilot: %w", cmp.Or(lastErr, err))
 	}
 
-	autopilotClientFactory := &apcli.ClientFactory{ClientFactoryInterface: &kubernetes.ClientFactory{
-		LoadRESTConfig: func() (*rest.Config, error) { return restConfig, nil },
-	}}
-
-	log.Info("Autopilot client factory created, booting up worker root controller")
 	autopilotRoot, err := apcont.NewRootWorker(aproot.RootConfig{
 		KubeConfig:          a.K0sVars.KubeletAuthConfigPath,
 		K0sDataDir:          a.K0sVars.DataDir,
@@ -80,7 +89,7 @@ func (a *Autopilot) Start(ctx context.Context) error {
 		ManagerPort:         8899,
 		MetricsBindAddr:     "0",
 		HealthProbeBindAddr: "0",
-	}, log, autopilotClientFactory)
+	}, log, a.clientFactory)
 	if err != nil {
 		return fmt.Errorf("failed to create autopilot worker: %w", err)
 	}
@@ -99,4 +108,90 @@ func (a *Autopilot) Start(ctx context.Context) error {
 // Stop stops Autopilot
 func (a *Autopilot) Stop() error {
 	return nil
+}
+
+// Gathers all kinds in the autopilot API group.
+func getAutopilotKinds() ([]string, error) {
+	var kinds []string
+
+	gv := autopilotv1beta2.SchemeGroupVersion
+	for kind := range k0sscheme.Scheme.KnownTypes(gv) {
+		// For some reason, the scheme also returns types from core/v1. Filter
+		// those out by only adding kinds which are _only_ in the autopilot
+		// group, and not in some other group as well. The only way to get all
+		// the GVKs for a certain type is by creating a new instance of that
+		// type and then asking the scheme about it.
+		obj, err := k0sscheme.Scheme.New(gv.WithKind(kind))
+		if err != nil {
+			return nil, err
+		}
+		gvks, _, err := k0sscheme.Scheme.ObjectKinds(obj)
+		if err != nil {
+			return nil, err
+		}
+
+		// Skip the kind if there's at least one GVK which is not in the
+		// autopilot group
+		if !slices.ContainsFunc(gvks, func(gvk schema.GroupVersionKind) bool {
+			return gvk.Group != autopilotv1beta2.GroupName
+		}) {
+			kinds = append(kinds, kind)
+		}
+	}
+
+	slices.Sort(kinds) // for cosmetic purposes
+	return kinds, nil
+}
+
+func waitUntilCRDsEstablished(ctx context.Context, clientFactory apcli.FactoryInterface, kinds []string) error {
+	client, err := clientFactory.GetExtensionClient()
+	if err != nil {
+		return err
+	}
+
+	// Watch all the CRDs until all the required ones are established.
+	log := logrus.WithField("component", "autopilot")
+	return watch.CRDs(client.CustomResourceDefinitions()).
+		WithErrorCallback(func(err error) (time.Duration, error) {
+			if retryAfter, e := watch.IsRetryable(err); e == nil {
+				log.WithError(err).Info(
+					"Transient error while watching for CRDs",
+					", starting over after ", retryAfter, " ...",
+				)
+				return retryAfter, nil
+			}
+
+			retryAfter := 10 * time.Second
+			log.WithError(err).Error(
+				"Error while watching CRDs",
+				", starting over after ", retryAfter, " ...",
+			)
+			return retryAfter, nil
+		}).
+		Until(ctx, func(item *apiextensionsv1.CustomResourceDefinition) (bool, error) {
+			if item.Spec.Group != autopilotv1beta2.GroupName {
+				return false, nil // Not an autopilot CRD.
+			}
+
+			// Find the established status for the CRD.
+			var established apiextensionsv1.ConditionStatus
+			for _, cond := range item.Status.Conditions {
+				if cond.Type == apiextensionsv1.Established {
+					established = cond.Status
+					break
+				}
+			}
+
+			if established != apiextensionsv1.ConditionTrue {
+				return false, nil // CRD not yet established.
+			}
+
+			// Remove the CRD's (list) kind from the list.
+			kinds = slices.DeleteFunc(kinds, func(kind string) bool {
+				return kind == item.Spec.Names.Kind || kind == item.Spec.Names.ListKind
+			})
+
+			// If the list is empty, all required CRDs are established.
+			return len(kinds) < 1, nil
+		})
 }


### PR DESCRIPTION
## Description

Instead of having multiple brute-force retry loops in a row, just have one that actually watches the CRDs and waits until it has observed all the Autopilot CRDs to be established. This covers API server reachability and CRD availability in one go.

It also ensures that controller-runtime registration is done only once. Since controller-runtime v0.19.0, registering the same thing twice will result in an error.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings