### PR TITLE
Implement leaderelector.Interface in terms of the new leader elector client

### DIFF
--- a/pkg/applier/manager_test.go
+++ b/pkg/applier/manager_test.go
@@ -27,12 +27,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k0sproject/k0s/internal/sync/value"
 	"github.com/k0sproject/k0s/internal/testutil"
 	"github.com/k0sproject/k0s/pkg/applier"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
+	"github.com/k0sproject/k0s/pkg/leaderelection"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -310,7 +312,7 @@ func writeStack(t *testing.T, dst string, src string) {
 
 type mockLeaderElector struct {
 	mu       sync.Mutex
-	leader   bool
+	leader   value.Latest[bool]
 	acquired []func()
 	lost     []func()
 }
@@ -318,8 +320,9 @@ type mockLeaderElector struct {
 func (e *mockLeaderElector) activate() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if !e.leader {
-		e.leader = true
+
+	if leader, _ := e.leader.Peek(); !leader {
+		e.leader.Set(true)
 		for _, fn := range e.acquired {
 			fn()
 		}
@@ -329,8 +332,8 @@ func (e *mockLeaderElector) activate() {
 func (e *mockLeaderElector) deactivate() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if e.leader {
-		e.leader = false
+	if leader, _ := e.leader.Peek(); leader {
+		e.leader.Set(false)
 		for _, fn := range e.lost {
 			fn()
 		}
@@ -340,14 +343,23 @@ func (e *mockLeaderElector) deactivate() {
 func (e *mockLeaderElector) IsLeader() bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	return e.leader
+	leader, _ := e.leader.Peek()
+	return leader
+}
+
+func (e *mockLeaderElector) CurrentStatus() (status leaderelection.Status, expired <-chan struct{}) {
+	leader, expired := e.leader.Peek()
+	if leader {
+		return leaderelection.StatusLeading, expired
+	}
+	return leaderelection.StatusPending, expired
 }
 
 func (e *mockLeaderElector) AddAcquiredLeaseCallback(fn func()) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.acquired = append(e.acquired, fn)
-	if e.leader {
+	if leader, _ := e.leader.Peek(); leader {
 		fn()
 	}
 }
@@ -356,7 +368,7 @@ func (e *mockLeaderElector) AddLostLeaseCallback(fn func()) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.lost = append(e.lost, fn)
-	if e.leader {
+	if leader, _ := e.leader.Peek(); !leader {
 		fn()
 	}
 }

--- a/pkg/component/controller/leaderelector/dummy.go
+++ b/pkg/component/controller/leaderelector/dummy.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/k0sproject/k0s/pkg/component/manager"
+	"github.com/k0sproject/k0s/pkg/leaderelection"
 )
 
 type Dummy struct {
@@ -36,6 +37,17 @@ func (l *Dummy) IsLeader() bool               { return l.Leader }
 
 func (l *Dummy) AddAcquiredLeaseCallback(fn func()) {
 	l.callbacks = append(l.callbacks, fn)
+}
+
+var never = make(<-chan struct{})
+
+func (l *Dummy) CurrentStatus() (leaderelection.Status, <-chan struct{}) {
+	var status leaderelection.Status
+	if l.Leader {
+		status = leaderelection.StatusLeading
+	}
+
+	return status, never
 }
 
 func (l *Dummy) AddLostLeaseCallback(func()) {}

--- a/pkg/component/controller/leaderelector/leasepool.go
+++ b/pkg/component/controller/leaderelector/leasepool.go
@@ -126,10 +126,12 @@ func (l *LeasePool) Stop() error {
 	return nil
 }
 
+// CurrentStatus is this lease pool's [leaderelection.StatusFunc].
 func (l *LeasePool) CurrentStatus() (leaderelection.Status, <-chan struct{}) {
 	return l.status.Peek()
 }
 
+// Deprecated: Use [LeasePool.CurrentStatus] instead.
 func (l *LeasePool) IsLeader() bool {
 	status, _ := l.CurrentStatus()
 	return status == leaderelection.StatusLeading

--- a/pkg/component/controller/leaderelector/types.go
+++ b/pkg/component/controller/leaderelector/types.go
@@ -16,9 +16,19 @@ limitations under the License.
 
 package leaderelector
 
+import "github.com/k0sproject/k0s/pkg/leaderelection"
+
 // Interface is the common leader elector component to manage each controller leader status.
 type Interface interface {
+	// Deprecated: Use [Interface.CurrentStatus] instead.
 	IsLeader() bool
+
+	// Deprecated: Use [Interface.CurrentStatus] instead.
 	AddAcquiredLeaseCallback(fn func())
+
+	// Deprecated: Use [Interface.CurrentStatus] instead.
 	AddLostLeaseCallback(fn func())
+
+	// CurrentStatus is this leader elector's [leaderelection.StatusFunc].
+	CurrentStatus() (status leaderelection.Status, expired <-chan struct{})
 }

--- a/pkg/component/controller/workerconfig/reconciler_test.go
+++ b/pkg/component/controller/workerconfig/reconciler_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
 	kube "github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/k0sproject/k0s/pkg/leaderelection"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -924,5 +925,9 @@ func (e *mockLeaderElector) AddAcquiredLeaseCallback(fn func()) {
 }
 
 func (e *mockLeaderElector) AddLostLeaseCallback(func()) {
+	panic("not expected to be called in tests")
+}
+
+func (e *mockLeaderElector) CurrentStatus() (leaderelection.Status, <-chan struct{}) {
 	panic("not expected to be called in tests")
 }

--- a/pkg/leaderelection/tasks.go
+++ b/pkg/leaderelection/tasks.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"context"
+	"errors"
+)
+
+// Indicates that the previously gained lead has been lost.
+var ErrLostLead = errors.New("lost the lead")
+
+// Returns the current leader election status. Whenever the status becomes
+// outdated, the returned expired channel will be closed.
+type StatusFunc func() (current Status, expired <-chan struct{})
+
+// Runs the provided tasks function when the lead is taken. It continuously
+// monitors the leader election status using statusFunc. When the lead is taken,
+// the tasks function is called with a context that is cancelled either when the
+// lead has been lost or ctx is done. After the tasks function returns, the
+// process is repeated until ctx is done.
+func RunLeaderTasks(ctx context.Context, statusFunc StatusFunc, tasks func(context.Context)) {
+	for {
+		status, statusExpired := statusFunc()
+
+		if status == StatusLeading {
+			ctx, cancel := context.WithCancelCause(ctx)
+			go func() {
+				select {
+				case <-statusExpired:
+					cancel(ErrLostLead)
+				case <-ctx.Done():
+				}
+			}()
+
+			tasks(ctx)
+		}
+
+		select {
+		case <-statusExpired:
+		case <-ctx.Done():
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Description

`Leaderelector.LeasePool` and `K0sControllersLeaseCounter` now use the new leader elector client internally. Deprecate all old interface methods in favor of `CurrentStatus`, which reports the current leader status along with a channel that is closed when the status changes. Callers should then call `CurrentStatus` again to get the new status.

This way, the leader elector doesn't have to keep track of callback methods, callers can't block each other, and there is no need to "deregister" when callers are no longer interested in leader status changes.

The old API is fully emulated via the new API, and can be easily removed once it's no longer being called.

As a PoC, convert the applier manager to the new API as the first component.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings