### PR TITLE
Always skip controller-runtime name validation

### DIFF
--- a/pkg/autopilot/controller/root_controller.go
+++ b/pkg/autopilot/controller/root_controller.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/utils/ptr"
 	cr "sigs.k8s.io/controller-runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
+	crconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	crman "sigs.k8s.io/controller-runtime/pkg/manager"
 	crmetricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	crwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -59,8 +60,6 @@ type rootController struct {
 	stopSubHandler         subControllerStopFunc
 	leaseWatcherCreator    leaseWatcherCreatorFunc
 	setupHandler           setupFunc
-
-	initialized bool
 }
 
 var _ aproot.Root = (*rootController)(nil)
@@ -153,6 +152,17 @@ func (c *rootController) Run(ctx context.Context) error {
 func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *logrus.Entry, event LeaseEventStatus) error {
 	managerOpts := crman.Options{
 		Scheme: scheme,
+		Controller: crconfig.Controller{
+			// Controller-runtime maintains a global checklist of controller
+			// names and does not currently provide a way to unregister the
+			// controller names used by discarded managers. The autopilot
+			// controller and worker components accidentally share some
+			// controller names. So it's necessary to suppress the global name
+			// check because the order in which components are started is not
+			// fully guaranteed for k0s controller nodes running an embedded
+			// worker.
+			SkipNameValidation: ptr.To(true),
+		},
 		WebhookServer: crwebhook.NewServer(crwebhook.Options{
 			Port: c.cfg.ManagerPort,
 		}),
@@ -160,16 +170,6 @@ func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *
 			BindAddress: c.cfg.MetricsBindAddr,
 		},
 		HealthProbeBindAddress: c.cfg.HealthProbeBindAddr,
-	}
-
-	// If this controller is already initialized, this means that all
-	// controller-runtime controllers have already been successfully registered
-	// to another manager. However, controller-runtime maintains a global
-	// checklist of controller names and doesn't currently provide a way to
-	// unregister names from discarded managers. So it's necessary to suppress
-	// the global name check whenever things are restarted for reconfiguration.
-	if c.initialized {
-		managerOpts.Controller.SkipNameValidation = ptr.To(true)
 	}
 
 	mgr, err := cr.NewManager(c.autopilotClientFactory.RESTConfig(), managerOpts)
@@ -231,9 +231,6 @@ func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *
 		logger.WithError(err).Error("unable to register 'update' controllers")
 		return err
 	}
-
-	// All the controller-runtime controllers have been registered.
-	c.initialized = true
 
 	// The controller-runtime start blocks until the context is cancelled.
 	if err := mgr.Start(ctx); err != nil {

--- a/pkg/autopilot/controller/root_worker.go
+++ b/pkg/autopilot/controller/root_worker.go
@@ -88,12 +88,16 @@ func (w *rootWorker) Run(ctx context.Context) error {
 	}
 
 	// In some cases, we need to wait on the worker side until controller deploys all autopilot CRDs
+	var attempt uint
 	return k8sretry.OnError(wait.Backoff{
 		Steps:    120,
 		Duration: 1 * time.Second,
 		Factor:   1.0,
 		Jitter:   0.1,
 	}, func(err error) bool {
+		attempt++
+		logger := logger.WithError(err).WithField("attempt", attempt)
+		logger.Debug("Failed to run controller manager, retrying after backoff")
 		return true
 	}, func() error {
 		cl, err := w.clientFactory.GetClient()


### PR DESCRIPTION
## Description

Controller-runtime maintains a global checklist of controller names and does not currently provide a way to unregister the controller names used by discarded managers. The autopilot controller and worker components accidentally share some controller names. So it's necessary to suppress the global name check because the order in which components are started is not fully guaranteed for k0s controller nodes running an embedded worker.

Merge the autopilot worker retry loops. It's not necessary to have two successive retry loops. In fact, it's counterproductive because indexers can only be registered with a manager once. A second attempt will result in an index conflict error. However, this is not a problem if the manager is created in the same retry loop.

Add retry logging to the remaining retry loop. This helps when troubleshooting issues.

Fixes:

* #4647

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings