### PR TITLE
Use unique controller names for Autopilot

### DIFF
--- a/pkg/autopilot/controller/plans/init.go
+++ b/pkg/autopilot/controller/plans/init.go
@@ -46,15 +46,15 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 
 	if leaderMode {
 		if err := registerNewPlanStateController(logger, mgr, cmdProviders); err != nil {
-			return fmt.Errorf("unable to register 'newplan' controller: %w", err)
+			return fmt.Errorf("unable to register newplan controller: %w", err)
 		}
 
 		if err := registerSchedulableWaitStateController(logger, mgr, cmdProviders); err != nil {
-			return fmt.Errorf("unable to register 'schedulablewait' controller: %w", err)
+			return fmt.Errorf("unable to register schedulablewait controller: %w", err)
 		}
 
 		if err := registerSchedulableStateController(logger, mgr, cmdProviders); err != nil {
-			return fmt.Errorf("unable to register 'schedulable' controller: %w", err)
+			return fmt.Errorf("unable to register schedulable controller: %w", err)
 		}
 	}
 
@@ -108,7 +108,7 @@ func registerSchedulableStateController(logger *logrus.Entry, mgr crman.Manager,
 // controller-runtime.
 func registerPlanStateController(name string, logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, handler appc.PlanStateHandler) error {
 	return cr.NewControllerManagedBy(mgr).
-		Named("planstate-" + name).
+		Named("planstate_" + name).
 		For(&apv1beta2.Plan{}).
 		WithEventFilter(eventFilter).
 		Complete(

--- a/pkg/autopilot/controller/root_controller.go
+++ b/pkg/autopilot/controller/root_controller.go
@@ -25,10 +25,10 @@ import (
 	apcli "github.com/k0sproject/k0s/pkg/autopilot/client"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
-	applan "github.com/k0sproject/k0s/pkg/autopilot/controller/plans"
+	"github.com/k0sproject/k0s/pkg/autopilot/controller/plans"
 	aproot "github.com/k0sproject/k0s/pkg/autopilot/controller/root"
-	apsig "github.com/k0sproject/k0s/pkg/autopilot/controller/signal"
-	apupdate "github.com/k0sproject/k0s/pkg/autopilot/controller/updates"
+	"github.com/k0sproject/k0s/pkg/autopilot/controller/signal"
+	"github.com/k0sproject/k0s/pkg/autopilot/controller/updates"
 	"github.com/k0sproject/k0s/pkg/kubernetes"
 
 	"github.com/sirupsen/logrus"
@@ -217,18 +217,18 @@ func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *
 	}
 	clusterID := string(ns.UID)
 
-	if err := apsig.RegisterControllers(ctx, logger, mgr, delegateMap[apdel.ControllerDelegateController], c.cfg.K0sDataDir, clusterID); err != nil {
-		logger.WithError(err).Error("unable to register 'signal' controllers")
+	if err := signal.RegisterControllers(ctx, logger, mgr, delegateMap[apdel.ControllerDelegateController], c.cfg.K0sDataDir, clusterID); err != nil {
+		logger.WithError(err).Error("unable to register signal controllers")
 		return err
 	}
 
-	if err := applan.RegisterControllers(ctx, logger, mgr, c.kubeClientFactory, leaderMode, delegateMap, c.cfg.ExcludeFromPlans); err != nil {
-		logger.WithError(err).Error("unable to register 'plans' controllers")
+	if err := plans.RegisterControllers(ctx, logger, mgr, c.kubeClientFactory, leaderMode, delegateMap, c.cfg.ExcludeFromPlans); err != nil {
+		logger.WithError(err).Error("unable to register plans controllers")
 		return err
 	}
 
-	if err := apupdate.RegisterControllers(ctx, logger, mgr, c.autopilotClientFactory, leaderMode, clusterID); err != nil {
-		logger.WithError(err).Error("unable to register 'update' controllers")
+	if err := updates.RegisterControllers(ctx, logger, mgr, c.autopilotClientFactory, leaderMode, clusterID); err != nil {
+		logger.WithError(err).Error("unable to register updates controllers")
 		return err
 	}
 

--- a/pkg/autopilot/controller/root_worker.go
+++ b/pkg/autopilot/controller/root_worker.go
@@ -43,6 +43,8 @@ type rootWorker struct {
 	cfg           aproot.RootConfig
 	log           *logrus.Entry
 	clientFactory apcli.FactoryInterface
+
+	initialized bool
 }
 
 var _ aproot.Root = (*rootWorker)(nil)
@@ -64,15 +66,14 @@ func (w *rootWorker) Run(ctx context.Context) error {
 	managerOpts := crman.Options{
 		Scheme: scheme,
 		Controller: crconfig.Controller{
-			// Controller-runtime maintains a global checklist of controller
-			// names and does not currently provide a way to unregister the
-			// controller names used by discarded managers. The autopilot
-			// controller and worker components accidentally share some
-			// controller names. So it's necessary to suppress the global name
-			// check because the order in which components are started is not
-			// fully guaranteed for k0s controller nodes running an embedded
-			// worker.
-			SkipNameValidation: ptr.To(true),
+			// If this controller is already initialized, this means that all
+			// controller-runtime controllers have already been successfully
+			// registered to another manager. However, controller-runtime
+			// maintains a global checklist of controller names and doesn't
+			// currently provide a way to unregister names from discarded
+			// managers. So it's necessary to suppress the global name check
+			// whenever things retried.
+			SkipNameValidation: ptr.To(w.initialized),
 		},
 		WebhookServer: crwebhook.NewServer(crwebhook.Options{
 			Port: w.cfg.ManagerPort,
@@ -118,6 +119,10 @@ func (w *rootWorker) Run(ctx context.Context) error {
 		if err := signal.RegisterControllers(ctx, logger, mgr, apdel.NodeControllerDelegate(), w.cfg.K0sDataDir, clusterID); err != nil {
 			return fmt.Errorf("unable to register signal controllers: %w", err)
 		}
+
+		// All the controller-runtime controllers have been registered.
+		w.initialized = true
+
 		// The controller-runtime start blocks until the context is cancelled.
 		if err := mgr.Start(ctx); err != nil {
 			return fmt.Errorf("unable to run controller-runtime manager for workers: %w", err)

--- a/pkg/autopilot/controller/root_worker.go
+++ b/pkg/autopilot/controller/root_worker.go
@@ -24,7 +24,7 @@ import (
 	apcli "github.com/k0sproject/k0s/pkg/autopilot/client"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	aproot "github.com/k0sproject/k0s/pkg/autopilot/controller/root"
-	apsig "github.com/k0sproject/k0s/pkg/autopilot/controller/signal"
+	"github.com/k0sproject/k0s/pkg/autopilot/controller/signal"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -115,8 +115,8 @@ func (w *rootWorker) Run(ctx context.Context) error {
 			return fmt.Errorf("unable to register indexers: %w", err)
 		}
 
-		if err := apsig.RegisterControllers(ctx, logger, mgr, apdel.NodeControllerDelegate(), w.cfg.K0sDataDir, clusterID); err != nil {
-			return fmt.Errorf("unable to register 'controlnodes' controllers: %w", err)
+		if err := signal.RegisterControllers(ctx, logger, mgr, apdel.NodeControllerDelegate(), w.cfg.K0sDataDir, clusterID); err != nil {
+			return fmt.Errorf("unable to register signal controllers: %w", err)
 		}
 		// The controller-runtime start blocks until the context is cancelled.
 		if err := mgr.Start(ctx); err != nil {

--- a/pkg/autopilot/controller/signal/airgap/download.go
+++ b/pkg/autopilot/controller/signal/airgap/download.go
@@ -17,6 +17,7 @@ package airgap
 import (
 	"crypto/sha256"
 	"path"
+	"strings"
 
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	apsigcomm "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common"
@@ -43,10 +44,11 @@ var _ apsigcomm.DownloadManifestBuilder = (*downloadManfiestBuilderAirgap)(nil)
 // moved to a `Downloading` status. At this point, it will attempt to download
 // the file provided in the update request.
 func registerDownloading(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, k0sDataDir string) error {
-	logger.Infof("Registering 'airgap-downloading' reconciler for '%s'", delegate.Name())
+	name := strings.ToLower(delegate.Name()) + "_airgap_downloading"
+	logger.Info("Registering reconciler: ", name)
 
 	return cr.NewControllerManagedBy(mgr).
-		Named("airgap-downloading").
+		Named(name).
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(

--- a/pkg/autopilot/controller/signal/airgap/init.go
+++ b/pkg/autopilot/controller/signal/airgap/init.go
@@ -38,15 +38,15 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 
 	hostname, err := apcomm.FindEffectiveHostname()
 	if err != nil {
-		return fmt.Errorf("unable to determine hostname for controlnode airgap 'signal' reconciler: %w", err)
+		return fmt.Errorf("unable to determine hostname: %w", err)
 	}
 
 	if err := registerSignalController(logger, mgr, SignalControllerEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "signal")), delegate); err != nil {
-		return fmt.Errorf("unable to register 'airgap-signal' controller: %w", err)
+		return fmt.Errorf("unable to register signal controller: %w", err)
 	}
 
 	if err := registerDownloading(logger, mgr, SignalControllerEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "airgap download")), delegate, k0sDataDir); err != nil {
-		return fmt.Errorf("unable to register 'airgap-downloading' controller: %w", err)
+		return fmt.Errorf("unable to register downloading controller: %w", err)
 	}
 
 	return nil

--- a/pkg/autopilot/controller/signal/airgap/signal.go
+++ b/pkg/autopilot/controller/signal/airgap/signal.go
@@ -17,6 +17,7 @@ package airgap
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
@@ -64,11 +65,12 @@ type signalControllerHandler struct {
 // updates.
 func registerSignalController(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate) error {
 	logr := logger.WithFields(logrus.Fields{"updatetype": "airgap"})
+	name := strings.ToLower(delegate.Name()) + "_airgap_signal"
 
-	logr.Infof("Registering 'airgap-signal' reconciler for '%s'", delegate.Name())
+	logr.Info("Registering reconciler: ", name)
 
 	return cr.NewControllerManagedBy(mgr).
-		Named("airgap-signal").
+		Named(name).
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(

--- a/pkg/autopilot/controller/signal/init.go
+++ b/pkg/autopilot/controller/signal/init.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
-	apsigag "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/airgap"
-	apsigk0s "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/k0s"
+	"github.com/k0sproject/k0s/pkg/autopilot/controller/signal/airgap"
+	"github.com/k0sproject/k0s/pkg/autopilot/controller/signal/k0s"
 
 	"github.com/sirupsen/logrus"
 	crman "sigs.k8s.io/controller-runtime/pkg/manager"
@@ -31,11 +31,11 @@ import (
 // RegisterControllers registers all of the autopilot controllers used by both controller
 // and worker modes.
 func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, k0sDataDir, clusterID string) error {
-	if err := apsigk0s.RegisterControllers(ctx, logger, mgr, delegate, clusterID); err != nil {
+	if err := k0s.RegisterControllers(ctx, logger, mgr, delegate, clusterID); err != nil {
 		return fmt.Errorf("unable to register k0s controllers: %w", err)
 	}
 
-	if err := apsigag.RegisterControllers(ctx, logger, mgr, delegate, k0sDataDir); err != nil {
+	if err := airgap.RegisterControllers(ctx, logger, mgr, delegate, k0sDataDir); err != nil {
 		return fmt.Errorf("unable to register airgap controllers: %w", err)
 	}
 

--- a/pkg/autopilot/controller/signal/k0s/apply.go
+++ b/pkg/autopilot/controller/signal/k0s/apply.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
@@ -78,15 +79,16 @@ func registerApplyingUpdate(
 	delegate apdel.ControllerDelegate,
 	k0sBinaryDir string,
 ) error {
-	logger.Infof("Registering 'applying-update' reconciler for '%s'", delegate.Name())
+	name := strings.ToLower(delegate.Name()) + "_k0s_applying_update"
+	logger.Info("Registering reconciler: ", name)
 
 	return cr.NewControllerManagedBy(mgr).
-		Named(delegate.Name() + "-applying-update").
+		Named(name).
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(
 			&applyingUpdate{
-				log:          logger.WithFields(logrus.Fields{"reconciler": "applying-update", "object": delegate.Name()}),
+				log:          logger.WithFields(logrus.Fields{"reconciler": "k0s-applying-update", "object": delegate.Name()}),
 				client:       mgr.GetClient(),
 				delegate:     delegate,
 				k0sBinaryDir: k0sBinaryDir,

--- a/pkg/autopilot/controller/signal/k0s/download.go
+++ b/pkg/autopilot/controller/signal/k0s/download.go
@@ -16,6 +16,7 @@ package k0s
 
 import (
 	"crypto/sha256"
+	"strings"
 
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
@@ -69,10 +70,11 @@ var _ apsigcomm.DownloadManifestBuilder = (*downloadManifestBuilderK0s)(nil)
 // moved to a `Downloading` status. At this point, it will attempt to download
 // the file provided in the update request.
 func registerDownloading(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, k0sBinaryDir string) error {
-	logger.Infof("Registering k0s 'downloading' reconciler for '%s'", delegate.Name())
+	name := strings.ToLower(delegate.Name()) + "_k0s_downloading"
+	logger.Info("Registering reconciler: ", name)
 
 	return cr.NewControllerManagedBy(mgr).
-		Named(delegate.Name() + "-downloading").
+		Named(name).
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(

--- a/pkg/autopilot/controller/signal/k0s/init.go
+++ b/pkg/autopilot/controller/signal/k0s/init.go
@@ -38,12 +38,12 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 
 	hostname, err := apcomm.FindEffectiveHostname()
 	if err != nil {
-		return fmt.Errorf("unable to determine hostname for controlnode 'signal' reconciler: %w", err)
+		return fmt.Errorf("unable to determine hostname: %w", err)
 	}
 
 	k0sBinaryPath, err := os.Executable()
 	if err != nil {
-		return fmt.Errorf("unable to determine k0s binary path for controlnode 'signal' reconciler: %w", err)
+		return fmt.Errorf("unable to determine k0s binary path: %w", err)
 	}
 	k0sBinaryDir := filepath.Dir(k0sBinaryPath)
 
@@ -54,31 +54,31 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 	}
 
 	if err := registerSignalController(logger, mgr, signalControllerEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s signal")), delegate, clusterID, k0sVersionHandler); err != nil {
-		return fmt.Errorf("unable to register k0s 'signal' controller: %w", err)
+		return fmt.Errorf("unable to register signal controller: %w", err)
 	}
 
 	if err := registerDownloading(logger, mgr, downloadEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s downloading")), delegate, k0sBinaryDir); err != nil {
-		return fmt.Errorf("unable to register k0s 'downloading' controller: %w", err)
+		return fmt.Errorf("unable to register downloading controller: %w", err)
 	}
 
 	if err := registerCordoning(logger, mgr, cordoningEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s cordoning")), delegate); err != nil {
-		return fmt.Errorf("unable to register k0s 'cordoning' controller: %w", err)
+		return fmt.Errorf("unable to register cordoning controller: %w", err)
 	}
 
 	if err := registerApplyingUpdate(logger, mgr, applyingUpdateEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s applying-update")), delegate, k0sBinaryDir); err != nil {
-		return fmt.Errorf("unable to register k0s 'applying-update' controller: %w", err)
+		return fmt.Errorf("unable to register applying-update controller: %w", err)
 	}
 
 	if err := registerRestart(logger, mgr, restartEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s restart")), delegate); err != nil {
-		return fmt.Errorf("unable to register k0s 'restart' controller: %w", err)
+		return fmt.Errorf("unable to register restart controller: %w", err)
 	}
 
 	if err := registerRestarted(logger, mgr, restartedEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s restarted")), delegate); err != nil {
-		return fmt.Errorf("unable to register k0s 'restarted' controller: %w", err)
+		return fmt.Errorf("unable to register restarted controller: %w", err)
 	}
 
 	if err := registerUncordoning(logger, mgr, unCordoningEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s uncordoning")), delegate); err != nil {
-		return fmt.Errorf("unable to register k0s 'uncordoning' controller: %w", err)
+		return fmt.Errorf("unable to register uncordoning controller: %w", err)
 	}
 
 	return nil

--- a/pkg/autopilot/controller/signal/k0s/restart_unix.go
+++ b/pkg/autopilot/controller/signal/k0s/restart_unix.go
@@ -19,6 +19,7 @@ package k0s
 import (
 	"context"
 	"fmt"
+	"strings"
 	"syscall"
 	"time"
 
@@ -70,15 +71,16 @@ type restart struct {
 // This controller is only interested in changes to signal nodes where its signaling
 // status is marked as `Restart`
 func registerRestart(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate) error {
-	logger.Infof("Registering 'restart' reconciler for '%s'", delegate.Name())
+	name := strings.ToLower(delegate.Name()) + "_k0s_restart"
+	logger.Info("Registering reconciler: ", name)
 
 	return cr.NewControllerManagedBy(mgr).
-		Named(delegate.Name() + "-restart").
+		Named(name).
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(
 			&restart{
-				log:      logger.WithFields(logrus.Fields{"reconciler": "restart", "object": delegate.Name()}),
+				log:      logger.WithFields(logrus.Fields{"reconciler": "k0s-restart", "object": delegate.Name()}),
 				client:   mgr.GetClient(),
 				delegate: delegate,
 			},

--- a/pkg/autopilot/controller/signal/k0s/restarted_unix.go
+++ b/pkg/autopilot/controller/signal/k0s/restarted_unix.go
@@ -19,6 +19,7 @@ package k0s
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
@@ -61,15 +62,16 @@ func restartedEventFilter(hostname string, handler apsigpred.ErrorHandler) crpre
 // This controller is only interested in changes to signal nodes where its signaling
 // status is marked as `Restart`
 func registerRestarted(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate) error {
-	logger.Infof("Registering 'restarted' reconciler for '%s'", delegate.Name())
+	name := strings.ToLower(delegate.Name()) + "_k0s_restarted"
+	logger.Info("Registering reconciler: ", name)
 
 	return cr.NewControllerManagedBy(mgr).
-		Named(delegate.Name() + "-restarted").
+		Named(name).
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(
 			&restarted{
-				log:      logger.WithFields(logrus.Fields{"reconciler": "restarted", "object": delegate.Name()}),
+				log:      logger.WithFields(logrus.Fields{"reconciler": "k0s-restarted", "object": delegate.Name()}),
 				client:   mgr.GetClient(),
 				delegate: delegate,
 			},

--- a/pkg/autopilot/controller/signal/k0s/signal.go
+++ b/pkg/autopilot/controller/signal/k0s/signal.go
@@ -17,6 +17,7 @@ package k0s
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
@@ -81,11 +82,12 @@ type signalControllerHandler struct {
 // mechanism in identifying incoming autopilot k0s signaling updates.
 func registerSignalController(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, clusterID string, k0sVersionHandler k0sVersionHandlerFunc) error {
 	logr := logger.WithFields(logrus.Fields{"updatetype": "k0s"})
+	name := strings.ToLower(delegate.Name()) + "_k0s_signal"
 
-	logr.Infof("Registering 'signal' reconciler for '%s'", delegate.Name())
+	logr.Info("Registering reconciler: ", name)
 
 	return cr.NewControllerManagedBy(mgr).
-		Named(delegate.Name() + "-signal").
+		Named(name).
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(

--- a/pkg/autopilot/controller/signal/k0s/uncordon.go
+++ b/pkg/autopilot/controller/signal/k0s/uncordon.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	autopilotv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
@@ -75,7 +76,8 @@ type uncordoning struct {
 // moved to a `Cordoning` status. At this point, it will attempt to cordong & drain
 // the node.
 func registerUncordoning(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate) error {
-	logger.Infof("Registering 'uncordoning' reconciler for '%s'", delegate.Name())
+	name := strings.ToLower(delegate.Name()) + "_k0s_uncordoning"
+	logger.Info("Registering reconciler: ", name)
 
 	// create the clientset
 	clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
@@ -84,12 +86,12 @@ func registerUncordoning(logger *logrus.Entry, mgr crman.Manager, eventFilter cr
 	}
 
 	return cr.NewControllerManagedBy(mgr).
-		Named(delegate.Name() + "-uncordoning").
+		Named(name).
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(
 			&uncordoning{
-				log:       logger.WithFields(logrus.Fields{"reconciler": "uncordoning", "object": delegate.Name()}),
+				log:       logger.WithFields(logrus.Fields{"reconciler": "k0s-uncordoning", "object": delegate.Name()}),
 				client:    mgr.GetClient(),
 				delegate:  delegate,
 				clientset: clientset,


### PR DESCRIPTION
## Description

There were some controllers that had the same name by accident. Make them unique by adding the delegate name as a prefix. Also, convert all names to snake_case, which is the canonical form to use. Now that all the controller names are unique, it's safe to run the first registration with name validation enabled, so that accidental name duplications result in errors (again) and can be fixed.

Follow-up to:

* #4888
* #5506

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings