### PR TITLE
Deprecate Autopilot client factory

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,9 +54,12 @@ linters-settings:
         files:
           - "!$test"
           - "!**/internal/testutil/**"
+          - "!**/internal/autopilot/testutil/**"
           - "!**/inttest/**"
         deny:
           - pkg: github.com/k0sproject/k0s/internal/testutil
+            desc: Usage of test code outside of tests.
+          - pkg: github.com/k0sproject/k0s/internal/autopilot/testutil
             desc: Usage of test code outside of tests.
           - pkg: github.com/stretchr/testify
             desc: Usage of test code outside of tests.

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -597,15 +597,12 @@ func (c *command) start(ctx context.Context) error {
 		Workloads:          c.EnableWorker,
 	})
 
-	restConfig, err := adminClientFactory.GetRESTConfig()
-	if err != nil {
-		return err
-	}
-	apClientFactory, err := apclient.NewClientFactory(restConfig)
-	if err != nil {
-		return err
-	}
-	clusterComponents.Add(ctx, controller.NewUpdateProber(apClientFactory, leaderElector))
+	clusterComponents.Add(ctx, controller.NewUpdateProber(
+		&apclient.ClientFactory{
+			ClientFactoryInterface: adminClientFactory,
+		},
+		leaderElector,
+	))
 
 	// Add the config source as the last component, so that the reconciliation
 	// starts after all other components have been started.

--- a/internal/autopilot/testutil/client.go
+++ b/internal/autopilot/testutil/client.go
@@ -85,6 +85,6 @@ func (f fakeClientFactory) GetExtensionClient() (extclient.ApiextensionsV1Interf
 	return f.clientExtensions, nil
 }
 
-func (f fakeClientFactory) RESTConfig() *rest.Config {
-	return nil
+func (f fakeClientFactory) GetRESTConfig() (*rest.Config, error) {
+	panic("GetRESTConfig not implemented for fakeClientFactory")
 }

--- a/internal/autopilot/testutil/client.go
+++ b/internal/autopilot/testutil/client.go
@@ -77,7 +77,7 @@ func (f fakeClientFactory) GetClient() (kubernetes.Interface, error) {
 	return f.client, nil
 }
 
-func (f fakeClientFactory) GetAutopilotClient() (apclient.Interface, error) {
+func (f fakeClientFactory) GetK0sClient() (apclient.Interface, error) {
 	return f.clientAutopilot, nil
 }
 

--- a/pkg/autopilot/client/client.go
+++ b/pkg/autopilot/client/client.go
@@ -27,7 +27,7 @@ import (
 // FactoryInterface is a collection of kubernetes clientset interfaces.
 type FactoryInterface interface {
 	GetClient() (kubernetes.Interface, error)
-	GetAutopilotClient() (apclient.Interface, error)
+	GetK0sClient() (apclient.Interface, error)
 	GetExtensionClient() (extclient.ApiextensionsV1Interface, error)
 	RESTConfig() *rest.Config
 }
@@ -67,8 +67,8 @@ func (cf *clientFactory) GetClient() (kubernetes.Interface, error) {
 	return cf.client, nil
 }
 
-// GetAutopilotClient returns the clientset for autopilot
-func (cf *clientFactory) GetAutopilotClient() (apclient.Interface, error) {
+// GetK0sClient returns the clientset for autopilot
+func (cf *clientFactory) GetK0sClient() (apclient.Interface, error) {
 	cf.mutex.Lock()
 	defer cf.mutex.Unlock()
 	var err error

--- a/pkg/autopilot/client/client.go
+++ b/pkg/autopilot/client/client.go
@@ -29,7 +29,7 @@ type FactoryInterface interface {
 	GetClient() (kubernetes.Interface, error)
 	GetK0sClient() (apclient.Interface, error)
 	GetExtensionClient() (extclient.ApiextensionsV1Interface, error)
-	RESTConfig() *rest.Config
+	GetRESTConfig() (*rest.Config, error)
 }
 
 type clientFactory struct {
@@ -107,6 +107,6 @@ func (cf *clientFactory) GetExtensionClient() (extclient.ApiextensionsV1Interfac
 	return cf.clientExtensions, nil
 }
 
-func (cf *clientFactory) RESTConfig() *rest.Config {
-	return cf.restConfig
+func (cf *clientFactory) GetRESTConfig() (*rest.Config, error) {
+	return cf.restConfig, nil
 }

--- a/pkg/autopilot/controller/readyprober.go
+++ b/pkg/autopilot/controller/readyprober.go
@@ -89,7 +89,7 @@ func (p readyProber) Probe() error {
 func (p readyProber) probeOne(target apv1beta2.PlanCommandTargetStatus) error {
 	p.log.Infof("Probing %v", target.Name)
 
-	client, err := p.clientFactory.GetAutopilotClient()
+	client, err := p.clientFactory.GetK0sClient()
 	if err != nil {
 		return err
 	}

--- a/pkg/autopilot/controller/root_controller.go
+++ b/pkg/autopilot/controller/root_controller.go
@@ -172,7 +172,12 @@ func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *
 		HealthProbeBindAddress: c.cfg.HealthProbeBindAddr,
 	}
 
-	mgr, err := cr.NewManager(c.autopilotClientFactory.RESTConfig(), managerOpts)
+	restConfig, err := c.autopilotClientFactory.GetRESTConfig()
+	if err != nil {
+		return err
+	}
+
+	mgr, err := cr.NewManager(restConfig, managerOpts)
 	if err != nil {
 		logger.WithError(err).Error("unable to start controller manager")
 		return err

--- a/pkg/autopilot/controller/root_worker.go
+++ b/pkg/autopilot/controller/root_worker.go
@@ -106,7 +106,12 @@ func (w *rootWorker) Run(ctx context.Context) error {
 		}
 		clusterID := string(ns.UID)
 
-		mgr, err := cr.NewManager(w.clientFactory.RESTConfig(), managerOpts)
+		restConfig, err := w.clientFactory.GetRESTConfig()
+		if err != nil {
+			return err
+		}
+
+		mgr, err := cr.NewManager(restConfig, managerOpts)
 		if err != nil {
 			return fmt.Errorf("failed to create controller manager: %w", err)
 		}

--- a/pkg/autopilot/controller/setup.go
+++ b/pkg/autopilot/controller/setup.go
@@ -124,7 +124,7 @@ func createNamespace(ctx context.Context, cf apcli.FactoryInterface, name string
 // for this physical host.
 func (sc *setupController) createControlNode(ctx context.Context, cf apcli.FactoryInterface, name, nodeName string) error {
 	logger := sc.log.WithField("component", "setup")
-	client, err := sc.clientFactory.GetAutopilotClient()
+	client, err := sc.clientFactory.GetK0sClient()
 	if err != nil {
 		return err
 	}

--- a/pkg/component/controller/autopilot.go
+++ b/pkg/component/controller/autopilot.go
@@ -48,13 +48,8 @@ func (a *Autopilot) Init(ctx context.Context) error {
 func (a *Autopilot) Start(ctx context.Context) error {
 	log := logrus.WithFields(logrus.Fields{"component": "autopilot"})
 
-	restConfig, err := a.AdminClientFactory.GetRESTConfig()
-	if err != nil {
-		return fmt.Errorf("creating autopilot client factory error: %w", err)
-	}
-	autopilotClientFactory, err := apcli.NewClientFactory(restConfig)
-	if err != nil {
-		return fmt.Errorf("creating autopilot client factory error: %w", err)
+	autopilotClientFactory := &apcli.ClientFactory{
+		ClientFactoryInterface: a.AdminClientFactory,
 	}
 
 	autopilotRoot, err := apcont.NewRootController(aproot.RootConfig{

--- a/pkg/component/controller/updateprober.go
+++ b/pkg/component/controller/updateprober.go
@@ -95,7 +95,7 @@ func (u *UpdateProber) checkUpdates(ctx context.Context) {
 	}
 	u.log.Debug("checking updates")
 	// Check if there's an active UpdateConfig, if there is no need to do this generic polling
-	apClient, err := u.APClientFactory.GetAutopilotClient()
+	apClient, err := u.APClientFactory.GetK0sClient()
 	if err != nil {
 		u.log.Warnf("failed to create k8s client: %s", err.Error())
 	}

--- a/pkg/component/worker/autopilot.go
+++ b/pkg/component/worker/autopilot.go
@@ -29,6 +29,7 @@ import (
 	aproot "github.com/k0sproject/k0s/pkg/autopilot/controller/root"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/config"
+	"github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -80,10 +81,9 @@ func (a *Autopilot) Start(ctx context.Context) error {
 		return errors.New("unable to create an autopilot client -- timed out")
 	}
 
-	autopilotClientFactory, err := apcli.NewClientFactory(restConfig)
-	if err != nil {
-		return fmt.Errorf("creating autopilot client factory error: %w", err)
-	}
+	autopilotClientFactory := &apcli.ClientFactory{ClientFactoryInterface: &kubernetes.ClientFactory{
+		LoadRESTConfig: func() (*rest.Config, error) { return restConfig, nil },
+	}}
 
 	log.Info("Autopilot client factory created, booting up worker root controller")
 	autopilotRoot, err := apcont.NewRootWorker(aproot.RootConfig{


### PR DESCRIPTION
## Description

The Autopilot client factory was basically a copy of the k0s client factory. Implement the former using the latter and add deprecation notes to all the old types and methods.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings