### PR TITLE
Remove storage parameter from DefaultClusterConfig

### DIFF
--- a/pkg/apis/k0s/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types.go
@@ -197,21 +197,24 @@ func (s *SchedulerSpec) IsZero() bool {
 	return len(s.ExtraArgs) == 0
 }
 
-func ConfigFromBytes(bytes []byte, defaultStorage ...*StorageSpec) (*ClusterConfig, error) {
-	config := DefaultClusterConfig(defaultStorage...)
-	err := strictyaml.YamlUnmarshalStrictIgnoringFields(bytes, config, "interval", "podSecurityPolicy")
+func ConfigFromBytes(bytes []byte) (*ClusterConfig, error) {
+	return DefaultClusterConfig().MergedWithYAML(bytes)
+}
+
+func (c *ClusterConfig) MergedWithYAML(bytes []byte) (*ClusterConfig, error) {
+	merged := c.DeepCopy()
+	err := strictyaml.YamlUnmarshalStrictIgnoringFields(bytes, merged, "interval", "podSecurityPolicy")
 	if err != nil {
-		return config, err
+		return nil, err
 	}
-	if config.Spec == nil {
-		config.Spec = DefaultClusterSpec(defaultStorage...)
+	if merged.Spec == nil {
+		merged.Spec = c.Spec
 	}
-	return config, nil
+	return merged, nil
 }
 
 // DefaultClusterConfig sets the default ClusterConfig values, when none are given
-func DefaultClusterConfig(defaultStorage ...*StorageSpec) *ClusterConfig {
-	clusterSpec := DefaultClusterSpec(defaultStorage...)
+func DefaultClusterConfig() *ClusterConfig {
 	return &ClusterConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
@@ -221,7 +224,7 @@ func DefaultClusterConfig(defaultStorage ...*StorageSpec) *ClusterConfig {
 			Name:      constant.ClusterConfigObjectName,
 			Namespace: constant.ClusterConfigNamespace,
 		},
-		Spec: clusterSpec,
+		Spec: DefaultClusterSpec(),
 	}
 }
 
@@ -237,7 +240,10 @@ func (c *ClusterConfig) UnmarshalJSON(data []byte) error {
 	if c.Spec != nil && c.Spec.Storage != nil {
 		storage = c.Spec.Storage
 	}
-	c.Spec = DefaultClusterSpec(storage)
+	c.Spec = DefaultClusterSpec()
+	if storage != nil {
+		c.Spec.Storage = storage
+	}
 
 	type config ClusterConfig
 	jc := (*config)(c)
@@ -251,7 +257,10 @@ func (c *ClusterConfig) UnmarshalJSON(data []byte) error {
 	}
 
 	if jc.Spec == nil {
-		jc.Spec = DefaultClusterSpec(storage)
+		jc.Spec = DefaultClusterSpec()
+		if storage != nil {
+			jc.Spec.Storage = storage
+		}
 		return nil
 	}
 	if jc.Spec.Storage == nil {
@@ -291,17 +300,10 @@ func (c *ClusterConfig) UnmarshalJSON(data []byte) error {
 }
 
 // DefaultClusterSpec default settings
-func DefaultClusterSpec(defaultStorage ...*StorageSpec) *ClusterSpec {
-	var storage *StorageSpec
-	if defaultStorage == nil || defaultStorage[0] == nil {
-		storage = DefaultStorageSpec()
-	} else {
-		storage = defaultStorage[0]
-	}
-
+func DefaultClusterSpec() *ClusterSpec {
 	spec := &ClusterSpec{
 		Extensions:        DefaultExtensions(),
-		Storage:           storage,
+		Storage:           DefaultStorageSpec(),
 		Network:           DefaultNetwork(),
 		API:               DefaultAPISpec(),
 		ControllerManager: DefaultControllerManagerSpec(),

--- a/pkg/apis/k0s/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"reflect"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -198,9 +197,9 @@ func (s *SchedulerSpec) IsZero() bool {
 	return len(s.ExtraArgs) == 0
 }
 
-func ConfigFromString(yml string, defaultStorage ...*StorageSpec) (*ClusterConfig, error) {
+func ConfigFromBytes(bytes []byte, defaultStorage ...*StorageSpec) (*ClusterConfig, error) {
 	config := DefaultClusterConfig(defaultStorage...)
-	err := strictyaml.YamlUnmarshalStrictIgnoringFields([]byte(yml), config, "interval", "podSecurityPolicy")
+	err := strictyaml.YamlUnmarshalStrictIgnoringFields(bytes, config, "interval", "podSecurityPolicy")
 	if err != nil {
 		return config, err
 	}
@@ -208,15 +207,6 @@ func ConfigFromString(yml string, defaultStorage ...*StorageSpec) (*ClusterConfi
 		config.Spec = DefaultClusterSpec(defaultStorage...)
 	}
 	return config, nil
-}
-
-// ConfigFromReader reads the configuration from any reader (can be stdin, file reader, etc)
-func ConfigFromReader(r io.Reader, defaultStorage ...*StorageSpec) (*ClusterConfig, error) {
-	input, err := io.ReadAll(r)
-	if err != nil {
-		return nil, err
-	}
-	return ConfigFromString(string(input), defaultStorage...)
 }
 
 // DefaultClusterConfig sets the default ClusterConfig values, when none are given

--- a/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
@@ -30,29 +30,29 @@ import (
 )
 
 func TestClusterDefaults(t *testing.T) {
-	c, err := ConfigFromString("apiVersion: k0s.k0sproject.io/v1beta1")
+	c, err := ConfigFromBytes([]byte("apiVersion: k0s.k0sproject.io/v1beta1"))
 	assert.NoError(t, err)
 	assert.Equal(t, DefaultStorageSpec(), c.Spec.Storage)
 }
 
 func TestUnknownFieldValidation(t *testing.T) {
-	_, err := ConfigFromString(`
+	_, err := ConfigFromBytes([]byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
-unknown: 1`)
+unknown: 1`))
 
 	assert.Error(t, err)
 }
 
 func TestStorageDefaults(t *testing.T) {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
   name: foobar
-`
+`)
 
-	c, err := ConfigFromString(yamlData)
+	c, err := ConfigFromBytes(yamlData)
 	assert.NoError(t, err)
 	assert.Equal(t, EtcdStorageType, c.Spec.Storage.Type)
 	addr, err := iface.FirstPublicAddress()
@@ -122,7 +122,7 @@ func TestClusterSpecCustomImages(t *testing.T) {
 }
 
 func TestEtcdDefaults(t *testing.T) {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
@@ -130,9 +130,9 @@ metadata:
 spec:
   storage:
     type: etcd
-`
+`)
 
-	c, err := ConfigFromString(yamlData)
+	c, err := ConfigFromBytes(yamlData)
 	assert.NoError(t, err)
 	assert.Equal(t, EtcdStorageType, c.Spec.Storage.Type)
 	addr, err := iface.FirstPublicAddress()
@@ -141,7 +141,7 @@ spec:
 }
 
 func TestNetworkValidation_Custom(t *testing.T) {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
@@ -151,16 +151,16 @@ spec:
     provider: custom
   storage:
     type: etcd
-`
+`)
 
-	c, err := ConfigFromString(yamlData)
+	c, err := ConfigFromBytes(yamlData)
 	assert.NoError(t, err)
 	errors := c.Validate()
 	assert.Zero(t, errors)
 }
 
 func TestNetworkValidation_Calico(t *testing.T) {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
@@ -170,16 +170,16 @@ spec:
     provider: calico
   storage:
     type: etcd
-`
+`)
 
-	c, err := ConfigFromString(yamlData)
+	c, err := ConfigFromBytes(yamlData)
 	assert.NoError(t, err)
 	errors := c.Validate()
 	assert.Zero(t, errors)
 }
 
 func TestNetworkValidation_Invalid(t *testing.T) {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
@@ -189,9 +189,9 @@ spec:
     provider: invalidProvider
   storage:
     type: etcd
-`
+`)
 
-	c, err := ConfigFromString(yamlData)
+	c, err := ConfigFromBytes(yamlData)
 	assert.NoError(t, err)
 	errors := c.Validate()
 	if assert.Len(t, errors, 1) {
@@ -200,7 +200,7 @@ spec:
 }
 
 func TestApiExternalAddress(t *testing.T) {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
@@ -209,16 +209,16 @@ spec:
   api:
     externalAddress: foo.bar.com
     address: 1.2.3.4
-`
+`)
 
-	c, err := ConfigFromString(yamlData)
+	c, err := ConfigFromBytes(yamlData)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://foo.bar.com:6443", c.Spec.API.APIAddressURL())
 	assert.Equal(t, "https://foo.bar.com:9443", c.Spec.API.K0sControlPlaneAPIAddress())
 }
 
 func TestApiNoExternalAddress(t *testing.T) {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
@@ -226,16 +226,16 @@ metadata:
 spec:
   api:
     address: 1.2.3.4
-`
+`)
 
-	c, err := ConfigFromString(yamlData)
+	c, err := ConfigFromBytes(yamlData)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://1.2.3.4:6443", c.Spec.API.APIAddressURL())
 	assert.Equal(t, "https://1.2.3.4:9443", c.Spec.API.K0sControlPlaneAPIAddress())
 }
 
 func TestNullValues(t *testing.T) {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
@@ -251,8 +251,8 @@ spec:
   installConfig: null
   telemetry: null
   konnectivity: null
-`
-	extensionsYamlData := `
+`)
+	extensionsYamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
@@ -260,9 +260,9 @@ metadata:
 spec:
   extensions:
     storage: null
-`
+`)
 
-	c, err := ConfigFromString(yamlData)
+	c, err := ConfigFromBytes(yamlData)
 	assert.NoError(t, err)
 	assert.Equal(t, DefaultClusterImages(), c.Spec.Images)
 	assert.Equal(t, DefaultStorageSpec(), c.Spec.Storage)
@@ -276,13 +276,13 @@ spec:
 	assert.Equal(t, DefaultClusterTelemetry(), c.Spec.Telemetry)
 	assert.Equal(t, DefaultKonnectivitySpec(), c.Spec.Konnectivity)
 
-	e, err := ConfigFromString(extensionsYamlData)
+	e, err := ConfigFromBytes(extensionsYamlData)
 	assert.NoError(t, err)
 	assert.Equal(t, DefaultExtensions(), e.Spec.Extensions)
 }
 
 func TestWorkerProfileConfig(t *testing.T) {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
@@ -303,8 +303,8 @@ spec:
       authentication:
         anonymous:
           enabled: false
-`
-	c, err := ConfigFromString(yamlData)
+`)
+	c, err := ConfigFromBytes(yamlData)
 	assert.NoError(t, err)
 	require.Len(t, c.Spec.WorkerProfiles, 2)
 	assert.Equal(t, "profile_XXX", c.Spec.WorkerProfiles[0].Name)
@@ -340,7 +340,7 @@ func TestDefaultClusterConfigYaml(t *testing.T) {
 }
 
 func TestFeatureGates(t *testing.T) {
-	yamlData := `
+	yamlData := []byte(`
     apiVersion: k0s.k0sproject.io/v1beta1
     kind: ClusterConfig
     metadata:
@@ -355,8 +355,8 @@ func TestFeatureGates(t *testing.T) {
         -
           name: feature_ZZZ
           enabled: false
-`
-	c, err := ConfigFromString(yamlData)
+`)
+	c, err := ConfigFromBytes(yamlData)
 	assert.NoError(t, err)
 	require.Len(t, c.Spec.FeatureGates, 3)
 	assert.Equal(t, "feature_XXX", c.Spec.FeatureGates[0].Name)

--- a/pkg/apis/k0s/v1beta1/extenstions_test.go
+++ b/pkg/apis/k0s/v1beta1/extenstions_test.go
@@ -87,7 +87,7 @@ func TestValidation(t *testing.T) {
 }
 
 func TestIntegerTimeoutParsing(t *testing.T) {
-	yaml := `
+	yaml := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
@@ -100,9 +100,9 @@ spec:
         chartname: prometheus-community/prometheus
         version: "14.6.1"
         timeout: 60000000000
-`
+`)
 
-	c, err := ConfigFromString(yaml)
+	c, err := ConfigFromBytes(yaml)
 	require := require.New(t)
 
 	require.NoError(err)
@@ -115,7 +115,7 @@ spec:
 }
 
 func TestDurationParsing(t *testing.T) {
-	yaml := `
+	yaml := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
@@ -128,9 +128,9 @@ spec:
         chartname: prometheus-community/prometheus
         version: "14.6.1"
         timeout: 20m
-`
+`)
 
-	c, err := ConfigFromString(yaml)
+	c, err := ConfigFromBytes(yaml)
 	require := require.New(t)
 
 	require.NoError(err)

--- a/pkg/apis/k0s/v1beta1/images_test.go
+++ b/pkg/apis/k0s/v1beta1/images_test.go
@@ -33,7 +33,7 @@ func getConfigYAML(t *testing.T, c *ClusterConfig) []byte {
 }
 
 func TestClusterImages_Customized(t *testing.T) {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1s
 kind: ClusterConfig
 spec:
@@ -44,8 +44,8 @@ spec:
     coredns:
       image: custom.io/coredns/coredns
       version: 1.0.0
-`
-	cfg, err := ConfigFromString(yamlData)
+`)
+	cfg, err := ConfigFromBytes(yamlData)
 	require.NoError(t, err)
 	a := cfg.Spec.Images
 
@@ -56,7 +56,7 @@ spec:
 }
 
 func TestStripDefaultsForDefaultImageList(t *testing.T) {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1s
 kind: ClusterConfig
 spec:
@@ -66,9 +66,9 @@ spec:
     nodeLocalLoadBalancing:
       enabled: true
       type: EnvoyProxy
-`
+`)
 
-	cfg, err := ConfigFromString(yamlData)
+	cfg, err := ConfigFromBytes(yamlData)
 	require.NoError(t, err)
 
 	strippedCfg := cfg.StripDefaults()

--- a/pkg/apis/k0s/v1beta1/network_test.go
+++ b/pkg/apis/k0s/v1beta1/network_test.go
@@ -100,14 +100,14 @@ func (s *NetworkSuite) TestAddresses() {
 }
 
 func (s *NetworkSuite) TestDomainMarshaling() {
-	yamlData := `
+	yamlData := []byte(`
 spec:
   storage:
     type: kine
   network:
     clusterDomain: something.local
-`
-	c, err := ConfigFromString(yamlData)
+`)
+	c, err := ConfigFromBytes(yamlData)
 	s.Require().NoError(err)
 	n := c.Spec.Network
 	s.Equal("kuberouter", n.Provider)
@@ -125,7 +125,7 @@ func (s *NetworkSuite) TestNetworkDefaults() {
 }
 
 func (s *NetworkSuite) TestCalicoDefaultsAfterMashaling() {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
@@ -134,9 +134,9 @@ spec:
   network:
     provider: calico
     calico:
-`
+`)
 
-	c, err := ConfigFromString(yamlData)
+	c, err := ConfigFromBytes(yamlData)
 	s.Require().NoError(err)
 	n := c.Spec.Network
 
@@ -148,7 +148,7 @@ spec:
 }
 
 func (s *NetworkSuite) TestKubeRouterDefaultsAfterMashaling() {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
@@ -157,9 +157,9 @@ spec:
   network:
     provider: kuberouter
     kuberouter:
-`
+`)
 
-	c, err := ConfigFromString(yamlData)
+	c, err := ConfigFromBytes(yamlData)
 	s.Require().NoError(err)
 	n := c.Spec.Network
 
@@ -174,15 +174,15 @@ spec:
 }
 
 func (s *NetworkSuite) TestKubeProxyDefaultsAfterMashaling() {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
   name: foobar
 spec:
-`
+`)
 
-	c, err := ConfigFromString(yamlData)
+	c, err := ConfigFromBytes(yamlData)
 	s.Require().NoError(err)
 	p := c.Spec.Network.KubeProxy
 
@@ -191,7 +191,7 @@ spec:
 }
 
 func (s *NetworkSuite) TestKubeProxyDisabling() {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
@@ -200,9 +200,9 @@ spec:
   network:
     kubeProxy:
       disabled: true
-`
+`)
 
-	c, err := ConfigFromString(yamlData)
+	c, err := ConfigFromBytes(yamlData)
 	s.Require().NoError(err)
 	p := c.Spec.Network.KubeProxy
 

--- a/pkg/apis/k0s/v1beta1/nllb_test.go
+++ b/pkg/apis/k0s/v1beta1/nllb_test.go
@@ -42,7 +42,7 @@ func TestNodeLocalLoadBalancing_IsEnabled(t *testing.T) {
 }
 
 func TestNodeLocalLoadBalancing_Unmarshal_ImageOverride(t *testing.T) {
-	yamlData := `
+	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
@@ -50,9 +50,9 @@ metadata:
 spec:
   images:
     repository: example.com
-`
+`)
 
-	c, err := ConfigFromString(yamlData)
+	c, err := ConfigFromBytes(yamlData)
 	require.NoError(t, err)
 	errors := c.Validate()
 	require.Nil(t, errors)
@@ -79,7 +79,7 @@ spec:
 
 	for _, field := range []string{"image", "version"} {
 		t.Run(field+"_empty", func(t *testing.T) {
-			c, err := ConfigFromString(fmt.Sprintf(yamlData, field, `""`))
+			c, err := ConfigFromBytes([]byte(fmt.Sprintf(yamlData, field, `""`)))
 			require.NoError(t, err)
 			require.NotNil(t, c)
 			require.Empty(t, c.Validate())
@@ -104,7 +104,7 @@ spec:
 		},
 	} {
 		t.Run(test.field+"_invalid", func(t *testing.T) {
-			c, err := ConfigFromString(fmt.Sprintf(yamlData, test.field, test.value))
+			c, err := ConfigFromBytes([]byte(fmt.Sprintf(yamlData, test.field, test.value)))
 			require.NoError(t, err)
 			require.NotNil(t, c)
 			errs := c.Validate()

--- a/pkg/apis/k0s/v1beta1/storage_test.go
+++ b/pkg/apis/k0s/v1beta1/storage_test.go
@@ -143,12 +143,12 @@ func TestStorageSpec_IsJoinable(t *testing.T) {
 }
 
 func TestKinePartialConfigLoading(t *testing.T) {
-	yaml := `
+	yaml := []byte(`
 spec:
   storage:
     type: kine
-`
-	c, err := ConfigFromString(yaml)
+`)
+	c, err := ConfigFromBytes(yaml)
 	assert.NoError(t, err)
 	assert.Equal(t, KineStorageType, c.Spec.Storage.Type)
 	assert.NotNil(t, c.Spec.Storage.Kine)

--- a/pkg/backup/manager_unix.go
+++ b/pkg/backup/manager_unix.go
@@ -189,7 +189,7 @@ func (bm Manager) getConfigForRestore() (*v1beta1.ClusterConfig, error) {
 		return nil, err
 	}
 
-	cfg, err := v1beta1.ConfigFromString(string(bytes))
+	cfg, err := v1beta1.ConfigFromBytes(bytes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/controller/workerconfig/reconciler_test.go
+++ b/pkg/component/controller/workerconfig/reconciler_test.go
@@ -96,7 +96,7 @@ func TestReconciler_Lifecycle(t *testing.T) {
 		t.Run("reconcile_fails", func(t *testing.T) {
 			underTest := createdReconciler(t, nil)
 
-			err := underTest.Reconcile(testContext(t), v1beta1.DefaultClusterConfig(nil))
+			err := underTest.Reconcile(testContext(t), v1beta1.DefaultClusterConfig())
 
 			require.Error(t, err)
 			assert.Equal(t, "cannot reconcile, not started: created", err.Error())
@@ -140,7 +140,7 @@ func TestReconciler_Lifecycle(t *testing.T) {
 		t.Run("reconcile_fails", func(t *testing.T) {
 			underTest := initializedReconciler(t, nil)
 
-			err := underTest.Reconcile(testContext(t), v1beta1.DefaultClusterConfig(nil))
+			err := underTest.Reconcile(testContext(t), v1beta1.DefaultClusterConfig())
 
 			require.Error(t, err)
 			assert.Equal(t, "cannot reconcile, not started: initialized", err.Error())
@@ -196,7 +196,7 @@ func TestReconciler_Lifecycle(t *testing.T) {
 			underTest, mockApplier := startedReconciler(t)
 			applied := mockApplier.expectApply(t, nil)
 
-			assert.NoError(t, underTest.Reconcile(testContext(t), v1beta1.DefaultClusterConfig(nil)))
+			assert.NoError(t, underTest.Reconcile(testContext(t), v1beta1.DefaultClusterConfig()))
 
 			assert.NotEmpty(t, applied(), "Expected some resources to be applied")
 		})
@@ -214,7 +214,7 @@ func TestReconciler_Lifecycle(t *testing.T) {
 		t.Helper()
 		underTest, mockApplier := startedReconciler(t)
 		applied := mockApplier.expectApply(t, nil)
-		require.NoError(t, underTest.Reconcile(testContext(t), v1beta1.DefaultClusterConfig(nil)))
+		require.NoError(t, underTest.Reconcile(testContext(t), v1beta1.DefaultClusterConfig()))
 
 		_ = applied() // wait until reconciliation happened
 		return underTest, mockApplier
@@ -242,7 +242,7 @@ func TestReconciler_Lifecycle(t *testing.T) {
 		t.Run("another_reconcile_succeeds", func(t *testing.T) {
 			underTest, mockApplier := reconciledReconciler(t)
 			applied := mockApplier.expectApply(t, nil)
-			clusterConfig := v1beta1.DefaultClusterConfig(nil)
+			clusterConfig := v1beta1.DefaultClusterConfig()
 			clusterConfig.Spec.WorkerProfiles = v1beta1.WorkerProfiles{
 				{Name: "foo", Config: &runtime.RawExtension{Raw: []byte("{}")}},
 			}
@@ -291,7 +291,7 @@ func TestReconciler_Lifecycle(t *testing.T) {
 		t.Run("reconcile_fails", func(t *testing.T) {
 			underTest := stoppedReconciler(t)
 
-			err := underTest.Reconcile(testContext(t), v1beta1.DefaultClusterConfig(nil))
+			err := underTest.Reconcile(testContext(t), v1beta1.DefaultClusterConfig())
 
 			require.Error(t, err)
 			assert.Equal(t, "cannot reconcile, not started: stopped", err.Error())
@@ -480,7 +480,7 @@ func TestReconciler_ResourceGeneration(t *testing.T) {
 }
 
 func TestReconciler_ReconcilesOnChangesOnly(t *testing.T) {
-	cluster := v1beta1.DefaultClusterConfig(nil)
+	cluster := v1beta1.DefaultClusterConfig()
 	clients := testutil.NewFakeClientFactory()
 	k0sVars, err := config.NewCfgVars(nil, t.TempDir())
 	require.NoError(t, err)
@@ -630,7 +630,7 @@ func TestReconciler_runReconcileLoop(t *testing.T) {
 
 func TestReconciler_LeaderElection(t *testing.T) {
 	var le mockLeaderElector
-	cluster := v1beta1.DefaultClusterConfig(nil)
+	cluster := v1beta1.DefaultClusterConfig()
 	clients := testutil.NewFakeClientFactory()
 	k0sVars, err := config.NewCfgVars(nil, t.TempDir())
 	require.NoError(t, err)

--- a/pkg/config/cfgvars.go
+++ b/pkg/config/cfgvars.go
@@ -200,17 +200,6 @@ func NewCfgVars(cobraCmd command, dirs ...string) (*CfgVars, error) {
 	return vars, nil
 }
 
-func (c *CfgVars) defaultStorageSpec() *v1beta1.StorageSpec {
-	if c.DefaultStorageType == v1beta1.KineStorageType {
-		return &v1beta1.StorageSpec{
-			Type: v1beta1.KineStorageType,
-			Kine: v1beta1.DefaultKineConfig(c.DataDir),
-		}
-	}
-
-	return v1beta1.DefaultStorageSpec()
-}
-
 var defaultConfigPath = constant.K0sConfigPathDefault
 
 func (c *CfgVars) NodeConfig() (*v1beta1.ClusterConfig, error) {
@@ -218,7 +207,15 @@ func (c *CfgVars) NodeConfig() (*v1beta1.ClusterConfig, error) {
 		return nil, errors.New("config path is not set")
 	}
 
-	var nodeConfig *v1beta1.ClusterConfig
+	nodeConfig := v1beta1.DefaultClusterConfig()
+
+	// Optionally override the default storage (used for single node clusters)
+	if c.DefaultStorageType == v1beta1.KineStorageType {
+		nodeConfig.Spec.Storage = &v1beta1.StorageSpec{
+			Type: v1beta1.KineStorageType,
+			Kine: v1beta1.DefaultKineConfig(c.DataDir),
+		}
+	}
 
 	if c.StartupConfigPath == "-" {
 		configReader := c.stdin
@@ -232,23 +229,22 @@ func (c *CfgVars) NodeConfig() (*v1beta1.ClusterConfig, error) {
 			return nil, err
 		}
 
-		nodeConfig, err = v1beta1.ConfigFromBytes(bytes, c.defaultStorageSpec())
+		nodeConfig, err = nodeConfig.MergedWithYAML(bytes)
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		cfgContent, err := os.ReadFile(c.StartupConfigPath)
-		if errors.Is(err, os.ErrNotExist) && c.StartupConfigPath == defaultConfigPath {
-			nodeConfig = v1beta1.DefaultClusterConfig(c.defaultStorageSpec())
-		} else if err == nil {
-			cfg, err := v1beta1.ConfigFromBytes(cfgContent, c.defaultStorageSpec())
-			if err != nil {
-				return nil, err
+		if err != nil {
+			if c.StartupConfigPath == defaultConfigPath && errors.Is(err, os.ErrNotExist) {
+				// The default configuration file doesn't exist; continue with the defaults.
+				return nodeConfig, nil
 			}
-			nodeConfig = cfg
-		} else {
+
 			return nil, err
 		}
+
+		return nodeConfig.MergedWithYAML(cfgContent)
 	}
 
 	if nodeConfig.Spec.Storage.Type == v1beta1.KineStorageType && nodeConfig.Spec.Storage.Kine == nil {

--- a/pkg/config/cfgvars.go
+++ b/pkg/config/cfgvars.go
@@ -227,8 +227,12 @@ func (c *CfgVars) NodeConfig() (*v1beta1.ClusterConfig, error) {
 			return nil, errors.New("stdin already grabbed")
 		}
 
-		var err error
-		nodeConfig, err = v1beta1.ConfigFromReader(configReader, c.defaultStorageSpec())
+		bytes, err := io.ReadAll(configReader)
+		if err != nil {
+			return nil, err
+		}
+
+		nodeConfig, err = v1beta1.ConfigFromBytes(bytes, c.defaultStorageSpec())
 		if err != nil {
 			return nil, err
 		}
@@ -237,7 +241,7 @@ func (c *CfgVars) NodeConfig() (*v1beta1.ClusterConfig, error) {
 		if errors.Is(err, os.ErrNotExist) && c.StartupConfigPath == defaultConfigPath {
 			nodeConfig = v1beta1.DefaultClusterConfig(c.defaultStorageSpec())
 		} else if err == nil {
-			cfg, err := v1beta1.ConfigFromString(string(cfgContent), c.defaultStorageSpec())
+			cfg, err := v1beta1.ConfigFromBytes(cfgContent, c.defaultStorageSpec())
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/config/cfgvars_test.go
+++ b/pkg/config/cfgvars_test.go
@@ -205,7 +205,7 @@ func TestNodeConfig_Default(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, nodeConfig)
-	assert.True(t, reflect.DeepEqual(v1beta1.DefaultClusterConfig(c.defaultStorageSpec()), nodeConfig))
+	assert.True(t, reflect.DeepEqual(v1beta1.DefaultClusterConfig(), nodeConfig))
 }
 
 func TestNodeConfig_Stdin(t *testing.T) {


### PR DESCRIPTION
## Description

The storage override occurs only during the initial loading of the node configuration, and can be modeled by applying the changes to the default configuration and then merging the user-provided configuration data into it.

Also remove `ConfigFromReader`: The function hid the fact that there was no benefit at all to providing the input as a reader. It merely used `io.ReadAll` to load the data into memory. Removing this, and exposing to callers the fact that the only supported input is just a byte slice, makes the code more straightforward.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings