### PR TITLE
Handle pushgateway image as any other image

### DIFF
--- a/pkg/airgap/images.go
+++ b/pkg/airgap/images.go
@@ -20,15 +20,10 @@ import (
 	"runtime"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
-	"github.com/k0sproject/k0s/pkg/constant"
 )
 
 // GetImageURIs returns all image tags
 func GetImageURIs(spec *v1beta1.ClusterSpec, all bool) []string {
-	pauseImage := v1beta1.ImageSpec{
-		Image:   constant.KubePauseContainerImage,
-		Version: constant.KubePauseContainerImageVersion,
-	}
 
 	imageURIs := []string{
 		spec.Images.Calico.CNI.URI(),
@@ -40,7 +35,15 @@ func GetImageURIs(spec *v1beta1.ClusterSpec, all bool) []string {
 		spec.Images.KubeRouter.CNI.URI(),
 		spec.Images.KubeRouter.CNIInstaller.URI(),
 		spec.Images.MetricsServer.URI(),
-		pauseImage.URI(),
+		spec.Images.Pause.URI(),
+	}
+
+	if all {
+		// Currently we can't determine if the user has enabled the PushGateway via
+		// config so include it only if all is requested
+		imageURIs = append(imageURIs,
+			spec.Images.PushGateway.URI(),
+		)
 	}
 
 	if spec.Network != nil {

--- a/pkg/apis/k0s/v1beta1/images.go
+++ b/pkg/apis/k0s/v1beta1/images.go
@@ -144,6 +144,7 @@ func (ci *ClusterImages) overrideImageRepositories() {
 	override(ci.KubeRouter.CNI)
 	override(ci.KubeRouter.CNIInstaller)
 	override(ci.Pause)
+	override(ci.PushGateway)
 }
 
 // CalicoImageSpec config group for calico related image settings

--- a/pkg/apis/k0s/v1beta1/images_test.go
+++ b/pkg/apis/k0s/v1beta1/images_test.go
@@ -99,6 +99,7 @@ func TestImagesRepoOverrideInConfiguration(t *testing.T) {
 			require.Equal(t, "my.repo/k0sproject/kube-router:"+constant.KubeRouterCNIImageVersion, testingConfig.Spec.Images.KubeRouter.CNI.URI())
 			require.Equal(t, "my.repo/k0sproject/cni-node:"+constant.KubeRouterCNIInstallerImageVersion, testingConfig.Spec.Images.KubeRouter.CNIInstaller.URI())
 			require.Equal(t, "my.repo/pause:"+constant.KubePauseContainerImageVersion, testingConfig.Spec.Images.Pause.URI())
+			require.Equal(t, "my.repo/k0sproject/pushgateway-ttl:"+constant.PushGatewayImageVersion, testingConfig.Spec.Images.PushGateway.URI())
 		})
 		t.Run("config_with_custom_images", func(t *testing.T) {
 			cfg := DefaultClusterConfig()


### PR DESCRIPTION
## Description

This PR has 3 fixes in it:
1. Allow overriding the image repo for pushgateway image
2. Include pushgateway image into airgap image list when `--all` is used
3. Handle pause image via config in airgap list, i.e. make it respect repo override too

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #5455 
Fixes #5456 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings