### PR TITLE
[Backport 1.31] Handle pushgateway image as any other image

### DIFF
--- a/pkg/airgap/images.go
+++ b/pkg/airgap/images.go
@@ -20,15 +20,10 @@ import (
 	"runtime"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
-	"github.com/k0sproject/k0s/pkg/constant"
 )
 
 // GetImageURIs returns all image tags
 func GetImageURIs(spec *v1beta1.ClusterSpec, all bool) []string {
-	pauseImage := v1beta1.ImageSpec{
-		Image:   constant.KubePauseContainerImage,
-		Version: constant.KubePauseContainerImageVersion,
-	}
 
 	imageURIs := []string{
 		spec.Images.Calico.CNI.URI(),
@@ -40,7 +35,15 @@ func GetImageURIs(spec *v1beta1.ClusterSpec, all bool) []string {
 		spec.Images.KubeRouter.CNI.URI(),
 		spec.Images.KubeRouter.CNIInstaller.URI(),
 		spec.Images.MetricsServer.URI(),
-		pauseImage.URI(),
+		spec.Images.Pause.URI(),
+	}
+
+	if all {
+		// Currently we can't determine if the user has enabled the PushGateway via
+		// config so include it only if all is requested
+		imageURIs = append(imageURIs,
+			spec.Images.PushGateway.URI(),
+		)
 	}
 
 	if spec.Network != nil {

--- a/pkg/apis/k0s/v1beta1/images.go
+++ b/pkg/apis/k0s/v1beta1/images.go
@@ -144,6 +144,7 @@ func (ci *ClusterImages) overrideImageRepositories() {
 	override(&ci.KubeRouter.CNI)
 	override(&ci.KubeRouter.CNIInstaller)
 	override(&ci.Pause)
+	override(&ci.PushGateway)
 }
 
 // CalicoImageSpec config group for calico related image settings

--- a/pkg/apis/k0s/v1beta1/images_test.go
+++ b/pkg/apis/k0s/v1beta1/images_test.go
@@ -76,6 +76,7 @@ func TestImagesRepoOverrideInConfiguration(t *testing.T) {
 			require.Equal(t, fmt.Sprintf("my.repo/k0sproject/kube-router:%s", constant.KubeRouterCNIImageVersion), testingConfig.Spec.Images.KubeRouter.CNI.URI())
 			require.Equal(t, fmt.Sprintf("my.repo/k0sproject/cni-node:%s", constant.KubeRouterCNIInstallerImageVersion), testingConfig.Spec.Images.KubeRouter.CNIInstaller.URI())
 			require.Equal(t, fmt.Sprintf("my.repo/pause:%s", constant.KubePauseContainerImageVersion), testingConfig.Spec.Images.Pause.URI())
+			require.Equal(t, fmt.Sprintf("my.repo/k0sproject/pushgateway-ttl:%s", constant.PushGatewayImageVersion), testingConfig.Spec.Images.PushGateway.URI())
 		})
 		t.Run("config_with_custom_images", func(t *testing.T) {
 			cfg := DefaultClusterConfig()


### PR DESCRIPTION
This PR has 3 fixes in it:
1. Allow overriding the image repo for pushgateway image
2. Include pushgateway image into airgap image list when `--all` is used
3. Handle pause image via config in airgap list, i.e. make it respect repo override too

Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>
(cherry picked from commit ff3fadcd8b1d03a8d97e74130aae92c8d470415c)

See #5520 

