### PR TITLE
[Backport release-1.31] Bump kine to v0.13.9

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -32,11 +32,11 @@ kubernetes_build_go_flags = "-v"
 #kubernetes_build_go_ldflags =
 kubernetes_build_go_ldflags_extra = "-extldflags=-static"
 
-kine_version = 0.13.5
+kine_version = 0.13.7
 kine_buildimage = $(golang_buildimage)
 kine_build_go_tags = nats
 #kine_build_go_cgo_enabled =
-# Flags taken from https://github.com/k3s-io/kine/blob/v0.13.5/scripts/build#L22
+# Flags taken from https://github.com/k3s-io/kine/blob/v0.13.7/scripts/build#L22
 kine_build_go_cgo_cflags = -DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1
 
 #kine_build_go_flags =

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -32,11 +32,11 @@ kubernetes_build_go_flags = "-v"
 #kubernetes_build_go_ldflags =
 kubernetes_build_go_ldflags_extra = "-extldflags=-static"
 
-kine_version = 0.13.3
+kine_version = 0.13.5
 kine_buildimage = $(golang_buildimage)
 kine_build_go_tags = nats
 #kine_build_go_cgo_enabled =
-# Flags taken from https://github.com/k3s-io/kine/blob/v0.13.3/scripts/build#L22
+# Flags taken from https://github.com/k3s-io/kine/blob/v0.13.5/scripts/build#L22
 kine_build_go_cgo_cflags = -DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1
 
 #kine_build_go_flags =

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -32,11 +32,11 @@ kubernetes_build_go_flags = "-v"
 #kubernetes_build_go_ldflags =
 kubernetes_build_go_ldflags_extra = "-extldflags=-static"
 
-kine_version = 0.13.2
+kine_version = 0.13.3
 kine_buildimage = $(golang_buildimage)
 kine_build_go_tags = nats
 #kine_build_go_cgo_enabled =
-# Flags taken from https://github.com/k3s-io/kine/blob/v0.13.2/scripts/build#L22
+# Flags taken from https://github.com/k3s-io/kine/blob/v0.13.3/scripts/build#L22
 kine_build_go_cgo_cflags = -DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1
 
 #kine_build_go_flags =

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -32,11 +32,11 @@ kubernetes_build_go_flags = "-v"
 #kubernetes_build_go_ldflags =
 kubernetes_build_go_ldflags_extra = "-extldflags=-static"
 
-kine_version = 0.13.7
+kine_version = 0.13.9
 kine_buildimage = $(golang_buildimage)
 kine_build_go_tags = nats
 #kine_build_go_cgo_enabled =
-# Flags taken from https://github.com/k3s-io/kine/blob/v0.13.7/scripts/build#L22
+# Flags taken from https://github.com/k3s-io/kine/blob/v0.13.9/scripts/build#L22
 kine_build_go_cgo_cflags = -DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1
 
 #kine_build_go_flags =

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -122,7 +122,7 @@ func (k *Kine) Start(ctx context.Context) error {
 			fmt.Sprintf("--endpoint=%s", k.Config.DataSource),
 			// NB: kine doesn't parse URLs properly, so construct potentially
 			// invalid URLs that are understood by kine.
-			// https://github.com/k3s-io/kine/blob/v0.13.7/pkg/util/network.go#L5-L13
+			// https://github.com/k3s-io/kine/blob/v0.13.9/pkg/util/network.go#L5-L13
 			fmt.Sprintf("--listen-address=unix://%s", k.K0sVars.KineSocketPath),
 			// Enable metrics on port 2380. The default is 8080, which clashes with kube-router.
 			"--metrics-bind-address=:2380",

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -122,7 +122,7 @@ func (k *Kine) Start(ctx context.Context) error {
 			fmt.Sprintf("--endpoint=%s", k.Config.DataSource),
 			// NB: kine doesn't parse URLs properly, so construct potentially
 			// invalid URLs that are understood by kine.
-			// https://github.com/k3s-io/kine/blob/v0.13.3/pkg/util/network.go#L5-L13
+			// https://github.com/k3s-io/kine/blob/v0.13.5/pkg/util/network.go#L5-L13
 			fmt.Sprintf("--listen-address=unix://%s", k.K0sVars.KineSocketPath),
 			// Enable metrics on port 2380. The default is 8080, which clashes with kube-router.
 			"--metrics-bind-address=:2380",

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -122,7 +122,7 @@ func (k *Kine) Start(ctx context.Context) error {
 			fmt.Sprintf("--endpoint=%s", k.Config.DataSource),
 			// NB: kine doesn't parse URLs properly, so construct potentially
 			// invalid URLs that are understood by kine.
-			// https://github.com/k3s-io/kine/blob/v0.13.2/pkg/util/network.go#L5-L13
+			// https://github.com/k3s-io/kine/blob/v0.13.3/pkg/util/network.go#L5-L13
 			fmt.Sprintf("--listen-address=unix://%s", k.K0sVars.KineSocketPath),
 			// Enable metrics on port 2380. The default is 8080, which clashes with kube-router.
 			"--metrics-bind-address=:2380",

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -122,7 +122,7 @@ func (k *Kine) Start(ctx context.Context) error {
 			fmt.Sprintf("--endpoint=%s", k.Config.DataSource),
 			// NB: kine doesn't parse URLs properly, so construct potentially
 			// invalid URLs that are understood by kine.
-			// https://github.com/k3s-io/kine/blob/v0.13.5/pkg/util/network.go#L5-L13
+			// https://github.com/k3s-io/kine/blob/v0.13.7/pkg/util/network.go#L5-L13
 			fmt.Sprintf("--listen-address=unix://%s", k.K0sVars.KineSocketPath),
 			// Enable metrics on port 2380. The default is 8080, which clashes with kube-router.
 			"--metrics-bind-address=:2380",


### PR DESCRIPTION
Backport to `release-1.31`:

* #5207
* #5244
* #5361
* #5551

See:

* #5518