### PR TITLE
[release 1.31] Fix Calico kube-controllers permissions

### DIFF
--- a/static/manifests/calico/ClusterRole/calico-kube-controllers.yaml
+++ b/static/manifests/calico/ClusterRole/calico-kube-controllers.yaml
@@ -1,5 +1,7 @@
 ---
 # Source: calico/templates/calico-kube-controllers-rbac.yaml
+# These permissions assume .Values.datastore != "etcd"
+# 
 # Include a clusterrole for the kube-controllers component,
 # and bind it to the calico-kube-controllers serviceaccount.
 kind: ClusterRole
@@ -81,3 +83,16 @@ rules:
       - update
       # watch for changes
       - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-kube-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-kube-controllers
+subjects:
+- kind: ServiceAccount
+  name: calico-kube-controllers
+  namespace: kube-system


### PR DESCRIPTION
## Description

Before we were adding permissions as if the datastore was etcd. This is wrong and although by default it seemed to work fine, under some circumstances it could cause some functionality not to work.

I noticed this issue initially in 1.32 and we have a fix for it in #5562. This PR isn't a backport because even though we have the same issue with same root cause the permissions are supposed to be different

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
