### PR TITLE
Don't try to install iptables binaries on non-Linux workers

### DIFF
--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -183,7 +183,7 @@ func (c *Command) Start(ctx context.Context, nodeName apitypes.NodeName, kubelet
 		c.WorkerProfile = "default-windows"
 	}
 
-	if controller == nil {
+	if controller == nil && runtime.GOOS == "linux" {
 		componentManager.Add(ctx, &iptables.Component{
 			IPTablesMode: c.WorkerOptions.IPTablesMode,
 			BinDir:       c.K0sVars.BinDir,


### PR DESCRIPTION
## Description

It's a Linux only thing and won't work on Windows.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
