### PR TITLE
Completely remove old Windows-only CLI flags

### DIFF
--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -60,7 +60,6 @@ Examples:
 	Note: Token can be passed either as a CLI argument or as a flag
 
 Flags:
-      --cidr-range string                              HACK: cidr range for the windows worker node (default "10.96.0.0/12")
   -c, --config string                                  config file, use '-' to read the config from stdin (default `+defaultConfigPath+`)
       --cri-socket string                              container runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]
       --data-dir string                                Data Directory for k0s. DO NOT CHANGE for an existing setup, things will break! (default `+defaultDataDir+`)

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -56,7 +56,6 @@ With the controller subcommand you can setup a single node cluster by running:
 	
 
 Flags:
-      --cidr-range string                              HACK: cidr range for the windows worker node (default "10.96.0.0/12")
   -c, --config string                                  config file, use '-' to read the config from stdin (default `+defaultConfigPath+`)
       --cri-socket string                              container runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]
       --data-dir string                                Data Directory for k0s. DO NOT CHANGE for an existing setup, things will break! (default `+defaultDataDir+`)

--- a/cmd/install/worker.go
+++ b/cmd/install/worker.go
@@ -33,9 +33,7 @@ func installWorkerCmd(installFlags *installFlags) *cobra.Command {
 		Use:   "worker",
 		Short: "Install k0s worker on a brand-new system. Must be run as root (or with sudo)",
 		Example: `Worker subcommand allows you to pass in all available worker parameters.
-All default values of worker command will be passed to the service stub unless overridden.
-
-Windows flags like "--api-server", "--cidr-range" and "--cluster-dns" will be ignored since install command doesn't yet support Windows services`,
+All default values of worker command will be passed to the service stub unless overridden.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if runtime.GOOS != "windows" && os.Geteuid() != 0 {

--- a/docs/experimental-windows.md
+++ b/docs/experimental-windows.md
@@ -15,7 +15,7 @@ During the first run, the calico install script is created as `C:\bootstrap.ps1`
 Install Mirantis Container Runtime on the Windows node(s), as it is required for the initial Calico set up).
 
 ```shell
-k0s worker --cri-socket=remote:npipe:////./pipe/containerd-containerd --cidr-range=<cidr_range> --cluster-dns=<clusterdns> --api-server=<k0s api> <token>
+k0s worker --cri-socket=remote:npipe:////./pipe/containerd-containerd <token>
 ```
 
 You must initiate the Cluster control with the correct config.
@@ -47,14 +47,6 @@ calicoctl ipam configure --strictaffinity=true
 ### Network connectivity in AWS
 
 Disable the `Change Source/Dest. Check` option for the network interface attached to your EC2 instance. In AWS, the console option for the network interface is in the **Actions** menu.
-
-### Hacks
-
-k0s offers the following CLI arguments in lieu of a formal means for passing cluster settings from controller plane to worker:
-
-- cidr-range
-- cluster-dns
-- api-server
 
 ## Useful commands
 

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -79,7 +79,6 @@ type ControllerOptions struct {
 
 // Shared worker cli flags
 type WorkerOptions struct {
-	CIDRRange        string
 	CloudProvider    bool
 	LogLevels        LogLevels
 	CriSocket        string
@@ -257,9 +256,14 @@ func GetWorkerFlags() *pflag.FlagSet {
 		workerOpts.LogLevels = DefaultLogLevels()
 	}
 
+	flagset.String("cidr-range", "", "")
+	flagset.VisitAll(func(f *pflag.Flag) {
+		f.Hidden = true
+		f.Deprecated = "it has no effect and will be removed in a future release"
+	})
+
 	flagset.String("kubelet-root-dir", "", "Kubelet root directory for k0s")
 	flagset.StringVar(&workerOpts.WorkerProfile, "profile", "default", "worker profile to use on the node")
-	flagset.StringVar(&workerOpts.CIDRRange, "cidr-range", "10.96.0.0/12", "HACK: cidr range for the windows worker node")
 	flagset.BoolVar(&workerOpts.CloudProvider, "enable-cloud-provider", false, "Whether or not to enable cloud provider support in kubelet")
 	flagset.StringVar(&workerOpts.TokenFile, "token-file", "", "Path to the file containing join-token.")
 	flagset.VarP((*logLevelsFlag)(&workerOpts.LogLevels), "logging", "l", "Logging Levels for the different components")


### PR DESCRIPTION
## Description

Hide and deprecate k0s worker `--cidr-range`. Remove all mentions of `--api-server`, `--cidr-range` and `--cluster-dns` from the codebase.

See:

* #3209

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
