### PR TITLE
[release-1.30] Bump Alpine to 3.19.6

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,6 +1,6 @@
 alpine_version = 3.19
 alpine_patch_version = $(alpine_version).6
-golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
+golang_buildimage=docker.io/library/golang:$(go_version)-alpine3.20
 go_version = 1.22.10
 
 runc_version = 1.1.15

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,5 @@
 alpine_version = 3.19
-alpine_patch_version = $(alpine_version).4
+alpine_patch_version = $(alpine_version).6
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
 go_version = 1.22.10
 


### PR DESCRIPTION
## Description

https://alpinelinux.org/posts/Alpine-3.18.10-3.19.5-3.20.4-released.html
https://alpinelinux.org/posts/Alpine-3.18.11-3.19.6-3.20.5-3.21.2-released.html

Fixes CVE-2024-9143.

Also use Go Docker image based on Alpine 3.20. Upstream no longer supports Alpine 3.19. Any further Go version bumps will require a newer Alpine version.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
