### PR TITLE
Bump kine to v0.13.10 (to fix a bug introduced in v0.13.4)

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -32,11 +32,11 @@ kubernetes_build_go_flags = "-v"
 #kubernetes_build_go_ldflags =
 kubernetes_build_go_ldflags_extra = "-extldflags=-static"
 
-kine_version = 0.13.9
+kine_version = 0.13.10
 kine_buildimage = $(golang_buildimage)
 kine_build_go_tags = nats
 #kine_build_go_cgo_enabled =
-# Flags taken from https://github.com/k3s-io/kine/blob/v0.13.9/scripts/build#L22
+# Flags taken from https://github.com/k3s-io/kine/blob/v0.13.10/scripts/build#L24
 kine_build_go_cgo_cflags = -DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1
 
 #kine_build_go_flags =

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -122,7 +122,7 @@ func (k *Kine) Start(ctx context.Context) error {
 			"--endpoint=" + k.Config.DataSource,
 			// NB: kine doesn't parse URLs properly, so construct potentially
 			// invalid URLs that are understood by kine.
-			// https://github.com/k3s-io/kine/blob/v0.13.9/pkg/util/network.go#L5-L13
+			// https://github.com/k3s-io/kine/blob/v0.13.10/pkg/util/network.go#L5-L13
 			"--listen-address=unix://" + k.K0sVars.KineSocketPath,
 			// Enable metrics on port 2380. The default is 8080, which clashes with kube-router.
 			"--metrics-bind-address=:2380",


### PR DESCRIPTION
## Description

Kine `v0.13.4` introduced a small bug which we hit when updating to `k0s` version `v1.32.1+k0s.0` (and made us revert the update for now). The main issue and the fix is described in this PR which is included in the latest release (`v0.13.10`): https://github.com/k3s-io/kine/pull/414

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [X] Manual test
- [ ] Auto test added

## Checklist

- [X] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [X] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
