### PR TITLE
Bump runc to v1.2.5

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -3,7 +3,7 @@ alpine_patch_version = $(alpine_version).2
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
 go_version = 1.23.6
 
-runc_version = 1.2.4
+runc_version = 1.2.5
 runc_buildimage = $(golang_buildimage)
 runc_build_go_tags = "seccomp"
 #runc_build_go_cgo_enabled =


### PR DESCRIPTION
https://github.com/opencontainers/runc/releases/tag/v1.2.5

