### PR TITLE
Adjust systemd service configuration based on `image-builder`

### DIFF
--- a/pkg/install/linux_systemd.go
+++ b/pkg/install/linux_systemd.go
@@ -38,6 +38,7 @@ KillMode=process
 LimitCORE=infinity
 TasksMax=infinity
 TimeoutStartSec=0
+OOMScoreAdjust=-999
 
 {{- if .ChRoot}}RootDirectory={{.ChRoot|cmd}}{{- end}}
 

--- a/pkg/install/service_linux.go
+++ b/pkg/install/service_linux.go
@@ -37,7 +37,7 @@ func configureServicePlatform(s service.Service, svcConfig *service.Config) {
 		svcConfig.Dependencies = []string{"After=network-online.target", "Wants=network-online.target"}
 		svcConfig.Option = map[string]interface{}{
 			"SystemdScript": systemdScript,
-			"LimitNOFILE":   999999,
+			"LimitNOFILE":   1048576,
 		}
 	}
 }


### PR DESCRIPTION
## Description

Syncs systemd service config with values that are used in vanilla `image-builder` images.

- https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/ansible/roles/containerd/templates/etc/systemd/system/containerd.service.d/memory-pressure.conf#L8
- https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/ansible/roles/containerd/templates/etc/systemd/system/containerd.service.d/limit-nofile.conf#L4

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

Manual systemd service test of config validity.

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
