### PR TITLE
Implement --init-only for controller

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -417,6 +417,10 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions) er
 
 	perfTimer.Checkpoint("starting-node-components")
 
+	if flags.InitOnly {
+		return nil
+	}
+
 	// Start components
 	err = nodeComponents.Start(ctx)
 	perfTimer.Checkpoint("finished-starting-node-components")

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -73,6 +73,7 @@ Flags:
       --enable-worker                                  enable worker (default false)
   -h, --help                                           help for controller
       --ignore-pre-flight-checks                       continue even if pre-flight checks fail
+      --init-only                                      only initialize controller and exit
       --iptables-mode string                           iptables mode (valid values: nft, legacy, auto). default: auto
       --k0s-cloud-provider-port int                    the port that k0s-cloud-provider binds on (default 10258)
       --k0s-cloud-provider-update-frequency duration   the frequency of k0s-cloud-provider node updates (default 2m0s)

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -68,6 +68,7 @@ Flags:
       --enable-metrics-scraper                         enable scraping metrics from the controller components (kube-scheduler, kube-controller-manager)
       --enable-worker                                  enable worker (default false)
   -h, --help                                           help for controller
+      --init-only                                      only initialize controller and exit
       --iptables-mode string                           iptables mode (valid values: nft, legacy, auto). default: auto
       --k0s-cloud-provider-port int                    the port that k0s-cloud-provider binds on (default 10258)
       --k0s-cloud-provider-update-frequency duration   the frequency of k0s-cloud-provider node updates (default 2m0s)

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -64,6 +64,7 @@ const (
 type ControllerOptions struct {
 	NoTaints          bool
 	DisableComponents []string
+	InitOnly          bool
 
 	ClusterComponents               *manager.Manager
 	EnableK0sCloudProvider          bool
@@ -309,6 +310,7 @@ func GetControllerFlags(controllerOpts *ControllerOptions) *pflag.FlagSet {
 	flagset.BoolVar(&controllerOpts.EnableDynamicConfig, "enable-dynamic-config", false, "enable cluster-wide dynamic config based on custom resource")
 	flagset.BoolVar(&controllerOpts.EnableMetricsScraper, "enable-metrics-scraper", false, "enable scraping metrics from the controller components (kube-scheduler, kube-controller-manager)")
 	flagset.StringVar(&controllerOpts.KubeControllerManagerExtraArgs, "kube-controller-manager-extra-args", "", "extra args for kube-controller-manager")
+	flagset.BoolVar(&controllerOpts.InitOnly, "init-only", false, "only initialize controller and exit")
 	return flagset
 }
 


### PR DESCRIPTION
Make it possible to only initialize the controller, creating the certificates etc without starting the controller. This is useful for automatting cluster setups in CI/CD pipelines and similar.

Fixes: https://github.com/k0sproject/k0s/issues/5650

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
