### PR TITLE
[lint] Enforce US spelling

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - gocritic          # another style/metalinter (dynamic rules supported)
     - goheader          # Checks is file headers matches a given pattern
     - intrange          # Checking for loops that could use an integer range
+    - misspell          # Finds commonly misspelled English words
     - nilnesserr        # Reports constructs that check for err != nil but return a different nil value error
     - nolintlint        # Find ill-formed or insufficiently explained nolint directives
     - nosprintfhostport # Detects misuses of Sprintf to construct hosts with ports in a URL
@@ -79,6 +80,8 @@ linters:
         regexp:
           year: 202[0-9]
       template-path: .go-header.txt
+    misspell:
+      locale: US
     revive:
       rules:
         # This forbids to name variables "close", which seems natural for "close" functions.

--- a/docs/autopilot-multicommand.md
+++ b/docs/autopilot-multicommand.md
@@ -115,7 +115,7 @@ processed by **autopilot**.
 * Lines **7-33** are the two **Commands** that make up this plan -- an `airgapupdate` and `k0supdate`.
 * Lines **38-55** are the associated status entries for the two **Commands**.
 
-The state of this **Plan** exerpt is that **autopilot** has successfully processed the **Plan**, and
+The state of this **Plan** excerpt is that **autopilot** has successfully processed the **Plan**, and
 has begun processing the `airgapupdate` **Command**. Its status indicates **SignalSent** which means
 that the **Signal Node** has been sent signaling information to perform an airgap update.
 

--- a/docs/autopilot.md
+++ b/docs/autopilot.md
@@ -30,8 +30,8 @@ spec:
   upgradeStrategy:
     type: periodic
     periodic:
-      # The folowing fields configures updates to happen only on Tue or Wed at 13:00-15:00
-      days: [Tuesdsay,Wednesday]
+      # The following fields configures updates to happen only on Tue or Wed at 13:00-15:00
+      days: [Tuesdays,Wednesday]
       startTime: "13:00"
       length: 2h
   planSpec: # This defines the plan to be created IF there are updates available
@@ -312,7 +312,7 @@ To read this status, this indicates that:
   waiting for the next opportunity to process a command.
 * There are three controller nodes
   * Two controllers have `SignalCompleted` successfully
-  * One is waiting to be signalled (`SignalPending`)
+  * One is waiting to be signaled (`SignalPending`)
 * There are also three worker nodes
   * All are awaiting signaling updates (`SignalPending`)
 
@@ -396,8 +396,8 @@ spec:
   upgradeStrategy:
     type: periodic
     periodic:
-      # The folowing fields configures updates to happen only on Tue or Wed at 13:00-15:00
-      days: [Tuesdsay,Wednesday]
+      # The following fields configures updates to happen only on Tue or Wed at 13:00-15:00
+      days: [Tuesdays,Wednesday]
       startTime: "13:00"
       length: 2h
   # Optional. Specifies a created Plan object

--- a/docs/contributors/index.md
+++ b/docs/contributors/index.md
@@ -31,7 +31,7 @@ The testing guidelines can be found here:
 
 By contributing, you agree that your contributions will be licensed as followed:
 
-- All content residing under the "docs/" directory of this repository is licensed under "Creative Commons Attribution Share Alike 4.0 International" (CC-BY-SA-4.0). See docs/LICENCE for details.
+- All content residing under the "docs/" directory of this repository is licensed under "Creative Commons Attribution Share Alike 4.0 International" (CC-BY-SA-4.0). See docs/LICENSE for details.
 - Content outside of the above mentioned directories or restrictions above is available under the "Apache License 2.0".
 
 ## Community

--- a/docs/dynamic-configuration.md
+++ b/docs/dynamic-configuration.md
@@ -69,6 +69,6 @@ k0s config status
 ```shell
 LAST SEEN   TYPE      REASON                OBJECT              MESSAGE
 64s         Warning   FailedReconciling     clusterconfig/k0s   failed to validate config: [invalid pod CIDR invalid ip address]
-59s         Normal    SuccessfulReconcile   clusterconfig/k0s   Succesfully reconciler cluster config
+59s         Normal    SuccessfulReconcile   clusterconfig/k0s   Successfully reconciler cluster config
 69s         Warning   FailedReconciling     clusterconfig/k0s   cannot change CNI provider from kuberouter to calico
 ```

--- a/docs/kube-bench/cfg/k0s-1.0/policies.yaml
+++ b/docs/kube-bench/cfg/k0s-1.0/policies.yaml
@@ -133,7 +133,7 @@ groups:
         text: "Minimize the admission of containers with capabilities assigned (Manual)"
         type: "manual"
         remediation: |
-          Review the use of capabilites in applications runnning on your cluster. Where a namespace
+          Review the use of capabilities in applications runnning on your cluster. Where a namespace
           contains applicaions which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false

--- a/docs/manifests.md
+++ b/docs/manifests.md
@@ -14,7 +14,7 @@ The use of Manifest Deployer is quite similar to the use the `kubectl apply` com
 
 - Each directory that is a direct descendant of `/var/lib/k0s/manifests` is considered to be its own "stack". Nested directories (further subfolders), however, are excluded from the stack mechanism and thus are not automatically deployed by the Manifest Deployer.
 
-- k0s uses the indepenent stack mechanism for some of its internal in-cluster components, as well as for other resources. Be sure to only touch the manifests that are not managed by k0s.
+- k0s uses the independent stack mechanism for some of its internal in-cluster components, as well as for other resources. Be sure to only touch the manifests that are not managed by k0s.
 
 - Explicitly define the namespace in the manifests (Manifest Deployer does not have a default namespace).
 

--- a/hack/copyright.sh
+++ b/hack/copyright.sh
@@ -25,7 +25,7 @@ get_year(){
     YEAR=$(TZ=UTC git log --follow --find-copies=90% -1 --diff-filter=A --pretty=format:%ad --date=format:%Y -- "$1")
     if [ -z "$YEAR" ]; then
         YEAR=$(TZ=UTC date +%Y)
-	    echo "WARN: $1 doesn't seem to be commited in the repo, assuming $YEAR" 1>&2
+	    echo "WARN: $1 doesn't seem to be committed in the repo, assuming $YEAR" 1>&2
     fi
     echo "$YEAR"
 }

--- a/internal/oci/download_test.go
+++ b/internal/oci/download_test.go
@@ -140,9 +140,9 @@ func startOCIMockServer(t *testing.T, tname string, test testFile) url.URL {
 					return
 				}
 				res := map[string]string{"token": tname}
-				marshalled, err := json.Marshal(res)
+				marshaled, err := json.Marshal(res)
 				assert.NoError(t, err)
-				_, _ = w.Write(marshalled)
+				_, _ = w.Write(marshaled)
 				return
 			}
 

--- a/inttest/kubeletcertrotate/kubeletcertrotate_test.go
+++ b/inttest/kubeletcertrotate/kubeletcertrotate_test.go
@@ -70,7 +70,7 @@ func (s *kubeletCertRotateSuite) SetupTest() {
 
 	// Knowing that `kube-controller-manager` is issuing certificates that live for
 	// only 3m, if we can successfully apply autopilot plans AFTER kubelet key/certs have changed, we should
-	// be able to confidentally say that the transport cert rotation is fine.
+	// be able to confidentially say that the transport cert rotation is fine.
 	workerSSH, err := s.SSH(s.Context(), s.WorkerNode(0))
 	s.Require().NoError(err)
 	s.T().Log("waiting to see kubelet rotating the client cert before triggering Plan creation")

--- a/pkg/applier/manager_test.go
+++ b/pkg/applier/manager_test.go
@@ -239,7 +239,7 @@ func TestManager(t *testing.T) {
 		assert.Equal(t, "applier", r.GetLabels()["component"])
 	}
 
-	// update the stack after the lease aquire and verify the changes are applied
+	// update the stack after the lease acquire and verify the changes are applied
 
 	writeLabel(t, filepath.Join(dir, "stack1/pod.yaml"), "custom2", "test")
 

--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -211,7 +211,7 @@ func (s *Stack) prune(ctx context.Context, mapper meta.ResettableRESTMapper) err
 			}
 		}
 	}
-	s.log.Debug("resources pruned succesfully")
+	s.log.Debug("resources pruned successfully")
 	s.keepResources = []string{}
 
 	return nil

--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable.go
@@ -58,7 +58,7 @@ func (aup *airgapupdate) Schedulable(ctx context.Context, planID string, cmd apv
 		return appc.PlanMissingSignalNode, false, nil
 	}
 
-	logger.Infof("Sending signalling to node='%s'", nextForSignal.Name)
+	logger.Infof("Sending signaling to node='%s'", nextForSignal.Name)
 
 	signalNodeCopy := signalNodeDelegate.DeepCopy(signalNode)
 	signalNodeCommandBuilder, err := signalNodeAirgapUpdateCommandBuilder(signalNodeCopy, cmd, status)

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable.go
@@ -79,7 +79,7 @@ func (kp *k0supdate) Schedulable(ctx context.Context, planID string, cmd apv1bet
 		return status.State, true, nil
 	}
 
-	logger.Infof("Sending signalling to node='%s'", nextForSignal.Name)
+	logger.Infof("Sending signaling to node='%s'", nextForSignal.Name)
 
 	// Add the signaling instructions to the nodes metadata.
 	//

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/update.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/utils/update.go
@@ -27,7 +27,7 @@ import (
 
 type SignalNodeCommandBuilder func() apsigv2.Command
 
-// UpdateSignalNode builds a signalling update request, and adds it to the provided node
+// UpdateSignalNode builds a signaling update request, and adds it to the provided node
 func UpdateSignalNode(node crcli.Object, planID string, cb SignalNodeCommandBuilder) error {
 	signalData := apsigv2.SignalData{
 		PlanID:  planID,

--- a/pkg/autopilot/controller/root_controller.go
+++ b/pkg/autopilot/controller/root_controller.go
@@ -241,7 +241,7 @@ func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *
 	// All the controller-runtime controllers have been registered.
 	c.initialized = true
 
-	// The controller-runtime start blocks until the context is cancelled.
+	// The controller-runtime start blocks until the context is canceled.
 	if err := mgr.Start(ctx); err != nil {
 		logger.WithError(err).Error("unable to run controller-runtime manager")
 		return err

--- a/pkg/autopilot/controller/root_controller_test.go
+++ b/pkg/autopilot/controller/root_controller_test.go
@@ -114,7 +114,7 @@ func TestModeSwitch(t *testing.T) {
 
 	// Despite the additional send of LeaseAcquired, only two events should
 	// have been processed. The additional 3rd stop event is a result of
-	// the cancelling of the context.
+	// the canceling of the context.
 
 	assert.Equal(t, 2, startCount)
 	assert.Equal(t, 3, stopCount)

--- a/pkg/autopilot/controller/root_worker.go
+++ b/pkg/autopilot/controller/root_worker.go
@@ -128,7 +128,7 @@ func (w *rootWorker) Run(ctx context.Context) error {
 		// All the controller-runtime controllers have been registered.
 		w.initialized = true
 
-		// The controller-runtime start blocks until the context is cancelled.
+		// The controller-runtime start blocks until the context is canceled.
 		if err := mgr.Start(ctx); err != nil {
 			return fmt.Errorf("unable to run controller-runtime manager for workers: %w", err)
 		}

--- a/pkg/autopilot/controller/updates/periodicupdater.go
+++ b/pkg/autopilot/controller/updates/periodicupdater.go
@@ -77,7 +77,7 @@ func (u *periodicUpdater) Run() error {
 	}
 	u.log.Debugf("using %s for update check period", checkDuration.String())
 	go func() {
-		// Check for update every checkDuration, return when context is cancelled
+		// Check for update every checkDuration, return when context is canceled
 		ticker := time.NewTicker(checkDuration)
 		u.ticker = ticker
 		defer ticker.Stop()

--- a/pkg/autopilot/signaling/v2/marshal.go
+++ b/pkg/autopilot/signaling/v2/marshal.go
@@ -22,9 +22,9 @@ const (
 	TagAutopilot = "autopilot"
 )
 
-// Marshal converts a signalling object to a map, including any nested structs
+// Marshal converts a signaling object to a map, including any nested structs
 // that belong to the value. Only fields that have the `autopilot` tag are
-// considered for marshalling.
+// considered for marshaling.
 func Marshal(m map[string]string, value interface{}) {
 	fields := reflect.TypeOf(value)
 	values := reflect.ValueOf(value)
@@ -48,7 +48,7 @@ func Marshal(m map[string]string, value interface{}) {
 type UnmarshalFieldTypeCollector func() reflect.Type
 type UnmarshalFieldValueCollector func() reflect.Value
 
-// Unmarshal uses reflection semantics to turn the marshalled map of values
+// Unmarshal uses reflection semantics to turn the marshaled map of values
 // back into a structure of unknown type. By relying on two reflection helper
 // functions, the reflect types + values can be specialized by the caller,
 // allowing this to be reused for all types.

--- a/pkg/component/controller/cplb/cplb_linux.go
+++ b/pkg/component/controller/cplb/cplb_linux.go
@@ -361,7 +361,7 @@ func (k *Keepalived) watchReconcilerUpdatesReverseProxy(ctx context.Context) err
 
 	select {
 	case <-ctx.Done():
-		return errors.New("context cancelled while starting the reverse proxy")
+		return errors.New("context canceled while starting the reverse proxy")
 	case <-k.updateCh:
 	}
 	k.setProxyRoutes()

--- a/pkg/component/controller/k0scloudprovider_test.go
+++ b/pkg/component/controller/k0scloudprovider_test.go
@@ -35,7 +35,7 @@ func EmptyAddressCollector(node *v1.Node) []v1.NodeAddress {
 // DummyCommand is a simple `k0scloudprovider.Command` that returns if the
 // provided channel is closed, or after a 30s timeout.  The main motivation is
 // to have a command that waits until completed, with notification.
-func DummyCommand(wg *sync.WaitGroup, cancelled *bool) (k0scloudprovider.Command, error) {
+func DummyCommand(wg *sync.WaitGroup, canceled *bool) (k0scloudprovider.Command, error) {
 	wg.Add(1)
 
 	return func(stopCh <-chan struct{}) {
@@ -46,24 +46,24 @@ func DummyCommand(wg *sync.WaitGroup, cancelled *bool) (k0scloudprovider.Command
 
 		select {
 		case <-stopCh:
-			*cancelled = true
+			*canceled = true
 		case <-t.C:
 		}
 	}, nil
 }
 
 // DummyCommandBuilder adapts `DummyCommand` to `CommandBuilder`
-func DummyCommandBuilder(wg *sync.WaitGroup, cancelled *bool) CommandBuilder {
+func DummyCommandBuilder(wg *sync.WaitGroup, canceled *bool) CommandBuilder {
 	return func() (k0scloudprovider.Command, error) {
-		return DummyCommand(wg, cancelled)
+		return DummyCommand(wg, canceled)
 	}
 }
 
 type K0sCloudProviderSuite struct {
 	suite.Suite
-	ccp       manager.Component
-	cancelled bool
-	wg        sync.WaitGroup
+	ccp      manager.Component
+	canceled bool
+	wg       sync.WaitGroup
 }
 
 // SetupTest builds a makeshift k0s-cloud-provider configuration, and
@@ -75,7 +75,7 @@ func (suite *K0sCloudProviderSuite) SetupTest() {
 		UpdateFrequency:  1 * time.Second,
 	}
 
-	suite.ccp = newK0sCloudProvider(config, DummyCommandBuilder(&suite.wg, &suite.cancelled))
+	suite.ccp = newK0sCloudProvider(config, DummyCommandBuilder(&suite.wg, &suite.canceled))
 	suite.NotNil(suite.ccp)
 }
 
@@ -85,7 +85,7 @@ func (suite *K0sCloudProviderSuite) TestInit() {
 }
 
 // TestRunStop covers the scenario of issuing a `Start()`, and ensuring
-// that when `Stop()` is called, the underlying goroutine is cancelled.
+// that when `Stop()` is called, the underlying goroutine is canceled.
 // This is effectively testing the close-channel semantics baked into
 // `Stop()`, without worrying about what was actually running.
 func (suite *K0sCloudProviderSuite) TestRunStop() {
@@ -97,7 +97,7 @@ func (suite *K0sCloudProviderSuite) TestRunStop() {
 	suite.NoError(suite.ccp.Stop())
 	suite.wg.Wait()
 
-	suite.True(suite.cancelled)
+	suite.True(suite.canceled)
 }
 
 // TestK0sCloudProviderTestSuite sets up the suite for testing.

--- a/pkg/component/prober/events_test.go
+++ b/pkg/component/prober/events_test.go
@@ -88,7 +88,7 @@ func TestEvents(t *testing.T) {
 		}
 	})
 
-	t.Run("emitter_observes_events_emited_by_components_registred_after_run_is_called", func(t *testing.T) {
+	t.Run("emitter_observes_events_emitted_by_components_registred_after_run_is_called", func(t *testing.T) {
 		prober := testProber(0)
 		ctx, cancel := context.WithCancel(t.Context())
 		go prober.Run(ctx)

--- a/pkg/component/prober/prober.go
+++ b/pkg/component/prober/prober.go
@@ -215,7 +215,7 @@ func (p *Prober) Register(name string, component any) {
 
 // ProbeError is a string that implements the error interface.
 // This is necessary because errors in golang are an interface and not structs,
-// which means they are marshalled as an empty json and cannot be unmarshalled.
+// which means they are marshaled as an empty json and cannot be unmarshalled.
 type ProbeError string
 
 // ProbeResult represents a result of a probe

--- a/pkg/component/prober/prober_test.go
+++ b/pkg/component/prober/prober_test.go
@@ -134,7 +134,7 @@ func TestMarshalling(t *testing.T) {
 
 	for _, source := range tests {
 		data, err := json.Marshal(source)
-		assert.NoError(t, err, "marshalling ProbeError shouldn't fail")
+		assert.NoError(t, err, "marshaling ProbeError shouldn't fail")
 
 		target := &ProbeResult{}
 		err = json.Unmarshal(data, target)

--- a/pkg/component/worker/static_pods.go
+++ b/pkg/component/worker/static_pods.go
@@ -421,7 +421,7 @@ func newStaticPodsServer(log logrus.FieldLogger, contentFn func() []byte) (*http
 		BaseContext:  func(net.Listener) context.Context { return ctx },
 	}
 
-	// Fire up a goroutine that'll close the HTTP server whenever the context is cancelled.
+	// Fire up a goroutine that'll close the HTTP server whenever the context is canceled.
 	go func() {
 		<-ctx.Done()
 		log.Debug("Closing HTTP server")

--- a/pkg/leaderelection/client_test.go
+++ b/pkg/leaderelection/client_test.go
@@ -178,7 +178,7 @@ func TestClient_LeadTakeover(t *testing.T) {
 			if t.Failed() {
 				return
 			}
-			t.Log("Red took the lead, cancelling Red's context")
+			t.Log("Red took the lead, canceling Red's context")
 			cancelRed()
 		},
 		func(runner string, status Status) {
@@ -195,7 +195,7 @@ func TestClient_LeadTakeover(t *testing.T) {
 			if t.Failed() {
 				return
 			}
-			t.Log("Black took the lead, cancelling Black's context")
+			t.Log("Black took the lead, canceling Black's context")
 			cancelBlack()
 		},
 		func(runner string, status Status) {

--- a/pkg/leaderelection/lease_pool.go
+++ b/pkg/leaderelection/lease_pool.go
@@ -39,7 +39,7 @@ type LeaseEvents struct {
 	LostLease     chan struct{}
 }
 
-// The LeaseConfiguration allows passing through various options to customise the lease.
+// The LeaseConfiguration allows passing through various options to customize the lease.
 type LeaseConfiguration struct {
 	name        string
 	identity    string

--- a/pkg/leaderelection/lease_pool_test.go
+++ b/pkg/leaderelection/lease_pool_test.go
@@ -90,10 +90,10 @@ func TestLeasePoolTriggersLostLeaseWhenCancelled(t *testing.T) {
 	require.NoError(t, err)
 
 	<-events.AcquiredLease
-	t.Log("lease acquired, cancelling leaser")
+	t.Log("lease acquired, canceling leaser")
 	cancel()
 	<-events.LostLease
-	t.Log("context cancelled and lease successfully lost")
+	t.Log("context canceled and lease successfully lost")
 }
 
 func TestLeasePoolWatcherReacquiresLostLease(t *testing.T) {
@@ -210,7 +210,7 @@ func TestSecondWatcherAcquiresReleasedLease(t *testing.T) {
 	for {
 		select {
 		case <-events1.AcquiredLease:
-			t.Log("First lease acquired, cancelling pool")
+			t.Log("First lease acquired, canceling pool")
 			cancel1()
 			receivedEvents = append(receivedEvents, "pool1-acquired")
 		case <-events1.LostLease:

--- a/pkg/performance/timer.go
+++ b/pkg/performance/timer.go
@@ -63,7 +63,7 @@ func (t *Timer) Start() *Timer {
 
 // Checkpoint records the time since the timer was started
 func (t *Timer) Checkpoint(name string) {
-	// if the timer was never started, we'll record an errored checkpoint that Output can recognise
+	// if the timer was never started, we'll record an errored checkpoint that Output can recognize
 	if t.startedAt.IsZero() {
 		t.buffer = append(t.buffer, checkpoint{
 			name: name,

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -221,7 +221,7 @@ func (s *Supervisor) Supervise() error {
 
 			select {
 			case <-ctx.Done():
-				s.log.Debug("respawn cancelled")
+				s.log.Debug("respawn canceled")
 				return
 			case <-time.After(s.TimeoutRespawn):
 				s.log.Debug("respawning")

--- a/pkg/token/joinclient_test.go
+++ b/pkg/token/joinclient_test.go
@@ -136,7 +136,7 @@ func TestJoinClient_Cancellation(t *testing.T) {
 			require.NoError(t, err)
 
 			err = test.funcUnderTest(clientContext, underTest)
-			assert.ErrorIs(t, err, context.Canceled, "Expected the call to be cancelled")
+			assert.ErrorIs(t, err, context.Canceled, "Expected the call to be canceled")
 			assert.Same(t, context.Cause(clientContext), assert.AnError, "Didn't receive an HTTP request")
 		})
 	}
@@ -182,7 +182,7 @@ func startFakeJoinServer(t *testing.T, handler func(http.ResponseWriter, *http.R
 	go func() { defer close(serverError); serverError <- server.ServeTLS(listener, "", "") }()
 	t.Cleanup(func() {
 		cancelRequests()
-		// We cannot use t.Context because this is during t.Cleanup because it's cancelled
+		// We cannot use t.Context because this is during t.Cleanup because it's canceled
 		if !assert.NoError(t, server.Shutdown(testutil.ContextBackground()), "Couldn't shutdown HTTP server") {
 			return
 		}


### PR DESCRIPTION
## Description

Enables `misspell` linter and forces US spelling for whole codebase.

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
