### PR TITLE
Fix ostests terraform script

### DIFF
--- a/hack/ostests/modules/k0sctl/main.tf
+++ b/hack/ostests/modules/k0sctl/main.tf
@@ -17,7 +17,7 @@ resource "terraform_data" "k0sctl_apply" {
     }
 
     command = <<-EOF
-      printf %s "$K0SCTL_CONFIG" | env -u SSH_AUTH_SOCK SSH_KNOWN_HOSTS='' "$K0SCTL_EXECUTABLE_PATH" apply --disable-telemetry -c -
+      printf %s "$K0SCTL_CONFIG" | env -u SSH_AUTH_SOCK SSH_KNOWN_HOSTS='' "$K0SCTL_EXECUTABLE_PATH" apply -c -
       EOF
   }
 }
@@ -65,7 +65,7 @@ data "external" "k0s_kubeconfig" {
     "env", "sh", "-ec",
     <<-EOS
       jq '.k0sctl_config | fromjson' |
-        { env -u SSH_AUTH_SOCK SSH_KNOWN_HOSTS='' "$1" kubeconfig --disable-telemetry -c - || echo ~~~FAIL; } |
+        { env -u SSH_AUTH_SOCK SSH_KNOWN_HOSTS='' "$1" kubeconfig -c - || echo ~~~FAIL; } |
         jq --raw-input --slurp "$2"
     EOS
     , "--",


### PR DESCRIPTION
## Description

ksctl 0.22.0 removed the flag --disable-telemetry, so terraform apply fails after bumping it to 0.23.0

This fixes the known issues with the ostests.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
