### PR TITLE
Define API's `sans` field as a set to prevent duplicate entries

### DIFF
--- a/pkg/apis/k0s/v1beta1/api.go
+++ b/pkg/apis/k0s/v1beta1/api.go
@@ -62,6 +62,7 @@ type APISpec struct {
 	Port int `json:"port,omitempty"`
 
 	// List of additional addresses to push to API servers serving the certificate
+	// +listType=set
 	SANs []string `json:"sans,omitempty"`
 }
 

--- a/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
+++ b/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
@@ -79,6 +79,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: set
                 type: object
               controllerManager:
                 description: ControllerManagerSpec defines the fields for the ControllerManager


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds the `+listType=set` annotation to the `SANs` field in the API spec, ensuring that the field is treated as a set in the generated CRD. This prevents duplicate entries in the array, which can cause confusion and potential issues with certificate generation.

The change is minimal and only affects the CRD schema definition, maintaining backwards compatibility while improving data integrity.

Fixes #5722

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Manually verified that:
1. The CRD generation works correctly with `make codegen`
2. The generated CRD includes the `x-kubernetes-list-type: set` property for the `sans` field
3. The change doesn't affect existing functionality

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
