### PR TITLE
Upload cosign transparency log and verify signatures before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           curl $CURL_OPTS --output cosign https://github.com/sigstore/cosign/releases/download/v2.4.2/cosign-linux-amd64
           chmod +x ./cosign
-          COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false --output-file=k0s.sig k0s
+          COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload -y --output-file=k0s.sig k0s
           cat k0s.sig
 
       - name: Upload Release Assets - Binary
@@ -195,7 +195,7 @@ jobs:
         run: |
           curl $CURL_OPTS --output cosign https://github.com/sigstore/cosign/releases/download/v2.4.2/cosign-linux-amd64
           chmod +x ./cosign
-          COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false --output-file=k0s.exe.sig k0s.exe
+          COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload -y --output-file=k0s.exe.sig k0s.exe
           cat k0s.exe.sig
 
       - name: Clean Docker
@@ -263,7 +263,7 @@ jobs:
         run: |
           curl $CURL_OPTS --output cosign https://github.com/sigstore/cosign/releases/download/v2.4.2/cosign-linux-arm64
           chmod +x ./cosign
-          COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false --output-file=k0s.sig k0s
+          COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload -y --output-file=k0s.sig k0s
           cat k0s.sig
 
       - name: Set up Go for smoke tests
@@ -350,7 +350,7 @@ jobs:
         run: |
           curl $CURL_OPTS --output cosign https://github.com/sigstore/cosign/releases/download/v2.4.2/cosign-linux-arm
           chmod +x ./cosign
-          COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload=false --output-file=k0s.sig k0s
+          COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload -y --output-file=k0s.sig k0s
           cat k0s.sig
 
       - name: Set up Go for smoke tests

--- a/docs/verifying-signs.md
+++ b/docs/verifying-signs.md
@@ -8,5 +8,5 @@ Binaries can be verified using the `cosign` tool, for example:
 cosign verify-blob \
   --key https://github.com/k0sproject/k0s/releases/download/v{{{ extra.k8s_version }}}%2Bk0s.0/cosign.pub \
   --signature https://github.com/k0sproject/k0s/releases/download/v{{{ extra.k8s_version }}}%2Bk0s.0/k0s-v{{{ extra.k8s_version }}}+k0s.0-amd64.sig \
-  --payload k0s-v{{{ extra.k8s_version }}}+k0s.0-amd64
+  k0s-v{{{ extra.k8s_version }}}+k0s.0-amd64
 ```


### PR DESCRIPTION
## Description

It was reported to us that cosign verify-blob fails with:

```
cosign verify-blob \
  --key https://github.com/k0sproject/k0s/releases/download/v1.32.2%2Bk0s.0/cosign.pub \
  --signature https://github.com/k0sproject/k0s/releases/download/v1.32.2%2Bk0s.0/k0s-v1.32.2+k0s.0-amd64.sig \
  k0s-v1.32.2+k0s.0-amd64
Error: signature not found in transparency log
main.go:74: error during command execution: signature not found in transparency log
```

The ultimate root cause for this is that we don't upload the transparency log, so the verification process can only be done by adding the flag `--insecure-ignore-tlog`.

This commit does 2 things:
1- Set `--tlog-upload=true`so that the transparency log can be verified 
2- Remove the flag `--payload` from the documentation. This flags was probably removed at some point and now is invalid.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
