### PR TITLE
Add defaultRoute strategy for konnectivity

### DIFF
--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -163,7 +163,7 @@ func (k *Konnectivity) serverArgs(count uint) []string {
 		"--delete-existing-uds-file": "true",
 		"--server-count":             strconv.FormatUint(uint64(count), 10),
 		"--server-id":                k.K0sVars.InvocationID,
-		"--proxy-strategies":         "destHost,default",
+		"--proxy-strategies":         "destHost,defaultRoute,default",
 		"--cipher-suites":            constant.AllowedTLS12CipherSuiteNames(),
 	}.ToArgs()
 }


### PR DESCRIPTION
To avoid breaking connectivity in the network set up when workers' networks are partitioned.

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
