### PR TITLE
Be less strict about CPLB vs. endpoint reconciler

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -272,7 +272,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions) er
 
 		if enableK0sEndpointReconciler {
 			enableK0sEndpointReconciler = false
-			logrus.Warn("Disabling k0s endpoint reconciler as it is incompatible with control plane load balancing")
+			logrus.Info("Disabling k0s endpoint reconciler in favor of control plane load balancing")
 		}
 
 		nodeComponents.Add(ctx, &cplb.Keepalived{

--- a/docs/cplb.md
+++ b/docs/cplb.md
@@ -32,10 +32,13 @@ rules in the control plane nodes which may be incompatible with custom CNI plugi
 
 ### External address
 
-If [`spec.api.externalAddress`](configuration.md#specapi) is defined it's mandatory to disable
-the [`endpoint-reconciler` component](configuration.md#disabling-controller-components) using the flag `--disable-components=endpoint-reconciler`.
+If [`spec.api.externalAddress`](configuration.md#specapi) is defined, control
+plane load balancing implicitly
+[disables](configuration.md#disabling-controller-components) k0s's endpoint
+reconciler component, just as if the `--disable-components=endpoint-reconciler`
+flag had been specified.
 
-### Node Local Load Balancing
+### Node Local load balancing
 
 CPLB is fully compatible with [NLLB](nllb.md), however NLLB is incompatible with [`spec.api.externalAddress`](configuration.md#specapi).
 


### PR DESCRIPTION
## Description

As CPLB will work just fine with `externalAddress` by implicitly disabling the endpoint reconciler, I think it makes sense to be less strict with users about requiring them to explicitly disable the reconciler.

Change the log statement to be Info instead of Warn, and change the tone in the docs a bit.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
