### PR TITLE
Add missing k8s.io/externaljwt replace config in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -307,6 +307,7 @@ replace (
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.3
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.3
 	k8s.io/endpointslice => k8s.io/endpointslice v0.32.3
+	k8s.io/externaljwt => k8s.io/externaljwt v0.32.3
 	k8s.io/kms => k8s.io/kms v0.32.3
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.3
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.3


### PR DESCRIPTION
## Description

The replace directive for the `k8s.io/externaljwt` dependency is missing, see https://github.com/kubernetes/kubernetes/blob/v1.32.3/go.mod#L243

Without it, the IDE cannot execute the `go list` command to create an index for this project:

```
go: k8s.io/externaljwt@v0.0.0: invalid version: unknown revision v0.0.0
```

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
