### PR TITLE
[Backport release-1.31] Bump kine to 0.13.12

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -32,11 +32,11 @@ kubernetes_build_go_flags = "-v"
 #kubernetes_build_go_ldflags =
 kubernetes_build_go_ldflags_extra = "-extldflags=-static"
 
-kine_version = 0.13.10
+kine_version = 0.13.12
 kine_buildimage = $(golang_buildimage)
 kine_build_go_tags = nats
 #kine_build_go_cgo_enabled =
-# Flags taken from https://github.com/k3s-io/kine/blob/v0.13.10/scripts/build#L24
+# Flags taken from https://github.com/k3s-io/kine/blob/v0.13.12/scripts/build#L24
 kine_build_go_cgo_cflags = -DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1
 
 #kine_build_go_flags =

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -122,7 +122,7 @@ func (k *Kine) Start(ctx context.Context) error {
 			fmt.Sprintf("--endpoint=%s", k.Config.DataSource),
 			// NB: kine doesn't parse URLs properly, so construct potentially
 			// invalid URLs that are understood by kine.
-			// https://github.com/k3s-io/kine/blob/v0.13.10/pkg/util/network.go#L5-L13
+			// https://github.com/k3s-io/kine/blob/v0.13.12/pkg/util/network.go#L5-L13
 			fmt.Sprintf("--listen-address=unix://%s", k.K0sVars.KineSocketPath),
 			// Enable metrics on port 2380. The default is 8080, which clashes with kube-router.
 			"--metrics-bind-address=:2380",


### PR DESCRIPTION
Backport to `release-1.31`:

* #5743

See:

* #5742