### PR TITLE
Remove "What happened to GitHub stargazers?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,6 @@
 ![k0s-logo-dark](docs/img/k0s-logo-2025-horizontal-inverted.svg#gh-dark-mode-only)
 ![k0s-logo-light](docs/img/k0s-logo-2025-horizontal.svg#gh-light-mode-only)
 
-## What happened to GitHub stargazers?
-
-In September 2022 we made a human error while creating some build automation scripts&tools for the GitHub repository. Our automation accidentally changed the repo to a private one for few minutes. That itself is not a big deal and everything was restored quickly. But the nasty side effect is that it also removed all the stargazers at that point. :(
-
-Before that mishap we had 4776 stargazers, making k0s one of the most popular Kubernetes distro out there.
-
-**So if you are reading this, and have not yet starred this repo we would highly appreciate the :star: to get our numbers closer to what they used to be.**
-
 <!-- Start Overview -->
 ## Overview
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,14 +11,6 @@
     end="<!-- End Overview -->"
 %}
 
-## What happened to GitHub stargazers?
-
-In September 2022 we made a human error while creating some build automation scripts&tools for the GitHub repository. Our automation accidentally changed the repo to a private one for few minutes. That itself is not a big deal and everything was restored quickly. But the nasty side effect is that it also removed all the stargazers at that point. :(
-
-Before that mishap we had 4776 stargazers, making k0s one of the most popular Kubernetes distro out there.
-
-**So if you are reading this, and have not yet starred the [k0s repository](https://github.com/k0sproject/k0s/) we would highly appreciate the :star: to get our numbers closer to what they used to be.**
-
 {%
     include-markdown "../README.md"
     start="<!-- Start Key Features -->"


### PR DESCRIPTION
## Description

The k0s repo is at 4.7k stars again, which it used to have before the little accident.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
