### PR TITLE
Bump go to v1.23.8

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.21
 alpine_patch_version = $(alpine_version).3
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.23.7
+go_version = 1.23.8
 
 runc_version = 1.2.6
 runc_buildimage = $(golang_buildimage)


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/Y2uBTVKjBQk/m/cs_6qIK5BAAJ
https://go.dev/doc/devel/release#go1.23.8
https://github.com/golang/go/issues?q=milestone%3AGo1.23.8+label%3ACherryPickApproved