### PR TITLE
 [Backport release-1.31] Bump go to v1.23.8 #5773 

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.19
 alpine_patch_version = $(alpine_version).7
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine3.20
-go_version = 1.23.7
+go_version = 1.23.8
 
 runc_version = 1.1.15
 runc_buildimage = $(golang_buildimage)


### PR DESCRIPTION
Manual backport to `release-1.30` of #5767.