### PR TITLE
Bump go to v1.24.2

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.21
 alpine_patch_version = $(alpine_version).3
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.23.8
+go_version = 1.24.2
 
 runc_version = 1.2.6
 runc_buildimage = $(golang_buildimage)


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/_G2hEiKx8SE/m/5uEc3vwVAgAJ https://groups.google.com/g/golang-announce/c/Y2uBTVKjBQk/m/cs_6qIK5BAAJ https://go.dev/doc/devel/release#go1.24.2
https://github.com/golang/go/issues?q=milestone%3AGo1.24.2+label%3ACherryPickApproved