### PR TITLE
Bump Kube router to 2.5.0

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -96,7 +96,7 @@ const (
 	CalicoNodeImage                    = "quay.io/k0sproject/calico-node"
 	KubeControllerImage                = "quay.io/k0sproject/calico-kube-controllers"
 	KubeRouterCNIImage                 = "quay.io/k0sproject/kube-router"
-	KubeRouterCNIImageVersion          = "v2.4.1-iptables1.8.9-0"
+	KubeRouterCNIImageVersion          = "v2.5.0-iptables1.8.11-0"
 	KubeRouterCNIInstallerImage        = "quay.io/k0sproject/cni-node"
 	KubeRouterCNIInstallerImageVersion = "1.3.0-k0s.0"
 	OpenEBSRepository                  = "https://openebs.github.io/charts"


### PR DESCRIPTION
https://github.com/cloudnativelabs/kube-router/releases/tag/v2.5.0