### PR TITLE
Fix the issue of unable to config the kubelet volumePluginDir and resolvConf parameters

### DIFF
--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -606,6 +606,7 @@ func (r *Reconciler) buildProfile(snapshot *snapshot) *workerconfig.Profile {
 			RotateCertificates: true,
 			ServerTLSBootstrap: true,
 			EventRecordQPS:     ptr.To(int32(0)),
+			VolumePluginDir:    "/usr/libexec/k0s/kubelet-plugins/volume/exec",
 		},
 		PauseImage:             snapshot.pauseImage.DeepCopy(),
 		NodeLocalLoadBalancing: snapshot.nodeLocalLoadBalancing.DeepCopy(),

--- a/pkg/component/controller/workerconfig/reconciler_test.go
+++ b/pkg/component/controller/workerconfig/reconciler_test.go
@@ -775,6 +775,7 @@ func makeKubeletConfig(t *testing.T, mods ...func(*kubeletConfig)) string {
 			"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
 			"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
 		},
+		VolumePluginDir: "/usr/libexec/k0s/kubelet-plugins/volume/exec",
 	}
 
 	for _, mod := range mods {

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -227,8 +227,9 @@ func (k *Kubelet) writeKubeletConfig() error {
 
 	config := k.Configuration.DeepCopy()
 	config.Authentication.X509.ClientCAFile = caPath
-	config.VolumePluginDir = k.K0sVars.KubeletVolumePluginDir
-	config.ResolverConfig = determineKubeletResolvConfPath()
+	if config.ResolverConfig == nil {
+		config.ResolverConfig = determineKubeletResolvConfPath()
+	}
 	config.StaticPodURL = staticPodURL
 	config.ContainerRuntimeEndpoint = containerRuntimeEndpoint.String()
 

--- a/pkg/config/cfgvars.go
+++ b/pkg/config/cfgvars.go
@@ -25,9 +25,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/spf13/pflag"
+
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
-	"github.com/spf13/pflag"
 )
 
 // CfgVars is a struct that holds all the config variables required for K0s
@@ -45,7 +46,6 @@ type CfgVars struct {
 	KineSocketPath             string              // The unix socket path for kine
 	KonnectivitySocketDir      string              // location of konnectivity's socket path
 	KubeletAuthConfigPath      string              // KubeletAuthConfigPath defines the default kubelet auth config path
-	KubeletVolumePluginDir     string              // location for kubelet plugins volume executables
 	ManifestsDir               string              // location for all stack manifests
 	RunDir                     string              // location of supervised pid files and sockets
 	KonnectivityKubeConfigPath string              // location for konnectivity kubeconfig
@@ -177,7 +177,6 @@ func NewCfgVars(cobraCmd command, dirs ...string) (*CfgVars, error) {
 		KineSocketPath:             filepath.Join(runDir, constant.KineSocket),
 		KonnectivitySocketDir:      filepath.Join(runDir, "konnectivity-server"),
 		KubeletAuthConfigPath:      filepath.Join(dataDir, "kubelet.conf"),
-		KubeletVolumePluginDir:     constant.KubeletVolumePluginDir,
 		ManifestsDir:               filepath.Join(dataDir, "manifests"),
 		RunDir:                     runDir,
 		KonnectivityKubeConfigPath: filepath.Join(certDir, "konnectivity.conf"),

--- a/pkg/constant/constant_unix.go
+++ b/pkg/constant/constant_unix.go
@@ -22,9 +22,6 @@ const (
 	// DataDirDefault is the default directory containing k0s state.
 	DataDirDefault = "/var/lib/k0s"
 
-	// KubeletVolumePluginDir defines the location for kubelet volume plugin executables.
-	KubeletVolumePluginDir = "/usr/libexec/k0s/kubelet-plugins/volume/exec"
-
 	KineSocket           = "kine/kine.sock:2379"
 	K0sConfigPathDefault = "/etc/k0s/k0s.yaml"
 )

--- a/pkg/constant/constant_windows.go
+++ b/pkg/constant/constant_windows.go
@@ -20,9 +20,6 @@ const (
 	// DataDirDefault is the default directory containing k0s state.
 	DataDirDefault = "C:\\var\\lib\\k0s"
 
-	// KubeletVolumePluginDir defines the location for kubelet plugins volume executables
-	KubeletVolumePluginDir = "C:\\usr\\libexec\\k0s\\kubelet-plugins\\volume\\exec"
-
 	KineSocket           = "kine\\kine.sock:2379"
 	K0sConfigPathDefault = "C:\\etc\\k0s\\k0s.yaml"
 )


### PR DESCRIPTION
## Description

Before this patch, the two kubelet configurations were only written to the ConfigMap and not persisted in the kubelet configuration file, because they were overwritten by hard-coded default settings. This patch corrects this behavior by allowing customization of these two parameters.

cc @twz123 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
