### PR TITLE
Remove EnableDynamicConfig from CfgVars

### DIFF
--- a/pkg/config/cfgvars.go
+++ b/pkg/config/cfgvars.go
@@ -54,7 +54,6 @@ type CfgVars struct {
 	RuntimeConfigPath          string              // A static copy of the config loaded at startup
 	StatusSocketPath           string              // The unix socket path for k0s status API
 	StartupConfigPath          string              // The path to the config file used at startup
-	EnableDynamicConfig        bool                // EnableDynamicConfig enables dynamic config
 
 	// Helm config
 	HelmHome             string
@@ -94,10 +93,6 @@ func WithCommand(cmd command) CfgVarOption {
 
 		if f, err := flags.GetString("status-socket"); err == nil && f != "" {
 			c.StatusSocketPath = f
-		}
-
-		if f, err := flags.GetBool("enable-dynamic-config"); err == nil {
-			c.EnableDynamicConfig = f
 		}
 
 		if f, err := flags.GetBool("single"); err == nil && f {

--- a/pkg/config/cfgvars_test.go
+++ b/pkg/config/cfgvars_test.go
@@ -62,11 +62,10 @@ func TestWithCommand(t *testing.T) {
 	// Create a fake flag set with some values
 	fakeFlags := &FakeFlagSet{
 		values: map[string]any{
-			"data-dir":              "/path/to/data",
-			"kubelet-root-dir":      "/path/to/kubelet",
-			"config":                "/path/to/config",
-			"status-socket":         "/path/to/socket",
-			"enable-dynamic-config": true,
+			"data-dir":         "/path/to/data",
+			"kubelet-root-dir": "/path/to/kubelet",
+			"config":           "/path/to/config",
+			"status-socket":    "/path/to/socket",
 		},
 	}
 
@@ -89,7 +88,6 @@ func TestWithCommand(t *testing.T) {
 	assert.Equal(t, dir, c.KubeletRootDir)
 	assert.Equal(t, "/path/to/config", c.StartupConfigPath)
 	assert.Equal(t, "/path/to/socket", c.StatusSocketPath)
-	assert.True(t, c.EnableDynamicConfig)
 }
 
 func TestWithCommand_DefaultsAndOverrides(t *testing.T) {


### PR DESCRIPTION
## Description

This is not used. There's a corresponding field in the `ControllerOptions` struct that is actually used in the codebase.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings