### PR TITLE
Use proper types on RISC-V

### DIFF
--- a/internal/pkg/sysinfo/probes/linux/types_signed.go
+++ b/internal/pkg/sysinfo/probes/linux/types_signed.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !(arm || riscv64)
 
 /*
 Copyright 2022 k0s authors
@@ -18,4 +18,4 @@ limitations under the License.
 
 package linux
 
-type utsChar = uint8
+type utsChar = int8

--- a/internal/pkg/sysinfo/probes/linux/types_unsigned.go
+++ b/internal/pkg/sysinfo/probes/linux/types_unsigned.go
@@ -1,4 +1,4 @@
-//go:build linux && !arm
+//go:build linux && (arm || riscv64)
 
 /*
 Copyright 2022 k0s authors
@@ -18,4 +18,4 @@ limitations under the License.
 
 package linux
 
-type utsChar = int8
+type utsChar = uint8


### PR DESCRIPTION
## Description

This makes the k0s sources compile on RISC-V.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings