### PR TITLE
Fix backwards compat for debug flag handling

### DIFF
--- a/cmd/airgap/airgap.go
+++ b/cmd/airgap/airgap.go
@@ -17,6 +17,7 @@ limitations under the License.
 package airgap
 
 import (
+	"github.com/k0sproject/k0s/cmd/internal"
 	"github.com/k0sproject/k0s/pkg/config"
 
 	"github.com/spf13/cobra"
@@ -32,6 +33,7 @@ func NewAirgapCmd() *cobra.Command {
 	}
 
 	var deprecatedFlags pflag.FlagSet
+	(&internal.DebugFlags{}).AddToFlagSet(&deprecatedFlags)
 	deprecatedFlags.AddFlagSet(config.GetPersistentFlagSet())
 	deprecatedFlags.AddFlagSet(config.FileInputFlag())
 	deprecatedFlags.VisitAll(func(f *pflag.Flag) {

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -17,24 +17,17 @@ limitations under the License.
 package config
 
 import (
-	"github.com/k0sproject/k0s/cmd/internal"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
 func NewConfigCmd() *cobra.Command {
-	var debugFlags internal.DebugFlags
-
 	cmd := &cobra.Command{
-		Use:              "config",
-		Short:            "Configuration related sub-commands",
-		Args:             cobra.NoArgs,
-		PersistentPreRun: debugFlags.Run,
-		RunE:             func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
+		Use:   "config",
+		Short: "Configuration related sub-commands",
+		Args:  cobra.NoArgs,
+		RunE:  func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
 	}
-
-	debugFlags.AddToFlagSet(cmd.PersistentFlags())
 
 	cmd.AddCommand(NewCreateCmd())
 	cmd.AddCommand(NewEditCmd())

--- a/cmd/config/create.go
+++ b/cmd/config/create.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"github.com/k0sproject/k0s/cmd/internal"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	k0sscheme "github.com/k0sproject/k0s/pkg/client/clientset/scheme"
 	"github.com/k0sproject/k0s/pkg/config"
@@ -29,12 +30,16 @@ import (
 )
 
 func NewCreateCmd() *cobra.Command {
-	var includeImages bool
+	var (
+		debugFlags    internal.DebugFlags
+		includeImages bool
+	)
 
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Output the default k0s configuration yaml to stdout",
-		Args:  cobra.NoArgs,
+		Use:              "create",
+		Short:            "Output the default k0s configuration yaml to stdout",
+		Args:             cobra.NoArgs,
+		PersistentPreRun: debugFlags.Run,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			config := v1beta1.DefaultClusterConfig()
 			if !includeImages {
@@ -58,13 +63,15 @@ func NewCreateCmd() *cobra.Command {
 		},
 	}
 
-	flags := cmd.Flags()
+	pflags := cmd.PersistentFlags()
+	debugFlags.AddToFlagSet(pflags)
 	config.GetPersistentFlagSet().VisitAll(func(f *pflag.Flag) {
 		f.Hidden = true
 		f.Deprecated = "it has no effect and will be removed in a future release"
-		cmd.PersistentFlags().AddFlag(f)
+		pflags.AddFlag(f)
 	})
-	flags.BoolVar(&includeImages, "include-images", false, "include the default images in the output")
+
+	cmd.Flags().BoolVar(&includeImages, "include-images", false, "include the default images in the output")
 
 	return cmd
 }

--- a/cmd/config/validate.go
+++ b/cmd/config/validate.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/k0sproject/k0s/cmd/internal"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/config"
 
@@ -30,12 +31,15 @@ import (
 )
 
 func NewValidateCmd() *cobra.Command {
+	var debugFlags internal.DebugFlags
+
 	cmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Validate k0s configuration",
 		Long: `Example:
    k0s config validate --config path_to_config.yaml`,
-		Args: cobra.NoArgs,
+		Args:             cobra.NoArgs,
+		PersistentPreRun: debugFlags.Run,
 		RunE: func(cmd *cobra.Command, _ []string) (err error) {
 			var bytes []byte
 
@@ -62,13 +66,15 @@ func NewValidateCmd() *cobra.Command {
 		},
 	}
 
-	flags := cmd.Flags()
+	pflags := cmd.PersistentFlags()
+	debugFlags.AddToFlagSet(pflags)
 	config.GetPersistentFlagSet().VisitAll(func(f *pflag.Flag) {
 		f.Hidden = true
 		f.Deprecated = "it has no effect and will be removed in a future release"
-		cmd.PersistentFlags().AddFlag(f)
+		pflags.AddFlag(f)
 	})
-	flags.AddFlagSet(config.FileInputFlag())
+
+	cmd.Flags().AddFlagSet(config.FileInputFlag())
 	_ = cmd.MarkFlagRequired("config")
 
 	return cmd

--- a/cmd/token/preshared.go
+++ b/cmd/token/preshared.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
 
+	"github.com/k0sproject/k0s/cmd/internal"
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/token"
@@ -67,11 +68,15 @@ func preSharedCmd() *cobra.Command {
 		},
 	}
 
-	flags := cmd.Flags()
+	var deprecatedFlags pflag.FlagSet
+	(&internal.DebugFlags{}).AddToFlagSet(&deprecatedFlags)
+	deprecatedFlags.AddFlagSet(config.GetPersistentFlagSet())
 	config.GetPersistentFlagSet().VisitAll(func(f *pflag.Flag) {
 		f.Hidden = true
-		flags.AddFlag(f)
+		cmd.PersistentFlags().AddFlag(f)
 	})
+
+	flags := cmd.Flags()
 	flags.StringVar(&certPath, "cert", "", "path to the CA certificate file")
 	runtime.Must(cobra.MarkFlagRequired(flags, "cert"))
 	flags.StringVar(&joinURL, "url", "", "url of the api server to join")

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -19,7 +19,6 @@ package token
 import (
 	"fmt"
 
-	"github.com/k0sproject/k0s/cmd/internal"
 	"github.com/k0sproject/k0s/pkg/token"
 
 	"github.com/spf13/cobra"
@@ -27,17 +26,12 @@ import (
 )
 
 func NewTokenCmd() *cobra.Command {
-	var debugFlags internal.DebugFlags
-
 	cmd := &cobra.Command{
-		Use:              "token",
-		Short:            "Manage join tokens",
-		Args:             cobra.NoArgs,
-		PersistentPreRun: debugFlags.Run,
-		RunE:             func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
+		Use:   "token",
+		Short: "Manage join tokens",
+		Args:  cobra.NoArgs,
+		RunE:  func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
 	}
-
-	debugFlags.AddToFlagSet(cmd.PersistentFlags())
 
 	cmd.AddCommand(tokenListCmd())
 	cmd.AddCommand(tokenInvalidateCmd())


### PR DESCRIPTION
## Description

The current version of the debug flag handling rejects debug flags on the airgap level, i.e. "k0s airgap -v" produces an error, which was valid in 1.32.

Add back the debug flags as hidden/deprecated on that level, and add explicit support for them on the level where they're actually used. Do a similar change for the config and token subcommands, so that the flags are only available for subcommands for which they make sense.

Fixes:

* #5390

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings