### PR TITLE
Bump calico to 3.29.3-1

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -92,7 +92,7 @@ const (
 	EnvoyProxyImage                    = "quay.io/k0sproject/envoy-distroless"
 	EnvoyProxyImageVersion             = "v1.32.3"
 	CalicoImage                        = "quay.io/k0sproject/calico-cni"
-	CalicoComponentImagesVersion       = "v3.29.3-0"
+	CalicoComponentImagesVersion       = "v3.29.3-1"
 	CalicoNodeImage                    = "quay.io/k0sproject/calico-node"
 	KubeControllerImage                = "quay.io/k0sproject/calico-kube-controllers"
 	KubeRouterCNIImage                 = "quay.io/k0sproject/kube-router"


### PR DESCRIPTION
go 1.23.7 -> 1.24.2
ipset 7.17 -> 7.23
iptables 1.8.9 -> 1.8.11
alpine 3.19/3.20 -> 3.21