### PR TITLE
Support for taking ownership of resources managed by k0s

### DIFF
--- a/docs/manifests.md
+++ b/docs/manifests.md
@@ -15,7 +15,7 @@ The use of Manifest Deployer is quite similar to the use the `kubectl apply` com
 - Each directory that is a direct descendant of `/var/lib/k0s/manifests` is considered to be its own "stack". Nested directories (further subfolders), however, are excluded from the stack mechanism and thus are not automatically deployed by the Manifest Deployer.
 
 - k0s uses the indepenent stack mechanism for some of its internal in-cluster components, as well as for other resources. Be sure to only touch the manifests that are not managed by k0s.
-
+  - If you want to take ownership of certain resources, you can add the `k0s.k0sproject.io/managed: false` label to those resources, indicating that they are no longer managed by k0s and k0s will not update them anymore.
 - Explicitly define the namespace in the manifests (Manifest Deployer does not have a default namespace).
 
 ## Example

--- a/pkg/applier/meta.go
+++ b/pkg/applier/meta.go
@@ -29,6 +29,9 @@ const (
 	// NameLabel stack label
 	NameLabel = MetaPrefix + "/stack"
 
+	// ManagedLabel defines the label key used to indicate whether a resource is managed by k0s.
+	ManagedLabel = MetaPrefix + "/managed"
+
 	// ChecksumAnnotation defines the annotation key to used for stack checksums
 	ChecksumAnnotation = MetaPrefix + "/stack-checksum"
 


### PR DESCRIPTION
## Description

> Especially for the CoreDNS config, there'd be another option that bypasses the k0s config: We could offer a way for users to just take ownership of the ConfigMap, for example. Say adding a label or annotation to it that tells k0s to not overwrite it.

Part of https://github.com/k0sproject/k0s/pull/5800#issuecomment-2847143849

ref https://github.com/k0sproject/k0s/issues/4021

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
