### PR TITLE
Change worker labels to be a map

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -667,7 +667,7 @@ func (c *command) startWorker(ctx context.Context, nodeName apitypes.NodeName, k
 	// opts to start the worker. Needs to be a copy so the original token and
 	// possibly other args won't get messed up.
 	wc := workercmd.Command(*(*config.CLIOptions)(c))
-	wc.Labels = append(wc.Labels, fields.OneTermEqualSelector(constant.K0SNodeRoleLabel, "control-plane").String())
+	wc.Labels[constant.K0SNodeRoleLabel] = "control-plane"
 	if opts.Mode() == config.ControllerPlusWorkerMode && !opts.NoTaints {
 		key := path.Join(constant.NodeRoleLabelNamespace, "master")
 		taint := fields.OneTermEqualSelector(key, ":NoSchedule")

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -80,7 +80,7 @@ Flags:
       --kube-controller-manager-extra-args string      extra args for kube-controller-manager
       --kubelet-extra-args string                      extra args for kubelet
       --kubelet-root-dir string                        Kubelet root directory for k0s
-      --labels strings                                 Node labels, list of key=value pairs
+      --labels mapStringString                         Node labels, list of key=value pairs
   -l, --logging stringToString                         Logging Levels for the different components (default [containerd=info,etcd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1])
       --no-taints                                      disable default taints for controller node
       --profile string                                 worker profile to use on the node (default "default")

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -73,7 +73,7 @@ Flags:
       --kube-controller-manager-extra-args string      extra args for kube-controller-manager
       --kubelet-extra-args string                      extra args for kubelet
       --kubelet-root-dir string                        Kubelet root directory for k0s
-      --labels strings                                 Node labels, list of key=value pairs
+      --labels mapStringString                         Node labels, list of key=value pairs
   -l, --logging stringToString                         Logging Levels for the different components (default [containerd=info,etcd=info,konnectivity-server=1,kube-apiserver=1,kube-controller-manager=1,kube-scheduler=1,kubelet=1])
       --no-taints                                      disable default taints for controller node
       --profile string                                 worker profile to use on the node (default "default")

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -41,6 +41,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
+	cliflag "k8s.io/component-base/cli/flag"
 	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	"github.com/sirupsen/logrus"
@@ -58,7 +59,7 @@ type Kubelet struct {
 	StaticPods          StaticPods
 	LogLevel            string
 	ClusterDNS          string
-	Labels              []string
+	Labels              map[string]string
 	Taints              []string
 	ExtraArgs           stringmap.StringMap
 	DualStackEnabled    bool
@@ -140,7 +141,7 @@ func (k *Kubelet) Start(ctx context.Context) error {
 	}
 
 	if len(k.Labels) > 0 {
-		args["--node-labels"] = strings.Join(k.Labels, ",")
+		args["--node-labels"] = ((*cliflag.ConfigurationMap)(&k.Labels)).String()
 	}
 
 	if k.DualStackEnabled && k.ExtraArgs["--node-ip"] == "" {


### PR DESCRIPTION
## Description

This is the way they're implemented in the kubelet, as well. Re-use Kubernetes' Cobra flag wrapper for (de-)serialization.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings