### PR TITLE
CPLB prevent IPVS routing loops

### DIFF
--- a/cmd/keepalived/keepalived_linux.go
+++ b/cmd/keepalived/keepalived_linux.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2025 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keepalived
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+func NewKeepalivedSetStateCmd() *cobra.Command {
+	var (
+		rundir string
+		state  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "keepalived-setstate",
+		Short: "Set keepalived state",
+		Long: `Example:
+   k0s keepalived-setstate -r <rundir> -s <state>`,
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
+			rundir = unescapeSingleQuotes(rundir)
+			// Verify that rundir is a valid directory
+			if err := validateRundir(rundir); err != nil {
+				return err
+			}
+
+			// generatedVirtualServers doesn't need to exist in order to be linked
+			// so we don't need to check for it.
+			// If it doesn't exist yet, we link it now and when k0s creates it, it
+			// will signal keepalived.
+			generatedVirtualServers := filepath.Join(rundir, "keepalived-virtualservers-generated.conf")
+
+			sourceFile := ""
+			switch state {
+			case "MASTER":
+				sourceFile = generatedVirtualServers
+			case "BACKUP":
+				sourceFile = os.DevNull
+			default:
+				return fmt.Errorf("invalid state %s, expected MASTER or BACKUP", state)
+
+			}
+
+			if err = createSymlink(rundir, sourceFile); err != nil {
+				return fmt.Errorf("failed to create symlink: %w", err)
+			}
+
+			pid, err := getPid(rundir)
+			if err != nil {
+				return err
+			}
+
+			if err := syscall.Kill(pid, syscall.SIGHUP); err != nil {
+				return fmt.Errorf("failed to send SIGHUP to pid %d: %w", pid, err)
+			}
+			return nil
+		},
+	}
+	// Add flags
+	cmd.Flags().StringVarP(&rundir, "run-dir", "r", "", "Path to the run-dir (required)")
+	cmd.Flags().StringVarP(&state, "state", "s", "", "State to set (MASTER or BACKUP) (required)")
+
+	// Mark flags as required
+	_ = cmd.MarkFlagRequired("rundir")
+	_ = cmd.MarkFlagRequired("state")
+
+	return cmd
+}
+
+func createSymlink(rundir string, sourceFile string) error {
+	consumedVirtualServers := filepath.Join(rundir, "keepalived-virtualservers-consumed.conf")
+
+	if err := os.Remove(consumedVirtualServers); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to remove consumed virtual servers path %q: %w", consumedVirtualServers, err)
+	}
+
+	if err := os.Symlink(sourceFile, consumedVirtualServers); err != nil {
+		return fmt.Errorf("failed to create soft link from %q to %q: %w", sourceFile, consumedVirtualServers, err)
+	}
+	return nil
+}
+
+func validateRundir(rundir string) error {
+	path, err := os.Stat(rundir)
+	if err != nil {
+		return fmt.Errorf("run-dir %q is invalid: %w", rundir, err)
+	}
+	if !path.IsDir() {
+		return fmt.Errorf("run-dir %q is not a directory", rundir)
+	}
+	return nil
+}
+
+func getPid(rundir string) (int, error) {
+	pidfile := filepath.Join(rundir, "keepalived.pid")
+	pidBytes, err := os.ReadFile(pidfile)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read pidfile %q: %w", pidfile, err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert pid %q to int: %w", pidBytes, err)
+	}
+	return pid, nil
+
+}
+
+func unescapeSingleQuotes(s string) string {
+	// Replace escaped single quotes with a single quote
+	return strings.ReplaceAll(s, `\'`, `'`)
+}

--- a/cmd/keepalived/keepalived_linux_test.go
+++ b/cmd/keepalived/keepalived_linux_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2025 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keepalived
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnscapeSingleQuotes(t *testing.T) {
+	assert.Equal(t, `It's a "nice" 'test'`, unescapeSingleQuotes(`It\'s a "nice" \'test'`))
+}

--- a/cmd/root_linux.go
+++ b/cmd/root_linux.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"github.com/k0sproject/k0s/cmd/backup"
 	"github.com/k0sproject/k0s/cmd/controller"
+	"github.com/k0sproject/k0s/cmd/keepalived"
 	"github.com/k0sproject/k0s/cmd/reset"
 	"github.com/k0sproject/k0s/cmd/restore"
 	"github.com/k0sproject/k0s/cmd/status"
@@ -29,6 +30,7 @@ import (
 func addPlatformSpecificCommands(root *cobra.Command) {
 	root.AddCommand(backup.NewBackupCmd())
 	root.AddCommand(controller.NewControllerCmd())
+	root.AddCommand(keepalived.NewKeepalivedSetStateCmd()) // hidden
 	root.AddCommand(reset.NewResetCmd())
 	root.AddCommand(restore.NewRestoreCmd())
 	root.AddCommand(status.NewStatusCmd())

--- a/pkg/component/controller/cplb/cplb_linux_test.go
+++ b/pkg/component/controller/cplb/cplb_linux_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2025 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cplb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapeSingleQuotes(t *testing.T) {
+	assert.Equal(t, `It\'s a "nice" \'test\'`, escapeSingleQuotes(`It's a "nice" \'test'`))
+}


### PR DESCRIPTION
## Description
This commit enables the load balancer feature exclusively on the master VRRP server and disables everywhere else, we rely on keepalived `notify_master` and `notify_backup` feature so it should be as reliable as it gets.

Fixes #5178

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
