### PR TITLE
fix(network_config): don't set kuberouter config if calico config provided

### DIFF
--- a/pkg/apis/k0s/v1beta1/network.go
+++ b/pkg/apis/k0s/v1beta1/network.go
@@ -196,12 +196,13 @@ func (n *Network) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if n.Provider == "calico" {
+	switch n.Provider {
+	case "calico":
 		if n.Calico == nil {
 			n.Calico = DefaultCalico()
 		}
 		n.KubeRouter = nil
-	} else if n.Provider == "kuberouter" {
+	case "kuberouter":
 		if n.KubeRouter == nil {
 			n.KubeRouter = DefaultKubeRouter()
 		}

--- a/pkg/apis/k0s/v1beta1/network.go
+++ b/pkg/apis/k0s/v1beta1/network.go
@@ -196,11 +196,15 @@ func (n *Network) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if n.Provider == "calico" && n.Calico == nil {
-		n.Calico = DefaultCalico()
+	if n.Provider == "calico" {
+		if n.Calico == nil {
+			n.Calico = DefaultCalico()
+		}
 		n.KubeRouter = nil
-	} else if n.Provider == "kuberouter" && n.KubeRouter == nil {
-		n.KubeRouter = DefaultKubeRouter()
+	} else if n.Provider == "kuberouter" {
+		if n.KubeRouter == nil {
+			n.KubeRouter = DefaultKubeRouter()
+		}
 		n.Calico = nil
 	}
 


### PR DESCRIPTION
## Description

When the network configuration has `provider` set to `calico` and a `calico` config is provided, a default `kuberouter` config is also being initialised in the struct. The following example illustrates the problem:

```go
package main

import (
	"fmt"

	k0sconfig "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
	k8syaml "sigs.k8s.io/yaml"
)

var resultYAML = `
apiVersion: k0s.k0sproject.io/v1beta1
kind: ClusterConfig
metadata:
  creationTimestamp: null
  name: embedded-cluster
spec:
  network:
    calico:
      flexVolumeDriverPath: /usr/libexec/k0s/kubelet-plugins/volume/exec/nodeagent~uds
      mode: vxlan
      mtu: 1450
      overlay: Always
      vxlanPort: 4789
      vxlanVNI: 4096
    provider: calico
`

func main() {
	var patched k0sconfig.ClusterConfig

	if err := k8syaml.Unmarshal([]byte(resultYAML), &patched); err != nil {
		fmt.Errorf("unable to unmarshal patched config: %w", err)
	}
	fmt.Printf("Provider: %s\n", patched.Spec.Network.Provider)
	fmt.Printf("Calico: %v\n", patched.Spec.Network.Calico)
	fmt.Printf("KubeRouter: %v\n", patched.Spec.Network.KubeRouter)
}

```

Renders:

```sh
$> go run main.go
Provider: calico
Calico: &{false map[] /usr/libexec/k0s/kubelet-plugins/volume/exec/nodeagent~uds   1450 vxlan Always 4789 4096}
KubeRouter: &{0x140004aab44 0 8080 Enabled false false   map[]}
```

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
