### PR TITLE
Disable telemetry by default

### DIFF
--- a/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
@@ -264,6 +264,7 @@ spec:
 
 	c, err := ConfigFromBytes(yamlData)
 	assert.NoError(t, err)
+	assert.False(t, c.Spec.Telemetry.IsEnabled())
 	assert.Equal(t, DefaultClusterImages(), c.Spec.Images)
 	assert.Equal(t, DefaultStorageSpec(), c.Spec.Storage)
 	assert.Equal(t, DefaultNetwork(), c.Spec.Network)

--- a/pkg/apis/k0s/v1beta1/telemetry.go
+++ b/pkg/apis/k0s/v1beta1/telemetry.go
@@ -22,18 +22,18 @@ var _ Validateable = (*ClusterTelemetry)(nil)
 
 // ClusterTelemetry holds telemetry related settings
 type ClusterTelemetry struct {
-	// +kubebuilder:default=true
+	// +kubebuilder:default=false
 	Enabled *bool `json:"enabled,omitempty"`
 }
 
 func (t *ClusterTelemetry) IsEnabled() bool {
-	return t == nil || t.Enabled == nil || *t.Enabled
+	return t != nil && t.Enabled != nil && *t.Enabled
 }
 
 // DefaultClusterTelemetry default settings
 func DefaultClusterTelemetry() *ClusterTelemetry {
 	return &ClusterTelemetry{
-		Enabled: ptr.To(true),
+		Enabled: ptr.To(false),
 	}
 }
 

--- a/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
+++ b/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
@@ -973,7 +973,7 @@ spec:
                 description: ClusterTelemetry holds telemetry related settings
                 properties:
                   enabled:
-                    default: true
+                    default: false
                     type: boolean
                 type: object
               workerProfiles:


### PR DESCRIPTION
## Description

The CNCF & Linux Foundation [policy](https://www.linuxfoundation.org/legal/telemetry-data-policy) says that telemetry should be opt-in for the users rather than opt-out as we currently have.


## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
