### PR TITLE
Introduce renovate bot

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,22 @@
+name: Renovate
+
+on:
+  workflow_dispatch: # Allows manual triggering
+  schedule:
+    - cron: '0 0 * * *' # Runs at 00:00 UTC every day
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v42.0.3
+        with:
+          configurationFile: "renovate.json"
+          token: '${{ github.token }}'
+        env:
+          LOG_LEVEL: debug
+          RENOVATE_AUTODISCOVER: true # Necessary for it to work on forks

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":configMigration",
+    ":gitSignOff"
+  ],
+  "includeForks": true,
+  "enabledManagers": [
+    "gomod",
+    "custom.regex"
+  ],
+  "packageRules": [
+    {
+      "description": "Ignore all Go dependencies by default",
+      "enabled": false,
+      "matchManagers": [
+        "gomod"
+      ]
+    },
+    {
+      "description": "Group all etcd updates (go.mod and Makefile) into a single PR",
+      "matchPackageNames": [
+        "go.etcd.io/etcd/**/v3",
+        "etcd-io/etcd"
+      ],
+      "groupName": "etcd dependencies",
+      "groupSlug": "etcd-all"
+    },
+    {
+      "description": "Ensure etcd in Makefile uses github-releases and is enabled",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchPackageNames": [
+        "etcd-io/etcd"
+      ],
+      "enabled": true
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update etcd version in embedded-bins/Makefile.variables",
+      "managerFilePatterns": [
+        "embedded-bins/Makefile.variables"
+      ],
+      "matchStrings": [
+        "etcd_version = (?<currentValue>v?[\\d\\.]+)"
+      ],
+      "depNameTemplate": "etcd-io/etcd",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update kine versions across the codebase",
+      "managerFilePatterns": [
+        "/(^|/)[Mm]akefile(\\.[^/]+)?$/",
+        "*.go"
+      ],
+      "matchStrings": [
+        "kine_version = (?<currentValue>[\\d\\.]+)",
+        "\\bkine/blob/(v?<currentValue>[\\d\\.]+)\\b"
+      ],
+      "depNameTemplate": "k3s-io/kine",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Dependabot has limited scope and it cannot update things based on regex or things that we define in Makefiles.

This is a very basic first configuration file for renovate bot which can update etcd and kine as a proof of concept so that we decide if we want to implement this and invest more time updating every component.

After this is merged we need an extra step which is enabling it in developer.mend.io.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
