### PR TITLE
Fix renovate etcd matcher

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,11 @@
     },
     {
       "description": "Group all etcd updates (go.mod and Makefile) into a single PR",
+      "matchManagers": [
+        "gomod",
+        "custom.regex"
+      ],
+      "enabled": true,
       "matchPackageNames": [
         "go.etcd.io/etcd/**/v3",
         "etcd-io/etcd"


### PR DESCRIPTION
## Description

Because we disable the gomod matchManager the etcd packages were only enabled with custom.regex. We need to enable it explicitly in the packageRule.
