### PR TITLE
[renovate bot] Add gomodtidy to renovate postUpdateOptions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,9 @@
     "gomod",
     "custom.regex"
   ],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
   "packageRules": [
     {
       "description": "Ignore all Go dependencies by default",


### PR DESCRIPTION
## Description

The renovate etcd pull request (https://github.com/k0sproject/k0s/pull/5865) is failing because it didn't execute go mod tidy.

This PR fixes it as we can see in https://github.com/juanluisvaladas/k0s/pull/21/commits/aa03bbbb89af180d503186b25dcd5ad670b4442f

```
$ git checkout aa03bbbb89af180d503186b25dcd5ad670b4442f
HEAD is now at aa03bbbb8 Update etcd dependencies to v3.6.0

$ go mod tidy

$ git status
HEAD detached at aa03bbbb8
nothing to commit, working tree clean
```

Funnily enough it looks like we won't be able to use renovate to bump etcd to 3.6.0 because it breaks `pkg/backup/etcd_unix.go`and we'll need to do another modifiation:

```
diff --git a/pkg/backup/etcd_unix.go b/pkg/backup/etcd_unix.go
index a89cec4b7..2058cd06b 100644
--- a/pkg/backup/etcd_unix.go
+++ b/pkg/backup/etcd_unix.go
@@ -66,7 +66,7 @@ func (e etcdStep) Backup() (StepResult, error) {
        lg := zap.NewNop()
 
        // save snapshot
-       if err = snapshot.Save(ctx, lg, *etcdClient.Config, path); err != nil {
+       if _, err = snapshot.SaveWithVersion(ctx, lg, *etcdClient.Config, path); err != nil {
```

But anyway that's a different topic.