### PR TITLE
Improve debugging experience for k0s inttests

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -20,16 +20,25 @@ bin/sonobuoy: | bin
 	$(curl) $(sonobuoy_url) | tar -C bin/ -zxv $(notdir $@)
 
 bootloose_alpine_build_cmdline := \
-	--build-arg GOLANG_IMAGE=$(golang_buildimage) \
-	--build-arg ALPINE_VERSION=$(alpine_patch_version) \
 	--build-arg ETCD_VERSION=$(etcd_version) \
 	--build-arg HELM_VERSION=$(helm_version) \
-	-t bootloose-alpine \
+	  --build-arg TARGETARCH=$(ARCH) \
 	-f bootloose-alpine/Dockerfile \
 	bootloose-alpine
 
 .bootloose-alpine.stamp: $(shell find bootloose-alpine -type f)
-	docker build --progress=plain --build-arg TARGETARCH=$(ARCH) $(bootloose_alpine_build_cmdline)
+	docker build --progress=plain \
+	  --build-arg BOOTLOOSE_BASE=docker.io/library/alpine:$(alpine_patch_version) \
+	  -t bootloose-alpine \
+	  $(bootloose_alpine_build_cmdline)
+	touch $@
+
+.bootloose-debug.stamp: $(shell find bootloose-alpine -type f)
+	docker build --progress=plain \
+	  -t bootloose-debug \
+	  --build-arg INCLUDE_DEBUG_TOOLS=true \
+	  --build-arg BOOTLOOSE_BASE=$(golang_buildimage) \
+	  $(bootloose_alpine_build_cmdline)
 	touch $@
 
 # This is a special target to test the bootloose alpine image locally for all supported platforms.
@@ -133,15 +142,25 @@ check-nllb: TIMEOUT=15m
 .PHONY: $(smoketests)
 include Makefile.variables
 
+# Determine the bootloose stamp dependency based on K0S_DEBUG
+# Default to .bootloose-alpine.stamp (the "otherwise" case from the request)
+BOOTLOOSE_STAMP_DEP := .bootloose-alpine.stamp
+ifeq ($(K0S_DEBUG_TESTS),true)
+  BOOTLOOSE_STAMP_DEP := .bootloose-debug.stamp
+  BOOTLOOSE_IMAGE ?= bootloose-debug
+else
+endif
+
 $(smoketests): K0S_PATH ?= $(realpath ../k0s)
 $(smoketests): K0S_IMAGES_BUNDLE ?= $(realpath ../airgap-image-bundle-linux-$(ARCH).tar)
-$(smoketests): .bootloose-alpine.stamp
+$(smoketests): $(BOOTLOOSE_STAMP_DEP)
 $(smoketests): TEST_PACKAGE ?= $(subst check-,,$@)
 $(smoketests):
 	K0S_PATH='$(K0S_PATH)' \
 	K0S_UPDATE_FROM_PATH='$(K0S_UPDATE_FROM_PATH)' \
 	K0S_IMAGES_BUNDLE='$(K0S_IMAGES_BUNDLE)' \
 	K0S_UPDATE_TO_VERSION='$(K0S_UPDATE_TO_VERSION)' \
+	$(if $(BOOTLOOSE_IMAGE),BOOTLOOSE_IMAGE='$(BOOTLOOSE_IMAGE)') \
 	go test -count=1 -v -timeout $(TIMEOUT) github.com/k0sproject/k0s/inttest/$(TEST_PACKAGE)
 .PHONY: clean
 

--- a/inttest/bootloose-alpine/Dockerfile
+++ b/inttest/bootloose-alpine/Dockerfile
@@ -1,13 +1,13 @@
-ARG ALPINE_VERSION
-ARG GOLANG_IMAGE
+ARG BOOTLOOSE_BASE
 
-FROM docker.io/library/alpine:$ALPINE_VERSION
+FROM $BOOTLOOSE_BASE
 
 ARG TARGETARCH
 ARG CRI_DOCKERD_VERSION=0.3.16
 ARG ETCD_VERSION
 ARG TROUBLESHOOT_VERSION=v0.115.1
 ARG HELM_VERSION
+ARG INCLUDE_DEBUG_TOOLS=false
 
 # Apply our changes to the image
 COPY root/ /
@@ -50,22 +50,27 @@ RUN curl --proto '=https' --tlsv1.2 -L https://get.helm.sh/helm-v$HELM_VERSION-l
 # Install etcd for smoke tests with external etcd
 # No arm or riscv64 binaries available (check-externaletcd won't work on ARMv7 or RISC-V)
 RUN if [ "$TARGETARCH" != arm ] && [ "$TARGETARCH" != riscv64 ]; then \
-    curl --proto '=https' --tlsv1.2 -L https://github.com/etcd-io/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-$TARGETARCH.tar.gz \
-      | tar xz -C /opt --strip-components=1; \
+  curl --proto '=https' --tlsv1.2 -L https://github.com/etcd-io/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-$TARGETARCH.tar.gz \
+  | tar xz -C /opt --strip-components=1; \
   fi
 
 # Install cri-dockerd shim for custom CRI testing
 # No arm or riscv64 binaries available (check-byocri won't work on ARMv7 or RISC-V)
 RUN if [ "$TARGETARCH" != arm ] && [ "$TARGETARCH" != riscv64 ]; then \
-    curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo /tmp/cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v$CRI_DOCKERD_VERSION/cri-dockerd-$CRI_DOCKERD_VERSION.$TARGETARCH.tgz \
-      && tar xf /tmp/cri-dockerd.tgz --directory /tmp/ \
-      && mv /tmp/cri-dockerd/cri-dockerd /usr/local/bin/cri-dockerd \
-      && rm -rf /tmp/cri-dockerd \
-      && chmod 755 /usr/local/bin/cri-dockerd; \
+  curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo /tmp/cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v$CRI_DOCKERD_VERSION/cri-dockerd-$CRI_DOCKERD_VERSION.$TARGETARCH.tgz \
+  && tar xf /tmp/cri-dockerd.tgz --directory /tmp/ \
+  && mv /tmp/cri-dockerd/cri-dockerd /usr/local/bin/cri-dockerd \
+  && rm -rf /tmp/cri-dockerd \
+  && chmod 755 /usr/local/bin/cri-dockerd; \
   fi
 
 RUN for u in etcd kube-apiserver kube-scheduler konnectivity-server; do \
-    adduser --system --shell /sbin/nologin --no-create-home --home /var/lib/k0s --disabled-password --gecos '' "$u"; \
+  adduser --system --shell /sbin/nologin --no-create-home --home /var/lib/k0s --disabled-password --gecos '' "$u"; \
   done
+
+RUN if [ "$INCLUDE_DEBUG_TOOLS" = "true" ]; then \
+  apk add --no-cache strace \
+  && go install github.com/go-delve/delve/cmd/dlv@latest; \
+  fi
 
 ADD cri-dockerd.sh /etc/init.d/cri-dockerd

--- a/inttest/common/bootloosesuite.go
+++ b/inttest/common/bootloosesuite.go
@@ -642,6 +642,12 @@ func (s *BootlooseSuite) InitController(idx int, k0sArgs ...string) error {
 	return s.WaitForKubeAPI(controllerNode, dataDirOpt)
 }
 
+// SetK0sCommand allows to set the command used to launch k0s, so that it
+// can be launched with some debugging tools such as strace or delve
+func (s *BootlooseSuite) SetK0sCommand(command string) {
+	s.Require().NoError(s.launchDelegate.SetK0sCommand(command))
+}
+
 // GetJoinToken generates join token for the asked role
 func (s *BootlooseSuite) GetJoinToken(role string, extraArgs ...string) (string, error) {
 	// assume we have main on node 0 always


### PR DESCRIPTION
## Description
Attaching a debugger or running the inttests with strace is super annoying and every time I need to do it I end up having to make a custom image and modifying the Bootloose suite or launching myself the k0s command. We should have a standardized way of doing this where we don't need to think and it's just a command to get that done.

This PR implements an optional, heavier debug image with delve and strace, a way to replace the command in the BootlooseSuite for a debugging command and documents it.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
