### PR TITLE
Use the backport workflow's token for renovate

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -8,6 +8,13 @@ on:
 jobs:
   renovate:
     runs-on: ubuntu-latest
+
+    # These permissions only affect the stock GitHub Actions token.
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -15,8 +22,13 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v42.0.3
         with:
-          configurationFile: "renovate.json"
-          token: '${{ github.token }}'
+          configurationFile: renovate.json
+          # Use the same token as the backport workflow. If this token is
+          # unavailable, i.e. if the workflow is triggered on a fork, use the
+          # stock GitHub Actions token instead ("Allow GitHub Actions to create
+          # and approve pull requests" must be selected in the fork's GitHub
+          # Actions settings).
+          token: "${{ secrets.GH_BACKPORT_TOKEN || github.token }}"
         env:
           LOG_LEVEL: debug
-          RENOVATE_AUTODISCOVER: true # Necessary for it to work on forks
+          RENOVATE_REPOSITORIES: "${{ github.repository }}"


### PR DESCRIPTION
## Description

So that the CI is triggered for renovate pull requests. Fallback to the stock GitHub Actions token, so that this can be tested on forks.

Also, do not rely on autodiscovery: Only update the repository in which the workflow is run.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
