### PR TITLE
[Backport release-1.32] Use the correct address for BuildServiceCIDR

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -563,7 +563,7 @@ func (c *command) start(ctx context.Context) error {
 			LogLevel:              c.LogLevels.KubeControllerManager,
 			K0sVars:               c.K0sVars,
 			SingleNode:            c.SingleNode,
-			ServiceClusterIPRange: nodeConfig.Spec.Network.BuildServiceCIDR(nodeConfig.Spec.API.Address),
+			ServiceClusterIPRange: nodeConfig.Spec.Network.BuildServiceCIDR(nodeConfig.Spec.API.APIAddress()),
 			ExtraArgs:             c.KubeControllerManagerExtraArgs,
 		})
 	}

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -49,7 +49,8 @@ import (
 type DualstackSuite struct {
 	common.BootlooseSuite
 
-	client *k8s.Clientset
+	client      *k8s.Clientset
+	defaultIPv6 bool
 }
 
 func (s *DualstackSuite) TestDualStackNodesHavePodCIDRs() {
@@ -61,9 +62,14 @@ func (s *DualstackSuite) TestDualStackNodesHavePodCIDRs() {
 }
 
 func (s *DualstackSuite) TestDualStackControlPlaneComponentsHaveServiceCIDRs() {
-	const expected = "--service-cluster-ip-range=10.96.0.0/12,fd01::/108"
+	const expectedIPv4 = "--service-cluster-ip-range=10.96.0.0/12,fd01::/108"
+	const expectedIPv6 = "--service-cluster-ip-range=fd01::/108,10.96.0.0/12"
 	node := s.ControllerNode(0)
 
+	expected := expectedIPv4
+	if s.defaultIPv6 {
+		expected = expectedIPv6
+	}
 	s.Contains(s.cmdlineForExecutable(node, "kube-apiserver"), expected)
 	s.Contains(s.cmdlineForExecutable(node, "kube-controller-manager"), expected)
 }
@@ -95,7 +101,9 @@ func (s *DualstackSuite) SetupSuite() {
 
 	if os.Getenv("K0S_NETWORK") == "kube-router" {
 		s.T().Log("Using kube-router network")
-		k0sConfig = k0sConfigWithKuberouterDualStack
+		ipv6Address := s.getIPv6Address(s.ControllerNode(0))
+		k0sConfig = fmt.Sprintf(k0sConfigWithKuberouterDualStack, ipv6Address)
+		s.defaultIPv6 = true
 	}
 	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfig)
 	controllerArgs := []string{"--config=/tmp/k0s.yaml"}
@@ -192,6 +200,17 @@ func (s *DualstackSuite) SetupSuite() {
 	s.client = client
 }
 
+func (s *DualstackSuite) getIPv6Address(nodeName string) string {
+	ssh, err := s.SSH(s.Context(), nodeName)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	ipAddress, err := ssh.ExecWithOutput(s.Context(), "ip -6 -oneline addr show eth0 | awk '{print $4}' | grep -v '^fe80' | cut -d/ -f1")
+	s.Require().NoError(err)
+	return ipAddress
+
+}
+
 func TestDualStack(t *testing.T) {
 
 	s := DualstackSuite{
@@ -200,6 +219,7 @@ func TestDualStack(t *testing.T) {
 			WorkerCount:     2,
 		},
 		nil,
+		false,
 	}
 
 	suite.Run(t, &s)
@@ -219,10 +239,13 @@ spec:
       IPv6podCIDR: "fd00::/108"
       IPv6serviceCIDR: "fd01::/108"
     podCIDR: 10.244.0.0/16
-    serviceCIDR: 10.96.0.0/12`
+    serviceCIDR: 10.96.0.0/12
+`
 
 const k0sConfigWithKuberouterDualStack = `
 spec:
+  api:
+    externalAddress: %s
   network:
     provider: kuberouter
     dualStack:
@@ -230,4 +253,5 @@ spec:
       IPv6podCIDR: "fd00::/108"
       IPv6serviceCIDR: "fd01::/108"
     podCIDR: 10.244.0.0/16
-    serviceCIDR: 10.96.0.0/12`
+    serviceCIDR: 10.96.0.0/12
+`

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -116,7 +116,7 @@ func (a *APIServer) Start(_ context.Context) error {
 		"requestheader-allowed-names":      "front-proxy-client",
 		"requestheader-client-ca-file":     path.Join(a.K0sVars.CertRootDir, "front-proxy-ca.crt"),
 		"service-account-key-file":         path.Join(a.K0sVars.CertRootDir, "sa.pub"),
-		"service-cluster-ip-range":         a.ClusterConfig.Spec.Network.BuildServiceCIDR(a.ClusterConfig.Spec.API.Address),
+		"service-cluster-ip-range":         a.ClusterConfig.Spec.Network.BuildServiceCIDR(a.ClusterConfig.Spec.API.APIAddress()),
 		"tls-min-version":                  "VersionTLS12",
 		"tls-cert-file":                    path.Join(a.K0sVars.CertRootDir, "server.crt"),
 		"tls-private-key-file":             path.Join(a.K0sVars.CertRootDir, "server.key"),


### PR DESCRIPTION
Backport to `release-1.32`:

* #5855

See:

* #5841