### PR TITLE
Correctly strip default storage spec from cluster config

### DIFF
--- a/pkg/apis/k0s/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types.go
@@ -86,7 +86,7 @@ func (c *ClusterConfig) StripDefaults() *ClusterConfig {
 		copy.Spec.Scheduler = nil
 	}
 	if reflect.DeepEqual(c.Spec.Storage, DefaultStorageSpec()) {
-		c.Spec.Storage = nil
+		copy.Spec.Storage = nil
 	}
 	if reflect.DeepEqual(copy.Spec.Network, DefaultNetwork()) {
 		copy.Spec.Network = nil

--- a/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
@@ -331,7 +331,11 @@ func TestStripDefaults(t *testing.T) {
 	a.Nil(stripped.Spec.API)
 	a.Nil(stripped.Spec.ControllerManager)
 	a.Nil(stripped.Spec.Scheduler)
+	a.Nil(stripped.Spec.Storage)
 	a.Nil(stripped.Spec.Network)
+	a.Nil(stripped.Spec.Telemetry)
+	a.Nil(stripped.Spec.Images)
+	a.Nil(stripped.Spec.Konnectivity)
 }
 
 func TestDefaultClusterConfigYaml(t *testing.T) {


### PR DESCRIPTION
## Description

The nil assignment happened on the original value, not on the copy.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
