### PR TITLE
[Backport release-1.30] Use the correct address for BuildServiceCIDR

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -543,7 +543,7 @@ func (c *command) start(ctx context.Context) error {
 			LogLevel:              c.Logging[constant.KubeControllerManagerComponentName],
 			K0sVars:               c.K0sVars,
 			SingleNode:            c.SingleNode,
-			ServiceClusterIPRange: nodeConfig.Spec.Network.BuildServiceCIDR(nodeConfig.Spec.API.Address),
+			ServiceClusterIPRange: nodeConfig.Spec.Network.BuildServiceCIDR(nodeConfig.Spec.API.APIAddress()),
 			ExtraArgs:             c.KubeControllerManagerExtraArgs,
 		})
 	}

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -112,7 +112,7 @@ func (a *APIServer) Start(_ context.Context) error {
 		"requestheader-allowed-names":      "front-proxy-client",
 		"requestheader-client-ca-file":     path.Join(a.K0sVars.CertRootDir, "front-proxy-ca.crt"),
 		"service-account-key-file":         path.Join(a.K0sVars.CertRootDir, "sa.pub"),
-		"service-cluster-ip-range":         a.ClusterConfig.Spec.Network.BuildServiceCIDR(a.ClusterConfig.Spec.API.Address),
+		"service-cluster-ip-range":         a.ClusterConfig.Spec.Network.BuildServiceCIDR(a.ClusterConfig.Spec.API.APIAddress()),
 		"tls-min-version":                  "VersionTLS12",
 		"tls-cert-file":                    path.Join(a.K0sVars.CertRootDir, "server.crt"),
 		"tls-private-key-file":             path.Join(a.K0sVars.CertRootDir, "server.key"),


### PR DESCRIPTION
Backport to `release-1.30`:

* #5895

See:

* #5890
* #5855
* #5841