### PR TITLE
[renovate] Replace includeForks ->  forkProcessing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     ":configMigration",
     ":gitSignOff"
   ],
-  "includeForks": true,
+  "forkProcessing": "enabled",
   "enabledManagers": [
     "gomod",
     "custom.regex"


### PR DESCRIPTION
Signed of copy and paste of #5884.

This commit replaces the deprecated field `includeForks` for `forkProcessing`