### PR TITLE
Remove leader election callbacks from EtcdMemberReconciler

### DIFF
--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -40,6 +40,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var _ manager.Component = (*EtcdMemberReconciler)(nil)
@@ -118,7 +119,9 @@ func (e *EtcdMemberReconciler) Start(ctx context.Context) error {
 
 	go func() {
 		defer close(done)
-		e.reconcile(ctx, log, client)
+		wait.UntilWithContext(ctx, func(ctx context.Context) {
+			e.reconcile(ctx, log, client)
+		}, 1*time.Minute)
 	}()
 
 	e.stop = func() { cancel(); <-done }

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -29,7 +29,7 @@ import (
 	"github.com/avast/retry-go"
 	etcdv1beta1 "github.com/k0sproject/k0s/pkg/apis/etcd/v1beta1"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
-	etcdmemberclient "github.com/k0sproject/k0s/pkg/client/clientset/typed/etcd/v1beta1"
+	etcdclient "github.com/k0sproject/k0s/pkg/client/clientset/typed/etcd/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/config"
@@ -55,13 +55,12 @@ func NewEtcdMemberReconciler(kubeClientFactory kubeutil.ClientFactoryInterface, 
 }
 
 type EtcdMemberReconciler struct {
-	clientFactory    kubeutil.ClientFactoryInterface
-	k0sVars          *config.CfgVars
-	etcdConfig       *v1beta1.EtcdConfig
-	etcdMemberClient etcdmemberclient.EtcdMemberInterface
-	leaderElector    leaderelector.Interface
-	mux              sync.Mutex
-	started          atomic.Bool
+	clientFactory kubeutil.ClientFactoryInterface
+	k0sVars       *config.CfgVars
+	etcdConfig    *v1beta1.EtcdConfig
+	leaderElector leaderelector.Interface
+	mux           sync.Mutex
+	started       atomic.Bool
 }
 
 func (e *EtcdMemberReconciler) Init(_ context.Context) error {
@@ -72,7 +71,7 @@ func (e *EtcdMemberReconciler) Init(_ context.Context) error {
 // This is needed to ensure all the member objects are in sync with the actual etcd cluster
 // We might get stale state if we remove the current leader as the leader will essentially
 // remove itself from the etcd cluster and after that tries to update the member object.
-func (e *EtcdMemberReconciler) resync(ctx context.Context) error {
+func (e *EtcdMemberReconciler) resync(ctx context.Context, client etcdclient.EtcdMemberInterface) error {
 	e.mux.Lock()
 	defer e.mux.Unlock()
 
@@ -85,12 +84,12 @@ func (e *EtcdMemberReconciler) resync(ctx context.Context) error {
 	// Use high timeout as etcd/api could be a bit slow when the leader changes
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
-	members, err := e.etcdMemberClient.List(ctx, metav1.ListOptions{})
+	members, err := client.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 	for _, member := range members.Items {
-		e.reconcileMember(ctx, &member)
+		e.reconcileMember(ctx, client, &member)
 	}
 	return nil
 }
@@ -98,17 +97,16 @@ func (e *EtcdMemberReconciler) resync(ctx context.Context) error {
 func (e *EtcdMemberReconciler) Start(ctx context.Context) error {
 	log := logrus.WithField("component", "EtcdMemberReconciler")
 
-	etcdMemberClient, err := e.clientFactory.GetEtcdMemberClient()
+	client, err := e.clientFactory.GetEtcdMemberClient()
 	if err != nil {
 		return err
 	}
-	e.etcdMemberClient = etcdMemberClient
 
 	e.leaderElector.AddAcquiredLeaseCallback(func() {
 		// Spin up resync in separate routine to not block the leader election
 		go func() {
 			log.Info("leader lease acquired, starting resync")
-			if err := e.resync(ctx); err != nil {
+			if err := e.resync(ctx, client); err != nil {
 				log.WithError(err).Error("failed to resync etcd members")
 			}
 		}()
@@ -126,7 +124,7 @@ func (e *EtcdMemberReconciler) Start(ctx context.Context) error {
 		// Need to be done in retry loop as during the initial startup the etcd might not be stable
 		err = retry.Do(
 			func() error {
-				return e.createMemberObject(ctx)
+				return e.createMemberObject(ctx, client)
 			},
 			retry.Delay(3*time.Second),
 			retry.Attempts(5),
@@ -143,7 +141,7 @@ func (e *EtcdMemberReconciler) Start(ctx context.Context) error {
 		}
 		e.started.Store(true)
 		var lastObservedVersion string
-		err = watch.EtcdMembers(etcdMemberClient).
+		err = watch.EtcdMembers(client).
 			WithErrorCallback(func(err error) (time.Duration, error) {
 				retryDelay, e := watch.IsRetryable(err)
 				if e == nil {
@@ -162,7 +160,7 @@ func (e *EtcdMemberReconciler) Start(ctx context.Context) error {
 				lastObservedVersion = member.ResourceVersion
 				log.Debugf("watch triggered on %s", member.Name)
 				if e.leaderElector.IsLeader() {
-					if err := e.resync(ctx); err != nil {
+					if err := e.resync(ctx, client); err != nil {
 						log.WithError(err).Error("failed to resync etcd members")
 					}
 				} else {
@@ -231,7 +229,7 @@ func (e *EtcdMemberReconciler) waitForCRD(ctx context.Context) error {
 
 }
 
-func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context) error {
+func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context, client etcdclient.EtcdMemberInterface) error {
 	log := logrus.WithFields(logrus.Fields{"component": "etcdMemberReconciler", "phase": "createMemberObject"})
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -258,7 +256,7 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context) error {
 	log.WithField("name", name).WithField("memberID", memberID).Info("creating EtcdMember object")
 
 	// Check if the object already exists
-	em, err = e.etcdMemberClient.Get(ctx, name, metav1.GetOptions{})
+	em, err = client.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Debug("EtcdMember object not found, creating it")
@@ -271,7 +269,7 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context) error {
 				},
 			}
 
-			em, err = e.etcdMemberClient.Create(ctx, em, metav1.CreateOptions{})
+			em, err = client.Create(ctx, em, metav1.CreateOptions{})
 			if err != nil {
 				return err
 			}
@@ -280,7 +278,7 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context) error {
 				MemberID:    memberIDStr,
 			}
 			em.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionTrue, "Member joined", time.Now())
-			_, err = e.etcdMemberClient.UpdateStatus(ctx, em, metav1.UpdateOptions{})
+			_, err = client.UpdateStatus(ctx, em, metav1.UpdateOptions{})
 			if err != nil {
 				log.WithError(err).Error("failed to update member status")
 			}
@@ -294,14 +292,14 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context) error {
 
 	log.Debug("EtcdMember object already exists, updating it")
 	// Update the object if it already exists
-	em, err = e.etcdMemberClient.Update(ctx, em, metav1.UpdateOptions{})
+	em, err = client.Update(ctx, em, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}
 	em.Status.PeerAddress = e.etcdConfig.PeerAddress
 	em.Status.MemberID = memberIDStr
 	em.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionTrue, "Member joined", time.Now())
-	_, err = e.etcdMemberClient.UpdateStatus(ctx, em, metav1.UpdateOptions{})
+	_, err = client.UpdateStatus(ctx, em, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}
@@ -309,7 +307,7 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context) error {
 	return nil
 }
 
-func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, member *etcdv1beta1.EtcdMember) {
+func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdclient.EtcdMemberInterface, member *etcdv1beta1.EtcdMember) {
 	log := logrus.WithFields(logrus.Fields{
 		"component":   "etcdMemberReconciler",
 		"phase":       "reconcile",
@@ -330,7 +328,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, member *etcd
 		log.WithError(err).Warn("failed to create etcd client")
 		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
 		member.Status.Message = err.Error()
-		if _, err = e.etcdMemberClient.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
+		if _, err = client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
 			log.WithError(err).Error("failed to update member state")
 		}
 
@@ -345,7 +343,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, member *etcd
 	if err != nil {
 		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
 		member.Status.Message = err.Error()
-		if _, err = e.etcdMemberClient.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
+		if _, err = client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
 			log.WithError(err).Error("failed to update member state")
 		}
 
@@ -358,7 +356,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, member *etcd
 		log.Debug("member marked for leave but not in actual member list, updating state to reflect that")
 		member.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionFalse, member.Status.Message, time.Now())
 		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusSuccess
-		member, err = e.etcdMemberClient.UpdateStatus(ctx, member, metav1.UpdateOptions{})
+		member, err = client.UpdateStatus(ctx, member, metav1.UpdateOptions{})
 		if err != nil {
 			log.WithError(err).Error("failed to update EtcdMember status")
 		}
@@ -403,7 +401,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, member *etcd
 			Errorf("Failed to delete etcd peer from cluster")
 		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
 		member.Status.Message = err.Error()
-		_, err = e.etcdMemberClient.UpdateStatus(ctx, member, metav1.UpdateOptions{})
+		_, err = client.UpdateStatus(ctx, member, metav1.UpdateOptions{})
 		if err != nil {
 			log.WithError(err).Error("failed to update EtcdMember status")
 		}
@@ -415,7 +413,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, member *etcd
 	member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusSuccess
 	member.Status.Message = "Member removed from cluster"
 	member.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionFalse, member.Status.Message, time.Now())
-	_, err = e.etcdMemberClient.UpdateStatus(ctx, member, metav1.UpdateOptions{})
+	_, err = client.UpdateStatus(ctx, member, metav1.UpdateOptions{})
 	if err != nil {
 		log.WithError(err).Error("failed to update EtcdMember status")
 	}


### PR DESCRIPTION
## Description

Use `leaderelection.RunLeaderTasks` instead.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
