### PR TITLE
[WIP] Allow empty image version on imageSpec

### DIFF
--- a/pkg/apis/k0s/v1beta1/images.go
+++ b/pkg/apis/k0s/v1beta1/images.go
@@ -35,7 +35,7 @@ type ImageSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	Image string `json:"image"`
 
-	// +kubebuilder:validation:Pattern="^[\\w][\\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$"
+	// +kubebuilder:validation:Pattern="(^$)|(^[\\w][\\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$)"
 	Version string `json:"version"`
 }
 
@@ -52,9 +52,11 @@ func (s *ImageSpec) Validate(path *field.Path) (errs field.ErrorList) {
 	}
 
 	// Validate the image contains a tag and optional digest
-	versionRe := regexp.MustCompile(`^` + reference.TagRegexp.String() + `(?:@` + reference.DigestRegexp.String() + `)?$`)
-	if !versionRe.MatchString(s.Version) {
-		errs = append(errs, field.Invalid(path.Child("version"), s.Version, "must match regular expression: "+versionRe.String()))
+	if len(s.Version) != 0 {
+		versionRe := regexp.MustCompile(`^` + reference.TagRegexp.String() + `(?:@` + reference.DigestRegexp.String() + `)?$`)
+		if !versionRe.MatchString(s.Version) {
+			errs = append(errs, field.Invalid(path.Child("version"), s.Version, "must match regular expression: "+versionRe.String()))
+		}
 	}
 
 	return

--- a/pkg/apis/k0s/v1beta1/images_test.go
+++ b/pkg/apis/k0s/v1beta1/images_test.go
@@ -152,6 +152,7 @@ func TestImageSpec_Validate(t *testing.T) {
 		{"my.registry/repo/image", "latest"},
 		{"my.registry/repo/image", "v1.0.0-rc1"},
 		{"my.registry/repo/image", "v1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+		{"my.registry/repo/image", ""},
 	}
 	for _, tc := range validTestCases {
 		t.Run(tc.Image+":"+tc.Version+"_valid", func(t *testing.T) {
@@ -171,10 +172,6 @@ func TestImageSpec_Validate(t *testing.T) {
 		Version string
 		Errs    field.ErrorList
 	}{
-		{
-			"my.registry/repo/image", "",
-			field.ErrorList{field.Invalid(field.NewPath("image").Child("version"), "", errVersionRe)},
-		},
 		// digest only is currently not supported
 		{
 			"my.registry/repo/image", "sha256:0000000000000000000000000000000000000000000000000000000000000000",

--- a/pkg/component/controller/clusterconfig_test.go
+++ b/pkg/component/controller/clusterconfig_test.go
@@ -43,6 +43,7 @@ func TestClusterConfigInitializer_Create(t *testing.T) {
 	leaderElector := leaderelector.Dummy{Leader: true}
 	initialConfig := k0sv1beta1.DefaultClusterConfig()
 	initialConfig.ResourceVersion = "42"
+	initialConfig.Spec.Images.CoreDNS.Image = "myrepo.org/coredns/coredns"
 
 	underTest := controller.NewClusterConfigInitializer(
 		clients, &leaderElector, initialConfig.DeepCopy(),
@@ -64,6 +65,8 @@ func TestClusterConfigInitializer_Create(t *testing.T) {
 		ClusterConfigs(constant.ClusterConfigNamespace).
 		Get(t.Context(), "k0s", metav1.GetOptions{})
 	if assert.NoError(t, err) {
+		assert.NotEqual(t, initialConfig.Spec.Images.CoreDNS.Version, actualConfig.Spec.Images.CoreDNS.Version)
+		initialConfig.Spec.Images.CoreDNS.Version = actualConfig.Spec.Images.CoreDNS.Version
 		assert.Equal(t, initialConfig, actualConfig)
 	}
 }

--- a/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
+++ b/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
@@ -255,7 +255,7 @@ spec:
                             minLength: 1
                             type: string
                           version:
-                            pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
+                            pattern: (^$)|(^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$)
                             type: string
                         required:
                         - image
@@ -268,7 +268,7 @@ spec:
                             minLength: 1
                             type: string
                           version:
-                            pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
+                            pattern: (^$)|(^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$)
                             type: string
                         required:
                         - image
@@ -281,7 +281,7 @@ spec:
                             minLength: 1
                             type: string
                           version:
-                            pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
+                            pattern: (^$)|(^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$)
                             type: string
                         required:
                         - image
@@ -295,7 +295,7 @@ spec:
                         minLength: 1
                         type: string
                       version:
-                        pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
+                        pattern: (^$)|(^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$)
                         type: string
                     required:
                     - image
@@ -315,7 +315,7 @@ spec:
                         minLength: 1
                         type: string
                       version:
-                        pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
+                        pattern: (^$)|(^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$)
                         type: string
                     required:
                     - image
@@ -328,7 +328,7 @@ spec:
                         minLength: 1
                         type: string
                       version:
-                        pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
+                        pattern: (^$)|(^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$)
                         type: string
                     required:
                     - image
@@ -345,7 +345,7 @@ spec:
                             minLength: 1
                             type: string
                           version:
-                            pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
+                            pattern: (^$)|(^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$)
                             type: string
                         required:
                         - image
@@ -358,7 +358,7 @@ spec:
                             minLength: 1
                             type: string
                           version:
-                            pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
+                            pattern: (^$)|(^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$)
                             type: string
                         required:
                         - image
@@ -372,7 +372,7 @@ spec:
                         minLength: 1
                         type: string
                       version:
-                        pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
+                        pattern: (^$)|(^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$)
                         type: string
                     required:
                     - image
@@ -385,7 +385,7 @@ spec:
                         minLength: 1
                         type: string
                       version:
-                        pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
+                        pattern: (^$)|(^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$)
                         type: string
                     required:
                     - image
@@ -398,7 +398,7 @@ spec:
                         minLength: 1
                         type: string
                       version:
-                        pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
+                        pattern: (^$)|(^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$)
                         type: string
                     required:
                     - image
@@ -856,7 +856,7 @@ spec:
                                 minLength: 1
                                 type: string
                               version:
-                                pattern: ^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$
+                                pattern: (^$)|(^[\w][\w.-]{0,127}(?:@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,})?$)
                                 type: string
                             required:
                             - image


### PR DESCRIPTION
## Description

K0smotron relies on using en mpty image version on airgapped clusters, this used to work until 1.32.1.

Fixes #5888

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
