### PR TITLE
Improve/extend renovate config (go version updates)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM $BUILDIMAGE
 ARG TARGETARCH
 RUN set -ex; \
 # Need to use the gold linker on ARM, Go really wants to have it.
-# https://github.com/golang/go/blob/go1.23.3/src/cmd/link/internal/ld/lib.go##L1661-L1680
+# https://github.com/golang/go/blob/go1.24.3/src/cmd/link/internal/ld/lib.go#L1674-L1693
   case "$TARGETARCH" in \
   arm*) binutils=binutils-gold ;; \
     *)    binutils=binutils ;; \

--- a/internal/pkg/file/atomic_test.go
+++ b/internal/pkg/file/atomic_test.go
@@ -214,7 +214,7 @@ func TestWriteAtomically(t *testing.T) {
 			)
 			assert.Equal(t, file, linkErr.New)
 			if runtime.GOOS == "windows" {
-				// https://github.com/golang/go/blob/go1.20/src/syscall/types_windows.go#L11
+				// https://github.com/golang/go/blob/go1.24.3/src/syscall/types_windows.go#L11
 				//revive:disable-next-line:var-naming
 				const ERROR_ACCESS_DENIED syscall.Errno = 5
 				var errno syscall.Errno

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:recommended",
     ":configMigration",
-    ":gitSignOff"
+    ":gitSignOff",
+    ":automergeMinor"
   ],
   "gitAuthor": "Renovate Bot <renovate@whitesourcesoftware.com>",
   "labels": [

--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,34 @@
   "customManagers": [
     {
       "customType": "regex",
+      "description": "Update minimum Go version",
+      "managerFilePatterns": [
+        "**/go.mod"
+      ],
+      "matchStrings": [
+        "^go (?<currentValue>\\d+\\.\\d+)\\.0\\b"
+      ],
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version",
+      "extractVersionTemplate": "^(?<version>\\d+\\.\\d+)",
+      "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Go toolchain version",
+      "managerFilePatterns": [
+        "**/*"
+      ],
+      "matchStrings": [
+        "\\bgo_version = (?<currentValue>\\d+(\\.\\d+){2})",
+        "\\bgolang/go/blob/go(?<currentValue>\\d+(\\.\\d+){2})"
+      ],
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
       "description": "Update etcd version in embedded-bins/Makefile.variables",
       "managerFilePatterns": [
         "embedded-bins/Makefile.variables"

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,10 @@
     ":configMigration",
     ":gitSignOff"
   ],
-  "forkProcessing": "enabled",
+  "gitAuthor": "Renovate Bot <renovate@whitesourcesoftware.com>",
+  "labels": [
+    "dependencies"
+  ],
   "enabledManagers": [
     "gomod",
     "custom.regex"
@@ -34,16 +37,6 @@
       ],
       "groupName": "etcd dependencies",
       "groupSlug": "etcd-all"
-    },
-    {
-      "description": "Ensure etcd in Makefile uses github-releases and is enabled",
-      "matchManagers": [
-        "custom.regex"
-      ],
-      "matchPackageNames": [
-        "etcd-io/etcd"
-      ],
-      "enabled": true
     }
   ],
   "customManagers": [
@@ -54,7 +47,7 @@
         "embedded-bins/Makefile.variables"
       ],
       "matchStrings": [
-        "etcd_version = (?<currentValue>v?[\\d\\.]+)"
+        "etcd_version = (?<currentValue>\\d+(\\.\\d+){2})"
       ],
       "depNameTemplate": "etcd-io/etcd",
       "datasourceTemplate": "github-releases",
@@ -65,11 +58,11 @@
       "description": "Update kine versions across the codebase",
       "managerFilePatterns": [
         "/(^|/)[Mm]akefile(\\.[^/]+)?$/",
-        "**.go"
+        "**/*.go"
       ],
       "matchStrings": [
-        "kine_version = (?<currentValue>[\\d\\.]+)",
-        "\\bkine/blob/v?(?<currentValue>[\\d\\.]+)\\b"
+        "kine_version = (?<currentValue>\\d+(\\.\\d+){2})",
+        "\\bkine/blob/v(?<currentValue>\\d+(\\.\\d+){2})"
       ],
       "depNameTemplate": "k3s-io/kine",
       "datasourceTemplate": "github-releases",


### PR DESCRIPTION
## Description

* Update some old Go source references
* Enable Go toolchain updates
* Enable auto-merge for Renovate Bot PRs
* Remove forkProcessing. It's not required, as the GitHub Action will pass the repository name as an argument.
* Set gitAuthor, as author auto-detection doesn't seem to be working. This fixes empty Signed-off-by trailers.
* Add the dependencies label to all the PRs, just like dependabot does.
* Remove redundant package rule for etcd.
* Refined regexes. No need to match for an optional v prefix, as it's not used anywhere. Currently, the only expected version pattern is x.y.z, so it makes sense to spell that out in the regexes.
* Fix go file glob for kine, so that it properly descends into subdirectories.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project
- [x] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
