### PR TITLE
Allow some renovate bumps in release branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,11 @@
   "labels": [
     "dependencies"
   ],
+  "baseBranches": [
+    "main",
+    "/^release-1\\.3[0-3]$/"
+  ],
+  "prTitleStrict": true,
   "enabledManagers": [
     "gomod",
     "custom.regex"
@@ -38,6 +43,25 @@
       ],
       "groupName": "etcd dependencies",
       "groupSlug": "etcd-all"
+    },
+    {
+      "description": "Only update the main branch by default",
+      "enabled": false,
+      "prTitleStrict": false,
+      "matchBaseBranches": [
+        "!main"
+      ]
+    },
+    {
+      "description": "Bump Go for release-1.32",
+      "enabled": true,
+      "matchBaseBranches": [
+        "release-1.32"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "allowedVersions": "<=1.23"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Description

This enables automatic version bumps for dependencies in release branches that don't follow the same minor version as the main branch. Unfortunately, this requires extra manual configuration per branch and dependency. Additionally, using base branches will change the branch name pattern used by Renovate Bot.

Use prTitleStrict for the main branch so that pull requests against it won't have a "(main)" suffix. Disable it for all other branches so they receive the suffix. As a proof of concept, add a rule to update Go 1.23 in the 1.32 release branch.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
