### PR TITLE
Add support for calico single stack IPv6

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -104,6 +104,12 @@ check-dualstack-kuberouter-dynamicconfig: export K0S_ENABLE_DYNAMIC_CONFIG=true
 check-dualstack-kuberouter-dynamicconfig: export K0S_NETWORK=kuberouter
 check-dualstack-kuberouter-dynamicconfig: TEST_PACKAGE=dualstack
 
+check-ipv6-kuberouter: export K0S_NETWORK=kuberouter
+check-ipv6-kuberouter: TEST_PACKAGE=ipv6
+
+check-ipv6-calico: export K0S_NETWORK=calico
+check-ipv6-calico: TEST_PACKAGE=ipv6
+
 check-ap-updater: .update-server.stamp
 check-ap-updater-periodic: .update-server.stamp
 check-ap-updater-periodic: TIMEOUT=10m

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -44,7 +44,8 @@ smoketests := \
 	check-extraargs \
 	check-hacontrolplane \
 	check-hostnameoverride \
-	check-ipv6 \
+	check-ipv6-calico \
+	check-ipv6-kuberouter \
 	check-k0scloudprovider \
 	check-kine \
 	check-kubectl \

--- a/static/manifests/calico/ConfigMap/calico-config.yaml
+++ b/static/manifests/calico/ConfigMap/calico-config.yaml
@@ -32,10 +32,8 @@ data:
           "nodename": "__KUBERNETES_NODE_NAME__",
           "mtu": __CNI_MTU__,
           "ipam": {
-              {{ if .DualStack }}
-              "assign_ipv4": "true",
-              "assign_ipv6": "true",
-              {{ end }}
+              "assign_ipv4": "{{ .EnableIPv4 }}",
+              "assign_ipv6": "{{ .EnableIPv6 }}",
               "type": "calico-ipam"
           },
           "policy": {

--- a/static/manifests/calico/DaemonSet/calico-node.yaml
+++ b/static/manifests/calico/DaemonSet/calico-node.yaml
@@ -145,9 +145,11 @@ spec:
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "k8s"
-            # Auto-detect the BGP IP address.
+            # The environment variable IP is only for IPv4. It's the IPv4 equivalent of the env IP6,
+            # but the default behavior is different. Single stack IPv6 clusters require it to be none,
+            # clusters with IPv4, single or dual stack, must set it to autodetect.
             - name: IP
-              value: "autodetect"
+              value: "{{ if .EnableIPv4 }}autodetect{{ else }}none{{ end }}"
             # Auto detect the iptables backend
             - name: FELIX_IPTABLESBACKEND
               value: "auto"
@@ -164,10 +166,10 @@ spec:
               value: "{{ if eq .Mode "bird" }}{{ .Overlay }}{{ else }}Never{{ end }}"
             # Enable or Disable VXLAN on the default IP pool.
             - name: CALICO_IPV4POOL_VXLAN
-              value: "{{ if eq .Mode "vxlan" }}{{ .Overlay }}{{ else }}Never{{ end }}"
+              value: "{{ if and (eq .Mode "vxlan") .EnableIPv4 }}{{ .Overlay }}{{ else }}Never{{ end }}"
             # Enable or Disable VXLAN on the default IPv6 IP pool.
             - name: CALICO_IPV6POOL_VXLAN
-              value: "{{ if eq .Mode "vxlan" }}{{ .Overlay }}{{ else }}Never{{ end }}"
+              value: "{{ if and (eq .Mode "vxlan") .EnableIPv6 }}{{ .Overlay }}{{ else }}Never{{ end }}"
             {{- if eq .Mode "vxlan" }}
             - name: FELIX_VXLANPORT
               value: "{{ .VxlanPort }}"
@@ -196,18 +198,20 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: veth_mtu
+            {{ if .EnableIPv4}}
             # The default IPv4 pool to create on startup if none exists. Pod IPs will be
             # chosen from this range. Changing this value after installation will have
             # no effect. This should fall within `--cluster-cidr`.
             - name: CALICO_IPV4POOL_CIDR
               value: "{{ .ClusterCIDRIPv4 }}"
+            {{ end }}
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
-            {{ if .DualStack  }}
+            {{ if .EnableIPv6  }}
             - name: CALICO_IPV6POOL_NAT_OUTGOING
               value: "true"
             - name: FELIX_IPV6SUPPORT


### PR DESCRIPTION
## Description

This commit fixes calico configuration on IPv6 single stack clusters.

Is is another small part of https://github.com/k0sproject/k0s/issues/5875 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
