### PR TITLE
[release-1.31] Bump calico to 3.28.4-0

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -92,7 +92,7 @@ const (
 	EnvoyProxyImage                    = "quay.io/k0sproject/envoy-distroless"
 	EnvoyProxyImageVersion             = "v1.31.5"
 	CalicoImage                        = "quay.io/k0sproject/calico-cni"
-	CalicoComponentImagesVersion       = "v3.28.2-0"
+	CalicoComponentImagesVersion       = "v3.28.4-0"
 	CalicoNodeImage                    = "quay.io/k0sproject/calico-node"
 	KubeControllerImage                = "quay.io/k0sproject/calico-kube-controllers"
 	KubeRouterCNIImage                 = "quay.io/k0sproject/kube-router"


### PR DESCRIPTION
go 1.22.7 -> 1.23.10
alpine 3.20 -> 3.21
flannel -> 5a977558e9fbbf93ff7ba927847fbca194e02416 (main branch)
CNI -> 9ffe547cb3b66f80dd32a00fc69a6d0082b55321 (main branch)