### PR TITLE
Overhaul docs templating

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -15,6 +15,10 @@ jobs:
   build:
     name: Deploy docs
     runs-on: ubuntu-24.04
+
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout k0s
         uses: actions/checkout@v4
@@ -57,8 +61,11 @@ jobs:
       # The old "main" gets deleted if it exists, head is more descriptive
       - name: mike deploy head
         if: contains(github.ref, 'refs/heads/main')
+        env:
+          PYTHONPATH: ${{ github.workspace }}/docs/mkdocs_modules
         run: |
-          KUBERNETES_VERSION="$(./vars.sh kubernetes_version)" mike deploy --push head
+          KUBERNETES_VERSION="$(./vars.sh kubernetes_version)"
+          K0S_VERSION="v$KUBERNETES_VERSION+head" mike deploy --push head
 
       # If a release has been published, deploy it as a new version
       - name: mike deploy new version
@@ -68,9 +75,10 @@ jobs:
           !github.event.release.draft &&
           !github.event.release.prerelease
         env:
-          VERSION: ${{ github.event.release.tag_name }}
+          PYTHONPATH: ${{ github.workspace }}/docs/mkdocs_modules
+          K0S_VERSION: ${{ github.event.release.tag_name }}
         run: |
-          KUBERNETES_VERSION="$(./vars.sh kubernetes_version)" mike deploy --push "$VERSION"
+          mike deploy --push "$K0S_VERSION"
 
       - name: Update mike version aliases
         if: github.repository == 'k0sproject/k0s'

--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,8 @@ docs-serve-dev: DOCS_DEV_PORT ?= 8000
 docs-serve-dev:
 	$(MAKE) -C docs .docker-image.serve-dev.stamp
 	$(DOCKER) run --rm \
-	  -e KUBERNETES_VERSION='$(kubernetes_version)' \
+	  -e PYTHONPATH=/k0s/docs/mkdocs_modules \
+	  -e K0S_VERSION=$(VERSION) \
 	  -v "$(CURDIR):/k0s:ro" \
 	  -p '$(DOCS_DEV_PORT):8000' \
 	  k0sdocs.docker-image.serve-dev

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,6 +1,7 @@
 # Keep in sync with the plugins.exclude section in mkdocs.yml as MkDocs will
 # copy over everything despite hidden files.
 
+__pycache__/
 /*.etag
 /.docker-image.*
 /k0s

--- a/docs/Dockerfile.serve-dev
+++ b/docs/Dockerfile.serve-dev
@@ -5,7 +5,7 @@ FROM python:${PYTHON_IMAGE_VERSION} as builder
 # Prepare Python virtual env
 ENV PYTHONUNBUFFERED 1
 RUN \
-  apk add --no-cache python3 \
+  apk add --no-cache make python3 \
   && python3 -m venv /mkdocs/venv
 
 # Copy requirements.txt

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,7 +18,7 @@ TARGET_VERSION ?= latest
 # gives: "Error: The 'docs_dir' should not be the parent directory of the config file."
 # even if docs_dir is "."
 docs: .require-mkdocs cli
-	cd .. && KUBERNETES_VERSION=$(kubernetes_version) mkdocs build --strict
+	cd .. && PYTHONPATH=$(CURDIR)/mkdocs_modules K0S_VERSION=$$('$(k0s_binary_path)/$(k0s_binary)' version) mkdocs build --strict
 
 .PHONY: .require-mkdocs
 .require-mkdocs:
@@ -41,9 +41,9 @@ endif
 
 .PHONY: k0s k0s.exe
 ifeq ($(TARGET_VERSION),local)
-cli: k0s_binary_path := $(abspath ..)
+docs cli: k0s_binary_path := $(abspath ..)
 else
-cli: k0s_binary_path := $(abspath .)
+docs cli: k0s_binary_path := $(abspath .)
 k0s k0s.exe::
 	[ ! -f '$@.etag' ] || { if [ ! -f '$@' ] || [ '$@.etag' -ot '$@' ]; then rm -- '$@.etag'; fi }
 	touch -- '$@.etag'
@@ -62,10 +62,10 @@ endif
 .PHONY: cli
 ifeq ($(detected_OS),windows)
 cli: k0s.exe
-cli: k0s_binary = k0s.exe
+docs cli: k0s_binary = k0s.exe
 else
 cli: k0s
-cli: k0s_binary = k0s
+docs cli: k0s_binary = k0s
 endif
 cli:
 	rm -rf cli

--- a/docs/airgap-install.md
+++ b/docs/airgap-install.md
@@ -24,7 +24,7 @@ means that your bundle can contain multi-arch images, and the import will be
 done using platform compatibility.
 
 [OCI Image Layout]: https://github.com/opencontainers/image-spec/blob/v1.0/image-layout.md
-[GitHub releases page]: https://github.com/k0sproject/k0s/releases/v{{{ extra.k8s_version }}}+k0s.0
+[GitHub releases page]: https://github.com/k0sproject/k0s/releases/{{{ k0s_version }}}
 
 ## Creating image bundles
 
@@ -119,7 +119,7 @@ metadata:
   name: k0s
 spec:
   k0s:
-    version: {{{ extra.k8s_version }}}+k0s.0
+    version: {{{ k0s_version }}}
   hosts:
     - role: controller
       ssh:

--- a/docs/autopilot-multicommand.md
+++ b/docs/autopilot-multicommand.md
@@ -62,20 +62,20 @@ processed by **autopilot**.
  6:  spec:
  7:    commands:
  8:    - airgapupdate:
- 9:        version: v{{{ extra.k8s_version }}}+k0s.0
+ 9:        version: {{{ k0s_version }}}
 10:        platforms:
 11:          linux-amd64:
-12:            url: https://github.com/k0sproject/k0s/releases/download/v{{{ extra.k8s_version }}}+k0s.0/k0s-airgap-bundle-v{{{ extra.k8s_version }}}+k0s.0-amd64
+12:            url: https://github.com/k0sproject/k0s/releases/download/{{{ k0s_version }}}/k0s-airgap-bundle-{{{ k0s_version }}}-amd64
 13:        workers:
 14:          discovery:
 15:            static:
 16:              nodes:
 17:              - worker0
 18:    - k0supdate:
-19:        version: v{{{ extra.k8s_version }}}+k0s.0
+19:        version: {{{ k0s_version }}}
 20:        platforms:
 21:          linux-amd64:
-22:            url: https://github.com/k0sproject/k0s/releases/download/v{{{ extra.k8s_version }}}+k0s.0/k0s-v{{{ extra.k8s_version }}}+k0s.0-amd64
+22:            url: https://github.com/k0sproject/k0s/releases/download/{{{ k0s_version }}}/k0s-{{{ k0s_version }}}-amd64
 23:        targets:
 24:          controllers:
 25:            discovery:

--- a/docs/autopilot.md
+++ b/docs/autopilot.md
@@ -103,10 +103,10 @@ spec:
 
   commands:
     - k0supdate:
-        version: v{{{ extra.k8s_version }}}+k0s.0
+        version: {{{ k0s_version }}}
         platforms:
           linux-amd64:
-            url: https://github.com/k0sproject/k0s/releases/download/v{{{ extra.k8s_version }}}+k0s.0/k0s-v{{{ extra.k8s_version }}}+k0s.0-amd64
+            url: https://github.com/k0sproject/k0s/releases/download/{{{ k0s_version }}}/k0s-{{{ k0s_version }}}-amd64
             sha256: '0000000000000000000000000000000000000000000000000000000000000000'
         targets:
           controllers:

--- a/docs/compose-cluster.yaml
+++ b/docs/compose-cluster.yaml
@@ -1,7 +1,9 @@
 name: compose-cluster
 
+x-k0s-image: &k0s-image docker.io/k0sproject/k0s:{{{ k0s_docker_version }}}
+
 x-k0s-controller: &k0s-controller
-  image: docker.io/k0sproject/k0s:v{{{extra.k8s_version}}}-k0s.0
+  image: *k0s-image
   networks:
     - k0s-net
   tmpfs:
@@ -27,7 +29,7 @@ x-k0s-controller: &k0s-controller
   restart: on-failure
 
 x-k0s-worker: &k0s-worker
-  image: docker.io/k0sproject/k0s:v{{{extra.k8s_version}}}-k0s.0
+  image: *k0s-image
   networks:
     - k0s-net
   depends_on:
@@ -59,7 +61,7 @@ networks:
 
 services:
   k0s-lb:
-    image: docker.io/traefik:v3.3.5
+    image: docker.io/library/traefik:v3.3.5
     container_name: k0s-lb
     hostname: k0s-lb
     networks:
@@ -126,7 +128,13 @@ services:
     hostname: k0s-controller-2
     depends_on:
       - k0s-controller-1
-    command: [ k0s, controller, --token-file, /run/secrets/k0sproject.io/tokens/controller ]
+    command:
+      [
+        k0s,
+        controller,
+        --token-file,
+        /run/secrets/k0sproject.io/tokens/controller,
+      ]
     volumes:
       - /var/lib/k0s # this is where k0s stores its data
       - k0s-token-secrets:/var/lib/k0s/manifests/k0s-token-secrets:ro

--- a/docs/compose.yaml
+++ b/docs/compose.yaml
@@ -1,6 +1,6 @@
 services:
   k0s-controller:
-    image: docker.io/k0sproject/k0s:v{{{extra.k8s_version}}}-k0s.0
+    image: docker.io/k0sproject/k0s:{{{ k0s_docker_version }}}
     container_name: k0s-controller
     hostname: k0s-controller
     network_mode: bridge # other modes are unsupported
@@ -13,13 +13,13 @@ services:
     tmpfs:
       - /run # this is where k0s stores runtime data
     devices:
-    - /dev/kmsg # required by kubelet's OOM watcher
+      - /dev/kmsg # required by kubelet's OOM watcher
     cap_add:
-     - sys_admin
-     - net_admin
-     - sys_ptrace
-     - sys_resource
-     - syslog
+      - sys_admin
+      - net_admin
+      - sys_ptrace
+      - sys_resource
+      - syslog
     security_opt:
       - seccomp:unconfined # allow access to the session keyring
     configs:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -498,8 +498,8 @@ Nodes under the `images` key all have the same basic structure:
 spec:
   images:
     coredns:
-      image: quay.io/k0sproject/coredns
-      version: 1.12.2
+      image: {{{ src_var('CoreDNSImage') }}}
+      version: {{{ src_var('CoreDNSImageVersion') }}}
 ```
 
 If you want the list of default images and their versions to be included, use `k0s config create --include-images`.
@@ -525,23 +525,26 @@ If you want the list of default images and their versions to be included, use `k
 
 #### Image example
 
+{% set cali_ver = src_var('CalicoComponentImagesVersion') -%}
+{% set metrics_ver = src_var('MetricsImageVersion') -%}
+
 ```yaml
 images:
-  repository: "my.own.repo"
+  repository: airgap-repo.local
   calico:
     kubecontrollers:
-      image: quay.io/k0sproject/calico-kube-controllers
-      version: v3.27.3-0
+      image: repo.acme.corp/k0sproject/calico-kube-controllers
+      version: {{{ cali_ver }}}
   metricsserver:
-    image: quay.io/k0sproject/metrics-server
-    version: v0.7.2
+    image: repo.acme.corp/k0sproject/metrics-server
+    version: {{{ metrics_ver }}}
 ```
 
 In the runtime the image names are calculated as
-`my.own.repo/k0sproject/calico-kube-controllers:v3.27.3-0` and
-`my.own.repo/metrics-server/metrics-server:v0.7.2`. This only affects the the
-images pull location, and thus omitting an image specification here will not
-disable component deployment.
+`airgap-repo.local/k0sproject/calico-kube-controllers:{{{ cali_ver }}}` and
+`airgap-repo.local/k0sproject/metrics-server:{{{ metrics_ver }}}`. This only
+affects the the images pull location, and thus omitting an image specification
+here will not disable component deployment.
 
 ### `spec.extensions.helm`
 

--- a/docs/cplb.md
+++ b/docs/cplb.md
@@ -212,7 +212,7 @@ spec:
     k0sBinaryPath: /opt/k0s
     uploadBinary: true
   k0s:
-    version: v{{{ extra.k8s_version }}}+k0s.0
+    version: {{{ k0s_version }}}
     config:
       spec:
         network:
@@ -333,7 +333,7 @@ INFO [ssh] worker-1.k0s.lab:22: waiting for node to become ready
 INFO ==> Running phase: Release exclusive host lock
 INFO ==> Running phase: Disconnect from hosts
 INFO ==> Finished in 2m20s
-INFO k0s cluster version v{{{ extra.k8s_version }}}+k0s.0  is now installed
+INFO k0s cluster version {{{ k0s_version }}} is now installed
 INFO Tip: To access the cluster you can now fetch the admin kubeconfig using:
 INFO      k0sctl kubeconfig
 ```
@@ -351,9 +351,9 @@ All three worker nodes are ready:
 ```console
 $ kubectl get nodes
 NAME                   STATUS   ROLES           AGE     VERSION
-worker-0.k0s.lab       Ready    <none>          8m51s   v{{{ extra.k8s_version }}}+k0s
-worker-1.k0s.lab       Ready    <none>          8m51s   v{{{ extra.k8s_version }}}+k0s
-worker-2.k0s.lab       Ready    <none>          8m51s   v{{{ extra.k8s_version }}}+k0s
+worker-0.k0s.lab       Ready    <none>          8m51s   {{{ k8s_version }}}+k0s
+worker-1.k0s.lab       Ready    <none>          8m51s   {{{ k8s_version }}}+k0s
+worker-2.k0s.lab       Ready    <none>          8m51s   {{{ k8s_version }}}+k0s
 ```
 
 Only one controller has the VIP:
@@ -394,9 +394,9 @@ And the cluster will be working normally:
 ```console
 $ kubectl get nodes
 NAME                   STATUS   ROLES           AGE     VERSION
-worker-0.k0s.lab       Ready    <none>          8m51s   v{{{ extra.k8s_version }}}+k0s
-worker-1.k0s.lab       Ready    <none>          8m51s   v{{{ extra.k8s_version }}}+k0s
-worker-2.k0s.lab       Ready    <none>          8m51s   v{{{ extra.k8s_version }}}+k0s
+worker-0.k0s.lab       Ready    <none>          8m51s   {{{ k8s_version }}}+k0s
+worker-1.k0s.lab       Ready    <none>          8m51s   {{{ k8s_version }}}+k0s
+worker-2.k0s.lab       Ready    <none>          8m51s   {{{ k8s_version }}}+k0s
 ```
 
 ## Troubleshooting

--- a/docs/install.md
+++ b/docs/install.md
@@ -70,7 +70,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
 
     ```shell
     $ sudo k0s status
-    Version: v{{{ extra.k8s_version }}}+k0s.0
+    Version: {{{ k0s_version }}}
     Process ID: 436
     Role: controller
     Workloads: true
@@ -86,7 +86,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
     ```shell
     $ sudo k0s kubectl get nodes
     NAME   STATUS   ROLES    AGE    VERSION
-    k0s    Ready    <none>   4m6s   v{{{ extra.k8s_version }}}+k0s
+    k0s    Ready    <none>   4m6s   {{{ k8s_version }}}+k0s
     ```
 
 ## Uninstall k0s

--- a/docs/k0s-in-docker.md
+++ b/docs/k0s-in-docker.md
@@ -13,13 +13,12 @@ registry. For simplicity, the examples given here use Docker Hub (GitHub
 requires separate authentication, which is not covered here). The image names
 are as follows:
 
-- `docker.io/k0sproject/k0s:v{{{extra.k8s_version}}}-k0s.0`
-- `ghcr.io/k0sproject/k0s:v{{{extra.k8s_version}}}-k0s.0`
+- `docker.io/k0sproject/k0s:{{{ k0s_docker_version }}}`
+- `ghcr.io/k0sproject/k0s:{{{ k0s_docker_version }}}`
 
 **Note:** Due to Docker's tag validation scheme, `-` is used as the k0s version
-separator instead of the usual `+`. For example, k0s version
-`v{{{extra.k8s_version}}}+k0s.0` is tagged as
-`docker.io/k0sproject/k0s:v{{{extra.k8s_version}}}-k0s.0`.
+separator instead of the usual `+`. For example, k0s version `{{{ k0s_version
+}}}` is tagged as `docker.io/k0sproject/k0s:{{{ k0s_docker_version }}}`.
 
 ## Start k0s
 
@@ -35,7 +34,7 @@ docker run -d --name k0s-controller --hostname k0s-controller \
   --tmpfs /run `# this is where k0s stores runtime data` \
   --privileged `# this is the easiest way to enable container-in-container workloads` \
   -p 6443:6443 `# publish the Kubernetes API server port` \
-  docker.io/k0sproject/k0s:v{{{extra.k8s_version}}}-k0s.0
+  docker.io/k0sproject/k0s:{{{ k0s_docker_version }}}
 ```
 
 Explanation of command line arguments:
@@ -54,7 +53,7 @@ Explanation of command line arguments:
   privileges.
 - `-p 6443:6443` exposes the container's Kubernetes API server port 6443 to the
   host, allowing you to interact with the cluster externally.
-- `docker.io/k0sproject/k0s:v{{{ extra.k8s_version }}}-k0s.0` is the name of the
+- `docker.io/k0sproject/k0s:{{{ k0s_docker_version }}}` is the name of the
   k0s image to run.
 
 By default, the k0s image starts a k0s controller with worker components enabled
@@ -74,7 +73,7 @@ docker run -d --name k0s-controller --hostname k0s-controller \
   --tmpfs /run `# this is where k0s stores runtime data` \
   --tmpfs /tmp `# allow writing temporary files` \
   -p 6443:6443 `# publish the Kubernetes API server port` \
-  docker.io/k0sproject/k0s:v{{{extra.k8s_version}}}-k0s.0 \
+  docker.io/k0sproject/k0s:{{{ k0s_docker_version }}} \
   k0s controller
 ```
 
@@ -100,7 +99,7 @@ application containers to separate workers.
      -v /var/lib/k0s -v /var/log/pods `# this is where k0s stores its data` \
      --tmpfs /run `# this is where k0s stores runtime data` \
      --privileged `# this is the easiest way to enable container-in-container workloads` \
-     docker.io/k0sproject/k0s:v{{{extra.k8s_version}}}-k0s.0 \
+     docker.io/k0sproject/k0s:{{{ k0s_docker_version }}} \
      k0s worker $token
    ```
 
@@ -130,7 +129,7 @@ application containers to separate workers.
      --cap-add sys_ptrace \
      --cap-add sys_resource \
      --cap-add syslog \
-     docker.io/k0sproject/k0s:v{{{extra.k8s_version}}}-k0s.0 \
+     docker.io/k0sproject/k0s:{{{ k0s_docker_version }}} \
      k0s worker "$token"
    ```
 
@@ -273,9 +272,9 @@ After a short while:
 ```console
 $ docker exec k0s-controller-1 k0s kc get node,po -A
 NAME                STATUS   ROLES    AGE     VERSION
-node/k0s-worker-1   Ready    <none>   1m36s   v{{{extra.k8s_version}}}+k0s
-node/k0s-worker-2   Ready    <none>   1m36s   v{{{extra.k8s_version}}}+k0s
-node/k0s-worker-3   Ready    <none>   1m36s   v{{{extra.k8s_version}}}+k0s
+node/k0s-worker-1   Ready    <none>   1m36s   {{{ k8s_version }}}+k0s
+node/k0s-worker-2   Ready    <none>   1m36s   {{{ k8s_version }}}+k0s
+node/k0s-worker-3   Ready    <none>   1m36s   {{{ k8s_version }}}+k0s
 
 NAMESPACE     NAME                                  READY   STATUS    RESTARTS   AGE
 kube-system   pod/coredns-7d4f7fbd5c-54lxp          1/1     Running   0          1m27s

--- a/docs/k0s-multi-node.md
+++ b/docs/k0s-multi-node.md
@@ -22,15 +22,15 @@ curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
 
 The download script accepts the following environment variables:
 
-| Variable                    | Purpose                                                              |
-|:----------------------------|:---------------------------------------------------------------------|
-| `K0S_VERSION=v{{{ extra.k8s_version }}}+k0s.0` | Select the version of k0s to be installed         |
-| `DEBUG=true`                                   | Output commands and their arguments at execution. |
+| Variable                          | Purpose                                           |
+|:----------------------------------|:--------------------------------------------------|
+| `K0S_VERSION={{{ k0s_version }}}` | Select the version of k0s to be installed         |
+| `DEBUG=true`                      | Output commands and their arguments at execution. |
 
 **Note**: If you require environment variables and use sudo, you can do:
 
 ```shell
-curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo K0S_VERSION=v{{{ extra.k8s_version }}}+k0s.0 sh
+curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo K0S_VERSION={{{ k0s_version }}} sh
 ```
 
 ### 2. Bootstrap a controller node
@@ -126,7 +126,7 @@ To get general information about your k0s instance's status:
 ```
 
 ```shell
-Version: v{{{ extra.k8s_version }}}+k0s.0
+Version: {{{ k0s_version }}}
 Process ID: 2769
 Parent Process ID: 1
 Role: controller
@@ -144,7 +144,7 @@ sudo k0s kubectl get nodes
 
 ```shell
 NAME   STATUS   ROLES    AGE    VERSION
-k0s    Ready    <none>   4m6s   v{{{ extra.k8s_version }}}+k0s
+k0s    Ready    <none>   4m6s   {{{ k8s_version }}}+k0s
 ```
 
 You can also access your cluster easily with [Lens](https://k8slens.dev/), simply by copying the kubeconfig and pasting it to Lens:

--- a/docs/k0sctl-install.md
+++ b/docs/k0sctl-install.md
@@ -80,8 +80,8 @@ INFO [ssh] 10.0.0.1:22: discovered 10.12.18.133 as private address
 INFO ==> Running phase: Validate hosts
 INFO ==> Running phase: Gather k0s facts
 INFO ==> Running phase: Download K0s on the hosts
-INFO [ssh] 10.0.0.2:22: downloading k0s 0.11.0
-INFO [ssh] 10.0.0.1:22: downloading k0s 0.11.0
+INFO [ssh] 10.0.0.2:22: downloading k0s {{{ k0s_version }}}
+INFO [ssh] 10.0.0.1:22: downloading k0s {{{ k0s_version }}}
 INFO ==> Running phase: Configure K0s
 WARN [ssh] 10.0.0.1:22: generating default configuration
 INFO [ssh] 10.0.0.1:22: validating configuration
@@ -98,7 +98,7 @@ INFO [ssh] 10.0.0.2:22: starting service
 INFO [ssh] 10.0.0.2:22: waiting for node to become ready
 INFO ==> Running phase: Disconnect from hosts
 INFO ==> Finished in 2m2s
-INFO k0s cluster version 0.11.0 is now installed
+INFO k0s cluster version {{{ k0s_version }}} is now installed
 INFO Tip: To access the cluster you can now fetch the admin kubeconfig using:
 INFO      k0sctl kubeconfig
 ```

--- a/docs/mkdocs_modules/k0s_mkdocs_hacks/macros.py
+++ b/docs/mkdocs_modules/k0s_mkdocs_hacks/macros.py
@@ -1,0 +1,43 @@
+import os
+import re
+import subprocess
+
+def define_env(env):
+    @env.filter
+    def ljust(value, width):
+        return str(value).ljust(width)
+
+    # Export the Go literals as a macro. Don't do it as a variable, as
+    # non-existent variables won't fail the docs build and would go unnoticed.
+    # The macro will fail with a KeyError if there's no such literal.
+    src_vars = parse_src_string_literals()
+    @env.macro
+    def src_var(name):
+        return src_vars[name]
+
+    build_vars = {}
+    @env.macro
+    def build_var(name):
+        if name not in build_vars:
+            proc = subprocess.run(['./vars.sh', name], capture_output=True, check=True, text=True)
+            build_vars[name] = proc.stdout.strip()
+        return build_vars[name]
+
+    env.variables.k0s_version = os.environ['K0S_VERSION']
+    env.variables.k0s_docker_version = os.environ['K0S_VERSION'].replace('+', '-')
+    env.variables.k8s_version = 'v' + build_var('kubernetes_version')
+
+def parse_src_string_literals():
+    # Hand-wavy pattern to get all literal consts/vars from a go file.
+    pattern = r'^(?:const|var)?\s+(\w+)\s*=\s*"([^"]+)"'
+    return parse_file_kv('pkg/constant/constant.go', pattern)
+
+def parse_file_kv(file_path, pattern):
+    pattern = re.compile(pattern)
+    parsed = {}
+    with open(file_path, 'r') as file:
+        for line_number, line in enumerate(file, start=1):
+            match = pattern.search(line)
+            if match:
+                parsed[match.group(1)] = match.group(2)
+    return parsed

--- a/docs/nllb.md
+++ b/docs/nllb.md
@@ -82,7 +82,7 @@ metadata:
   name: k0s-cluster
 spec:
   k0s:
-    version: v{{{ extra.k8s_version }}}+k0s.0
+    version: {{{ k0s_version }}}
     config:
       spec:
         network:
@@ -168,11 +168,11 @@ INFO ==> Running phase: Validate hosts
 INFO ==> Running phase: Gather k0s facts
 INFO ==> Running phase: Validate facts
 INFO ==> Running phase: Upload k0s binaries to hosts
-INFO [ssh] 10.81.146.254:22: uploading k0s binary from /home/k0sctl/.cache/k0sctl/k0s/linux/amd64/k0s-v{{{ extra.k8s_version }}}+k0s.0
-INFO [ssh] 10.81.146.113:22: uploading k0s binary from /home/k0sctl/.cache/k0sctl/k0s/linux/amd64/k0s-v{{{ extra.k8s_version }}}+k0s.0
-INFO [ssh] 10.81.146.51:22: uploading k0s binary from /home/k0sctl/.cache/k0sctl/k0s/linux/amd64/k0s-v{{{ extra.k8s_version }}}+k0s.0
-INFO [ssh] 10.81.146.198:22: uploading k0s binary from /home/k0sctl/.cache/k0sctl/k0s/linux/amd64/k0s-v{{{ extra.k8s_version }}}+k0s.0
-INFO [ssh] 10.81.146.184:22: uploading k0s binary from /home/k0sctl/.cache/k0sctl/k0s/linux/amd64/k0s-v{{{ extra.k8s_version }}}+k0s.0
+INFO [ssh] 10.81.146.254:22: uploading k0s binary from /home/k0sctl/.cache/k0sctl/k0s/linux/amd64/k0s-{{{ k0s_version }}}
+INFO [ssh] 10.81.146.113:22: uploading k0s binary from /home/k0sctl/.cache/k0sctl/k0s/linux/amd64/k0s-{{{ k0s_version }}}
+INFO [ssh] 10.81.146.51:22: uploading k0s binary from /home/k0sctl/.cache/k0sctl/k0s/linux/amd64/k0s-{{{ k0s_version }}}
+INFO [ssh] 10.81.146.198:22: uploading k0s binary from /home/k0sctl/.cache/k0sctl/k0s/linux/amd64/k0s-{{{ k0s_version }}}
+INFO [ssh] 10.81.146.184:22: uploading k0s binary from /home/k0sctl/.cache/k0sctl/k0s/linux/amd64/k0s-{{{ k0s_version }}}
 INFO ==> Running phase: Configure k0s
 INFO [ssh] 10.81.146.254:22: validating configuration
 INFO [ssh] 10.81.146.184:22: validating configuration
@@ -212,7 +212,7 @@ INFO [ssh] 10.81.146.51:22: waiting for node to become ready
 INFO ==> Running phase: Release exclusive host lock
 INFO ==> Running phase: Disconnect from hosts
 INFO ==> Finished in 3m30s
-INFO k0s cluster version v{{{ extra.k8s_version }}}+k0s.0 is now installed
+INFO k0s cluster version {{{ k0s_version }}} is now installed
 INFO Tip: To access the cluster you can now fetch the admin kubeconfig using:
 INFO      k0sctl kubeconfig
 ```
@@ -247,11 +247,14 @@ kubernetes   10.81.146.113:6443,10.81.146.184:6443,10.81.146.254:6443   2m49s
 The first controller is the current k0s leader. The two worker nodes can be
 listed, too:
 
+{% set kubelet_ver = k8s_version + '+k0s' -%}
+{% set kubelet_ver_len = kubelet_ver | length -%}
+
 ```console
 $ kubectl get nodes -owide
-NAME           STATUS   ROLES    AGE     VERSION       INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
-k0s-worker-0   Ready    <none>   2m16s   v{{{ extra.k8s_version }}}+k0s   10.81.146.198   <none>        Alpine Linux v3.17   5.15.83-0-virt   containerd://1.7.27
-k0s-worker-1   Ready    <none>   2m15s   v{{{ extra.k8s_version }}}+k0s   10.81.146.51    <none>        Alpine Linux v3.17   5.15.83-0-virt   containerd://1.7.27
+NAME           STATUS   ROLES    AGE     {{{ 'VERSION'   | ljust(kubelet_ver_len) }}}   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
+k0s-worker-0   Ready    <none>   2m16s   {{{ kubelet_ver | ljust(kubelet_ver_len) }}}   10.81.146.198   <none>        Alpine Linux v3.17   5.15.83-0-virt   containerd://{{{ build_var('containerd_version') }}}
+k0s-worker-1   Ready    <none>   2m15s   {{{ kubelet_ver | ljust(kubelet_ver_len) }}}   10.81.146.51    <none>        Alpine Linux v3.17   5.15.83-0-virt   containerd://{{{ build_var('containerd_version') }}}
 ```
 
 There is one node-local load balancer pod running for each worker node:
@@ -295,9 +298,9 @@ k0s-controller-1
 $ sed -i s#https://10\\.81\\.146\\.254:6443#https://10.81.146.184:6443#g k0s-kubeconfig
 
 $ kubectl get nodes -owide
-NAME           STATUS   ROLES    AGE     VERSION       INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
-k0s-worker-0   Ready    <none>   3m35s   v{{{ extra.k8s_version }}}+k0s   10.81.146.198   <none>        Alpine Linux v3.17   5.15.83-0-virt   containerd://1.7.27
-k0s-worker-1   Ready    <none>   3m34s   v{{{ extra.k8s_version }}}+k0s   10.81.146.51    <none>        Alpine Linux v3.17   5.15.83-0-virt   containerd://1.7.27
+NAME           STATUS   ROLES    AGE     {{{ 'VERSION'   | ljust(kubelet_ver_len) }}}   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
+k0s-worker-0   Ready    <none>   3m35s   {{{ kubelet_ver | ljust(kubelet_ver_len) }}}   10.81.146.198   <none>        Alpine Linux v3.17   5.15.83-0-virt   containerd://{{{ build_var('containerd_version') }}}
+k0s-worker-1   Ready    <none>   3m34s   {{{ kubelet_ver | ljust(kubelet_ver_len) }}}   10.81.146.51    <none>        Alpine Linux v3.17   5.15.83-0-virt   containerd://{{{ build_var('containerd_version') }}}
 
 $ kubectl -n kube-system get pods -owide -l app.kubernetes.io/managed-by=k0s,app.kubernetes.io/component=nllb
 NAME                READY   STATUS    RESTARTS   AGE     IP              NODE           NOMINATED NODE   READINESS GATES

--- a/docs/raspberry-pi4.md
+++ b/docs/raspberry-pi4.md
@@ -125,7 +125,7 @@ Download a [k0s release](https://github.com/k0sproject/k0s/releases/latest). For
 example:
 
 ```shell
-wget -O /tmp/k0s https://github.com/k0sproject/k0s/releases/download/v{{{ extra.k8s_version }}}+k0s.0/k0s-v{{{ extra.k8s_version }}}+k0s.0-arm64 # replace version number!
+wget -O /tmp/k0s https://github.com/k0sproject/k0s/releases/download/{{{ k0s_version }}}/k0s-{{{ k0s_version }}}-arm64 # replace version number!
 sudo install /tmp/k0s /usr/local/bin/k0s
 ```
 
@@ -142,7 +142,7 @@ At this point you can run `k0s`:
 
 ```console
 ubuntu@ubuntu:~$ k0s version
-v{{{ extra.k8s_version }}}+k0s.0
+{{{ k0s_version }}}
 ```
 
 To check if k0s's [system requirements](system-requirements.md) and [external
@@ -283,12 +283,15 @@ Aug 18 09:56:04 ubuntu k0s[2720]: 2022/08/18 09:56:04 [INFO] encoded CSR
 Aug 18 09:56:04 ubuntu k0s[2720]: 2022/08/18 09:56:04 [INFO] signed certificate with serial number 336800507542010809697469355930007636411790073226
 ```
 
+{% set kubelet_ver = k8s_version + '+k0s' -%}
+{% set kubelet_ver_len = kubelet_ver | length -%}
+
 When the cluster is up, try to have a look:
 
 ```console
 ubuntu@ubuntu:~$ sudo k0s kc get nodes -owide
-NAME     STATUS   ROLES           AGE     VERSION       INTERNAL-IP    EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
-ubuntu   Ready    control-plane   4m41s   v{{{ extra.k8s_version }}}+k0s   10.152.56.54   <none>        Ubuntu 22.04.1 LTS   5.15.0-1013-raspi   containerd://1.7.27
+NAME     STATUS   ROLES           AGE     {{{ 'VERSION'   | ljust(kubelet_ver_len) }}}   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
+ubuntu   Ready    control-plane   4m41s   {{{ kubelet_ver | ljust(kubelet_ver_len) }}}   10.152.56.54   <none>        Ubuntu 22.04.1 LTS   5.15.0-1013-raspi   containerd://{{{ build_var('containerd_version') }}}
 ubuntu@ubuntu:~$ sudo k0s kc get pod -owide -A
 NAMESPACE     NAME                              READY   STATUS    RESTARTS   AGE     IP             NODE     NOMINATED NODE   READINESS GATES
 kube-system   kube-proxy-kkv2l                  1/1     Running   0          4m44s   10.152.56.54   ubuntu   <none>           <none>
@@ -445,7 +448,7 @@ As this is a worker node, we cannot access the Kubernetes API via the builtin
 
 ```console
 ubuntu@ubuntu:~$ sudo k0s status
-Version: v{{{ extra.k8s_version }}}+k0s.0
+Version: {{{ k0s_version }}}
 Process ID: 1631
 Role: worker
 Workloads: true
@@ -496,12 +499,16 @@ Using the above kubeconfig, you can now access and use the cluster:
 
 ```console
 ubuntu@ubuntu:~$ KUBECONFIG=/path/to/kubeconfig kubectl get nodes,deployments,pods -owide -A
-NAME          STATUS   ROLES    AGE    VERSION       INTERNAL-IP    EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
-node/ubuntu   Ready    <none>   5m1s   v{{{ extra.k8s_version }}}+k0s   10.152.56.54   <none>        Ubuntu 22.04.1 LTS   5.15.0-1013-raspi   containerd://1.7.27
+NAME          STATUS   ROLES    AGE    {{{ 'VERSION'   | ljust(kubelet_ver_len) }}}   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
+node/ubuntu   Ready    <none>   5m1s   {{{ kubelet_ver | ljust(kubelet_ver_len) }}}   10.152.56.54   <none>        Ubuntu 22.04.1 LTS   5.15.0-1013-raspi   containerd://{{{ build_var('containerd_version') }}}
 
-NAMESPACE     NAME                             READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS       IMAGES                                                 SELECTOR
-kube-system   deployment.apps/coredns          1/1     1            1           33m   coredns          quay.io/k0sproject/coredns:1.12.2                      k8s-app=kube-dns
-kube-system   deployment.apps/metrics-server   1/1     1            1           33m   metrics-server   quay.io/k0sproject/metrics-server:v0.7.2               k8s-app=metrics-server
+{% set coredns = src_var('CoreDNSImage') + ':' + src_var('CoreDNSImageVersion') -%}
+{% set metrics_server = src_var('MetricsImage') + ':' + src_var('MetricsImageVersion') -%}
+{% set len = [coredns, metrics_server] | map('length') | max -%}
+
+NAMESPACE     NAME                             READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS       {{{ 'IMAGES'       | ljust(len) }}}   SELECTOR
+kube-system   deployment.apps/coredns          1/1     1            1           33m   coredns          {{{ coredns        | ljust(len) }}}   k8s-app=kube-dns
+kube-system   deployment.apps/metrics-server   1/1     1            1           33m   metrics-server   {{{ metrics_server | ljust(len) }}}   k8s-app=metrics-server
 
 NAMESPACE     NAME                                  READY   STATUS    RESTARTS   AGE    IP             NODE     NOMINATED NODE   READINESS GATES
 kube-system   pod/coredns-88b745646-pkk5w           1/1     Running   0          33m    10.244.0.5     ubuntu   <none>           <none>

--- a/docs/raspberry-pi5.md
+++ b/docs/raspberry-pi5.md
@@ -71,7 +71,7 @@ Download a [k0s release](https://github.com/k0sproject/k0s/releases/latest). For
 example:
 
   ```shell
-  wget -O /tmp/k0s https://github.com/k0sproject/k0s/releases/download/v{{{ extra.k8s_version }}}+k0s.0/k0s-v{{{ extra.k8s_version }}}+k0s.0-arm64 # replace version number!
+  wget -O /tmp/k0s https://github.com/k0sproject/k0s/releases/download/{{{ k0s_version }}}/k0s-{{{ k0s_version }}}-arm64 # replace version number!
   sudo install /tmp/k0s /usr/local/bin/k0s
   ```
 
@@ -88,7 +88,7 @@ At this point you can run `k0s`:
 
   ```console
   $ sudo k0s version
-  v{{{ extra.k8s_version }}}+k0s.0
+  {{{ k0s_version }}}
   ```
 
 To check if k0s's [system requirements](system-requirements.md) and [external
@@ -248,7 +248,7 @@ For this example, we'll create a cluster.yaml that describes your known Pi 5 dev
       k0sctl v0.21.0 Copyright 2023, k0sctl authors.
       INFO ==> Running phase: Set k0s version
       INFO Looking up latest stable k0s version
-      INFO Using k0s version v{{{ extra.k8s_version }}}+k0s.0
+      INFO Using k0s version {{{ k0s_version }}}
       INFO ==> Running phase: Connect to hosts
       INFO [ssh] 192.168.31.93:22: connected
       INFO ==> Running phase: Detect host operating systems
@@ -261,7 +261,7 @@ For this example, we'll create a cluster.yaml that describes your known Pi 5 dev
       INFO ==> Running phase: Validate hosts
       INFO ==> Running phase: Validate facts
       INFO ==> Running phase: Download k0s on hosts
-      INFO [ssh] 192.168.31.93:22: downloading k0s v{{{ extra.k8s_version }}}+k0s.0
+      INFO [ssh] 192.168.31.93:22: downloading k0s {{{ k0s_version }}}
       INFO ==> Running phase: Install k0s binaries on hosts
       INFO [ssh] 192.168.31.93:22: validating configuration
       INFO ==> Running phase: Configure k0s
@@ -273,7 +273,7 @@ For this example, we'll create a cluster.yaml that describes your known Pi 5 dev
       INFO ==> Running phase: Release exclusive host lock
       INFO ==> Running phase: Disconnect from hosts
       INFO ==> Finished in 4m14s
-      INFO k0s cluster version v{{{ extra.k8s_version }}}+k0s.0 is now installed
+      INFO k0s cluster version {{{ k0s_version }}} is now installed
       INFO Tip: To access the cluster you can now fetch the admin kubeconfig using:
       INFO      k0sctl kubeconfig --config cluster.yaml
       ```
@@ -290,7 +290,7 @@ For this example, we'll create a cluster.yaml that describes your known Pi 5 dev
       $ export KUBECONFIG=pi_cluster.kubeconfig
       $ kubectl get nodes
       NAME   STATUS   ROLES           AGE     VERSION
-      pi     Ready    control-plane   2m54s   v{{{ extra.k8s_version }}}+k0s
+      pi     Ready    control-plane   2m54s   {{{ k8s_version }}}+k0s
       ```
 
 ## Tear down k0s on Pi 5

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -28,8 +28,14 @@ The biggest new k0s features will typically only be delivered on top of the late
 
 ## Version string
 
+{% set version_parts = k0s_version.split('+', maxsplit=1) -%}
+
 The k0s version string consists of the Kubernetes version and the k0s version. For example:
 
-- v{{{ extra.k8s_version }}}+k0s.0
+```text
+{{{ version_parts | join('+') }}}
+```
 
-The Kubernetes version ({{{ extra.k8s_version }}}) is the first part, and the last part (k0s.0) reflects the k0s version, which is built on top of the certain Kubernetes version.
+The Kubernetes version (`{{{ version_parts[0] }}}`) is the first part, and the
+last part (`{{{ version_parts[1] }}}`) reflects the k0s version, which is built
+on top of the certain Kubernetes version.

--- a/docs/reset.md
+++ b/docs/reset.md
@@ -79,8 +79,8 @@ K0sctl can be used to connect and reset all cluster nodes in a single command.
     INFO ==> Running phase: Prepare hosts
     INFO ==> Running phase: Gather k0s facts
     INFO [ssh] 13.53.43.63:22: found existing configuration
-    INFO [ssh] 13.53.43.63:22: is running k0s controller version v{{{ extra.k8s_version }}}+k0s.0
-    INFO [ssh] 13.53.218.149:22: is running k0s worker version v{{{ extra.k8s_version }}}+k0s.0
+    INFO [ssh] 13.53.43.63:22: is running k0s controller version {{{ k0s_version }}}
+    INFO [ssh] 13.53.218.149:22: is running k0s worker version {{{ k0s_version }}}
     INFO [ssh] 13.53.43.63:22: checking if worker  has joined
     INFO ==> Running phase: Reset workers
     INFO [ssh] 13.53.218.149:22: reset

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -316,10 +316,13 @@ metrics][cadvisor-metrics] when using cri-dockerd.
 
 The successful configuration can be verified by executing the following command:
 
+{% set kubelet_ver = k8s_version + '+k0s' -%}
+{% set kubelet_ver_len = kubelet_ver | length -%}
+
 ```console
 $ kubectl get nodes -o wide
-NAME              STATUS   ROLES    AGE   VERSION       INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
-docker-worker-0   Ready    <none>   15m   v{{{ extra.k8s_version }}}+k0s   172.27.77.155   <none>        Ubuntu 22.04.3 LTS   5.15.0-82-generic   docker://24.0.7
+NAME              STATUS   ROLES    AGE   {{{ 'VERSION'   | ljust(kubelet_ver_len) }}}   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
+docker-worker-0   Ready    <none>   15m   {{{ kubelet_ver | ljust(kubelet_ver_len) }}}   172.27.77.155   <none>        Ubuntu 22.04.3 LTS   5.15.0-82-generic   docker://24.0.7
 ```
 
 On the worker nodes, the Kubernetes containers should be listed as regular

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -52,7 +52,7 @@ You can configure the desired cluster version in the k0sctl configuration by set
 ```yaml
 spec:
   k0s:
-    version: {{{ extra.k8s_version }}}+k0s.0
+    version: {{{ k0s_version }}}
 ```
 
 If you do not specify a version, k0sctl checks online for the latest version and defaults to it.
@@ -75,7 +75,7 @@ INFO[0027] [ssh] 10.0.0.17:22: waiting for node to become ready again
 INFO[0027] [ssh] 10.0.0.17:22: upgrade successful
 INFO[0027] ==> Running phase: Disconnect from hosts
 INFO[0027] ==> Finished in 27s
-INFO[0027] k0s cluster version {{{ extra.k8s_version }}}+k0s.0 is now installed
+INFO[0027] k0s cluster version {{{ k0s_version }}} is now installed
 INFO[0027] Tip: To access the cluster you can now fetch the admin kubeconfig using:
 INFO[0027]      k0sctl kubeconfig
 ```

--- a/docs/verifying-signs.md
+++ b/docs/verifying-signs.md
@@ -6,7 +6,7 @@ Binaries can be verified using the `cosign` tool, for example:
 
 ```shell
 cosign verify-blob \
-  --key https://github.com/k0sproject/k0s/releases/download/v{{{ extra.k8s_version }}}%2Bk0s.0/cosign.pub \
-  --signature https://github.com/k0sproject/k0s/releases/download/v{{{ extra.k8s_version }}}%2Bk0s.0/k0s-v{{{ extra.k8s_version }}}+k0s.0-amd64.sig \
-  k0s-v{{{ extra.k8s_version }}}+k0s.0-amd64
+  --key https://github.com/k0sproject/k0s/releases/download/{{{ k8s_version }}}%2Bk0s.0/cosign.pub \
+  --signature https://github.com/k0sproject/k0s/releases/download/{{{ k8s_version }}}%2Bk0s.0/k0s-{{{ k0s_version }}}-amd64.sig \
+  k0s-{{{ k0s_version }}}-amd64
 ```

--- a/docs/worker-node-config.md
+++ b/docs/worker-node-config.md
@@ -8,24 +8,21 @@ The `k0s worker` command accepts the `--labels` flag, with which you can make th
 
 For example, running the worker with `k0s worker --token-file k0s.token --labels="k0sproject.io/foo=bar,k0sproject.io/other=xyz"` results in:
 
-```shell
-kubectl get node --show-labels
-```
+{% set kubelet_ver = k8s_version + '+k0s' -%}
+{% set kubelet_ver_len = kubelet_ver | length -%}
 
-```shell
-NAME      STATUS     ROLES    AGE   VERSION        LABELS
-worker0   NotReady   <none>   10s   v{{{ extra.k8s_version }}}+k0s  beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,k0sproject.io/foo=bar,k0sproject.io/other=xyz,kubernetes.io/arch=amd64,kubernetes.io/hostname=worker0,kubernetes.io/os=linux
+```console
+$ kubectl get node --show-labels
+NAME      STATUS     ROLES    AGE   {{{ 'VERSION'   | ljust(kubelet_ver_len) }}}   LABELS
+worker0   NotReady   <none>   10s   {{{ kubelet_ver | ljust(kubelet_ver_len) }}}   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,k0sproject.io/foo=bar,k0sproject.io/other=xyz,kubernetes.io/arch=amd64,kubernetes.io/hostname=worker0,kubernetes.io/os=linux
 ```
 
 Controller worker nodes are assigned `node.k0sproject.io/role=control-plane` and `node-role.kubernetes.io/control-plane=true` labels:
 
-```shell
-kubectl get node --show-labels
-```
-
-```shell
-NAME          STATUS     ROLES           AGE   VERSION        LABELS
-controller0   NotReady   control-plane   10s   v{{{ extra.k8s_version }}}+k0s  beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/hostname=worker0,kubernetes.io/os=linux,node.k0sproject.io/role=control-plane,node-role.kubernetes.io/control-plane=true
+```console
+$ kubectl get node --show-labels
+NAME          STATUS     ROLES           AGE   {{{ 'VERSION'   | ljust(kubelet_ver_len) }}}   LABELS
+controller0   NotReady   control-plane   10s   {{{ kubelet_ver | ljust(kubelet_ver_len) }}}   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/hostname=worker0,kubernetes.io/os=linux,node.k0sproject.io/role=control-plane,node-role.kubernetes.io/control-plane=true
 ```
 
 **Note:** Setting the labels is only effective on the first registration of the node. Changing the labels thereafter has no effect.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,11 +117,14 @@ plugins:
   - macros:
       j2_variable_start_string: "{{{"
       j2_variable_end_string: "}}}"
+      modules:
+        - k0s_mkdocs_hacks.macros
   - exclude:
       glob:
         - internal/*
         - "*.etag"
         - custom_theme/*
+        - mkdocs_modules/*
         - Dockerfile.serve-dev
         - k0s
         - k0s.exe
@@ -148,7 +151,6 @@ markdown_extensions:
   - footnotes
 
 extra:
-  k8s_version: !!python/object/apply:os.getenv ["KUBERNETES_VERSION"]
   generator: false
   social:
     - icon: fontawesome/brands/github


### PR DESCRIPTION
## Description

Allows for deeper integration into the sources and build system, obtaining values from a single source of truth. This should reduce the number of search-and-replace actions that typically occur across the codebase.

Introduce a custom MkDocs macro module to enable more advanced templating in the documentation. Add the src_var and build_var macros to make values stored as literal variables or constants in the sources or variables declared in the build system accessible.

Add the custom ljust filter to maintain the correct table layout when replacing values of varying lengths.

Update the Makefiles and GitHub workflows to support the custom module. Replace the KUBERNETES_VERSION environment variable with build_var('kubernetes_version') and forward the k0s version to the documentation build. Use the k0s version directly instead of constructing it from the Kubernetes version in each template replacement. Use the new macros and filters to replace some previously hardcoded values.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
