### PR TITLE
[Backport release-1.32] Bump calico to 3.29.4-0

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -92,7 +92,7 @@ const (
 	EnvoyProxyImage                    = "quay.io/k0sproject/envoy-distroless"
 	EnvoyProxyImageVersion             = "v1.31.5"
 	CalicoImage                        = "quay.io/k0sproject/calico-cni"
-	CalicoComponentImagesVersion       = "v3.29.3-1"
+	CalicoComponentImagesVersion       = "v3.29.4-0"
 	CalicoNodeImage                    = "quay.io/k0sproject/calico-node"
 	KubeControllerImage                = "quay.io/k0sproject/calico-kube-controllers"
 	KubeRouterCNIImage                 = "quay.io/k0sproject/kube-router"

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -92,7 +92,7 @@ const (
 	EnvoyProxyImage                    = "quay.io/k0sproject/envoy-distroless"
 	EnvoyProxyImageVersion             = "v1.31.5"
 	CalicoImage                        = "quay.io/k0sproject/calico-cni"
-	CalicoComponentImagesVersion       = "v3.29.3-0"
+	CalicoComponentImagesVersion       = "v3.29.3-1"
 	CalicoNodeImage                    = "quay.io/k0sproject/calico-node"
 	KubeControllerImage                = "quay.io/k0sproject/calico-kube-controllers"
 	KubeRouterCNIImage                 = "quay.io/k0sproject/kube-router"


### PR DESCRIPTION
Backport to `release-1.32`:

* #5806
* #5972

See:

* #5954