### PR TITLE
[Backport release-1.32] Bump CoreDNS to v1.12.2

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -488,8 +488,8 @@ Nodes under the `images` key all have the same basic structure:
 spec:
   images:
     coredns:
-      image: quay.io/coredns/coredns
-      version: v1.7.0
+      image: quay.io/k0sproject/coredns
+      version: 1.12.2
 ```
 
 If you want the list of default images and their versions to be included, use `k0s config create --include-images`.

--- a/docs/raspberry-pi4.md
+++ b/docs/raspberry-pi4.md
@@ -500,7 +500,7 @@ NAME          STATUS   ROLES    AGE    VERSION       INTERNAL-IP    EXTERNAL-IP 
 node/ubuntu   Ready    <none>   5m1s   v{{{ extra.k8s_version }}}+k0s   10.152.56.54   <none>        Ubuntu 22.04.1 LTS   5.15.0-1013-raspi   containerd://1.7.27
 
 NAMESPACE     NAME                             READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS       IMAGES                                                 SELECTOR
-kube-system   deployment.apps/coredns          1/1     1            1           33m   coredns          quay.io/k0sproject/coredns:1.12.1                      k8s-app=kube-dns
+kube-system   deployment.apps/coredns          1/1     1            1           33m   coredns          quay.io/k0sproject/coredns:1.12.2                      k8s-app=kube-dns
 kube-system   deployment.apps/metrics-server   1/1     1            1           33m   metrics-server   registry.k8s.io/metrics-server/metrics-server:v0.7.2   k8s-app=metrics-server
 
 NAMESPACE     NAME                                  READY   STATUS    RESTARTS   AGE    IP             NODE     NOMINATED NODE   READINESS GATES

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -88,7 +88,7 @@ const (
 	KubeProxyImage                     = "quay.io/k0sproject/kube-proxy"
 	KubeProxyImageVersion              = "v1.32.5"
 	CoreDNSImage                       = "quay.io/k0sproject/coredns"
-	CoreDNSImageVersion                = "1.12.1"
+	CoreDNSImageVersion                = "1.12.2"
 	EnvoyProxyImage                    = "quay.io/k0sproject/envoy-distroless"
 	EnvoyProxyImageVersion             = "v1.31.5"
 	CalicoImage                        = "quay.io/k0sproject/calico-cni"


### PR DESCRIPTION
Backport to release-1.32:

* #5971

See:

* #5963