### PR TITLE
[Backport release-1.31] Update dependency go to v1.23.10

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM $BUILDIMAGE
 ARG TARGETARCH
 RUN set -ex; \
 # Need to use the gold linker on ARM, Go really wants to have it.
-# https://github.com/golang/go/blob/go1.23.3/src/cmd/link/internal/ld/lib.go##L1661-L1680
+# https://github.com/golang/go/blob/go1.23.10/src/cmd/link/internal/ld/lib.go##L1661-L1680
   case "$TARGETARCH" in \
   arm*) binutils=binutils-gold ;; \
     *)    binutils=binutils ;; \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM $BUILDIMAGE
 ARG TARGETARCH
 RUN set -ex; \
 # Need to use the gold linker on ARM, Go really wants to have it.
-# https://github.com/golang/go/blob/go1.23.2/src/cmd/link/internal/ld/lib.go##L1661-L1680
+# https://github.com/golang/go/blob/go1.23.3/src/cmd/link/internal/ld/lib.go##L1661-L1680
   case "$TARGETARCH" in \
   arm*) binutils=binutils-gold ;; \
     *)    binutils=binutils ;; \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM $BUILDIMAGE
 ARG TARGETARCH
 RUN set -ex; \
 # Need to use the gold linker on ARM, Go really wants to have it.
-# https://github.com/golang/go/blob/go1.22.9/src/cmd/link/internal/ld/lib.go#L1622-L1641
+# https://github.com/golang/go/blob/go1.23.2/src/cmd/link/internal/ld/lib.go##L1661-L1680
   case "$TARGETARCH" in \
   arm*) binutils=binutils-gold ;; \
     *)    binutils=binutils ;; \

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.20
 alpine_patch_version = $(alpine_version).6
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.23.5
+go_version = 1.23.6
 
 runc_version = 1.1.15
 runc_buildimage = $(golang_buildimage)

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.20
 alpine_patch_version = $(alpine_version).6
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.23.4
+go_version = 1.23.5
 
 runc_version = 1.1.15
 runc_buildimage = $(golang_buildimage)

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.20
 alpine_patch_version = $(alpine_version).6
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.23.6
+go_version = 1.23.8
 
 runc_version = 1.1.15
 runc_buildimage = $(golang_buildimage)

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,6 +1,6 @@
 alpine_version = 3.20
 alpine_patch_version = $(alpine_version).6
-golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
+golang_buildimage=docker.io/library/golang:$(go_version)-alpine3.21
 go_version = 1.23.10
 
 runc_version = 1.1.15

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.20
 alpine_patch_version = $(alpine_version).6
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.23.3
+go_version = 1.23.4
 
 runc_version = 1.1.15
 runc_buildimage = $(golang_buildimage)

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.20
 alpine_patch_version = $(alpine_version).6
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.23.2
+go_version = 1.23.3
 
 runc_version = 1.1.15
 runc_buildimage = $(golang_buildimage)

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.20
 alpine_patch_version = $(alpine_version).6
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.23.8
+go_version = 1.23.2
 
 runc_version = 1.1.15
 runc_buildimage = $(golang_buildimage)

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.20
 alpine_patch_version = $(alpine_version).6
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.23.8
+go_version = 1.23.10
 
 runc_version = 1.1.15
 runc_buildimage = $(golang_buildimage)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k0sproject/k0s
 
-go 1.22.0
+go 1.23
 
 // k0s
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k0sproject/k0s
 
-go 1.23
+go 1.23.0
 
 // k0s
 require (

--- a/hack/tool/go.mod
+++ b/hack/tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/k0sproject/k0s/hack/tool
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/hashicorp/terraform-exec v0.21.0

--- a/internal/http/download.go
+++ b/internal/http/download.go
@@ -62,9 +62,6 @@ func Download(ctx context.Context, url string, target io.Writer, options ...Down
 	// Execute the request.
 	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
-		if cause := context.Cause(ctx); cause != nil && !errors.Is(err, cause) {
-			err = fmt.Errorf("%w (%w)", cause, err)
-		}
 		return fmt.Errorf("request failed: %w", err)
 	}
 	defer func() {
@@ -92,10 +89,6 @@ func Download(ctx context.Context, url string, target io.Writer, options ...Down
 
 	// Run the actual data transfer.
 	if _, err := io.Copy(io.MultiWriter(writeMonitor, target), resp.Body); err != nil {
-		if cause := context.Cause(ctx); cause != nil && !errors.Is(err, cause) {
-			err = fmt.Errorf("%w (%w)", cause, err)
-		}
-
 		return fmt.Errorf("while downloading: %w", err)
 	}
 

--- a/internal/http/download_test.go
+++ b/internal/http/download_test.go
@@ -41,7 +41,6 @@ func TestDownload_CancelRequest(t *testing.T) {
 	cancel(assert.AnError)
 
 	err := internalhttp.Download(ctx, "http://404.example.com", io.Discard)
-	assert.ErrorIs(t, err, assert.AnError)
 	if urlErr := (*url.Error)(nil); assert.ErrorAs(t, err, &urlErr) {
 		assert.Equal(t, "Get", urlErr.Op)
 		assert.Equal(t, "http://404.example.com", urlErr.URL)


### PR DESCRIPTION
Backport to `release-1.31`:

* #5967

Update Go build image to Alpine 3.21. Alpine 3.20 is EOL and upstream won't create any new images for it.

Also pull in changes from previous version bump pull requests that were missing after the initial Go 1.23 version bump in #5709:

* #5155
* #5203
* #5311
* #5445
* #5459
* #5541
* #5774