### PR TITLE
Let Renovate Bot bump the Alpine version

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,5 @@
-alpine_version = 3.21
-alpine_patch_version = $(alpine_version).3
+alpine_patch_version = 3.21.3
+alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
 go_version = 1.24.4
 

--- a/renovate.json
+++ b/renovate.json
@@ -123,6 +123,18 @@
     },
     {
       "customType": "regex",
+      "description": "Update Alpine version",
+      "managerFilePatterns": [
+        "embedded-bins/Makefile.variables"
+      ],
+      "matchStrings": [
+        "alpine_patch_version\\s*=\\s*(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "docker.io/library/alpine",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
       "description": "Update Python version",
       "managerFilePatterns": [
         "docs/Makefile.variables"


### PR DESCRIPTION
## Description

To have a single version string, deduce the alpine_version from the alpine_patch_version instead of the other way around.

See:

* #5957.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
