### PR TITLE
Use Mergiraf when backporting PRs

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -32,6 +32,20 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_BACKPORT_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Mergiraf
+        env:
+          MERGIRAF_VERSION: v0.10.0 # renovate: datasource=gitea-releases registryUrl=https://codeberg.org depName=mergiraf/mergiraf
+        run: |
+          mkdir .git/mergiraf
+          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo .git/mergiraf/mergiraf.tar.gz "https://codeberg.org/mergiraf/mergiraf/releases/download/$MERGIRAF_VERSION/mergiraf_x86_64-unknown-linux-musl.tar.gz"
+          tar xvf .git/mergiraf/mergiraf.tar.gz -C .git/mergiraf
+          .git/mergiraf/mergiraf --version
+          .git/mergiraf/mergiraf languages --gitattributes >.git/info/attributes
+          git config merge.conflictStyle diff3
+          git config merge.mergiraf.name mergiraf
+          git config merge.mergiraf.driver '${{ github.workspace }}/.git/mergiraf/mergiraf merge --git %O %A %B -s %S -x %X -y %Y -p %P -l %L'
+
       - name: Create backport PRs
         uses: korthout/backport-action@v3.2.0
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -145,6 +145,20 @@
       "depNameTemplate": "python",
       "datasourceTemplate": "python-version",
       "versioningTemplate": "python"
+    },
+    {
+      "customType": "regex",
+      "description": "Generic version updates for YAML files",
+      "managerFilePatterns": [
+        "**/*.yaml",
+        "**/*.yml"
+      ],
+      "matchStrings": [
+        ":\\s*[\"']?(?<currentValue>\\S+?)[\"']?\\s*#\\s*renovate:\\s*datasource=(?<datasource>\\S+)(\\s+registryUrl=(?<registryUrl>.+))?\\s+depName=(?<depName>\\S+)(\\s+versioning=(?<versioning>.+))?\n"
+      ],
+      "datasourceTemplate": "{{{datasource}}}",
+      "registryUrlTemplate": "{{#if registryUrl}}{{{registryUrl}}}{{/if}}",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }
   ]
 }


### PR DESCRIPTION
## Description

This might enable automatic backports that would otherwise need to be done manually. Add a generic renovate rule for YAML files and use that to create Mergiraf version bump PRs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
