### PR TITLE
[conformance] Replace removed vpc for domain

### DIFF
--- a/inttest/sonobuoy/terraform/controller.tf
+++ b/inttest/sonobuoy/terraform/controller.tf
@@ -37,7 +37,7 @@ resource "aws_instance" "cluster-controller" {
 resource "aws_eip" "controller-ext" {
   count    = var.controller_count
   instance = aws_instance.cluster-controller[count.index].id
-  vpc      = true
+  domain   = "vpc"
   tags = {
     Name = format("%s-controller-ip-%d", local.cluster_unique_identifier, count.index)
     Role = "controller"


### PR DESCRIPTION
## Description
vpc = true has been deprecated for a while and finally removed.

Probably these tests need more work and we want to change more things such as data.http.k0s_version.0.body which is also deprecated, but this fixes our current blocker.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
