### PR TITLE
Add SPDX/REUSE copyright/license headers to Markdown docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # k0s - The Zero Friction Kubernetes
 
 <!-- When changing this file, consider to change ../README.md, too! -->

--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -1,1 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2024 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 {% include-markdown "../ADOPTERS.md" %}

--- a/docs/airgap-install.md
+++ b/docs/airgap-install.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Air gapped Installation
 
 You can install k0s in environments without Internet access. Air gapped

--- a/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
+++ b/docs/architecture/adr-001-autopilot-oci-basic-auth-support.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2024 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # ADR 1: Add Support for OCI Registry and HTTP Authentication
 
 ## Context

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2024 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Architecture
 
 **Note:** As k0s is a dynamic project, the product architecture may occasionally outpace the documentation. The high level concepts and patterns, however, should always apply.

--- a/docs/autopilot-multicommand.md
+++ b/docs/autopilot-multicommand.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2022 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # **Multi-Command Plans**
 
 **Autopilot** relies on a **Plan** for defining the **Commands** that should be

--- a/docs/autopilot.md
+++ b/docs/autopilot.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Autopilot
 
 A tool for updating your `k0s` controller and worker nodes using specialized plans.

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Backup/Restore overview
 
 k0s has integrated support for backing up cluster state and configuration. The k0s backup utility is aiming to back up and restore k0s managed parts of the cluster.

--- a/docs/cis_benchmark.md
+++ b/docs/cis_benchmark.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Kube-bench Security Benchmark
 
 [Kube-bench](https://github.com/aquasecurity/kube-bench) is an open source tool which can be used to verify security best practices as defined in CIS Kubernetes Benchmark. It provides a number of tests to help harden your k0s clusters. By default, k0s will pass Kube-bench benchmarks with some exceptions, which are shown below.

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Cloud providers
 
 K0s supports all [Kubernetes cloud controllers]. However, those must be installed as separate cluster add-ons since k0s builds Kubernetes components in *providerless* mode.

--- a/docs/commercial-support.md
+++ b/docs/commercial-support.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Commercial support
 
 Commercial support for k0s if offered by [Mirantis Inc.](https://mirantis.com).

--- a/docs/configuration-validation.md
+++ b/docs/configuration-validation.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Configuration validation
 
 k0s command-line interface has the ability to validate config syntax:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Configuration options
 
 ## Using a configuration file

--- a/docs/containerd_config.md
+++ b/docs/containerd_config.md
@@ -1,1 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 See [runtime](runtime.md).

--- a/docs/contributors/docs.md
+++ b/docs/contributors/docs.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Contributing to the k0s documentation
 
 We use [mkdocs](https://www.mkdocs.org) and [mike](https://github.com/jimporter/mike) for publishing docs to [docs.k0sproject.io](https://docs.k0sproject.io).

--- a/docs/contributors/github_workflow.md
+++ b/docs/contributors/github_workflow.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # GitHub Workflow
 
 This guide assumes you have already cloned the upstream repo to your system via `git clone`, or via `go get github.com/k0sproject/k0s`.

--- a/docs/contributors/index.md
+++ b/docs/contributors/index.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Getting Started
 
 Thank you for taking the time to make a contribution to k0s. The following document is a set of guidelines and instructions for contributing to k0s.

--- a/docs/contributors/testing.md
+++ b/docs/contributors/testing.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Testing Your Code
 
 k0s uses github actions to run automated tests on any PR, before merging.

--- a/docs/cplb.md
+++ b/docs/cplb.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2024 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Control plane load balancing
 
 For clusters that don't have an [externally managed load balancer](high-availability.md#load-balancer) for the k0s

--- a/docs/custom-ca.md
+++ b/docs/custom-ca.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2022 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Install using custom CA certificates and SA key pair
 
 k0s generates all needed certificates automatically in the `<data-dir>/pki` directory (`/var/lib/k0s/pki`, by default).

--- a/docs/custom-cri-runtime.md
+++ b/docs/custom-cri-runtime.md
@@ -1,1 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 See [runtime](runtime.md).

--- a/docs/dual-stack.md
+++ b/docs/dual-stack.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # IPv4/IPv6 dual-stack networking
 
 Enabling dual-stack networking in k0s allows your cluster to handle both IPv4 and

--- a/docs/dynamic-configuration.md
+++ b/docs/dynamic-configuration.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Dynamic configuration
 
 k0s comes with the option to enable dynamic configuration for cluster level components. This covers all the components other than etcd (or SQLite) and the Kubernetes API server. This option enables k0s configuration directly via Kubernetes API as opposed to using a configuration file for all cluster configuration.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Environment variables
 
 `k0s install` does not support environment variables.

--- a/docs/examples/ansible-playbook.md
+++ b/docs/examples/ansible-playbook.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Creating a cluster with an Ansible Playbook
 
 Ansible is a popular infrastructure-as-code tool that can use to automate tasks for the purpose of achieving the desired state in a system. With Ansible (and the k0s-Ansible playbook) you can quickly install a multi-node Kubernetes Cluster.

--- a/docs/examples/gitops-flux.md
+++ b/docs/examples/gitops-flux.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2022 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Using GitOps with Flux
 
 This tutorial describes the benefits of using GitOps with k0s and provides an example of deploying an application with Flux v2.

--- a/docs/examples/metallb-loadbalancer.md
+++ b/docs/examples/metallb-loadbalancer.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Installing MetalLB Load Balancer
 
 This tutorial covers the installation of MetalLB load balancer on k0s. k0s doesn't come with an in-built load balancer, but it's easy to deploy MetalLB as shown in this document.

--- a/docs/examples/nginx-ingress.md
+++ b/docs/examples/nginx-ingress.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Installing NGINX Ingress Controller
 
 This tutorial covers the installation of [Ingress NGINX Controller], which is an

--- a/docs/examples/oidc/oidc-cluster-configuration.md
+++ b/docs/examples/oidc/oidc-cluster-configuration.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # OpenID Connect integration
 
 Developers use `kubectl` to access Kubernetes clusters. By default `kubectl` uses a certificate to authenticate to the Kubernetes API. This means that when multiple developers need to access a cluster, the certificate needs to be shared. Sharing the credentials to access a Kubernetes cluster presents a significant security problem. Compromise of the certificate is very easy and the consequences can be catastrophic.

--- a/docs/examples/oidc/oidc-provider-configuration.md
+++ b/docs/examples/oidc/oidc-provider-configuration.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Providers
 
 We use Google Cloud as a provider for the sake of the example. Check your vendor documentation in case if you use some other vendor.

--- a/docs/examples/openebs.md
+++ b/docs/examples/openebs.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # OpenEBS
 
 This tutorial covers the installation of OpenEBS as a Helm extension. OpenEBS

--- a/docs/examples/rook-ceph.md
+++ b/docs/examples/rook-ceph.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Installing Ceph Storage with Rook
 
 In this tutorial you'll create a Ceph storage for k0s. Ceph is a highly scalable, distributed storage solution. It offers object, block, and file storage, and it's designed to run on any common hardware. Ceph implements data replication into multiple volumes that makes it fault-tolerant. Another clear advantage of Ceph in Kubernetes is the dynamic provisioning. This means that applications just need to request the storage (persistent volume claim) and Ceph will automatically provision the requested storage without a manual creation of the persistent volume each time.

--- a/docs/examples/traefik-ingress.md
+++ b/docs/examples/traefik-ingress.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Installing Traefik Ingress Controller
 
 You can configure k0s with the [Traefik Ingress Controller], a [MetalLB service load balancer], and deploy the Traefik Dashboard using a service sample. To do this you leverage Helm's extensible bootstrapping functionality to add the correct extensions to the `k0s.yaml` file during cluster configuration.

--- a/docs/experimental-windows.md
+++ b/docs/experimental-windows.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Run k0s worker nodes in Windows
 
 **IMPORTANT**: Windows support for k0s is under active development and **must be** considered experimental.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Cluster extensions
 
 k0s allows users to use extensions to extend cluster functionality.

--- a/docs/external-runtime-deps.md
+++ b/docs/external-runtime-deps.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2022 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # External runtime dependencies
 
 k0s is packaged as a single binary, which includes all the needed components.

--- a/docs/governance/cncf/gtr.md
+++ b/docs/governance/cncf/gtr.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2025 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # General Technical Review (GTR)
 
 This document collects information for the [CNCF General Technical Review]. It is built to support the [k0s CNCF Sandbox application] but will be a living document that we update regularly.

--- a/docs/governance/cncf/security-self-assessment.md
+++ b/docs/governance/cncf/security-self-assessment.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2025 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # CNCF TAG-Security self-assessment
 
 This document serves as the k0s project [CNCF TAG-Security self-assessment].

--- a/docs/helm-charts.md
+++ b/docs/helm-charts.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Helm Charts
 
 Defining your extensions as Helm charts is one of two methods you can use to run k0s with your preferred extensions (the other being through the use of [Manifest Deployer](manifests.md)).

--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Control Plane High Availability
 
 You can create high availability for the control plane by distributing the control plane across multiple nodes and installing a load balancer on top. Etcd can be co-located with the controller nodes (default in k0s) to achieve highly available data store at the same time.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Quick Start Guide
 
  On completion of the Quick Start you will have a full Kubernetes cluster with a single node that includes both the controller and the worker. Such a setup is ideal for environments that do not require high-availability and multiple nodes.

--- a/docs/internal/upgrading-calico.md
+++ b/docs/internal/upgrading-calico.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Upgrading Calico
 
 k0s bundles Kubernetes manifests for Calico. The manifests are retrieved

--- a/docs/k0s-in-docker.md
+++ b/docs/k0s-in-docker.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Run k0s in Docker
 
 You can create a k0s cluster on top of Docker.

--- a/docs/k0s-multi-node.md
+++ b/docs/k0s-multi-node.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Manual Install (Advanced)
 
 You can manually set up k0s nodes by creating a multi-node cluster that is locally managed on each node. This involves several steps, to first install each node separately, and to then connect the node together using access tokens.

--- a/docs/k0s-single-node.md
+++ b/docs/k0s-single-node.md
@@ -1,1 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 See the [Quick Start Guide](install.md).

--- a/docs/k0sctl-install.md
+++ b/docs/k0sctl-install.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Install using k0sctl
 
 k0sctl is a command-line tool for bootstrapping and managing k0s clusters. k0sctl connects to the provided hosts using SSH and gathers information on the hosts, with which it forms a cluster by configuring the hosts, deploying k0s, and then connecting the k0s nodes together.

--- a/docs/manifests.md
+++ b/docs/manifests.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Manifest Deployer
 
 Included with k0s, Manifest Deployer is one of two methods you can use to run k0s with your preferred extensions (the other being by defining your extensions as [Helm charts](helm-charts.md)).

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Networking
 
 ## In-cluster networking

--- a/docs/nllb.md
+++ b/docs/nllb.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Node-local load balancing
 
 For clusters that don't have an [externally managed load balancer] for the k0s

--- a/docs/podsecurity.md
+++ b/docs/podsecurity.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2022 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Pod Security Standards
 
 Since Pod Security Policies have been removed in Kubernetes v1.25, Kubernetes

--- a/docs/raspberry-pi4.md
+++ b/docs/raspberry-pi4.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Create a Raspberry Pi 4 cluster
 
 ## Prerequisites

--- a/docs/raspberry-pi5.md
+++ b/docs/raspberry-pi5.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2025 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Create a Raspberry Pi 5 cluster
 
 ## Prerequisites

--- a/docs/reinstall-k0sctl.md
+++ b/docs/reinstall-k0sctl.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2022 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Reinstall a node
 
 `k0sctl` currently does not support changing all the configuration of containerd (`state`, `root`) on the fly.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Releases
 
 This page describes how we release and support the k0s project. [Mirantis Inc.](https://mirantis.com) can also provide [commercial support](commercial-support.md) for k0s.

--- a/docs/remove_controller.md
+++ b/docs/remove_controller.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Remove or replace a controller
 
 You can manually remove or replace a controller from a multi-node k0s cluster (>=3 controllers) without downtime.

--- a/docs/reset.md
+++ b/docs/reset.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Reset (Uninstall)
 
 Resetting k0s nodes essentially reverts them to a pre-k0s state. This operation

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Runtime
 
 k0s supports any container runtime that implements the [CRI] specification.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2025 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Security policy
 
 For the security policy, please refer to the [upstream k0s documentation](https://github.com/k0sproject/k0s/blob/main/SECURITY.md).

--- a/docs/selinux.md
+++ b/docs/selinux.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2022 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # SELinux Overview
 
 SELinux enforces mandatory access control policies that confine user programs and system services, as well as access to files and network resources. Limiting privilege to the minimum required to work reduces or eliminates the ability of these programs and daemons to cause harm if faulty or compromised.

--- a/docs/shell-completion.md
+++ b/docs/shell-completion.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Enabling Shell Completion
 
 ## Introduction

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Storage
 
 ## CSI

--- a/docs/system-monitoring.md
+++ b/docs/system-monitoring.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2022 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # System components monitoring
 
 Controller nodes [are isolated](architecture/index.md#control-plane) by default, which thus means that a cluster user cannot schedule workloads onto controller nodes.

--- a/docs/system-requirements.md
+++ b/docs/system-requirements.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # System requirements
 
 This page describes the system requirements for k0s.

--- a/docs/troubleshooting/FAQ.md
+++ b/docs/troubleshooting/FAQ.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Frequently asked questions
 
 ## How is k0s pronounced?

--- a/docs/troubleshooting/certificate-authorities.md
+++ b/docs/troubleshooting/certificate-authorities.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2024 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Certificate Authorities (CAs)
 
 ## Overview of CAs managed by k0s

--- a/docs/troubleshooting/logs.md
+++ b/docs/troubleshooting/logs.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2024 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Logs
 
 k0s runs most of the Kubernetes and other system components as plain Linux child processes. As it acts as a watchdog for the child processes it also combines the logs for all such processes into its own log stream.

--- a/docs/troubleshooting/support-dump.md
+++ b/docs/troubleshooting/support-dump.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2024 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Support Insight
 
 In many cases, especially when looking for [commercial support](../commercial-support.md) there's a need for share the cluster state with other people.

--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Common Pitfalls
 
 There are few common cases we've seen where k0s fails to run properly.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Upgrade
 
 The k0s upgrade is a simple process due to its single binary distribution. The k0s single binary file includes all the necessary parts for the upgrade and essentially the upgrade process is to replace that file and restart the service.

--- a/docs/user-management.md
+++ b/docs/user-management.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # User Management
 
 Kubernetes, and thus k0s, does not have any built-in functionality to manage users. Kubernetes relies solely on external sources for user identification and authentication. A client certificate is considered an external source in this case as Kubernetes API server "just" validates that the certificate is signed by a trusted CA. This means that it is recommended to use e.g. [OpenID Connect](./examples/oidc/oidc-cluster-configuration.md) to configure the API server to trust tokens issued by an external Identity Provider.

--- a/docs/verifying-signs.md
+++ b/docs/verifying-signs.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Verifying Signed Binaries
 
 K0smotron team provides signed binaries for k0s. The signatures are created using [cosign](https://docs.sigstore.dev/signing/quickstart/).

--- a/docs/worker-node-config.md
+++ b/docs/worker-node-config.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Configuration options for worker nodes
 
 Although the `k0s worker` command does not take in any special YAML configuration, there are still methods for configuring the workers to run various components.

--- a/hack/copyright.sh
+++ b/hack/copyright.sh
@@ -30,9 +30,14 @@ has_date_copyright(){
 	grep -q -F "SPDX-FileCopyrightText: $DATE k0s authors" "$FILE"
 }
 
-# Deliberately do not search in docs as the date of the matches for the
-# Copyright notice aren't related to the date of the document.
-for i in $(find cmd hack internal inttest pkg static -type f -name '*.go' -not -name 'zz_generated*'); do
+find_files_to_check() {
+    # All the Go files
+    find cmd hack internal inttest pkg static -type f -name '*.go' -not -name 'zz_generated*'
+    # All the markdown documentation, excluding the auto-generated CLI docs
+    find docs -type f -name '*.md' -not -path 'docs/cli/*'
+}
+
+for i in $(find_files_to_check); do
     case "$i" in
     pkg/client/clientset/*)
         if ! has_basic_copyright "$i"; then


### PR DESCRIPTION
## Description

Depends on:

* [x] #6045

Add support for them to `hack/copyright.sh`, as well.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
