### PR TITLE
Properly initialize kubelet directories on Windows

### DIFF
--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -72,8 +72,9 @@ var _ manager.Component = (*Kubelet)(nil)
 func (k *Kubelet) Init(_ context.Context) error {
 
 	if runtime.GOOS == "windows" {
-		err := assets.Stage(k.K0sVars.BinDir, "kubelet.exe")
-		return err
+		if err := assets.Stage(k.K0sVars.BinDir, "kubelet.exe"); err != nil {
+			return err
+		}
 	}
 
 	if runtime.GOOS == "linux" {


### PR DESCRIPTION
## Description

The staging code for kubelet.exe was short-circuiting the Init method, thus skipping the rest of its code. Instead, only return early on error conditions, just like the code for Linux does it.

Fixes:

* #5095

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
