### PR TITLE
[docs] make security docs always point to main

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,1 +1,3 @@
-{% include-markdown "../SECURITY.md" %}
+# Security policy
+
+For the security policy, please refer to the [upstream k0s documentation](https://github.com/k0sproject/k0s/blob/main/SECURITY.md).


### PR DESCRIPTION
## Description

This prevents having supported branches showing incorrect documentation such as: https://docs.k0sproject.io/v1.32.6+k0s.0/security/

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
