### PR TITLE
Fix CRI runtime connections on Windows

### DIFF
--- a/cmd/ctr/ctr.go
+++ b/cmd/ctr/ctr.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
-	"github.com/k0sproject/k0s/pkg/component/worker"
+	"github.com/k0sproject/k0s/pkg/component/worker/containerd"
 	"github.com/k0sproject/k0s/pkg/config"
 
 	"github.com/containerd/containerd/cmd/ctr/app"
@@ -46,7 +46,7 @@ func setDefaultValues(runDir string, flags []cli.Flag) {
 		if f, ok := flag.(cli.StringFlag); ok {
 			switch f.Name {
 			case "address, a":
-				f.Value = worker.GetContainerdAddress(runDir)
+				f.Value = containerd.Address(runDir)
 				flags[i] = f
 			case "namespace, n":
 				f.Value = "k8s.io"

--- a/pkg/component/worker/containerd/component.go
+++ b/pkg/component/worker/containerd/component.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -130,17 +129,11 @@ func (c *Component) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to setup containerd config: %w", err)
 	}
 
-	var runtimeEndpoint *url.URL
-
 	if runtime.GOOS == "windows" {
 		if err := c.windowsStart(ctx); err != nil {
 			return fmt.Errorf("failed to start windows server: %w", err)
 		}
-
-		runtimeEndpoint = &url.URL{Scheme: "npipe", Path: "//./pipe/containerd-containerd"}
 	} else {
-		socketPath := filepath.Join(c.K0sVars.RunDir, "containerd.sock")
-
 		c.supervisor = supervisor.Supervisor{
 			Name:    "containerd",
 			BinPath: assets.BinPath("containerd", c.K0sVars.BinDir),
@@ -149,7 +142,7 @@ func (c *Component) Start(ctx context.Context) error {
 			Args: []string{
 				"--root=" + filepath.Join(c.K0sVars.DataDir, "containerd"),
 				"--state=" + filepath.Join(c.K0sVars.RunDir, "containerd"),
-				"--address=" + socketPath,
+				"--address=" + Address(c.K0sVars.RunDir),
 				"--log-level=" + c.LogLevel,
 				"--config=" + c.confPath,
 			},
@@ -158,8 +151,6 @@ func (c *Component) Start(ctx context.Context) error {
 		if err := c.supervisor.Supervise(); err != nil {
 			return err
 		}
-
-		runtimeEndpoint = &url.URL{Scheme: "unix", Path: socketPath}
 	}
 
 	go c.watchDropinConfigs(ctx)
@@ -169,7 +160,7 @@ func (c *Component) Start(ctx context.Context) error {
 	err := wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
 		Duration: 100 * time.Millisecond, Factor: 1.2, Jitter: 0.05, Steps: 30,
 	}, func(ctx context.Context) (bool, error) {
-		rt := containerruntime.NewContainerRuntime(runtimeEndpoint)
+		rt := containerruntime.NewContainerRuntime(Endpoint(c.K0sVars.RunDir))
 		if lastErr = rt.Ping(ctx); lastErr != nil {
 			log.WithError(lastErr).Debug("Failed to ping containerd")
 			return false, nil

--- a/pkg/component/worker/containerd/utils_other.go
+++ b/pkg/component/worker/containerd/utils_other.go
@@ -5,6 +5,22 @@
 
 package containerd
 
+import (
+	"net/url"
+	"path/filepath"
+)
+
+func Address(runDir string) string {
+	return filepath.Join(runDir, "containerd.sock")
+}
+
+func Endpoint(runDir string) *url.URL {
+	return &url.URL{
+		Scheme: "unix",
+		Path:   filepath.ToSlash(Address(runDir)),
+	}
+}
+
 func winExecute(args ...string) error {
 	panic("Invariant broken: this function should never be called on non-winodws platforms")
 }

--- a/pkg/component/worker/containerd/utils_windows.go
+++ b/pkg/component/worker/containerd/utils_windows.go
@@ -4,14 +4,27 @@
 package containerd
 
 import (
+	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 
 	"github.com/Microsoft/hcsshim"
 	"github.com/avast/retry-go"
 	"github.com/sirupsen/logrus"
 )
+
+func Address(_ string) string {
+	return `\\.\pipe\containerd-containerd`
+}
+
+func Endpoint(runDir string) *url.URL {
+	return &url.URL{
+		Scheme: "npipe",
+		Path:   filepath.ToSlash(Address(runDir)),
+	}
+}
 
 // PowerShell struct
 type PowerShell struct {

--- a/pkg/component/worker/cri_runtime.go
+++ b/pkg/component/worker/cri_runtime.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"path/filepath"
-	"runtime"
 	"strings"
+
+	"github.com/k0sproject/k0s/pkg/component/worker/containerd"
 )
 
 type RuntimeEndpoint = url.URL
@@ -21,23 +21,7 @@ func GetContainerRuntimeEndpoint(criSocketFlag, k0sRunDir string) (*RuntimeEndpo
 		return parseCRISocketFlag(criSocketFlag)
 	}
 
-	return getContainerRuntimeEndpoint(k0sRunDir), nil
-}
-
-func getContainerRuntimeEndpoint(k0sRunDir string) *RuntimeEndpoint {
-	if runtime.GOOS == "windows" {
-		return &url.URL{Scheme: "npipe", Path: "//./pipe/containerd-containerd"}
-	}
-
-	return &url.URL{Scheme: "unix", Path: filepath.ToSlash(GetContainerdAddress(k0sRunDir))}
-}
-
-func GetContainerdAddress(k0sRunDir string) string {
-	if runtime.GOOS == "windows" {
-		return getContainerRuntimeEndpoint(k0sRunDir).String()
-	}
-
-	return filepath.Join(k0sRunDir, "containerd.sock")
+	return containerd.Endpoint(k0sRunDir), nil
 }
 
 func parseCRISocketFlag(criSocketFlag string) (*RuntimeEndpoint, error) {

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -23,6 +23,7 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/component/prober"
+	workercontainerd "github.com/k0sproject/k0s/pkg/component/worker/containerd"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/debounce"
@@ -52,7 +53,7 @@ var _ manager.Component = (*OCIBundleReconciler)(nil)
 func NewOCIBundleReconciler(vars *config.CfgVars) *OCIBundleReconciler {
 	return &OCIBundleReconciler{
 		ociBundleDir:      vars.OCIBundleDir,
-		containerdAddress: GetContainerdAddress(vars.RunDir),
+		containerdAddress: workercontainerd.Address(vars.RunDir),
 		log:               logrus.WithField("component", "OCIBundleReconciler"),
 		EventEmitter:      prober.NewEventEmitter(),
 		alreadyImported:   map[string]time.Time{},

--- a/pkg/container/runtime/cri_other.go
+++ b/pkg/container/runtime/cri_other.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"net/url"
+)
+
+func newCRIRuntime(runtimeEndpoint *url.URL) *CRIRuntime {
+	return &CRIRuntime{
+		target:      runtimeEndpoint.String(),
+		dialOptions: defaultGRPCDialOptions,
+	}
+}

--- a/pkg/container/runtime/cri_windows.go
+++ b/pkg/container/runtime/cri_windows.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"net/url"
+	"path/filepath"
+	"slices"
+
+	"github.com/Microsoft/go-winio"
+	"google.golang.org/grpc"
+)
+
+func newCRIRuntime(runtimeEndpoint *url.URL) *CRIRuntime {
+	if runtimeEndpoint.Scheme != "npipe" {
+		return &CRIRuntime{
+			target:      runtimeEndpoint.String(),
+			dialOptions: defaultGRPCDialOptions,
+		}
+	}
+
+	return &CRIRuntime{
+		target: (&url.URL{
+			Scheme: "passthrough", // https://github.com/grpc/grpc-go/issues/7288#issuecomment-2141190333
+			Opaque: filepath.FromSlash(runtimeEndpoint.Path),
+		}).String(),
+
+		dialOptions: slices.Concat(
+			defaultGRPCDialOptions,
+			[]grpc.DialOption{
+				grpc.WithContextDialer(winio.DialPipeContext),
+			},
+		),
+	}
+}

--- a/pkg/container/runtime/runtime.go
+++ b/pkg/container/runtime/runtime.go
@@ -16,5 +16,5 @@ type ContainerRuntime interface {
 }
 
 func NewContainerRuntime(runtimeEndpoint *url.URL) ContainerRuntime {
-	return &CRIRuntime{runtimeEndpoint.String()}
+	return newCRIRuntime(runtimeEndpoint)
 }


### PR DESCRIPTION
## Description

gRPC-Go has evolved. The Dialer for named pipes must now be specified explicitly. Additionally, the "dns" resolver is now the default, which breaks named pipes. Add conditional compilation for the creation of the `CRIRuntime` struct. For Windows, this pulls in the go-winio Dialer and switches to the "passthrough" resolver.

Rename `CRIRuntime` internals. Give them more appropriate names: `criSocketPath` is really a gRPC target string. `getRuntimeClient` and `getRuntimeClientConnection` actually create new connections. Rename them accordingly. Remove internal `nil` checks for the runtime client and the connection. They will never be `nil` when `err` is `nil`.

Move containerd address/endpoint functions into containerd package. Use conditional compilation instead of `runtime.GOOS` switches.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
