### PR TITLE
Use correct job name for nightly OS tests notification

### DIFF
--- a/.github/workflows/ostests-nightly.yaml
+++ b/.github/workflows/ostests-nightly.yaml
@@ -99,7 +99,7 @@ jobs:
     with: { target-os: linux, target-arch: amd64 }
 
   e2e-tests:
-    name: "${{ needs.select.outputs.os }} :: ${{ needs.select.outputs.network-provider }}"
+    name: "${{ needs.select.outputs.os }} :: ${{ needs.select.outputs.network-provider }} / e2e tests"
     needs: [select, build]
     uses: ./.github/workflows/ostests-e2e.yaml
     with:


### PR DESCRIPTION
## Description

For callable jobs, the actual job name is a concatenation of the job name used in the calling workflow and the name used in the called one.

Fixes:

* #6007

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
