### PR TITLE
Use a custom Slack notification for nightly OS tests

### DIFF
--- a/.github/workflows/ostests-nightly.yaml
+++ b/.github/workflows/ostests-nightly.yaml
@@ -120,12 +120,56 @@ jobs:
       contents: read
       actions: read
 
+    env:
+      OSTESTS_OS: ${{ needs.select.outputs.os }}
+      OSTESTS_NETWORK_PROVIDER: ${{ needs.select.outputs.network-provider }}
+
     steps:
+      - name: Prepare Slack message
+        id: prepare-slack-message
+        # A jq program that converts the job result into a Slack message.
+        # Message format described here: https://api.slack.com/surfaces/messages#payloads
+        # The block structure can be tested online: https://app.slack.com/block-kit-builder
+        run: |
+          gh api /repos/{owner}/{repo}/actions/runs/{{ github.run_id }}/jobs -q '
+            def fmt_duration:
+              if . >= 3600 then "\(./3600|floor) h \((.%3600/60|floor)) min"
+              elif . >= 60 then "\(./60|floor) min \(.%60) sec"
+              else "\(.) sex"
+              end;
+
+            [.jobs[] | select(.name | startswith("\($ENV.OSTESTS_OS) :: \($ENV.OSTESTS_NETWORK_PROVIDER)"))] | first as $job |
+            ":\(if $job.conclusion == "success" then "rocket" else "collision" end): *Nightly OS test run: \($job.conclusion)*" as $text |
+            [$job.steps[] | select(.conclusion == "failure")] | first as $failedStep | {
+              text: $text, mrkdwn: true,
+              blocks: [
+                {
+                  type: "section",
+                  text: { type: "mrkdwn", text: $text },
+                  accessory: {
+                    type: "button",
+                    text: { type: "plain_text", text: "View job run" },
+                    "url": "\($job.html_url)"
+                  }
+                },
+                {
+                  type: "section",
+                  fields: [
+                    { type: "mrkdwn", text: "*OS:* `\($ENV.OSTESTS_OS)`" },
+                    { type: "mrkdwn", text: "*Provider:* `\($ENV.OSTESTS_NETWORK_PROVIDER)`" },
+                    { type: "mrkdwn", text: "*Attempt:* \($job.run_attempt)" },
+                    { type: "mrkdwn", text: if $failedStep then "*Failed:* `\($failedStep.name)`" else "_All steps succeeded_" end },
+                    { type: "mrkdwn", text: "*Started:* \($job.started_at | fromdateiso8601 | gmtime | strftime("%Y-%m-%d %H:%M")) GMT" },
+                    { type: "mrkdwn", text: "*Took:* \(($job.completed_at | fromdateiso8601) - ($job.started_at | fromdateiso8601) | fmt_duration)" }
+                  ]
+                }
+              ]
+            } | "payload=" + tojson
+          ' >>"$GITHUB_OUTPUT"
+
       - name: Notify Slack
-        uses: 8398a7/action-slack@v3.18.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
-          job_name: "${{ needs.select.outputs.os }} :: ${{ needs.select.outputs.network-provider }}"
-          status: ${{ needs.e2e-tests.result }}
-          fields: workflow,commit,job,took
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: ${{ steps.prepare-slack-message.outputs.payload }}


### PR DESCRIPTION
## Description

This provides more useful feedback and gives more freedom over the layout of the message. Also, this allows for using the official Slack GitHub Action.

![success](https://github.com/user-attachments/assets/19135898-321a-4729-b152-5d582269803c)
![failure](https://github.com/user-attachments/assets/cd37b66a-e5d9-4630-821f-1b3d10b8a9a7)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
