### PR TITLE
Fix the nightly OS tests Slack notification

### DIFF
--- a/.github/workflows/ostests-nightly.yaml
+++ b/.github/workflows/ostests-nightly.yaml
@@ -120,18 +120,19 @@ jobs:
       contents: read
       actions: read
 
-    env:
-      OSTESTS_OS: ${{ needs.select.outputs.os }}
-      OSTESTS_NETWORK_PROVIDER: ${{ needs.select.outputs.network-provider }}
-
     steps:
       - name: Prepare Slack message
         id: prepare-slack-message
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_REPO: "${{ github.repository }}"
+          OSTESTS_OS: "${{ needs.select.outputs.os }}"
+          OSTESTS_NETWORK_PROVIDER: "${{ needs.select.outputs.network-provider }}"
         # A jq program that converts the job result into a Slack message.
         # Message format described here: https://api.slack.com/surfaces/messages#payloads
         # The block structure can be tested online: https://app.slack.com/block-kit-builder
         run: |
-          gh api /repos/{owner}/{repo}/actions/runs/{{ github.run_id }}/jobs -q '
+          gh api "/repos/{owner}/{repo}/actions/runs/$GITHUB_RUN_ID/jobs" -q '
             def fmt_duration:
               if . >= 3600 then "\(./3600|floor) h \((.%3600/60|floor)) min"
               elif . >= 60 then "\(./60|floor) min \(.%60) sec"

--- a/.github/workflows/ostests-nightly.yaml
+++ b/.github/workflows/ostests-nightly.yaml
@@ -159,7 +159,7 @@ jobs:
                     { type: "mrkdwn", text: "*OS:* `\($ENV.OSTESTS_OS)`" },
                     { type: "mrkdwn", text: "*Provider:* `\($ENV.OSTESTS_NETWORK_PROVIDER)`" },
                     { type: "mrkdwn", text: "*Attempt:* \($job.run_attempt)" },
-                    { type: "mrkdwn", text: if $failedStep then "*Failed:* `\($failedStep.name)`" else "_All steps succeeded_" end },
+                    { type: "mrkdwn", text: if $failedStep then "*Failed:* `\($failedStep.name)`" else "_No failed steps._" end },
                     { type: "mrkdwn", text: "*Started:* \($job.started_at | fromdateiso8601 | gmtime | strftime("%Y-%m-%d %H:%M")) GMT" },
                     { type: "mrkdwn", text: "*Took:* \(($job.completed_at | fromdateiso8601) - ($job.started_at | fromdateiso8601) | fmt_duration)" }
                   ]


### PR DESCRIPTION
## Description

The GitHub run ID substitution was missing the dollar sign. Replace it with an environment variable substitution, as the run ID is automatically available as GITHUB_RUN_ID. Add the required environment variables for the gh CLI. Without a git checkout, it won't know the owner and repo. It needs a secret, too. Move the other two environment variable declarations from the job into the step, as they're only used there.

The claim "All steps succeeded" is actually not true. "No failed steps" is a more appropriate statement. Also use a full stop at the end.

Fixes:

* #6068

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
