### PR TITLE
One graceful termination request per orphaned process

### DIFF
--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -284,8 +284,8 @@ const exitCheckInterval = 200 * time.Millisecond
 // s.TimeoutStop, the process is forcibly terminated.
 func (s *Supervisor) killProcess(ph procHandle) error {
 	// Kill the process pid
-	deadlineTicker := time.NewTicker(s.TimeoutStop)
-	defer deadlineTicker.Stop()
+	deadlineTimer := time.NewTimer(s.TimeoutStop)
+	defer deadlineTimer.Stop()
 	checkTicker := time.NewTicker(exitCheckInterval)
 	defer checkTicker.Stop()
 
@@ -307,7 +307,7 @@ Loop:
 			} else if err != nil {
 				return fmt.Errorf("failed to terminate gracefully: %w", err)
 			}
-		case <-deadlineTicker.C:
+		case <-deadlineTimer.C:
 			break Loop
 		}
 	}


### PR DESCRIPTION
## Description

When cleaning up old processes from PID files, don't send a graceful termination request every 200 milliseconds. This may confuse programs and cause them to respond differently to subsequent requests, e.g. by interrupting their cleanup procedures. Instead, send a graceful termination request only once.

Make `deadlineTicker` a `deadlineTimer.` It should trigger only once and then exit the poll loop, so it doesn't need to be a ticker.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
