### PR TITLE
Use Go's os.Process API when cleaning up PID files

### DIFF
--- a/pkg/supervisor/prochandle.go
+++ b/pkg/supervisor/prochandle.go
@@ -25,9 +25,9 @@ type procHandle interface {
 	// Reads and returns the process's environment.
 	environ() ([]string, error)
 
-	// Terminates the process gracefully.
-	terminateGracefully() error
+	// Requests graceful process termination.
+	requestGracefulShutdown() error
 
-	// Terminates the process forcibly.
-	terminateForcibly() error
+	// Kills the process.
+	kill() error
 }

--- a/pkg/supervisor/prochandle.go
+++ b/pkg/supervisor/prochandle.go
@@ -16,9 +16,15 @@ limitations under the License.
 
 package supervisor
 
+import (
+	"io"
+)
+
 // A handle to a running process. May be used to inspect the process properties
 // and terminate it.
 type procHandle interface {
+	io.Closer
+
 	// Reads and returns the process's command line.
 	cmdline() ([]string, error)
 

--- a/pkg/supervisor/prochandle_unix.go
+++ b/pkg/supervisor/prochandle_unix.go
@@ -34,6 +34,7 @@ func newProcHandle(pid int) (procHandle, error) {
 	return unixPID(pid), nil
 }
 
+// cmdline implements [procHandle].
 func (pid unixPID) cmdline() ([]string, error) {
 	cmdline, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(int(pid)), "cmdline"))
 	if err != nil {
@@ -46,6 +47,7 @@ func (pid unixPID) cmdline() ([]string, error) {
 	return strings.Split(string(cmdline), "\x00"), nil
 }
 
+// environ implements [procHandle].
 func (pid unixPID) environ() ([]string, error) {
 	env, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(int(pid)), "environ"))
 	if err != nil {
@@ -58,10 +60,12 @@ func (pid unixPID) environ() ([]string, error) {
 	return strings.Split(string(env), "\x00"), nil
 }
 
-func (pid unixPID) terminateGracefully() error {
+// requestGracefulShutdown implements [procHandle].
+func (pid unixPID) requestGracefulShutdown() error {
 	return syscall.Kill(int(pid), syscall.SIGTERM)
 }
 
-func (pid unixPID) terminateForcibly() error {
+// kill implements [procHandle].
+func (pid unixPID) kill() error {
 	return syscall.Kill(int(pid), syscall.SIGKILL)
 }

--- a/pkg/supervisor/prochandle_windows.go
+++ b/pkg/supervisor/prochandle_windows.go
@@ -20,7 +20,7 @@ import (
 	"syscall"
 )
 
-// newProcHandle is not implemented on Windows.
-func newProcHandle(int) (procHandle, error) {
+// openPID is not implemented on Windows.
+func openPID(int) (procHandle, error) {
 	return nil, syscall.EWINDOWS
 }

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -281,26 +281,26 @@ func (s *Supervisor) maybeKillPidFile() error {
 const exitCheckInterval = 200 * time.Millisecond
 
 // Tries to terminate a process gracefully. If it's still running after
-// s.TimeoutStop, the process is forcibly terminated.
+// s.TimeoutStop, the process is killed.
 func (s *Supervisor) killProcess(ph procHandle) error {
 	if shouldKill, err := s.shouldKillProcess(ph); err != nil || !shouldKill {
 		return err
 	}
 
-	if err := ph.terminateGracefully(); errors.Is(err, syscall.ESRCH) {
+	if err := ph.requestGracefulShutdown(); errors.Is(err, syscall.ESRCH) {
 		return nil
 	} else if err != nil {
-		return fmt.Errorf("failed to terminate gracefully: %w", err)
+		return fmt.Errorf("failed to request graceful termination: %w", err)
 	}
 
 	if terminate, err := s.waitForTermination(ph); err != nil || !terminate {
 		return err
 	}
 
-	if err := ph.terminateForcibly(); errors.Is(err, syscall.ESRCH) {
+	if err := ph.kill(); errors.Is(err, syscall.ESRCH) {
 		return nil
 	} else if err != nil {
-		return fmt.Errorf("failed to terminate forcibly: %w", err)
+		return fmt.Errorf("failed to kill: %w", err)
 	}
 
 	return nil

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -266,10 +266,11 @@ func (s *Supervisor) maybeKillPidFile() error {
 		return fmt.Errorf("failed to parse PID file %s: %w", s.PidFile, err)
 	}
 
-	ph, err := newProcHandle(p)
+	ph, err := openPID(p)
 	if err != nil {
 		return fmt.Errorf("cannot interact with PID %d from PID file %s: %w", p, s.PidFile, err)
 	}
+	defer ph.Close()
 
 	if err := s.killProcess(ph); err != nil {
 		return fmt.Errorf("failed to kill PID %d from PID file %s: %w", p, s.PidFile, err)


### PR DESCRIPTION
## Description

In recent Go versions, Go's process API gained the ability to open processes using pidfds on kernels that support it. Support was added in Linux 5.3. This addresses a possible race condition that may occur if the kernel reuses recycled PIDs. Keeping an open file descriptor guarantees that the PID won't be recycled. This ensures that the signal is sent to the intended process and not to another process that was assigned the same recycled PID. On older kernels, it simply falls back to the old, racy implementation that uses PIDs.

Rename some `procHandle` methods:

* `newProcHandle` -> `openPID`  
  Indicates that the handle needs to be closed now.
* `terminateGracefully` -> `requestGracefulTermination`  
  This reflects better the fact that this is an asynchronous method, i.e. it won't block until the process actually terminated.
* `terminateForcefully` -> `kill`
 
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
