### PR TITLE
Use Ctrl+Break events to shutdown supervised Windows processes

### DIFF
--- a/pkg/supervisor/detachattr_windows.go
+++ b/pkg/supervisor/detachattr_windows.go
@@ -18,8 +18,11 @@ package supervisor
 
 import "syscall"
 
-// DetachAttr creates the proper syscall attributes to run the managed processes
-// on windows it doesn't use any arguments but just to keep signature similar
+// Creates the proper syscall attributes to run the managed processes. Puts
+// processes into their own process group, so that Ctrl+Break events will only
+// affect the spawned processes, but not k0s itself.
 func DetachAttr(int, int) *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{}
+	return &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
 }

--- a/pkg/supervisor/prochandle_unix.go
+++ b/pkg/supervisor/prochandle_unix.go
@@ -83,3 +83,11 @@ func (p *unixProcess) requestGracefulShutdown() error {
 func (p *unixProcess) kill() error {
 	return p.process.Kill()
 }
+
+func requestGracefulShutdown(p *os.Process) error {
+	if err := p.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("failed to send SIGTERM: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/supervisor/prochandle_windows.go
+++ b/pkg/supervisor/prochandle_windows.go
@@ -24,3 +24,22 @@ import (
 func openPID(int) (procHandle, error) {
 	return nil, syscall.EWINDOWS
 }
+
+func requestGracefulShutdown(p *os.Process) error {
+	// Graceful shutdown not implemented on Windows. This requires attaching to
+	// the target process's console and generating a CTRL+BREAK (or CTRL+C)
+	// event. Since a process can only be attached to a single console at a
+	// time, this would require k0s to detach from its own console, which is
+	// definitely not something that k0s wants to do. There might be ways to do
+	// this by generating the event via a separate helper process, but that's
+	// left open here as a TODO.
+	// https://learn.microsoft.com/en-us/windows/console/freeconsole
+	// https://learn.microsoft.com/en-us/windows/console/attachconsole
+	// https://learn.microsoft.com/en-us/windows/console/generateconsolectrlevent
+	// https://learn.microsoft.com/en-us/windows/console/ctrl-c-and-ctrl-break-signals
+	if err := p.Kill(); err != nil {
+		return fmt.Errorf("failed to kill process: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description

Enables graceful shutdown of supervised Windows processes. Before that, they were simply killed.

According to <https://stackoverflow.com/q/1798771/>, the _only_ somewhat straight-forward option for sending a shutdown request is to send Ctrl+Break events to processes which have been started with the CREATE_NEW_PROCESS_GROUP flag. Sending Ctrl+C seems to require at least some helper process. If Ctrl+Break will _actually_ trigger a graceful process shutdown is dependent of the program being run. According to the above Stack Overflow question, this is e.g. not the case for Python.

Luckily, the Go runtime translates Ctrl+Break events into `os.Interrupt` signals, and all of k0s's supervised executables are Go programs, so this mostly fine.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
