### PR TITLE
[release-1.32] Verify airgap bundle integrity in bundler script

### DIFF
--- a/.github/workflows/build-airgap-image-bundle.yml
+++ b/.github/workflows/build-airgap-image-bundle.yml
@@ -61,8 +61,9 @@ jobs:
           mkdir -p "embedded-bins/staging/$TARGET_OS/bin"
           make --touch airgap-images.txt
           make "airgap-image-bundle-$TARGET_OS-$TARGET_ARCH.tar"
-          tar tf "airgap-image-bundle-$TARGET_OS-$TARGET_ARCH.tar" >/dev/null
           sha256sum "airgap-image-bundle-$TARGET_OS-$TARGET_ARCH.tar"
+          stat "airgap-image-bundle-$TARGET_OS-$TARGET_ARCH.tar"
+          tar tf "airgap-image-bundle-$TARGET_OS-$TARGET_ARCH.tar" >/dev/null
 
       - name: "Upload :: Airgap image bundle"
         uses: actions/upload-artifact@v4

--- a/hack/image-bundler/Dockerfile
+++ b/hack/image-bundler/Dockerfile
@@ -1,6 +1,6 @@
 ARG ALPINE_VERSION
 FROM docker.io/library/alpine:$ALPINE_VERSION
 
-RUN apk add --no-cache containerd containerd-ctr
+RUN apk add --no-cache tar containerd containerd-ctr
 COPY bundler.sh /
 CMD /bundler.sh

--- a/hack/image-bundler/bundler.sh
+++ b/hack/image-bundler/bundler.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
+#shellcheck shell=ash
 
-set -eu
+set -euo pipefail
 
 containerd </dev/null >&2 &
 #shellcheck disable=SC2064
@@ -32,6 +33,12 @@ done
   exit 1
 }
 
+out="${TMPDIR-/tmp}/bundle.tar"
 echo Exporting images ... >&2
-ctr images export --platform "$TARGET_PLATFORM" -- - "$@"
+set +x
+ctr images export --platform "$TARGET_PLATFORM" -- - "$@" >"$out"
+sha256sum -- "$out" >&2
+stat -- "$out" >&2
+tar tf "$out" >/dev/null
+cat -- "$out"
 echo Images exported. >&2


### PR DESCRIPTION
## Description

Airgap image bundle files are sometimes truncated. A previous assessment attributed this to stdout buffers in Docker not being flushed properly when the container shuts down. The initial fix was to add a 5-second delay after `ctr` completes. However, this appears to be the wrong solution, or at least an incomplete one. Even with a 30-second delay, the bundle can still be truncated.

Add an image bundle verification step directly in the bundler script itself, so that the resulting files inside the Docker container and on the GitHub runner can be compared.

Surprisingly, this check appears to resolve the truncation issue as a side effect. I have no idea why that is.

See:

* #5472

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
