### PR TITLE
Let Renovate Bot update container image tags

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -95,6 +95,27 @@
     },
     {
       "customType": "regex",
+      "description": "Update container image tags in non-Dockerfiles",
+      "managerFilePatterns": [
+        "**/*.go",
+        "**/*.md",
+        "**/*.patch",
+        "**/*.py",
+        "**/*.sh",
+        "**/*.tf",
+        "**/*.tftpl",
+        "**/*.txt",
+        "**/*.yaml",
+        "**/*.yml"
+      ],
+      "matchStrings": [
+        "\\b(?<depName>(docker|quay)\\.io/[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*)(:|.*\n.*= \")v?(?<currentValue>[a-z0-9_][\\w.-]{0,127})"
+      ],
+      "datasourceTemplate": "docker",
+      "extractVersionTemplate": "^v?(?<version>[\\w][\\w.-]{0,127})"
+    },
+    {
+      "customType": "regex",
       "description": "Update etcd version in embedded-bins/Makefile.variables",
       "managerFilePatterns": [
         "embedded-bins/Makefile.variables"


### PR DESCRIPTION
## Description

This applies specifically to non-Dockerfiles that contain a versioned reference to a container image.

Supports only fully qualified references from Docker Hub and Quay.io. The regular expressions for image names and versions are taken from docker/distribution. The special delimiter `(:|.*\n.*=")` also allows for updating container image versions in constant.go.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
