### PR TITLE
More generic renovate updates via comments

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -35,10 +35,10 @@ jobs:
 
       - name: Setup Mergiraf
         env:
-          MERGIRAF_VERSION: v0.12.1 # renovate: datasource=gitea-releases registryUrl=https://codeberg.org depName=mergiraf/mergiraf
+          MERGIRAF_VERSION: 0.12.1 # renovate: datasource=gitea-releases registryUrl=https://codeberg.org depName=mergiraf/mergiraf
         run: |
           mkdir .git/mergiraf
-          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo .git/mergiraf/mergiraf.tar.gz "https://codeberg.org/mergiraf/mergiraf/releases/download/$MERGIRAF_VERSION/mergiraf_x86_64-unknown-linux-musl.tar.gz"
+          curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -sSLfo .git/mergiraf/mergiraf.tar.gz "https://codeberg.org/mergiraf/mergiraf/releases/download/v$MERGIRAF_VERSION/mergiraf_x86_64-unknown-linux-musl.tar.gz"
           tar xvf .git/mergiraf/mergiraf.tar.gz -C .git/mergiraf
           .git/mergiraf/mergiraf --version
           .git/mergiraf/mergiraf languages --gitattributes >.git/info/attributes

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
-      TOFU_VERSION: 1.9.0
+      TOFU_VERSION: 1.9.0 # renovate: datasource=github-releases depName=opentofu/opentofu
 
     defaults:
       run:

--- a/.github/workflows/prepare-build-env.sh
+++ b/.github/workflows/prepare-build-env.sh
@@ -5,11 +5,13 @@ set -eu
 goVersion="$(./vars.sh go_version)"
 k0sctlVersion="$(./vars.sh FROM=hack/tool k0sctl_version)"
 golangciLintVersion="$(./vars.sh FROM=hack/tools golangci-lint_version)"
+cosignVersion="$(./vars.sh FROM=hack/tools cosign_version)"
 pythonVersion="$(./vars.sh FROM=docs python_version)"
 
 cat <<EOF >>"$GITHUB_ENV"
 GO_VERSION=$goVersion
 GOLANGCI_LINT_VERSION=$golangciLintVersion
+COSIGN_VERSION=$cosignVersion
 K0SCTL_VERSION=$k0sctlVersion
 PYTHON_VERSION=$pythonVersion
 EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
-          curl $CURL_OPTS --output cosign https://github.com/sigstore/cosign/releases/download/v2.4.2/cosign-linux-amd64
+          curl $CURL_OPTS --output cosign https://github.com/sigstore/cosign/releases/download/v$COSIGN_VERSION/cosign-linux-amd64
           chmod +x ./cosign
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload -y --output-file=k0s.sig k0s
           cat k0s.sig
@@ -184,6 +184,9 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
+      - name: Prepare build environment
+        run: .github/workflows/prepare-build-env.sh
+
       - name: Build
         run: make EMBEDDED_BINS_BUILDMODE=docker k0s.exe
         env:
@@ -194,7 +197,7 @@ jobs:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
-          curl $CURL_OPTS --output cosign https://github.com/sigstore/cosign/releases/download/v2.4.2/cosign-linux-amd64
+          curl $CURL_OPTS --output cosign https://github.com/sigstore/cosign/releases/download/v$COSIGN_VERSION/cosign-linux-amd64
           chmod +x ./cosign
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload -y --output-file=k0s.exe.sig k0s.exe
           cat k0s.exe.sig
@@ -261,7 +264,7 @@ jobs:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
-          curl $CURL_OPTS --output cosign https://github.com/sigstore/cosign/releases/download/v2.4.2/cosign-linux-arm64
+          curl $CURL_OPTS --output cosign https://github.com/sigstore/cosign/releases/download/v$COSIGN_VERSION/cosign-linux-arm64
           chmod +x ./cosign
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload -y --output-file=k0s.sig k0s
           cat k0s.sig
@@ -347,7 +350,7 @@ jobs:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
-          curl $CURL_OPTS --output cosign https://github.com/sigstore/cosign/releases/download/v2.4.2/cosign-linux-arm
+          curl $CURL_OPTS --output cosign https://github.com/sigstore/cosign/releases/download/v$COSIGN_VERSION/cosign-linux-arm
           chmod +x ./cosign
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob --key env://COSIGN_KEY --tlog-upload -y --output-file=k0s.sig k0s
           cat k0s.sig

--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ sign-sbom: sbom/spdx.json
 	  -v "$(CURDIR):/k0s" \
 	  -v "$(CURDIR)/sbom:/out" \
 	  -e COSIGN_PASSWORD="$(COSIGN_PASSWORD)" \
-	  ghcr.io/sigstore/cosign/cosign:v2.4.2 \
+	  ghcr.io/sigstore/cosign/cosign:v$(cosign_version) \
 	  sign-blob \
 	  --key /k0s/cosign.key \
 	  --tlog-upload=false \
@@ -337,6 +337,6 @@ sign-pub-key:
 	  -v "$(CURDIR):/k0s" \
 	  -v "$(CURDIR)/sbom:/out" \
 	  -e COSIGN_PASSWORD="$(COSIGN_PASSWORD)" \
-	  ghcr.io/sigstore/cosign/cosign:v2.4.2 \
+	  ghcr.io/sigstore/cosign/cosign:v$(cosign_version) \
 	  public-key \
 	  --key /k0s/cosign.key --output-file /out/cosign.pub

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ lint-copyright:
 .PHONY: lint-go
 lint-go: GOLANGCI_LINT_FLAGS ?=
 lint-go: $(GO_ENV_REQUISITES) go.sum bindata
-	CGO_ENABLED=0 $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(golangci-lint_version)
+	CGO_ENABLED=0 $(GO) install github.com/golangci/golangci-lint/v$(word 1,$(subst ., ,$(golangci-lint_version)))/cmd/golangci-lint@v$(golangci-lint_version)
 	CGO_CFLAGS='$(BUILD_CGO_CFLAGS)' $(GO_ENV) golangci-lint run --verbose --build-tags=$(subst $(space),$(comma),$(BUILD_GO_TAGS)) $(GOLANGCI_LINT_FLAGS) $(GO_LINT_DIRS)
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ $(controller_gen_targets): $(GO_ENV_REQUISITES) hack/tools/boilerplate.go.txt ha
 	rm -rf 'static/_crds/$(dir $(@:pkg/apis/%/.controller-gen.stamp=%))'
 	gendir="$$(mktemp -d .controller-gen.tmp.XXXXXX)" \
 	  && trap "rm -rf -- $$gendir" INT EXIT \
-	  && CGO_ENABLED=0 $(GO) run sigs.k8s.io/controller-tools/cmd/controller-gen@v$(controller-gen_version) \
+	  && CGO_ENABLED=0 $(GO) run sigs.k8s.io/controller-tools/cmd/controller-gen@v$(controller-tools_version) \
 	    paths="./$(dir $@)..." \
 	    object:headerFile=hack/tools/boilerplate.go.txt output:object:dir="$$gendir" \
 	    crd output:crd:dir='static/_crds/$(dir $(@:pkg/apis/%/.controller-gen.stamp=%))' \

--- a/docs/Makefile.variables
+++ b/docs/Makefile.variables
@@ -1,1 +1,2 @@
+# renovate: datasource=python-version depName=python versioning=python
 python_version = 3.13.5

--- a/docs/cplb.md
+++ b/docs/cplb.md
@@ -484,7 +484,7 @@ can be filtered with `component=keepalived`.
 controller0:/# journalctl -u k0scontroller | grep component=keepalived
 time="2024-11-19 12:56:11" level=info msg="Starting to supervise" component=keepalived
 time="2024-11-19 12:56:11" level=info msg="Started successfully, go nuts pid 409" component=keepalived
-time="2024-11-19 12:56:11" level=info msg="Tue Nov 19 12:56:11 2024: Starting Keepalived v2.2.8 (04/04,2023), git commit v2.2.7-154-g292b299e+" component=keepalived stream=stderr
+time="2024-11-19 12:56:11" level=info msg="Tue Nov 19 12:56:11 2024: Starting Keepalived v{{{ build_var('keepalived_version') }}}" component=keepalived stream=stderr
 [...]
 ```
 

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,8 +1,10 @@
+# renovate: datasource=docker depName=docker.io/library/alpine versioning=docker
 alpine_patch_version = 3.22.1
 alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
 go_version = 1.24.5
 
+# renovate: datasource=github-releases depName=opencontainers/runc
 runc_version = 1.2.6
 runc_buildimage = $(golang_buildimage)
 runc_build_go_tags = "seccomp"
@@ -43,6 +45,7 @@ kine_build_go_cgo_cflags = -DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1
 kine_build_go_ldflags = "-w -s"
 kine_build_go_ldflags_extra = "-extldflags=-static"
 
+# renovate: datasource=github-releases depName=etcd-io/etcd
 etcd_version = 3.6.2
 etcd_buildimage = $(golang_buildimage)
 #etcd_build_go_tags =
@@ -52,8 +55,9 @@ etcd_build_go_cgo_enabled = 0
 etcd_build_go_ldflags = "-w -s"
 #etcd_build_go_ldflags_extra =
 
-konnectivity_buildimage = $(golang_buildimage)
+# renovate: datasource=github-tags depName=kubernetes-sigs/apiserver-network-proxy
 konnectivity_version = 0.32.0
+konnectivity_buildimage = $(golang_buildimage)
 #konnectivity_build_go_tags =
 konnectivity_build_go_cgo_enabled = 0
 #konnectivity_build_go_cgo_cflags =
@@ -64,6 +68,7 @@ konnectivity_build_go_ldflags_extra = "-extldflags=-static"
 iptables_version = 1.8.11
 iptables_buildimage = docker.io/library/alpine:$(alpine_patch_version)
 
+# renovate: datasource=github-releases depName=acassen/keepalived
 keepalived_version = 2.2.8
 keepalived_buildimage = docker.io/library/alpine:$(alpine_patch_version)
 

--- a/hack/tools/Makefile.variables
+++ b/hack/tools/Makefile.variables
@@ -1,2 +1,3 @@
 controller-tools_version = 0.17.1
 golangci-lint_version = 2.1.1
+cosign_version = 2.4.2

--- a/hack/tools/Makefile.variables
+++ b/hack/tools/Makefile.variables
@@ -1,3 +1,6 @@
+# renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
 controller-tools_version = 0.17.1
+# renovate: datasource=github-releases depName=golangci/golangci-lint
 golangci-lint_version = 2.1.1
+# renovate: datasource=github-releases depName=sigstore/cosign
 cosign_version = 2.4.2

--- a/hack/tools/Makefile.variables
+++ b/hack/tools/Makefile.variables
@@ -1,2 +1,2 @@
-controller-gen_version = 0.17.1
+controller-tools_version = 0.17.1
 golangci-lint_version = 2.1.1

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -1,4 +1,5 @@
-sonobuoy_version := 0.57.2
+# renovate: datasource=github-releases depName=vmware-tanzu/sonobuoy
+sonobuoy_version = 0.57.2
 smoketests := \
 	check-addons \
 	check-airgap \

--- a/inttest/bootloose-alpine/Dockerfile
+++ b/inttest/bootloose-alpine/Dockerfile
@@ -4,9 +4,9 @@ ARG GOLANG_IMAGE
 FROM docker.io/library/alpine:$ALPINE_VERSION
 
 ARG TARGETARCH
-ARG CRI_DOCKERD_VERSION=0.3.16
+ARG CRI_DOCKERD_VERSION=0.3.16 # renovate: datasource=github-releases depName=Mirantis/cri-dockerd
 ARG ETCD_VERSION
-ARG TROUBLESHOOT_VERSION=v0.115.1
+ARG TROUBLESHOOT_VERSION=0.115.1 # renovate: datasource=github-releases depName=replicatedhq/troubleshoot
 ARG HELM_VERSION
 
 # Apply our changes to the image
@@ -38,7 +38,7 @@ RUN sed -i -e 's/^\(tty[0-9]\)/# \1/' /etc/inittab
 RUN sed -i -e 's/^root:!:/root::/' /etc/shadow
 
 # Install troublbeshoot support bundle
-RUN curl --proto '=https' --tlsv1.2 -L https://github.com/replicatedhq/troubleshoot/releases/download/$TROUBLESHOOT_VERSION/support-bundle_linux_$TARGETARCH.tar.gz \
+RUN curl --proto '=https' --tlsv1.2 -L https://github.com/replicatedhq/troubleshoot/releases/download/v$TROUBLESHOOT_VERSION/support-bundle_linux_$TARGETARCH.tar.gz \
   | tar xzO support-bundle >/usr/local/bin/kubectl-supportbundle \
   && chmod +x /usr/local/bin/kubectl-supportbundle
 

--- a/renovate.json
+++ b/renovate.json
@@ -31,11 +31,7 @@
       ]
     },
     {
-      "description": "Group all etcd updates (go.mod and Makefile) into a single PR",
-      "matchManagers": [
-        "gomod",
-        "custom.regex"
-      ],
+      "description": "Group all etcd updates",
       "enabled": true,
       "matchPackageNames": [
         "go.etcd.io/etcd/**/v3",
@@ -43,6 +39,25 @@
       ],
       "groupName": "etcd dependencies",
       "groupSlug": "etcd-all"
+    },
+    {
+      "description": "Group all konnectivity updates",
+      "enabled": true,
+      "matchDepNames": [
+        "**/apiserver-network-proxy*",
+        "sigs.k8s.io/apiserver-network-proxy/*"
+      ],
+      "groupName": "konnectivity dependencies",
+      "groupSlug": "konnectivity"
+    },
+    {
+      "description": "Group all sonobuoy updates",
+      "enabled": true,
+      "matchDepNames": [
+        "**/sonobuoy"
+      ],
+      "groupName": "sonobuoy dependencies",
+      "groupSlug": "sonobuoy"
     },
     {
       "description": "Only update the main branch by default",
@@ -138,19 +153,6 @@
     },
     {
       "customType": "regex",
-      "description": "Update etcd version in embedded-bins/Makefile.variables",
-      "managerFilePatterns": [
-        "embedded-bins/Makefile.variables"
-      ],
-      "matchStrings": [
-        "etcd_version = (?<currentValue>\\d+(\\.\\d+){2})"
-      ],
-      "depNameTemplate": "etcd-io/etcd",
-      "datasourceTemplate": "github-releases",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
       "description": "Update kine versions across the codebase",
       "managerFilePatterns": [
         "/(^|/)[Mm]akefile(\\.[^/]+)?$/",
@@ -166,42 +168,20 @@
     },
     {
       "customType": "regex",
-      "description": "Update Alpine version",
+      "description": "Generic version updates based on comments",
       "managerFilePatterns": [
-        "embedded-bins/Makefile.variables"
-      ],
-      "matchStrings": [
-        "alpine_patch_version[ \\t]*=[ \\t]*(?<currentValue>\\S+)"
-      ],
-      "depNameTemplate": "docker.io/library/alpine",
-      "datasourceTemplate": "docker"
-    },
-    {
-      "customType": "regex",
-      "description": "Update Python version",
-      "managerFilePatterns": [
-        "docs/Makefile.variables"
-      ],
-      "matchStrings": [
-        "python_version[ \\t]*=[ \\t]*(?<currentValue>\\S+)"
-      ],
-      "depNameTemplate": "python",
-      "datasourceTemplate": "python-version",
-      "versioningTemplate": "python"
-    },
-    {
-      "customType": "regex",
-      "description": "Generic version updates for YAML files",
-      "managerFilePatterns": [
+        "**/Makefile*",
+        "**/Dockerfile*",
         "**/*.yaml",
         "**/*.yml"
       ],
       "matchStrings": [
-        ":[ \\t]*[\"']?(?<currentValue>\\S+?)[\"']?[ \\t]*# renovate: datasource=(?<datasource>\\S+)( registryUrl=(?<registryUrl>.+))? depName=(?<depName>\\S+)( versioning=(?<versioning>.+))?\\n"
+        "# renovate: datasource=(?<datasource>\\S+)( registryUrl=(?<registryUrl>.+))? depName=(?<depName>\\S+)( versioning=(?<versioning>.+))?\\n[^:=\\n]+[:=][ \\t]*[\"']?(?<currentValue>\\S+?)[\"']?[ \\t]*(:?#|\\n)",
+        "[=:][ \\t]*[\"']?(?<currentValue>\\S+?)[\"']?[ \\t]*# renovate: datasource=(?<datasource>\\S+)( registryUrl=(?<registryUrl>.+))? depName=(?<depName>\\S+)( versioning=(?<versioning>.+))?\\n"
       ],
       "datasourceTemplate": "{{{datasource}}}",
-      "registryUrlTemplate": "{{#if registryUrl}}{{{registryUrl}}}{{/if}}",
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "extractVersionTemplate": "^v?(?<version>.+)"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -131,7 +131,7 @@
         "**/*.yml"
       ],
       "matchStrings": [
-        "\\b(?<depName>(docker|quay)\\.io/[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*)(:|.*\n.*= \")v?(?<currentValue>[a-z0-9_][\\w.-]{0,127})"
+        "\\b(?<depName>(docker|quay)\\.io/[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*)(:|.*\\n.*= \")v?(?<currentValue>[a-z0-9_][\\w.-]{0,127})"
       ],
       "datasourceTemplate": "docker",
       "extractVersionTemplate": "^v?(?<version>[\\w][\\w.-]{0,127})"
@@ -171,7 +171,7 @@
         "embedded-bins/Makefile.variables"
       ],
       "matchStrings": [
-        "alpine_patch_version\\s*=\\s*(?<currentValue>\\S+)"
+        "alpine_patch_version[ \\t]*=[ \\t]*(?<currentValue>\\S+)"
       ],
       "depNameTemplate": "docker.io/library/alpine",
       "datasourceTemplate": "docker"
@@ -183,7 +183,7 @@
         "docs/Makefile.variables"
       ],
       "matchStrings": [
-        "python_version\\s*=\\s*(?<currentValue>\\S+)"
+        "python_version[ \\t]*=[ \\t]*(?<currentValue>\\S+)"
       ],
       "depNameTemplate": "python",
       "datasourceTemplate": "python-version",
@@ -197,7 +197,7 @@
         "**/*.yml"
       ],
       "matchStrings": [
-        ":\\s*[\"']?(?<currentValue>\\S+?)[\"']?\\s*#\\s*renovate:\\s*datasource=(?<datasource>\\S+)(\\s+registryUrl=(?<registryUrl>.+))?\\s+depName=(?<depName>\\S+)(\\s+versioning=(?<versioning>.+))?\n"
+        ":[ \\t]*[\"']?(?<currentValue>\\S+?)[\"']?[ \\t]*# renovate: datasource=(?<datasource>\\S+)( registryUrl=(?<registryUrl>.+))? depName=(?<depName>\\S+)( versioning=(?<versioning>.+))?\\n"
       ],
       "datasourceTemplate": "{{{datasource}}}",
       "registryUrlTemplate": "{{#if registryUrl}}{{{registryUrl}}}{{/if}}",


### PR DESCRIPTION
## Description

Add more file patterns for Makefiles and Dockerfiles. Add appropriate comments to the files. Allow for "prefix" comments on their own line. Makefiles will include all the spaces until the first comment sign, which is not what we want. Allow the equals sign as an additional separator, besides the colon. Remove `registryUrlTemplate`, as it should be picked up from the named group automatically. Gracefully ignore any v prefixes in versions. Remove some now superfluous special cases from the Renovate config.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
