### PR TITLE
Add a final "summarize" job to CI graph

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -432,3 +432,20 @@ jobs:
       - name: "Docker prune"
         if: always() && matrix.arch == 'arm'
         run: docker system prune --force --filter "until=$((24*7))h"
+
+  # Have a final job that "summarizes" the workflow run. Currently, it does
+  # nothing, but can be added to branch protection rules to capture the overall
+  # outcome of all the dynamic jobs.
+  summarize:
+    name: "Go build :: Summarize"
+    runs-on: ubuntu-24.04
+    needs:
+      - unittests-k0s
+      - smoketests
+      - smoketest-arm
+      - autopilot-tests
+      - generate-sbom
+
+    steps:
+      - name: Summarize
+        run: echo All jobs passed.


### PR DESCRIPTION
## Description

Have a final job that "summarizes" the workflow runs. Currently, it does nothing, but can be added to branch protection rules to capture the overall outcome of all the dynamic jobs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
