### PR TITLE
Determine inttest configs from smoke test name

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -66,33 +66,32 @@ get-conformance-results: bin/sonobuoy
 
 TIMEOUT ?= 6m
 
-check-ctr: TIMEOUT=10m
-
-# Config change smoke runs actually many cases hence a bit longer timeout
-check-configchange: TIMEOUT=8m
-
-# Backup check runs two scenarios
-check-backup: TIMEOUT=10m
+check-ap-controllerworker: K0S_UPDATE_FROM_BIN ?= ../k0s
+check-ap-controllerworker: export K0S_UPDATE_FROM_PATH ?= $(realpath $(K0S_UPDATE_FROM_BIN))
 
 # Autopilot 3x3 HA test can take a while to run
 check-ap-ha3x3: K0S_UPDATE_FROM_BIN ?= ../k0s
 check-ap-ha3x3: export K0S_UPDATE_FROM_PATH ?= $(realpath $(K0S_UPDATE_FROM_BIN))
 check-ap-ha3x3: export K0S_UPDATE_TO_VERSION ?= $(shell ../k0s version)
 
-check-ap-controllerworker: K0S_UPDATE_FROM_BIN ?= ../k0s
-check-ap-controllerworker: export K0S_UPDATE_FROM_PATH ?= $(realpath $(K0S_UPDATE_FROM_BIN))
-
-check-kubeletcertrotate: TIMEOUT=15m
-
 check-ap-updater: .update-server.stamp
 check-ap-updater-periodic: .update-server.stamp
 check-ap-updater-periodic: TIMEOUT=10m
 
-check-network-conformance-kuberouter: TIMEOUT=15m
-check-network-conformance-calico: TIMEOUT=15m
+# Backup check runs two scenarios
+check-backup: TIMEOUT=10m
 
-check-network-conformance-kuberouter-nft: TIMEOUT=15m
+# Config change smoke runs actually many cases hence a bit longer timeout
+check-configchange: TIMEOUT=8m
+
+check-ctr: TIMEOUT=10m
+
+check-kubeletcertrotate: TIMEOUT=15m
+
+check-network-conformance-calico: TIMEOUT=15m
 check-network-conformance-calico-nft: TIMEOUT=15m
+check-network-conformance-kuberouter: TIMEOUT=15m
+check-network-conformance-kuberouter-nft: TIMEOUT=15m
 
 check-nllb: TIMEOUT=15m
 check-nllb-ipv6: TIMEOUT=15m

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -1,6 +1,5 @@
 ARCH := $(shell go env GOARCH)
 OS := $(shell go env GOOS)
-K0S_UPDATE_TO_VERSION ?= $(shell ../k0s version)
 
 sonobuoy_url = https://github.com/vmware-tanzu/sonobuoy/releases/download/v${sonobuoy_version}/sonobuoy_${sonobuoy_version}_$(OS)_$(ARCH).tar.gz
 
@@ -77,10 +76,11 @@ check-backup: TIMEOUT=10m
 
 # Autopilot 3x3 HA test can take a while to run
 check-ap-ha3x3: K0S_UPDATE_FROM_BIN ?= ../k0s
-check-ap-ha3x3: K0S_UPDATE_FROM_PATH ?= $(realpath $(K0S_UPDATE_FROM_BIN))
+check-ap-ha3x3: export K0S_UPDATE_FROM_PATH ?= $(realpath $(K0S_UPDATE_FROM_BIN))
+check-ap-ha3x3: export K0S_UPDATE_TO_VERSION ?= $(shell ../k0s version)
 
 check-ap-controllerworker: K0S_UPDATE_FROM_BIN ?= ../k0s
-check-ap-controllerworker: K0S_UPDATE_FROM_PATH ?= $(realpath $(K0S_UPDATE_FROM_BIN))
+check-ap-controllerworker: export K0S_UPDATE_FROM_PATH ?= $(realpath $(K0S_UPDATE_FROM_BIN))
 
 check-customports-dynamicconfig: export K0S_ENABLE_DYNAMIC_CONFIG=true
 check-customports-dynamicconfig: TEST_PACKAGE=customports
@@ -149,16 +149,10 @@ check-nllb-ipv6: TEST_PACKAGE=nllb
 .PHONY: $(smoketests)
 include Makefile.variables
 
-$(smoketests): K0S_PATH ?= $(realpath ../k0s)
-$(smoketests): K0S_IMAGES_BUNDLE ?= $(realpath ../airgap-image-bundle-linux-$(ARCH).tar)
-$(smoketests): .bootloose-alpine.stamp
+$(smoketests): export K0S_IMAGES_BUNDLE ?= $(realpath ../airgap-image-bundle-linux-$(ARCH).tar)
 $(smoketests): TEST_PACKAGE ?= $(subst check-,,$@)
-$(smoketests):
-	K0S_PATH='$(K0S_PATH)' \
-	K0S_UPDATE_FROM_PATH='$(K0S_UPDATE_FROM_PATH)' \
-	K0S_IMAGES_BUNDLE='$(K0S_IMAGES_BUNDLE)' \
-	K0S_UPDATE_TO_VERSION='$(K0S_UPDATE_TO_VERSION)' \
-	go test -count=1 -v -timeout $(TIMEOUT) github.com/k0sproject/k0s/inttest/$(TEST_PACKAGE)
+$(smoketests): .bootloose-alpine.stamp
+	K0S_INTTEST_TARGET='$(subst check-,,$@)' go test -count=1 -v -timeout $(TIMEOUT) github.com/k0sproject/k0s/inttest/$(TEST_PACKAGE)
 .PHONY: clean
 
 clean:

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -83,39 +83,29 @@ check-ap-controllerworker: K0S_UPDATE_FROM_BIN ?= ../k0s
 check-ap-controllerworker: export K0S_UPDATE_FROM_PATH ?= $(realpath $(K0S_UPDATE_FROM_BIN))
 
 check-customports-dynamicconfig: export K0S_ENABLE_DYNAMIC_CONFIG=true
-check-customports-dynamicconfig: TEST_PACKAGE=customports
 
 check-kubeletcertrotate: TIMEOUT=15m
 
 check-cplb-ipvs-ipv6: export K0S_IPV6_ONLY=yes
-check-cplb-ipvs-ipv6: TEST_PACKAGE=cplb-ipvs
 
 check-cplb-userspace-extaddr: export K0S_USE_EXTERNAL_ADDRESS=yes
-check-cplb-userspace-extaddr: TEST_PACKAGE=cplb-userspace
 
 check-cplb-userspace-ipv6: export K0S_USE_EXTERNAL_ADDRESS=yes
 check-cplb-userspace-ipv6: export K0S_IPV6_ONLY=yes
-check-cplb-userspace-ipv6: TEST_PACKAGE=cplb-userspace
 
 check-dualstack-calico: export K0S_NETWORK=calico
-check-dualstack-calico: TEST_PACKAGE=dualstack
 
 check-dualstack-calico-dynamicconfig: export K0S_ENABLE_DYNAMIC_CONFIG=true
 check-dualstack-calico-dynamicconfig: export K0S_NETWORK=calico
-check-dualstack-calico-dynamicconfig: TEST_PACKAGE=dualstack
 
 check-dualstack-kuberouter: export K0S_NETWORK=kube-router
-check-dualstack-kuberouter: TEST_PACKAGE=dualstack
 
 check-dualstack-kuberouter-dynamicconfig: export K0S_ENABLE_DYNAMIC_CONFIG=true
 check-dualstack-kuberouter-dynamicconfig: export K0S_NETWORK=kuberouter
-check-dualstack-kuberouter-dynamicconfig: TEST_PACKAGE=dualstack
 
 check-ipv6-calico: export K0S_NETWORK=calico
-check-ipv6-calico: TEST_PACKAGE=ipv6
 
 check-ipv6-kuberouter: export K0S_NETWORK=kuberouter
-check-ipv6-kuberouter: TEST_PACKAGE=ipv6
 
 check-ap-updater: .update-server.stamp
 check-ap-updater-periodic: .update-server.stamp
@@ -123,36 +113,38 @@ check-ap-updater-periodic: TIMEOUT=10m
 
 check-network-conformance-kuberouter: TIMEOUT=15m
 check-network-conformance-kuberouter: export K0S_NETWORK_CONFORMANCE_CNI=kuberouter
-check-network-conformance-kuberouter: TEST_PACKAGE=network-conformance
 check-network-conformance-calico: TIMEOUT=15m
 check-network-conformance-calico: export K0S_NETWORK_CONFORMANCE_CNI=calico
-check-network-conformance-calico: TEST_PACKAGE=network-conformance
 
 check-network-conformance-kuberouter-nft: TIMEOUT=15m
 check-network-conformance-kuberouter-nft: export K0S_NETWORK_CONFORMANCE_CNI=kuberouter
 check-network-conformance-kuberouter-nft: export K0S_NETWORK_CONFORMANCE_PROXY_MODE=nftables
-check-network-conformance-kuberouter-nft: TEST_PACKAGE=network-conformance
 check-network-conformance-calico-nft: TIMEOUT=15m
 check-network-conformance-calico-nft: export K0S_NETWORK_CONFORMANCE_CNI=calico
 check-network-conformance-calico-nft: export K0S_NETWORK_CONFORMANCE_PROXY_MODE=nftables
-check-network-conformance-calico-nft: TEST_PACKAGE=network-conformance
-
 
 check-metricsscraper-singlenode: export K0S_SINGLENODE=1
-check-metricsscraper-singlenode: TEST_PACKAGE=metricsscraper
 
 check-nllb: TIMEOUT=15m
 check-nllb-ipv6: TIMEOUT=15m
 check-nllb-ipv6: export K0S_IPV6_ONLY=yes
-check-nllb-ipv6: TEST_PACKAGE=nllb
 
 .PHONY: $(smoketests)
 include Makefile.variables
 
+# Determine the inttest package automatically by finding the longest prefix of
+# the target name for which a directory exists.
+determine_inttest_package = package='$(subst check-,,$@)'; prefix=''; \
+  for part in $(subst -, ,$(@:check-%=%)); do \
+    { [ -z "$$prefix" ] && prefix="$$part"; } || prefix="$$prefix-$$part"; \
+    [ ! -d "$$prefix" ] || package="$$prefix"; \
+  done; \
+  echo "$$package"
+
 $(smoketests): export K0S_IMAGES_BUNDLE ?= $(realpath ../airgap-image-bundle-linux-$(ARCH).tar)
-$(smoketests): TEST_PACKAGE ?= $(subst check-,,$@)
+$(smoketests): K0S_INTTEST_PACKAGE ?= $(shell $(determine_inttest_package))
 $(smoketests): .bootloose-alpine.stamp
-	K0S_INTTEST_TARGET='$(subst check-,,$@)' go test -count=1 -v -timeout $(TIMEOUT) github.com/k0sproject/k0s/inttest/$(TEST_PACKAGE)
+	K0S_INTTEST_TARGET=$(subst check-,,$@) go test -count=1 -v -timeout $(TIMEOUT) github.com/k0sproject/k0s/inttest/$(K0S_INTTEST_PACKAGE)
 .PHONY: clean
 
 clean:

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -82,52 +82,20 @@ check-ap-ha3x3: export K0S_UPDATE_TO_VERSION ?= $(shell ../k0s version)
 check-ap-controllerworker: K0S_UPDATE_FROM_BIN ?= ../k0s
 check-ap-controllerworker: export K0S_UPDATE_FROM_PATH ?= $(realpath $(K0S_UPDATE_FROM_BIN))
 
-check-customports-dynamicconfig: export K0S_ENABLE_DYNAMIC_CONFIG=true
-
 check-kubeletcertrotate: TIMEOUT=15m
-
-check-cplb-ipvs-ipv6: export K0S_IPV6_ONLY=yes
-
-check-cplb-userspace-extaddr: export K0S_USE_EXTERNAL_ADDRESS=yes
-
-check-cplb-userspace-ipv6: export K0S_USE_EXTERNAL_ADDRESS=yes
-check-cplb-userspace-ipv6: export K0S_IPV6_ONLY=yes
-
-check-dualstack-calico: export K0S_NETWORK=calico
-
-check-dualstack-calico-dynamicconfig: export K0S_ENABLE_DYNAMIC_CONFIG=true
-check-dualstack-calico-dynamicconfig: export K0S_NETWORK=calico
-
-check-dualstack-kuberouter: export K0S_NETWORK=kube-router
-
-check-dualstack-kuberouter-dynamicconfig: export K0S_ENABLE_DYNAMIC_CONFIG=true
-check-dualstack-kuberouter-dynamicconfig: export K0S_NETWORK=kuberouter
-
-check-ipv6-calico: export K0S_NETWORK=calico
-
-check-ipv6-kuberouter: export K0S_NETWORK=kuberouter
 
 check-ap-updater: .update-server.stamp
 check-ap-updater-periodic: .update-server.stamp
 check-ap-updater-periodic: TIMEOUT=10m
 
 check-network-conformance-kuberouter: TIMEOUT=15m
-check-network-conformance-kuberouter: export K0S_NETWORK_CONFORMANCE_CNI=kuberouter
 check-network-conformance-calico: TIMEOUT=15m
-check-network-conformance-calico: export K0S_NETWORK_CONFORMANCE_CNI=calico
 
 check-network-conformance-kuberouter-nft: TIMEOUT=15m
-check-network-conformance-kuberouter-nft: export K0S_NETWORK_CONFORMANCE_CNI=kuberouter
-check-network-conformance-kuberouter-nft: export K0S_NETWORK_CONFORMANCE_PROXY_MODE=nftables
 check-network-conformance-calico-nft: TIMEOUT=15m
-check-network-conformance-calico-nft: export K0S_NETWORK_CONFORMANCE_CNI=calico
-check-network-conformance-calico-nft: export K0S_NETWORK_CONFORMANCE_PROXY_MODE=nftables
-
-check-metricsscraper-singlenode: export K0S_SINGLENODE=1
 
 check-nllb: TIMEOUT=15m
 check-nllb-ipv6: TIMEOUT=15m
-check-nllb-ipv6: export K0S_IPV6_ONLY=yes
 
 .PHONY: $(smoketests)
 include Makefile.variables

--- a/inttest/common/bootloosesuite.go
+++ b/inttest/common/bootloosesuite.go
@@ -1548,17 +1548,25 @@ func (s *BootlooseSuite) maybeAddBinPath(volumes []config.Volume) ([]config.Volu
 		return volumes, nil
 	}
 
-	binPath := os.Getenv("K0S_PATH")
-	if binPath == "" {
-		return nil, errors.New("failed to locate k0s binary: K0S_PATH environment variable not set")
+	exePathErrMsg := "failed to locate k0s executable"
+	exePath, binPathSet := os.LookupEnv("K0S_PATH")
+	if !binPathSet {
+		exePathErrMsg += ": K0S_PATH environment variable not set"
+		// Assume that inttests are called from the inttest/<test-name> folder,
+		// hence the k0s executable is supposedly located at ../../k0s.
+		var err error
+		exePath, err = filepath.Abs(filepath.Join("..", "..", "k0s"))
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", exePathErrMsg, err)
+		}
 	}
 
-	fileInfo, err := os.Stat(binPath)
+	fileInfo, err := os.Stat(exePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to locate k0s binary %s: %w", binPath, err)
+		return nil, fmt.Errorf("%s: %w", exePathErrMsg, err)
 	}
 	if fileInfo.IsDir() {
-		return nil, fmt.Errorf("failed to locate k0s binary %s: is a directory", binPath)
+		return nil, fmt.Errorf("%s: is a directory: %q", exePathErrMsg, exePath)
 	}
 
 	updateFromBinPath := os.Getenv("K0S_UPDATE_FROM_PATH")
@@ -1570,14 +1578,14 @@ func (s *BootlooseSuite) maybeAddBinPath(volumes []config.Volume) ([]config.Volu
 			ReadOnly:    true,
 		}, config.Volume{
 			Type:        "bind",
-			Source:      binPath,
+			Source:      exePath,
 			Destination: k0sNewBindMountFullPath,
 			ReadOnly:    true,
 		})
 	} else {
 		volumes = append(volumes, config.Volume{
 			Type:        "bind",
-			Source:      binPath,
+			Source:      exePath,
 			Destination: k0sBindMountFullPath,
 			ReadOnly:    true,
 		})

--- a/inttest/cplb-ipvs/cplbipvs_test.go
+++ b/inttest/cplb-ipvs/cplbipvs_test.go
@@ -235,14 +235,15 @@ func (s *cplbIPVSSuite) hasVIP(ctx context.Context, node string, vip string) boo
 // virtual IP is working by joining a node to the cluster using the VIP.
 func TestCPLBIPVSSuite(t *testing.T) {
 	s := &cplbIPVSSuite{
-		common.BootlooseSuite{
+		BootlooseSuite: common.BootlooseSuite{
 			ControllerCount: 3,
 			WorkerCount:     1,
 		},
-		os.Getenv("K0S_IPV6_ONLY") == "yes",
 	}
 
-	if s.isIPv6Only {
+	if strings.Contains(os.Getenv("K0S_INTTEST_TARGET"), "ipv6") {
+		t.Log("Configuring IPv6 only networking")
+		s.isIPv6Only = true
 		s.Networks = []string{"bridge-ipv6"}
 		s.AirgapImageBundleMountPoints = []string{"/var/lib/k0s/images/bundle-ipv6.tar"}
 	}

--- a/inttest/customports/customports_test.go
+++ b/inttest/customports/customports_test.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/k0sproject/k0s/inttest/common"
@@ -103,7 +104,7 @@ func (s *customPortsSuite) TestControllerJoinsWithCustomPort() {
 	s.PutFile("controller2", "/tmp/k0s.yaml", config)
 
 	controllerArgs := []string{"--config=/tmp/k0s.yaml"}
-	if os.Getenv("K0S_ENABLE_DYNAMIC_CONFIG") == "true" {
+	if strings.Contains(os.Getenv("K0S_INTTEST_TARGET"), "dynamicconfig") {
 		s.T().Log("Enabling dynamic config for controllers")
 		controllerArgs = append(controllerArgs, "--enable-dynamic-config")
 	}

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -96,9 +96,11 @@ func (s *DualstackSuite) SetupSuite() {
 	s.Require().True(isDockerIPv6Enabled, "Please enable IPv6 in docker before running this test")
 	s.BootlooseSuite.SetupSuite()
 
+	target := os.Getenv("K0S_INTTEST_TARGET")
+
 	k0sConfig := k0sConfigWithCalicoDualStack
 
-	if os.Getenv("K0S_NETWORK") == "kube-router" {
+	if strings.Contains(target, "kuberouter") {
 		s.T().Log("Using kube-router network")
 		ipv6Address := s.getIPv6Address(s.ControllerNode(0))
 		k0sConfig = fmt.Sprintf(k0sConfigWithKuberouterDualStack, ipv6Address)
@@ -106,7 +108,7 @@ func (s *DualstackSuite) SetupSuite() {
 	}
 	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfig)
 	controllerArgs := []string{"--config=/tmp/k0s.yaml"}
-	if os.Getenv("K0S_ENABLE_DYNAMIC_CONFIG") == "true" {
+	if strings.Contains(os.Getenv("K0S_INTTEST_TARGET"), "dynamicconfig") {
 		s.T().Log("Enabling dynamic config for controller")
 		controllerArgs = append(controllerArgs, "--enable-dynamic-config")
 	}

--- a/inttest/ipv6/ipv6_test.go
+++ b/inttest/ipv6/ipv6_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/k0sproject/k0s/inttest/common"
@@ -68,7 +69,7 @@ func (s *IPv6Suite) TestK0sGetsUp() {
 
 	var k0sConfig, cniDS string
 
-	if os.Getenv("K0S_NETWORK") == "kube-router" {
+	if strings.Contains(os.Getenv("K0S_INTTEST_TARGET"), "kuberouter") {
 		s.T().Log("Using kube-router network")
 		k0sConfig = fmt.Sprintf(k0sConfigWithKuberouter, common.FirstPublicIPv6Address(&s.BootlooseSuite, s.ControllerNode(0), ""))
 		cniDS = "kube-router"

--- a/inttest/metricsscraper/metricsscraper_test.go
+++ b/inttest/metricsscraper/metricsscraper_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"os"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,7 +39,7 @@ type MetricsScraperSuite struct {
 func (s *MetricsScraperSuite) TestK0sGetsUp() {
 	flags := []string{"--enable-metrics-scraper"}
 	expectedJobs := []string{"kube-controller-manager", "kube-scheduler"}
-	if _, singleNode := os.LookupEnv("K0S_SINGLENODE"); singleNode {
+	if strings.Contains(os.Getenv("K0S_INTTEST_TARGET"), "singlenode") {
 		flags = append(flags, "--single")
 		expectedJobs = append(expectedJobs, "kine")
 	} else {

--- a/inttest/nllb/nllb_test.go
+++ b/inttest/nllb/nllb_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -350,13 +351,15 @@ nameserver 2001:4860:4860::8888
 
 func TestNodeLocalLoadBalancingSuite(t *testing.T) {
 	s := suite{
-		common.BootlooseSuite{
+		BootlooseSuite: common.BootlooseSuite{
 			ControllerCount: 3,
 			WorkerCount:     2,
 		},
-		os.Getenv("K0S_IPV6_ONLY") == "yes",
 	}
-	if s.isIPv6Only {
+
+	if strings.Contains(os.Getenv("K0S_INTTEST_TARGET"), "ipv6") {
+		t.Log("Configuring IPv6 only networking")
+		s.isIPv6Only = true
 		s.Networks = []string{"bridge-ipv6"}
 		s.AirgapImageBundleMountPoints = []string{"/var/lib/k0s/images/bundle-ipv6.tar"}
 	}


### PR DESCRIPTION
## Description

Instead of manually exporting the required environment variables in the Go test invocation, export the Make variables directly. This makes the command line easier to read. As an exception to this rule, introduce the new variable `K0S_INTTEST_TARGET` via the command line to make it clear which target is being executed. This allows for removing a lot of config switches from the Makefile.

Deduce `K0S_PATH` from the current directory if it is not set. This eliminates the need to define `K0S_PATH` in every case and relies on the fact that the inttests are always executed with the working directory set to their source directory.

Move the `K0S_UPDATE_TO_VERSION` definition to the ap-ha3x3 inttest, which is the only one that needs it.

If not specified explicitly, the inttest package to be executed will be determined by the longest prefix of the target name for which a directory exists.

Sort the inttest targets alphabetically.
 
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
