### PR TITLE
Replace deprecated endpoint API calls for EndpointSlices 

### DIFF
--- a/pkg/component/controller/apiendpointreconciler.go
+++ b/pkg/component/controller/apiendpointreconciler.go
@@ -160,8 +160,8 @@ func (a *APIEndpointReconciler) reconcileEndpoints(ctx context.Context) error {
 func (a *APIEndpointReconciler) createEndpoint(ctx context.Context, ipAddresses []string) error {
 	ep := &discoveryv1.EndpointSlice{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "Endpoints",
-			APIVersion: "v1",
+			Kind:       "EndpointSlice",
+			APIVersion: "discovery.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "kubernetes",

--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -397,13 +397,14 @@ func extractAPIServerAddresses(es *discoveryv1.EndpointSlice) ([]k0snet.HostPort
 
 	var ports []uint16
 	for pIdx, port := range es.Ports {
-		if port.Protocol == nil || *port.Protocol != corev1.ProtocolTCP || port.Name == nil || *port.Name != "https" {
+		if port.Protocol == nil || *port.Protocol != corev1.ProtocolTCP ||
+			port.Name == nil || *port.Name != "https" {
 			// FIXME: is a more sophisticated port detection required?
 			// E.g. does the service object need to be inspected?
 			continue
 		}
 		if port.Port == nil || *port.Port < 1 || *port.Port > math.MaxUint16 {
-			path := field.NewPath("subsets").Index(pIdx).Child("ports").Index(pIdx).Child("port")
+			path := field.NewPath("ports").Index(pIdx).Child("port")
 			warning := field.Invalid(path, port.Port, "out of range")
 			warnings = append(warnings, warning)
 			continue

--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
 
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -377,9 +378,9 @@ func (r *Reconciler) reconcileAPIServers(ctx context.Context, updates chan<- upd
 		return err
 	}
 
-	return watch.Endpoints(client.CoreV1().Endpoints("default")).
+	return watch.EndpointSlices(client.DiscoveryV1().EndpointSlices("default")).
 		WithObjectName("kubernetes").
-		Until(ctx, func(endpoints *corev1.Endpoints) (bool, error) {
+		Until(ctx, func(endpoints *discoveryv1.EndpointSlice) (bool, error) {
 			apiServers, err := extractAPIServerAddresses(endpoints)
 			if err != nil {
 				return false, err
@@ -389,57 +390,50 @@ func (r *Reconciler) reconcileAPIServers(ctx context.Context, updates chan<- upd
 		})
 }
 
-func extractAPIServerAddresses(endpoints *corev1.Endpoints) ([]k0snet.HostPort, error) {
+// extractAPIServerAddresses extracts the API server addresses from the given EndpointSlice.
+func extractAPIServerAddresses(es *discoveryv1.EndpointSlice) ([]k0snet.HostPort, error) {
 	var warnings []error
 	apiServers := []k0snet.HostPort{}
 
-	for sIdx, subset := range endpoints.Subsets {
-		var ports []uint16
-		for pIdx, port := range subset.Ports {
+	var ports []uint16
+	for pIdx, port := range es.Ports {
+		if port.Protocol == nil || *port.Protocol != corev1.ProtocolTCP || port.Name == nil || *port.Name != "https" {
 			// FIXME: is a more sophisticated port detection required?
 			// E.g. does the service object need to be inspected?
-			if port.Protocol != corev1.ProtocolTCP || port.Name != "https" {
-				continue
-			}
-
-			if port.Port < 0 || port.Port > math.MaxUint16 {
-				path := field.NewPath("subsets").Index(sIdx).Child("ports").Index(pIdx).Child("port")
-				warning := field.Invalid(path, port.Port, "out of range")
-				warnings = append(warnings, warning)
-				continue
-			}
-
-			ports = append(ports, uint16(port.Port))
+			continue
 		}
+		if port.Port == nil || *port.Port < 1 || *port.Port > math.MaxUint16 {
+			path := field.NewPath("subsets").Index(pIdx).Child("ports").Index(pIdx).Child("port")
+			warning := field.Invalid(path, port.Port, "out of range")
+			warnings = append(warnings, warning)
+			continue
+		}
+		ports = append(ports, uint16(*port.Port))
+	}
 
-		if len(ports) < 1 {
-			path := field.NewPath("subsets").Index(sIdx)
-			warning := field.Forbidden(path, "no suitable TCP/https ports found")
+	for aIdx, ep := range es.Endpoints {
+		var addr string
+		if len(ep.Addresses) >= 1 {
+			// FIXME: if there are multiple addresses per endpoint, should they all be used?
+			// Is that even possible in this specific scenario?
+			addr = ep.Addresses[0]
+		} else if ep.Hostname != nil && *ep.Hostname != "" {
+			addr = *ep.Hostname
+		} else {
+			path := field.NewPath("addresses").Index(aIdx)
+			warning := field.Forbidden(path, "neither ip nor hostname specified")
 			warnings = append(warnings, warning)
 			continue
 		}
 
-		for aIdx, address := range subset.Addresses {
-			host := address.IP
-			if host == "" {
-				host = address.Hostname
-			}
-			if host == "" {
-				path := field.NewPath("addresses").Index(aIdx)
-				warning := field.Forbidden(path, "neither ip nor hostname specified")
-				warnings = append(warnings, warning)
+		for _, port := range ports {
+			apiServer, err := k0snet.NewHostPort(addr, port)
+			if err != nil {
+				warnings = append(warnings, fmt.Errorf("%s:%d: %w", addr, port, err))
 				continue
 			}
 
-			for _, port := range ports {
-				apiServer, err := k0snet.NewHostPort(host, port)
-				if err != nil {
-					warnings = append(warnings, fmt.Errorf("%s:%d: %w", host, port, err))
-					continue
-				}
-
-				apiServers = append(apiServers, *apiServer)
-			}
+			apiServers = append(apiServers, *apiServer)
 		}
 	}
 

--- a/pkg/kubernetes/watch/core.go
+++ b/pkg/kubernetes/watch/core.go
@@ -5,6 +5,7 @@ package watch
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 )
 
 func ConfigMaps(client Provider[*corev1.ConfigMapList]) *Watcher[corev1.ConfigMap] {
@@ -13,6 +14,10 @@ func ConfigMaps(client Provider[*corev1.ConfigMapList]) *Watcher[corev1.ConfigMa
 
 func Endpoints(client Provider[*corev1.EndpointsList]) *Watcher[corev1.Endpoints] {
 	return FromClient[*corev1.EndpointsList, corev1.Endpoints](client)
+}
+
+func EndpointSlices(client Provider[*discoveryv1.EndpointSliceList]) *Watcher[discoveryv1.EndpointSlice] {
+	return FromClient[*discoveryv1.EndpointSliceList, discoveryv1.EndpointSlice](client)
 }
 
 func Nodes(client Provider[*corev1.NodeList]) *Watcher[corev1.Node] {

--- a/pkg/kubernetes/watch/core.go
+++ b/pkg/kubernetes/watch/core.go
@@ -12,10 +12,6 @@ func ConfigMaps(client Provider[*corev1.ConfigMapList]) *Watcher[corev1.ConfigMa
 	return FromClient[*corev1.ConfigMapList, corev1.ConfigMap](client)
 }
 
-func Endpoints(client Provider[*corev1.EndpointsList]) *Watcher[corev1.Endpoints] {
-	return FromClient[*corev1.EndpointsList, corev1.Endpoints](client)
-}
-
 func EndpointSlices(client Provider[*discoveryv1.EndpointSliceList]) *Watcher[discoveryv1.EndpointSlice] {
 	return FromClient[*discoveryv1.EndpointSliceList, discoveryv1.EndpointSlice](client)
 }


### PR DESCRIPTION
## Description

Kubernetes 1.33 [deprecated the endpoints API](https://kubernetes.io/blog/2025/04/24/endpoints-deprecation/). I believe this should replace all the endpoints API calls in favor of the 

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
