### PR TITLE
Use tags instead of releases when updating keepalived

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -67,7 +67,7 @@ konnectivity_build_go_ldflags_extra = "-extldflags=-static"
 iptables_version = 1.8.11
 iptables_buildimage = docker.io/library/alpine:$(alpine_patch_version)
 
-# renovate: datasource=github-releases depName=acassen/keepalived
+# renovate: datasource=github-tags depName=acassen/keepalived
 keepalived_version = 2.2.8
 keepalived_buildimage = docker.io/library/alpine:$(alpine_patch_version)
 


### PR DESCRIPTION
## Description

The keepalived project doesn't use GitHub releases at all.

Fixes:
* #6146

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
