### PR TITLE
Add unit test for konnectivity versions

### DIFF
--- a/pkg/constant/constant_test.go
+++ b/pkg/constant/constant_test.go
@@ -116,6 +116,22 @@ func TestContainerdModuleVersions(t *testing.T) {
 	)
 }
 
+func TestKonnectivityModuleVersions(t *testing.T) {
+	konnectivityVersion := getVersion(t, "konnectivity")
+
+	assertPackageModules(t,
+		func(modulePath string) bool {
+			return strings.HasPrefix(modulePath, "sigs.k8s.io/apiserver-network-proxy/")
+		},
+		func(t *testing.T, pkgPath string, module *packages.Module) bool {
+			return !assert.Equal(t, "v"+konnectivityVersion, module.Version,
+				"Module version for package %s doesn't match: %+#v",
+				pkgPath, module,
+			)
+		},
+	)
+}
+
 func getVersion(t *testing.T, component string) string {
 	cmd := exec.Command("sh", "./vars.sh", component+"_version")
 	cmd.Dir = filepath.Join("..", "..")


### PR DESCRIPTION
## Description

There has been an accidental downgrade of konnectivity in the go.mod file that caused the k0s executable to use a different version than the embedded konnectivity-server executable. Add a unit test similar to the others which ensures that the go.mod and the embedded binaries use matching versions of konnectivity.

See:

* #6153
* #6184

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
