### PR TITLE
fix: controller worker upgrades fail with load balancer

### DIFF
--- a/pkg/component/worker/utils.go
+++ b/pkg/component/worker/utils.go
@@ -8,13 +8,17 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/pkg/config"
+	"github.com/k0sproject/k0s/pkg/constant"
 
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
@@ -138,4 +142,109 @@ func writeKubeletBootstrapKubeconfig(kubeconfig clientcmdapi.Config) (string, er
 	}
 
 	return bootstrapFile.Name(), nil
+}
+
+// CreateDirectKubeletKubeconfig creates a kubelet kubeconfig that points directly to the local API
+// server instead of using NLLB. This is used on controller+worker nodes where we want kubelet to
+// connect directly to the local API server.
+func CreateDirectKubeletKubeconfig(ctx context.Context, k0sVars *config.CfgVars, nodeName apitypes.NodeName) (string, error) {
+	log := logrus.WithFields(logrus.Fields{"component": "bootstrap-kubelet", "node_name": nodeName})
+
+	nodeConfig, err := k0sVars.NodeConfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to load node config: %w", err)
+	}
+
+	apiSpec := nodeConfig.Spec.API
+
+	// Determine the local API server address
+	var localAPIServer string
+	if apiSpec.OnlyBindToAddress {
+		// API server binds only to specific address, use that address with proper IPv6 bracketing
+		localAPIServer = net.JoinHostPort(apiSpec.Address, strconv.Itoa(apiSpec.Port))
+	} else {
+		// API server binds to all interfaces, use localhost
+		// Try to resolve localhost to get the appropriate loopback address (IPv4/IPv6)
+		loopbackIP, err := getLoopbackIP(ctx)
+		if err != nil {
+			log.WithError(err).Warn("Failed to resolve localhost, falling back to 127.0.0.1")
+			loopbackIP = net.IPv4(127, 0, 0, 1)
+		}
+		localAPIServer = net.JoinHostPort(loopbackIP.String(), strconv.Itoa(apiSpec.Port))
+	}
+
+	log.Debugf("Using direct local API server URL for kubelet: %s", localAPIServer)
+
+	directKubeconfig, err := readKubeconfig(k0sVars.KubeletAuthConfigPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read kubeconfig: %w", err)
+	}
+
+	directKubeconfigPath := filepath.Join(k0sVars.RunDir, "kubelet-direct.conf")
+
+	if err := writePatchedKubeconfig(directKubeconfigPath, directKubeconfig, localAPIServer); err != nil {
+		return "", fmt.Errorf("failed to write load-balanced kubeconfig file: %w", err)
+	}
+
+	log.Debugf("Wrote direct kubeconfig file: %s", directKubeconfigPath)
+	return directKubeconfigPath, nil
+}
+
+// readKubeconfig reads a kubeconfig file and returns a clientcmdapi.Config
+func readKubeconfig(path string) (*clientcmdapi.Config, error) {
+	kubeconfig, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve non-absolute paths in case the kubeconfig gets written to another folder.
+	err = clientcmd.ResolveLocalPaths(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := clientcmdapi.MinifyConfig(kubeconfig); err != nil {
+		return nil, err
+	}
+
+	return kubeconfig, err
+}
+
+// writePatchedKubeconfig writes a kubeconfig file with the given server address
+func writePatchedKubeconfig(path string, kubeconfig *clientcmdapi.Config, server string) error {
+	kubeconfig = kubeconfig.DeepCopy()
+	if err := clientcmdapi.MinifyConfig(kubeconfig); err != nil {
+		return err
+	}
+
+	cluster := kubeconfig.Clusters[kubeconfig.Contexts[kubeconfig.CurrentContext].Cluster]
+	clusterServer, err := url.Parse(cluster.Server)
+	if err != nil {
+		return fmt.Errorf("invalid server: %w", err)
+	}
+	clusterServer.Host = server
+	cluster.Server = clusterServer.String()
+
+	bytes, err := clientcmd.Write(*kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	return file.WriteContentAtomically(path, bytes, constant.CertSecureMode)
+}
+
+// getLoopbackIP resolves localhost to get the appropriate loopback IP address (IPv4 or IPv6)
+func getLoopbackIP(ctx context.Context) (net.IP, error) {
+	localIPs, err := net.DefaultResolver.LookupIPAddr(ctx, "localhost")
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve localhost: %w", err)
+	}
+
+	for _, addr := range localIPs {
+		if addr.IP.IsLoopback() {
+			return addr.IP, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no loopback IPs found for localhost: %v", localIPs)
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #6071 

When a multi-controller controller+worker cluster with a load balancer is upgraded, the kubelet on the controller+worker that is upgraded first can get directed to any of the other controller upstreams. This violates the Kubernetes [version skew policy](https://kubernetes.io/releases/version-skew-policy/#kubelet) connecting to an upstream running the prior version. Upgrades from 1.30 to 1.31 fail due to a change in the API schema.

```
Jun 30 23:19:28 diamon-ec-3 k0s[32219]: time="2025-06-30 23:19:28" level=info msg="E0630 23:19:28.670043   32369 reflector.go:158] \"Unhandled Error\" err=\"k8s.io/client-go/informers/factory.go:160: Failed to watch *v1.Service: failed to list *v1.Service: \\\"spec.clusterIP\\\" is not a known field selector: only \\\"metadata.name\\\", \\\"metadata.namespace\\\"\" logger=\"UnhandledError\"" component=kubelet stream=stderr
```

This change overrides the API server address in the Kubelet conf to connect directly to the API server running on localhost rather than through the load balancer.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
