### PR TITLE
Enable concurrency for k0s airgap bundle-artifacts

### DIFF
--- a/cmd/airgap/bundleartifacts_test.go
+++ b/cmd/airgap/bundleartifacts_test.go
@@ -86,6 +86,7 @@ func TestBundleArtifactsCmd_WithPlatforms(t *testing.T) {
 					underTest.SetArgs([]string{
 						"--insecure-registries", insecureRegistriesFlag,
 						"--platform", platform,
+						"--concurrency", "1", // predictable output
 						ref,
 					})
 					underTest.SetIn(iotest.ErrReader(errors.New("unexpected read from standard input")))

--- a/pkg/airgap/ociartifactsbundler.go
+++ b/pkg/airgap/ociartifactsbundler.go
@@ -58,7 +58,7 @@ type OCIArtifactsBundler struct {
 	RewriteTarget         RewriteRefFunc
 }
 
-func (b *OCIArtifactsBundler) Run(ctx context.Context, refs []reference.Named, out io.Writer) error {
+func (b *OCIArtifactsBundler) Run(ctx context.Context, refs []reference.Named, concurrency int, out io.Writer) error {
 	var client *http.Client
 	if len := len(refs); len < 1 {
 		b.Log.Warn("No artifacts to bundle")
@@ -76,7 +76,7 @@ func (b *OCIArtifactsBundler) Run(ctx context.Context, refs []reference.Named, o
 
 	copyOpts := oras.CopyOptions{
 		CopyGraphOptions: oras.CopyGraphOptions{
-			Concurrency:    1, // reproducible output
+			Concurrency:    concurrency,
 			FindSuccessors: findSuccessors(b.PlatformMatcher),
 			PreCopy: func(ctx context.Context, desc imagespecv1.Descriptor) error {
 				if desc.MediaType == images.MediaTypeDockerSchema1Manifest {


### PR DESCRIPTION
## Description

Adds a flag to define the concurrency level and defaults to 3. The default value is 3 because the default value of ORAS is 3 and because after some primitive testing in my environment it seems pretty optimal:

1- Increasing the value from 1 to 2 is a massive difference. Time is reduced consistently between 60 and 80% in my environment (NVMe, wired 600mbps optical fiber connection)

2- Increasing from 2 to 3 is usually around 5-20% better, but it's not nearly as consistent

3- The difference after 3 is far too small and inconsistent to be able to tell which value is optimal without far more exhaustive and rigorous testing.

Usually in my build environment it lowers the build time from well over a minute to 13-20 seconds.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
