### PR TITLE
Make coreDNS run as nonRoot

### DIFF
--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -187,6 +187,7 @@ spec:
             - NET_BIND_SERVICE
             drop:
             - all
+          runAsNonRoot: true
           readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -75,7 +75,7 @@ const (
 	KubeProxyImage                     = "quay.io/k0sproject/kube-proxy"
 	KubeProxyImageVersion              = "v1.34.0-beta.0"
 	CoreDNSImage                       = "quay.io/k0sproject/coredns"
-	CoreDNSImageVersion                = "1.12.2"
+	CoreDNSImageVersion                = "1.12.2-1"
 	EnvoyProxyImage                    = "quay.io/k0sproject/envoy-distroless"
 	EnvoyProxyImageVersion             = "v1.34.3"
 	CalicoImage                        = "quay.io/k0sproject/calico-cni"


### PR DESCRIPTION
## Description

CoreDNS currently runs with both UID and GID 0. This commit allows it to run

The PR is currently blocked waiting for https://github.com/k0sproject/image-builder/pull/187

This is part of https://github.com/k0sproject/k0s/issues/5956 


## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
