### PR TITLE
Improve worker profile validation

### DIFF
--- a/pkg/apis/k0s/v1beta1/workerprofile.go
+++ b/pkg/apis/k0s/v1beta1/workerprofile.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
 )
 
 var _ Validateable = (*WorkerProfiles)(nil)
@@ -22,7 +23,7 @@ func (wps WorkerProfiles) Validate() []error {
 	var errors []error
 	for _, p := range wps {
 		if err := p.Validate(); err != nil {
-			errors = append(errors, err)
+			errors = append(errors, err...)
 		}
 	}
 	return errors
@@ -37,26 +38,29 @@ type WorkerProfile struct {
 	Config *runtime.RawExtension `json:"values,omitempty"`
 }
 
-var lockedFields = map[string]struct{}{
-	"clusterDNS":    {},
-	"clusterDomain": {},
-	"apiVersion":    {},
-	"kind":          {},
-	"staticPodURL":  {},
-}
-
 // Validate validates instance
-func (wp *WorkerProfile) Validate() error {
-	var parsed map[string]any
-	err := json.Unmarshal(wp.Config.Raw, &parsed)
-	if err != nil {
-		return err
-	}
+func (wp *WorkerProfile) Validate() []error {
 
-	for field := range parsed {
-		if _, found := lockedFields[field]; found {
-			return fmt.Errorf("field `%s` is prohibited to override in worker profile", field)
-		}
+	var errs []error
+
+	kubeletCfg := &kubeletv1beta1.KubeletConfiguration{}
+	if err := json.Unmarshal(wp.Config.Raw, kubeletCfg); err != nil {
+		errs = append(errs, fmt.Errorf("failed to decode worker profile %q: %w", wp.Name, err))
 	}
-	return nil
+	if kubeletCfg.ClusterDNS != nil {
+		errs = append(errs, fmt.Errorf("field `clusterDNS` is prohibited to override in worker profile %q", wp.Name))
+	}
+	if kubeletCfg.ClusterDomain != "" {
+		errs = append(errs, fmt.Errorf("field `clusterDomain` is prohibited to override in worker profile %q", wp.Name))
+	}
+	if kubeletCfg.APIVersion != "" {
+		errs = append(errs, fmt.Errorf("field `apiVersion` is prohibited to override in worker profile %q", wp.Name))
+	}
+	if kubeletCfg.Kind != "" {
+		errs = append(errs, fmt.Errorf("field `kind` is prohibited to override in worker profile %q", wp.Name))
+	}
+	if kubeletCfg.StaticPodURL != "" {
+		errs = append(errs, fmt.Errorf("field `staticPodURL` is prohibited to override in worker profile %q", wp.Name))
+	}
+	return errs
 }

--- a/pkg/apis/k0s/v1beta1/workerprofile_test.go
+++ b/pkg/apis/k0s/v1beta1/workerprofile_test.go
@@ -27,7 +27,7 @@ func TestWorkerProfile(t *testing.T) {
 			{
 				name: "Locked field clusterDNS",
 				spec: map[string]any{
-					"clusterDNS": "8.8.8.8",
+					"clusterDNS": []string{"8.8.8.8"},
 				},
 				valid: false,
 			},
@@ -55,6 +55,20 @@ func TestWorkerProfile(t *testing.T) {
 				name: "Locked field staticPodURL",
 				spec: map[string]any{
 					"staticPodURL": "foo",
+				},
+				valid: false,
+			}, {
+				name: "Valid kubelet configuration",
+				spec: map[string]any{
+					"cpuManagerPolicy": "static",
+					"cpuManagerPolicyOptions": map[string]string{
+						"full-pcpus-only": "true",
+					}},
+				valid: true,
+			}, {
+				name: "Invalid kubelet configuration",
+				spec: map[string]any{
+					"cpuManagerPolicyOptions": "full-pcpus-only=true",
 				},
 				valid: false,
 			},


### PR DESCRIPTION
## Description

An invalid worker profile that was a syntactically correct yaml would fail in an unexpected way. The validation step wouldn't throw an error and the configmaps wouldn't be created. Detect the problem early and exit early.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
