### PR TITLE
Add "idempotency" to image repository override

### DIFF
--- a/pkg/apis/k0s/v1beta1/images.go
+++ b/pkg/apis/k0s/v1beta1/images.go
@@ -231,6 +231,17 @@ func getHostName(imageName string) string {
 }
 
 func overrideRepository(repository string, originalImage string) string {
+	if repository == "" {
+		return originalImage
+	}
+
+	// "Idempotency": if the image already starts with the repository prefix, don't override
+	// This is needed sinice in some cases we run the override multiple times, e.g. when
+	// we unmarshal the config multiple times.
+	if strings.HasPrefix(originalImage, repository) {
+		return originalImage
+	}
+
 	if host := getHostName(originalImage); host != "" {
 		return strings.Replace(originalImage, host, repository, 1)
 	}

--- a/pkg/apis/k0s/v1beta1/images_test.go
+++ b/pkg/apis/k0s/v1beta1/images_test.go
@@ -106,28 +106,77 @@ func TestImagesRepoOverrideInConfiguration(t *testing.T) {
 }
 
 func TestOverrideFunction(t *testing.T) {
-	repository := "my.registry"
-	testCases := []struct {
-		Input  string
-		Output string
-	}{
-		{
-			Input:  "repo/image",
-			Output: "my.registry/repo/image",
-		},
-		{
-			Input:  "registry.com/repo/image",
-			Output: "my.registry/repo/image",
-		},
-		{
-			Input:  "image",
-			Output: "my.registry/image",
-		},
-	}
+	t.Run("overrideRepository without path", func(t *testing.T) {
+		repository := "my.registry"
+		testCases := []struct {
+			Input  string
+			Output string
+		}{
+			{
+				Input:  "repo/image",
+				Output: "my.registry/repo/image",
+			},
+			{
+				Input:  "registry.com/repo/image",
+				Output: "my.registry/repo/image",
+			},
+			{
+				Input:  "image",
+				Output: "my.registry/image",
+			},
+		}
 
-	for _, tc := range testCases {
-		assert.Equal(t, tc.Output, overrideRepository(repository, tc.Input))
-	}
+		for _, tc := range testCases {
+			assert.Equal(t, tc.Output, overrideRepository(repository, tc.Input))
+		}
+	})
+	t.Run("overrideRepository with path", func(t *testing.T) {
+		repository := "my.registry/foo"
+		testCases := []struct {
+			Input  string
+			Output string
+		}{
+			{
+				Input:  "repo/image",
+				Output: "my.registry/foo/repo/image",
+			},
+			{
+				Input:  "registry.com/repo/image",
+				Output: "my.registry/foo/repo/image",
+			},
+			{
+				Input:  "image",
+				Output: "my.registry/foo/image",
+			},
+		}
+		for _, tc := range testCases {
+			assert.Equal(t, tc.Output, overrideRepository(repository, tc.Input))
+		}
+	})
+	t.Run("overrideRepository with repo path and double invocation", func(t *testing.T) {
+		repository := "my.registry/foo"
+		testCases := []struct {
+			Input  string
+			Output string
+		}{
+			{
+				Input:  "repo/image",
+				Output: "my.registry/foo/repo/image",
+			},
+			{
+				Input:  "registry.com/repo/image",
+				Output: "my.registry/foo/repo/image",
+			},
+			{
+				Input:  "image",
+				Output: "my.registry/foo/image",
+			},
+		}
+		for _, tc := range testCases {
+			assert.Equal(t, tc.Output, overrideRepository(repository, overrideRepository(repository, tc.Input)))
+		}
+	})
+
 }
 
 func TestImageSpec_Validate(t *testing.T) {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When we use dynamic config, the given config is unmarshaled twice: once when we read the config from disk, and then store it in k8s api, and then second time when we read it from the API. Since the override is wired in the unmarshaling it'll be invoked twice for a given image. Now the second time it'll be invoked for an image that is already overridden. This results in duplicating the possible path element(s) in the override repo.

To fix this I added prefix matching to prevent overriding an image which already has the given repo prefix.

Fixes #6230

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
