### PR TITLE
Push k0s image to quay registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -480,6 +480,13 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: quay.io
+
       - name: Fetch k0s amd64
         uses: actions/download-artifact@v4
         with:
@@ -511,6 +518,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
             ghcr.io/k0sproject/k0s:${{ needs.release.outputs.image_tag }}
+            quay.io/k0sproject/k0s:${{ needs.release.outputs.image_tag }}
             docker.io/k0sproject/k0s:${{ needs.release.outputs.image_tag }}
           build-args: |
             ALPINE_VERSION=${{ env.ALPINE_PATCH_VERSION }}


### PR DESCRIPTION
## Description

Pushing k0s image to quay registry. We gonna use this image instead of k0sproject/k0s in k0smotron to avoid Docker Hub rate limits