### PR TITLE
Run network conformance tests on calico on IPv6

### DIFF
--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -69,7 +69,7 @@ jobs:
           name: airgap-image-bundle-linux-amd64
 
       - name: Download ipv6 image bundle
-        if: inputs.name == 'calico-ipv6' || inputs.name == 'kuberouter-ipv6'
+        if: inputs.name == 'calico-ipv6' || inputs.name == 'kuberouter-ipv6' || (startsWith(inputs.name, 'network-conformance-') && contains(inputs.name, '-ipv6'))
         uses: actions/download-artifact@v4
         with:
           name: ipv6-image-bundle-linux-amd64

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /airgap-image-bundle-linux-arm64.tar
 /airgap-image-bundle-linux-arm.tar
 /airgap-image-bundle-linux-riscv64.tar
+/ipv6-test-images.txt
 /ipv6-image-bundle-linux-amd64.tar
 /ipv6-image-bundle-linux-arm64.tar
 /ipv6-image-bundle-linux-arm.tar

--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,12 @@ ipv6-image-bundle-linux-riscv64.tar: embedded-bins/Makefile.variables
 		docker.io/library/nginx:1.29.0-alpine \
 		docker.io/library/alpine:$(alpine_version) \
 		docker.io/curlimages/curl:8.15.0 \
+		docker.io/sonobuoy/sonobuoy:v$(sonobuoy_version) \
+		registry.k8s.io/conformance:v$(kubernetes_version) \
+		registry.k8s.io/e2e-test-images/agnhost:2.56 \
+		registry.k8s.io/e2e-test-images/jessie-dnsutils:1.7 \
+		registry.k8s.io/e2e-test-images/nginx:1.14-4 \
+		registry.k8s.io/pause:3.10 \
 		| ./k0s airgap bundle-artifacts -v --platform='$(TARGET_PLATFORM)' -o '$@'
 
 .PHONY: $(smoketests)

--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,13 @@ airgap-image-bundle-linux-arm.tar \
 airgap-image-bundle-linux-riscv64.tar: k0s airgap-images.txt
 	./k0s airgap bundle-artifacts -v --platform='$(TARGET_PLATFORM)' -o '$@' <airgap-images.txt
 
+
+ipv6-test-images.txt: embedded-bins/Makefile.variables $(shell find hack/gen-test-images-list/ -type f)
+	$(GO) run -tags=hack hack/gen-test-images-list/cmd/main.go -o '$@' \
+		-alpine-version=$(alpine_version) \
+		-kubernetes-version=$(kubernetes_version) \
+		-sonobuoy-version=$(sonobuoy_version)
+
 ipv6-image-bundle-linux-amd64.tar:   TARGET_PLATFORM := linux/amd64
 ipv6-image-bundle-linux-arm64.tar:   TARGET_PLATFORM := linux/arm64
 ipv6-image-bundle-linux-arm.tar:     TARGET_PLATFORM := linux/arm/v7
@@ -256,7 +263,7 @@ ipv6-image-bundle-linux-riscv64.tar: TARGET_PLATFORM := linux/riscv64
 ipv6-image-bundle-linux-amd64.tar \
 ipv6-image-bundle-linux-arm64.tar \
 ipv6-image-bundle-linux-arm.tar \
-ipv6-image-bundle-linux-riscv64.tar: embedded-bins/Makefile.variables
+ipv6-image-bundle-linux-riscv64.tar: ipv6-test-images.txt
 	printf '%s\n' \
 		docker.io/library/nginx:1.29.0-alpine \
 		docker.io/library/alpine:$(alpine_version) \

--- a/hack/gen-test-images-list/cmd/main.go
+++ b/hack/gen-test-images-list/cmd/main.go
@@ -1,0 +1,20 @@
+//go:build hack
+
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	genimages "github.com/k0sproject/k0s/hack/gen-test-images-list"
+)
+
+func main() {
+	if err := genimages.GenImagesList(os.Args[0], os.Args[1:]...); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}

--- a/hack/gen-test-images-list/gen-images-list.go
+++ b/hack/gen-test-images-list/gen-images-list.go
@@ -1,0 +1,61 @@
+//go:build hack
+
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gentestimageslist
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	imageutils "k8s.io/kubernetes/test/utils/image"
+)
+
+func GenImagesList(name string, args ...string) error {
+	var outputFile, alpineVersion, kubernetesVersion, sonobuoyVersion string
+
+	flags := flag.NewFlagSet(name, flag.ExitOnError)
+	flags.SetOutput(os.Stdout)
+	flags.StringVar(&outputFile, "o", "", "Output file for the generated images list")
+	flags.StringVar(&alpineVersion, "alpine-version", "", "Alpine version to use")
+	flags.StringVar(&kubernetesVersion, "kubernetes-version", "", "Kubernetes version to use")
+	flags.StringVar(&sonobuoyVersion, "sonobuoy-version", "", "Sonobuoy version to use")
+	err := flags.Parse(args)
+
+	if err != nil || outputFile == "" || alpineVersion == "" || kubernetesVersion == "" || sonobuoyVersion == "" {
+		buf := flags.Output()
+		if err != nil {
+			fmt.Fprintln(buf, "Error:", err)
+		}
+		fmt.Fprintf(buf, "Usage: %s -o <output-file> -alpine-version <alpine-version> -kubernetes-version <kubernetes-version> -sonobuoy-version <sonobuoy-version>\n", name)
+
+		return err
+	}
+
+	images := []string{
+		"docker.io/library/nginx:1.29.0-alpine",
+		"docker.io/curlimages/curl:8.15.0",
+		"docker.io/library/alpine:" + alpineVersion,
+		"docker.io/sonobuoy/sonobuoy:" + sonobuoyVersion,
+		"registry.k8s.io/conformance:v" + kubernetesVersion,
+		imageutils.GetE2EImage(imageutils.Agnhost),
+		imageutils.GetE2EImage(imageutils.JessieDnsutils),
+		imageutils.GetE2EImage(imageutils.Nginx),
+		imageutils.GetE2EImage(imageutils.Pause),
+	}
+
+	f, err := os.Create(outputFile)
+	if err != nil {
+		return fmt.Errorf("failed to create output file %q: %w", outputFile, err)
+	}
+	defer f.Close()
+
+	for _, img := range images {
+		if _, err := fmt.Fprintln(f, img); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -63,6 +63,8 @@ smoketests := \
 	check-metricsscraper-singlenode \
 	check-multicontroller \
 	check-network-conformance-calico \
+	check-network-conformance-calico-ipv6 \
+	check-network-conformance-calico-ipv6-nft \
 	check-network-conformance-calico-nft \
 	check-network-conformance-kuberouter \
 	check-network-conformance-kuberouter-nft \
@@ -84,4 +86,6 @@ air_gapped_smoketests := \
 	check-cplb-ipvs-ipv6 \
 	check-cplb-userspace-ipv6 \
 	check-kuberouter-ipv6 \
+	check-network-conformance-calico-ipv6 \
+	check-network-conformance-calico-ipv6-nft \
 	check-nllb-ipv6

--- a/inttest/network-conformance/network_test.go
+++ b/inttest/network-conformance/network_test.go
@@ -18,6 +18,9 @@ import (
 	"github.com/vmware-tanzu/sonobuoy/pkg/dynamic"
 	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
+	"sigs.k8s.io/yaml"
+
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 )
 
 type networkSuite struct {
@@ -27,7 +30,26 @@ type networkSuite struct {
 }
 
 func (s *networkSuite) TestK0sGetsUp() {
-	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", fmt.Sprintf(k0sConfig, s.cni, s.proxyMode))
+	// Build k0s config from structs and marshal to YAML
+	{
+		clusterCfg := &v1beta1.ClusterConfig{
+			Spec: &v1beta1.ClusterSpec{
+				Network: func() *v1beta1.Network {
+					network := v1beta1.DefaultNetwork()
+					network.Provider = s.cni
+					if network.KubeProxy == nil {
+						network.KubeProxy = v1beta1.DefaultKubeProxy()
+					}
+					network.KubeProxy.Mode = s.proxyMode
+					return network
+				}(),
+			},
+		}
+		config, err := yaml.Marshal(clusterCfg)
+		s.Require().NoError(err)
+		s.WriteFileContent(s.ControllerNode(0), "/tmp/k0s.yaml", config)
+	}
+
 	s.Require().NoError(s.InitController(0, "--config=/tmp/k0s.yaml", "--disable-components=metrics-server"))
 	s.Require().NoError(s.RunWorkers())
 
@@ -141,11 +163,3 @@ func TestNetworkSuite(t *testing.T) {
 	t.Logf("Testing %s using %s", s.cni, s.proxyMode)
 	suite.Run(t, &s)
 }
-
-const k0sConfig = `
-spec:
-  network:
-    provider: %s
-    kubeProxy:
-      mode: %s
-`


### PR DESCRIPTION
## Description

The PR has three commits:
1- Modify the network conformance test to marshal the configuration from a struct. This is consistent with what we've done in other IPv6 tests as using templates is a bit odd for the `podCIDR`and `serviceCIDR` otherwise.
2- Actually modify the test so that it can run on IPv6, add the Makefile targets and include the images in the budle.
3- Make sure we're acquiring the conformance test images from the kubernetes repository so that we can forget about keeping these new images up to date.

This is part of #5875

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
