### PR TITLE
Semantic kubelet config validation for worker profiles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	k8s.io/api v0.34.0-beta.0
 	k8s.io/apiextensions-apiserver v0.34.0-beta.0
 	k8s.io/apimachinery v0.34.0-beta.0
+	k8s.io/apiserver v0.34.0-beta.0
 	k8s.io/cli-runtime v0.34.0-beta.0
 	k8s.io/client-go v0.34.0-beta.0
 	k8s.io/cloud-provider v0.34.0-beta.0
@@ -109,6 +110,7 @@ require (
 	github.com/containerd/containerd/api v1.8.0 // indirect
 	github.com/containerd/continuity v0.4.4 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
+	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
 	github.com/containerd/go-cni v1.1.9 // indirect
 	github.com/containerd/go-runc v1.1.0 // indirect
@@ -126,6 +128,7 @@ require (
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
+	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
@@ -148,6 +151,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
+	github.com/google/cadvisor v0.52.1 // indirect
 	github.com/google/cel-go v0.25.0 // indirect
 	github.com/google/certificate-transparency-go v1.1.4 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
@@ -170,6 +174,7 @@ require (
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/karrick/godirwalk v1.17.0 // indirect
 	github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
@@ -184,6 +189,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
+	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
@@ -201,6 +207,7 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/opencontainers/cgroups v0.0.1 // indirect
 	github.com/opencontainers/selinux v1.11.1 // indirect
 	github.com/otiai10/mint v1.6.3 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
@@ -262,8 +269,8 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiserver v0.34.0-beta.0 // indirect
 	k8s.io/controller-manager v0.34.0-beta.0 // indirect
+	k8s.io/cri-client v0.34.0-beta.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kms v0.34.0-beta.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab h1:UKkYhof1njT1/xq4SEg5z+VpTgjmNeHwPGRQl7takDI=
+github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
@@ -86,6 +88,8 @@ github.com/containerd/continuity v0.4.4 h1:/fNVfTJ7wIl/YPMHjf+5H32uFhl63JucB34Pl
 github.com/containerd/continuity v0.4.4/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
+github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
+github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY=
 github.com/containerd/fifo v1.1.0/go.mod h1:bmC4NWMbXlt2EZ0Hc7Fx7QzTFxgPID13eH0Qu+MAb2o=
 github.com/containerd/go-cni v1.1.9 h1:ORi7P1dYzCwVM6XPN4n3CbkuOx/NZ2DOqy+SHRdo9rU=
@@ -128,6 +132,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/docker/docker v26.1.4+incompatible h1:vuTpXDuoga+Z38m1OZHzl7NKisKWaWlhjQk7IDPSLsU=
+github.com/docker/docker v26.1.4+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
@@ -146,6 +152,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/euank/go-kmsg-parser v2.0.0+incompatible h1:cHD53+PLQuuQyLZeriD1V/esuG4MuU0Pjs5y6iknohY=
+github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
 github.com/evanphx/json-patch v5.9.11+incompatible h1:ixHHqfcGvxhWkniF1tWxBHA0yb4Z+d1UQi45df52xW8=
 github.com/evanphx/json-patch v5.9.11+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
@@ -238,6 +246,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
+github.com/google/cadvisor v0.52.1 h1:sC8SZ6jio9ds+P2dk51bgbeYeufxo55n0X3tmrpA9as=
+github.com/google/cadvisor v0.52.1/go.mod h1:OAhPcx1nOm5YwMh/JhpUOMKyv1YKLRtS9KgzWPndHmA=
 github.com/google/cel-go v0.25.0 h1:jsFw9Fhn+3y2kBbltZR4VEz5xKkcIFRPDnuEzAGv5GY=
 github.com/google/cel-go v0.25.0/go.mod h1:hjEb6r5SuOSlhCHmFoLzu8HGCERvIsDAbxDAyNU/MmI=
 github.com/google/certificate-transparency-go v1.1.4 h1:hCyXHDbtqlr/lMXU0D4WgbalXL0Zk4dSWWMbPV8VrqY=
@@ -322,6 +332,8 @@ github.com/k0sproject/version v0.8.0 h1:Yh1SFDeBqQ7etrGwffY8bWKdbAUjeBOhiZ6oQuuz
 github.com/k0sproject/version v0.8.0/go.mod h1:iNV3O8blndsQhxZ8zACfpQhrLDlrTvDlCzx+vgCFtSI=
 github.com/kardianos/service v1.2.4 h1:XNlGtZOYNx2u91urOdg/Kfmc+gfmuIo1Dd3rEi2OgBk=
 github.com/kardianos/service v1.2.4/go.mod h1:E4V9ufUuY82F7Ztlu1eN9VXWIQxg8NoLQlmFe0MtrXc=
+github.com/karrick/godirwalk v1.17.0 h1:b4kY7nqDdioR/6qnbHQyDvmA17u5G1cZ6J+CZXwSWoI=
+github.com/karrick/godirwalk v1.17.0/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46 h1:veS9QfglfvqAw2e+eeNT/SbGySq8ajECXJ9e4fPoLhY=
@@ -374,6 +386,8 @@ github.com/mesosphere/toml-merge v0.2.0 h1:stCUgrwbictiebeHRqEJ1NfQl/h5noyFKR0LB
 github.com/mesosphere/toml-merge v0.2.0/go.mod h1:WYpgeqeG5puUtv2NREGyOIqTnYuWswyo7CBgx6QK80s=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
+github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible h1:aKW/4cBs+yK6gpqU3K/oIwk9Q/XICqd3zOX/UFuvqmk=
+github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -382,6 +396,8 @@ github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQ
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
+github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
@@ -430,6 +446,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=
 github.com/onsi/gomega v1.36.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
+github.com/opencontainers/cgroups v0.0.1 h1:MXjMkkFpKv6kpuirUa4USFBas573sSAY082B4CiHEVA=
+github.com/opencontainers/cgroups v0.0.1/go.mod h1:s8lktyhlGUqM7OSRL5P7eAW6Wb+kWPNvt4qvVfzA5vs=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
@@ -813,6 +831,12 @@ k8s.io/controller-manager v0.34.0-beta.0 h1:xayidx5Jc8p0p2KLCzYMDcmL4OrFg7Ju3pWN
 k8s.io/controller-manager v0.34.0-beta.0/go.mod h1:Xapg/266jiskg2z0BU2SHe7WQPhM7kUZ7N9mF/4VT3E=
 k8s.io/cri-api v0.34.0-beta.0 h1:m40PvwDyITXFK7T/sGb5VwWVc2hc8uuUOYU/KCkUzk8=
 k8s.io/cri-api v0.34.0-beta.0/go.mod h1:4qVUjidMg7/Z9YGZpqIDygbkPWkg3mkS1PvOx/kpHTE=
+k8s.io/cri-client v0.34.0-beta.0 h1:DpBcDCKYp7WXON2NT63rdiafyfGu6d9JA0HpZL0ZF7s=
+k8s.io/cri-client v0.34.0-beta.0/go.mod h1:F5RfPzIln1gOsFp8GBDhTnPU9k1neaV39zAv3tfT5WA=
+k8s.io/csi-translation-lib v0.34.0-beta.0 h1:ADZMZuSwkKrI3Zvxy83sOH0WRdNSXb+iRmy1BvSwic4=
+k8s.io/csi-translation-lib v0.34.0-beta.0/go.mod h1:BQqcJ5SDsLYsS6W7x02EP9IURQqRwKgPKcnq4L389wg=
+k8s.io/dynamic-resource-allocation v0.34.0-beta.0 h1:YZT2NChdhAZvleKJ0Qkr9nDicccZn46oao5nNRIKQf4=
+k8s.io/dynamic-resource-allocation v0.34.0-beta.0/go.mod h1:5gPJ1yY65oPraR68rqwVQ2pZdasa50QhQ10MfvgW9Bk=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 k8s.io/kms v0.34.0-beta.0 h1:xff0luUkuygaOGpRuK0UIRPwlwQv9WsZCam5FCzF6qQ=
@@ -821,6 +845,8 @@ k8s.io/kube-aggregator v0.34.0-beta.0 h1:Rsb8uY5WMCIqZTzj7Y7o04VrbXtWLP3KfKuxGKp
 k8s.io/kube-aggregator v0.34.0-beta.0/go.mod h1:7zXZqSVm5cqouNwrQzuSMV8EgX/nU99qASyqEG+z0YU=
 k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b h1:MloQ9/bdJyIu9lb1PzujOPolHyvO06MXG5TUIj2mNAA=
 k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b/go.mod h1:UZ2yyWbFTpuhSbFhv24aGNOdoRdJZgsIObGBUaYVsts=
+k8s.io/kube-scheduler v0.34.0-beta.0 h1:s7DjCj9SEJsBRcMkV2r10K9kpAgbBO6I0XYP3biP3XI=
+k8s.io/kube-scheduler v0.34.0-beta.0/go.mod h1:R9vKIRHjz7EGp3uPs2g/daN7M7h3TxdIhAIo4SIqsdA=
 k8s.io/kubectl v0.34.0-beta.0 h1:/+3GYVZ/pV/PgTMnNMJs/cJUkuTNjg4uBi24fwRHBRs=
 k8s.io/kubectl v0.34.0-beta.0/go.mod h1:KuIDehbT8ImI5BHx+Qoz3Da6RL6s7fKRBLt9gl9Mj10=
 k8s.io/kubelet v0.34.0-beta.0 h1:wgSZwR2jIGf0fXCGtf553bz7/gCCxHjlXQXQlO183KY=

--- a/pkg/apis/k0s/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types.go
@@ -388,7 +388,6 @@ func (s *ClusterSpec) Validate() (errs []error) {
 		"scheduler":         s.Scheduler,
 		"storage":           s.Storage,
 		"network":           s.Network,
-		"workerProfiles":    s.WorkerProfiles,
 		"telemetry":         s.Telemetry,
 		"install":           s.Install,
 		"extensions":        s.Extensions,
@@ -398,6 +397,8 @@ func (s *ClusterSpec) Validate() (errs []error) {
 			errs = append(errs, fmt.Errorf("%s: %w", name, err))
 		}
 	}
+
+	errs = append(errs, s.WorkerProfiles.Validate(field.NewPath("workerProfiles"))...)
 
 	for _, err := range s.Images.Validate(field.NewPath("images")) {
 		errs = append(errs, err)

--- a/pkg/apis/k0s/v1beta1/workerprofile.go
+++ b/pkg/apis/k0s/v1beta1/workerprofile.go
@@ -47,17 +47,17 @@ func (wp *WorkerProfile) Validate() []error {
 	if err := json.Unmarshal(wp.Config.Raw, kubeletCfg); err != nil {
 		errs = append(errs, fmt.Errorf("failed to decode worker profile %q: %w", wp.Name, err))
 	}
-	if kubeletCfg.ClusterDNS != nil {
-		errs = append(errs, fmt.Errorf("field `clusterDNS` is prohibited to override in worker profile %q", wp.Name))
-	}
-	if kubeletCfg.ClusterDomain != "" {
-		errs = append(errs, fmt.Errorf("field `clusterDomain` is prohibited to override in worker profile %q", wp.Name))
-	}
 	if kubeletCfg.APIVersion != "" {
 		errs = append(errs, fmt.Errorf("field `apiVersion` is prohibited to override in worker profile %q", wp.Name))
 	}
 	if kubeletCfg.Kind != "" {
 		errs = append(errs, fmt.Errorf("field `kind` is prohibited to override in worker profile %q", wp.Name))
+	}
+	if kubeletCfg.ClusterDNS != nil {
+		errs = append(errs, fmt.Errorf("field `clusterDNS` is prohibited to override in worker profile %q", wp.Name))
+	}
+	if kubeletCfg.ClusterDomain != "" {
+		errs = append(errs, fmt.Errorf("field `clusterDomain` is prohibited to override in worker profile %q", wp.Name))
 	}
 	if kubeletCfg.StaticPodURL != "" {
 		errs = append(errs, fmt.Errorf("field `staticPodURL` is prohibited to override in worker profile %q", wp.Name))

--- a/pkg/apis/k0s/v1beta1/workerprofile.go
+++ b/pkg/apis/k0s/v1beta1/workerprofile.go
@@ -5,13 +5,19 @@ package v1beta1
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
+	"k8s.io/kubernetes/cmd/kubelet/app/options"
+	kubeletscheme "k8s.io/kubernetes/pkg/kubelet/apis/config/scheme"
+	kubeletvalidation "k8s.io/kubernetes/pkg/kubelet/apis/config/validation"
 )
 
 // WorkerProfiles profiles collection
@@ -59,7 +65,7 @@ func (wp *WorkerProfile) Validate(path *field.Path) (errs []error) {
 func (wp *WorkerProfile) validateConfig(path *field.Path) []error {
 	var errs []error
 
-	// Decode the kubelet config.
+	// Decode the versioned kubelet config.
 	kubeletCfg := &kubeletv1beta1.KubeletConfiguration{}
 	if err := json.Unmarshal(wp.Config.Raw, kubeletCfg); err != nil {
 		errs = append(errs, (*shortenedFieldError)(field.Invalid(path, wp.Config.Raw, err.Error())))
@@ -88,6 +94,47 @@ func (wp *WorkerProfile) validateConfig(path *field.Path) []error {
 	}
 	if kubeletCfg.StaticPodURL != "" {
 		errs = append(errs, reservedField("staticPodURL"))
+	}
+
+	// Get the kubelet scheme and apply the defaults to the versioned config.
+	scheme, _, err := kubeletscheme.NewSchemeAndCodecs()
+	if err != nil {
+		errs = append(errs, fmt.Errorf("failed to get kubelet scheme: %w", err))
+		return errs
+	}
+	scheme.Default(kubeletCfg)
+
+	// Create a new kubelet config and use the scheme to convert the versioned config into it.
+	validatedCfg, err := options.NewKubeletConfiguration()
+	if err != nil {
+		errs = append(errs, fmt.Errorf("failed to get kubelet default configuration: %w", err))
+		return errs
+	}
+	if err := scheme.Convert(kubeletCfg, validatedCfg, nil); err != nil {
+		errs = append(errs, (*shortenedFieldError)(field.Invalid(path, wp.Config.Raw, err.Error())))
+		return errs
+	}
+
+	// Run the kubelet's own config validation. Pass in the Kubernetes default
+	// feature gate settings. These will be automatically merged with the
+	// feature gates specified in the kubelet configuration by the validation
+	// function.
+	defaultGates := utilfeature.DefaultMutableFeatureGate.DeepCopyAndReset()
+	if err := kubeletvalidation.ValidateKubeletConfiguration(validatedCfg, defaultGates); err != nil {
+		// Flatten aggregate validation errors
+		var (
+			agg            utilerrors.Aggregate
+			validationErrs []error
+		)
+		if errors.As(err, &agg) {
+			validationErrs = agg.Errors()
+		} else {
+			validationErrs = []error{err}
+		}
+
+		for _, err := range validationErrs {
+			errs = append(errs, (*shortenedFieldError)(field.Invalid(path, wp.Config.Raw, err.Error())))
+		}
 	}
 
 	return errs

--- a/pkg/apis/k0s/v1beta1/workerprofile_test.go
+++ b/pkg/apis/k0s/v1beta1/workerprofile_test.go
@@ -16,6 +16,23 @@ import (
 )
 
 func TestWorkerProfiles(t *testing.T) {
+	t.Run("name validation", func(t *testing.T) {
+		profiles := WorkerProfiles{
+			{Name: ""},
+			{Name: "-me -not -DNS -name"},
+			{Name: "sixty-four-characters-looooooooooooooooooooooooooooooooooooooong"},
+			{Name: "legit"},
+		}
+
+		errs := profiles.Validate(field.NewPath("nameValidation"))
+		require.Lenf(t, errs, 3, "%s", errors.Join(errs...))
+		assert.ErrorContains(t, errs[0], "nameValidation[0].name: Required value")
+		assert.ErrorContains(t, errs[1], "nameValidation[1].name: Invalid value: ")
+		assert.ErrorContains(t, errs[1], "a lowercase RFC 1123 label must consist of ")
+		assert.ErrorContains(t, errs[2], "nameValidation[2].name: Invalid value: ")
+		assert.ErrorContains(t, errs[2], "must be no more than 63 characters")
+	})
+
 	t.Run("worker_profile_validation", func(t *testing.T) {
 		cases := []struct {
 			name string
@@ -87,6 +104,7 @@ func TestWorkerProfiles(t *testing.T) {
 				require.NoError(t, err)
 
 				profiles := WorkerProfiles{{
+					Name:   "test-case",
 					Config: &runtime.RawExtension{Raw: value},
 				}}
 

--- a/pkg/apis/k0s/v1beta1/workerprofile_test.go
+++ b/pkg/apis/k0s/v1beta1/workerprofile_test.go
@@ -63,7 +63,8 @@ func TestWorkerProfiles(t *testing.T) {
 			{
 				name: "Locked field clusterDNS",
 				spec: map[string]any{
-					"clusterDNS": []string{"8.8.8.8"},
+					// These should be valid IPs, but kubelet won't validate the input.
+					"clusterDNS": []string{"bogus"},
 				},
 				msg: "workerProfiles[0].values.clusterDNS: Forbidden: may not be used in k0s worker profiles",
 			},
@@ -95,6 +96,13 @@ func TestWorkerProfiles(t *testing.T) {
 					"cpuManagerPolicyOptions": "full-pcpus-only=true",
 				},
 				msg: "workerProfiles[0].values: Invalid value: json: cannot unmarshal string into Go struct field KubeletConfiguration.cpuManagerPolicyOptions of type map[string]string",
+			},
+			{
+				name: "kubelet configuration validation",
+				spec: map[string]any{
+					"systemCgroups": "system.slice",
+				},
+				msg: `workerProfiles[0].values: Invalid value: invalid configuration: systemCgroups (--system-cgroups) was specified and cgroupRoot (--cgroup-root) was not specified`,
 			},
 		}
 


### PR DESCRIPTION
## Description

Follow-up to #6241.

Use the kubelet's config validation code to verify the semantic correctness of the worker profiles.

Validate worker profile names. Those are used as part of ConfigMap names and used as label values, so validate them accordingly. Ignore nil configs, so that you don't need to specify an empty object as an empty kubelet config. Use field paths instead of the possibly empty profile names in error messages.

Allow apiVersion and kind in the KubeletConfiguration, so that they don't need to be stripped out when copying otherwise valid KubeletConfigurations into worker profiles. Fail fast and skip field validations if JSON decoding fails, since those validations would be irrelevant or misleading in that case.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
