### PR TITLE
Revert "Bump actions/checkout from 4 to 5"

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -26,7 +26,7 @@ jobs:
       )
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           # required to find all branches
           fetch-depth: 0

--- a/.github/workflows/build-airgap-image-bundle.yml
+++ b/.github/workflows/build-airgap-image-bundle.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: "Build :: Checkout"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout k0s
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Prepare build environment
         run: .github/workflows/prepare-build-env.sh
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout k0s
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Build docs dev container
         run: make -C docs .docker-image.serve-dev.stamp

--- a/.github/workflows/build-ipv6-image-bundle.yml
+++ b/.github/workflows/build-ipv6-image-bundle.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: "Build :: Checkout"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/build-k0s.yml
+++ b/.github/workflows/build-k0s.yml
@@ -41,7 +41,7 @@ jobs:
           endpoint: builders
 
       - name: "Build :: Checkout"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # for `git describe`
           persist-credentials: false

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Run git checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout k0s
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Prepare build environment
         run: .github/workflows/prepare-build-env.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
     name: Lint markdown
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - uses: DavidAnson/markdownlint-cli2-action@v20.0.0
         with:
           config: .markdownlint.jsonc

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: "Workflow run :: Checkout"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -132,7 +132,7 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Generate SBOM
         run: |
@@ -171,7 +171,7 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -278,7 +278,7 @@ jobs:
           endpoint: builders
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # for `git describe`
           persist-credentials: false
@@ -388,7 +388,7 @@ jobs:
           endpoint: builders
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # for `git describe`
           persist-credentials: false

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,7 +34,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -72,7 +72,7 @@ jobs:
         working-directory: hack/ostests
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: hack/ostests
           persist-credentials: false

--- a/.github/workflows/ostests-e2e.yaml
+++ b/.github/workflows/ostests-e2e.yaml
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: "Workflow run :: Checkout"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout k0s
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           endpoint: builders
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Prepare build environment
         run: .github/workflows/prepare-build-env.sh
@@ -182,7 +182,7 @@ jobs:
           endpoint: builders
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Prepare build environment
         run: .github/workflows/prepare-build-env.sh
@@ -248,7 +248,7 @@ jobs:
           endpoint: builders
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Prepare build environment
         run: .github/workflows/prepare-build-env.sh
@@ -334,7 +334,7 @@ jobs:
           docker system prune --all --volumes --force
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Prepare build environment
         run: .github/workflows/prepare-build-env.sh
@@ -465,7 +465,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Run git checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -530,7 +530,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Run git checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Generate SBOM
         env:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v43.0.7

--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Generate SBOM
         env:

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           show-progress: false


### PR DESCRIPTION
## Description

There are no official ARMv7 builds available for Node.js 24 and higher, so the checkout action fails on 32-bit ARM runners. There doesn't seem to be a quick fix, so downgrade again to buy time to figure out what to do.

Reverts:

* #6255

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
