### PR TITLE
[Backport release-1.32] Properly initialize kubelet directories on Windows

### DIFF
--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -72,8 +72,9 @@ var _ manager.Component = (*Kubelet)(nil)
 func (k *Kubelet) Init(_ context.Context) error {
 
 	if runtime.GOOS == "windows" {
-		err := assets.Stage(k.K0sVars.BinDir, "kubelet.exe", constant.BinDirMode)
-		return err
+		if err := assets.Stage(k.K0sVars.BinDir, "kubelet.exe", constant.BinDirMode); err != nil {
+			return err
+		}
 	}
 
 	if runtime.GOOS == "linux" {


### PR DESCRIPTION
Backport to `release-1.32`:

* #6049

See:

* #6048
* #5095