### PR TITLE
Build the airgap image artifact in a reproducible way

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,8 +247,7 @@ airgap-image-bundle-linux-amd64.tar \
 airgap-image-bundle-linux-arm64.tar \
 airgap-image-bundle-linux-arm.tar \
 airgap-image-bundle-linux-riscv64.tar: k0s airgap-images.txt
-	./k0s airgap bundle-artifacts -v --platform='$(TARGET_PLATFORM)' -o '$@' <airgap-images.txt
-
+	./k0s airgap bundle-artifacts --concurrency=1 -v --platform='$(TARGET_PLATFORM)' -o '$@' <airgap-images.txt
 
 ipv6-test-images.txt: embedded-bins/Makefile.variables $(shell find hack/gen-test-images-list/ -type f)
 	$(GO) run -tags=hack hack/gen-test-images-list/cmd/main.go -o '$@' \

--- a/cmd/airgap/bundleartifacts.go
+++ b/cmd/airgap/bundleartifacts.go
@@ -44,7 +44,12 @@ func newAirgapBundleArtifactsCmd(log logrus.FieldLogger, rewriteBundleRef airgap
 		Long: `Bundles artifacts needed for airgapped installations into a tarball. Fetches the
 artifacts from their OCI registries and bundles them into an OCI Image Layout
 archive (written to standard output by default). Reads names from standard input
-if no names are given on the command line.`,
+if no names are given on the command line.
+
+Note that if you need the tarball to be reproducible, you must specify
+--concurrency=1. This ensures that the images are added in the specified order
+instead of in an arbitrary order based on when they finish downloading.
+`,
 		PersistentPreRun: debugFlags.Run,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)

--- a/cmd/airgap/bundleartifacts_test.go
+++ b/cmd/airgap/bundleartifacts_test.go
@@ -86,7 +86,7 @@ func TestBundleArtifactsCmd_WithPlatforms(t *testing.T) {
 					underTest.SetArgs([]string{
 						"--insecure-registries", insecureRegistriesFlag,
 						"--platform", platform,
-						"--concurrency", "1", // predictable output
+						"--concurrency", "1", // reproducible output
 						ref,
 					})
 					underTest.SetIn(iotest.ErrReader(errors.New("unexpected read from standard input")))


### PR DESCRIPTION
## Description

As this file is shipped as part of the GitHub releases, it makes sense to build it in a reproducible way.

Make the image download concurrency a field of the bundler. As this is a "configuration" flag, this should go to the struct, instead of being passed as an argument to the Run method.

Also add some flag validation: What does a concurrency of -42 mean? ORAS will just fallback to its default value in that case. As this is a bit weird to document on the CLI flag, and given that k0s already hard-codes a default value by itself, it makes sense to disallow non-positive concurrency values completely.

Follow-up of:

* #6216

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
