### PR TITLE
Fix ipv6 test images generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,17 +264,7 @@ ipv6-image-bundle-linux-amd64.tar \
 ipv6-image-bundle-linux-arm64.tar \
 ipv6-image-bundle-linux-arm.tar \
 ipv6-image-bundle-linux-riscv64.tar: ipv6-test-images.txt
-	printf '%s\n' \
-		docker.io/library/nginx:1.29.0-alpine \
-		docker.io/library/alpine:$(alpine_version) \
-		docker.io/curlimages/curl:8.15.0 \
-		docker.io/sonobuoy/sonobuoy:v$(sonobuoy_version) \
-		registry.k8s.io/conformance:v$(kubernetes_version) \
-		registry.k8s.io/e2e-test-images/agnhost:2.56 \
-		registry.k8s.io/e2e-test-images/jessie-dnsutils:1.7 \
-		registry.k8s.io/e2e-test-images/nginx:1.14-4 \
-		registry.k8s.io/pause:3.10 \
-		| ./k0s airgap bundle-artifacts -v --platform='$(TARGET_PLATFORM)' -o '$@'
+	./k0s airgap bundle-artifacts -v --platform='$(TARGET_PLATFORM)' -o '$@' <ipv6-test-images.txt
 
 .PHONY: $(smoketests)
 $(air_gapped_smoketests): airgap-image-bundle-linux-$(HOST_ARCH).tar

--- a/hack/gen-test-images-list/gen-images-list.go
+++ b/hack/gen-test-images-list/gen-images-list.go
@@ -38,7 +38,7 @@ func GenImagesList(name string, args ...string) error {
 		"docker.io/library/nginx:1.29.1-alpine",
 		"docker.io/curlimages/curl:8.15.0",
 		"docker.io/library/alpine:" + alpineVersion,
-		"docker.io/sonobuoy/sonobuoy:" + sonobuoyVersion,
+		"docker.io/sonobuoy/sonobuoy:v" + sonobuoyVersion,
 		"registry.k8s.io/conformance:v" + kubernetesVersion,
 		imageutils.GetE2EImage(imageutils.Agnhost),
 		imageutils.GetE2EImage(imageutils.JessieDnsutils),


### PR DESCRIPTION
## Description

We were accidentally using the hardcoded list instead of the appropriate list generated by hack/gen-test-images-list. Also there was a typo in one of the images.


## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
