### PR TITLE
Add cgroup auto-detection for kubelet & containerd

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -57,6 +57,14 @@ state = "/run/k0s/containerd"
   address = "/run/k0s/containerd.sock"
 ```
 
+## Automatic cgroup driver detection and upgrade safety
+
+k0s automatically detects the appropriate cgroup driver (systemd or cgroupfs) for your environment. On new installations, k0s will select the best driver based on the host's init system (systemd or otherwise). On upgrades, k0s will preserve the previously used cgroup driver for compatibility and stability.
+
+This detection logic ensures that both kubelet and containerd are always configured to use the same cgroup driver, preventing mismatches and related issues. The detection is performed at startup and is upgrade-safe: if a previous kubelet configuration is found, its cgroup driver setting is respected; otherwise, detection is based on the current environment.
+
+You can still override the cgroup driver by specifying `cgroupDriver` in a the containerd configuration. Make sure you configure both containerd and kubelet to use the same driver.
+
 ## k0s managed dynamic runtime configuration
 
 As of 1.27.1, k0s allows dynamic configuration of containerd CRI runtimes. This
@@ -192,6 +200,10 @@ For more details on how to configure registry hosts, please refer to the
     spec:
       runtimeClassName: gvisor
       containers:
+    k0s supports any container runtime that implements the [CRI] specification.
+
+    ## Automatic cgroup driver detection and upgrade safety
+
       - name: nginx
         image: nginx
     ```

--- a/docs/worker-node-config.md
+++ b/docs/worker-node-config.md
@@ -77,3 +77,7 @@ There is an `--iptables-mode` flag to specify the mode explicitly. Valid values:
 ```shell
 k0s worker --iptables-mode=nft
 ```
+
+## Cgroup driver detection
+
+k0s automatically detects and manages the cgroup driver (systemd or cgroupfs) for both kubelet and containerd. On upgrades, k0s preserves the previously used driver for compatibility. You can override the driver by specifying `cgroupDriver` in a worker profile or kubelet config. See below for worker profile examples.

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -11,6 +11,7 @@ import (
 
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component/worker"
+	"github.com/k0sproject/k0s/pkg/component/worker/cgroup"
 	workerconfig "github.com/k0sproject/k0s/pkg/component/worker/config"
 	"github.com/k0sproject/k0s/pkg/component/worker/containerd"
 	"github.com/k0sproject/k0s/pkg/config"
@@ -81,12 +82,13 @@ func newContainersStep(debug bool, k0sVars *config.CfgVars, criSocketFlag string
 		if debug {
 			logLevel = "debug"
 		}
+		cGroupMgr := cgroup.NewCgroupManager(k0sVars.KubeletConfigPath)
 		containers.managedContainerd = containerd.NewComponent(logLevel, k0sVars, &workerconfig.Profile{
 			PauseImage: &k0sv1beta1.ImageSpec{
 				Image:   constant.KubePauseContainerImage,
 				Version: constant.KubePauseContainerImageVersion,
 			},
-		})
+		}, cGroupMgr)
 	}
 
 	return &containers, nil

--- a/pkg/component/worker/cgroup/manager.go
+++ b/pkg/component/worker/cgroup/manager.go
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cgroup
+
+import (
+	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
+)
+
+// CgroupManager abstracts cgroup driver logic for different init systems.
+type CgroupManager interface {
+	// ApplyToConfig applies cgroup driver/slice defaults to the config if not set
+	ApplyToConfig(cfg *kubeletv1beta1.KubeletConfiguration)
+	Driver() string
+}

--- a/pkg/component/worker/cgroup/manager_linux.go
+++ b/pkg/component/worker/cgroup/manager_linux.go
@@ -1,0 +1,122 @@
+//go:build linux
+// +build linux
+
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cgroup
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
+)
+
+// Ensure implementations satisfy the interface
+var _ CgroupManager = (*systemdCgroupManager)(nil)
+var _ CgroupManager = (*genericCgroupManager)(nil)
+
+// NewCgroupManager returns a cgroup manager based on detection/upgrade logic.
+// If prevConfigPath is non-empty and a previous cgroup driver is found, it will be used for compatibility.
+func NewCgroupManager(prevConfigPath string) CgroupManager {
+	if prevConfigPath != "" {
+		if prev, ok := detectPreviousCgroupDriver(prevConfigPath); ok {
+			switch prev {
+			case "systemd":
+				return &systemdCgroupManager{}
+			case "cgroupfs":
+				return &genericCgroupManager{}
+			}
+		}
+	}
+	if isSystemd() {
+		return &systemdCgroupManager{}
+	}
+	return &genericCgroupManager{}
+}
+
+// detectPreviousCgroupDriver tries to read the cgroupDriver from a kubelet config file.
+// Returns (driver, true) if config exists, ("", false) if not.
+func detectPreviousCgroupDriver(path string) (string, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+	var cfg struct {
+		CgroupDriver string `yaml:"cgroupDriver"`
+	}
+	dec := yaml.NewDecoder(f)
+	if err := dec.Decode(&cfg); err != nil {
+		// config exists, but couldn't decode, treat as no previous driver
+		return "", false
+	}
+	if cfg.CgroupDriver == "" {
+		// config exists, but no previous driver set: kubelet defaults to cgroupfs
+		fmt.Printf("Detected previous cgroup driver from %s: (empty, defaulting to cgroupfs)\n", path)
+		return "cgroupfs", true
+	}
+	fmt.Printf("Detected previous cgroup driver from %s: %s\n", path, cfg.CgroupDriver)
+	return cfg.CgroupDriver, true
+}
+
+// isSystemd detects if systemd is the init system (linux only).
+func isSystemd() bool {
+	data, err := os.ReadFile("/proc/1/comm")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(data)) == "systemd"
+}
+
+// The implementations follow the previous defaults we've had to ensure compatibility with existing configurations.
+// For any real cgroup slice etc changes we need to figure out how to safely migrate existing setups.
+
+// Systemd implementation
+type systemdCgroupManager struct{}
+
+// Driver implements CgroupManager.
+func (s *systemdCgroupManager) Driver() string {
+	return "systemd"
+}
+
+func (s *systemdCgroupManager) ApplyToConfig(cfg *kubeletv1beta1.KubeletConfiguration) {
+	if cfg == nil {
+		return
+	}
+	if cfg.CgroupDriver == "" {
+		cfg.CgroupDriver = "systemd"
+	}
+	if cfg.KubeletCgroups == "" {
+		cfg.KubeletCgroups = "/system.slice/containerd.service"
+	}
+	if cfg.KubeReservedCgroup == "" {
+		cfg.KubeReservedCgroup = "system.slice"
+	}
+}
+
+// Generic implementation for non-systemd setups
+type genericCgroupManager struct{}
+
+// Driver implements CgroupManager.
+func (g *genericCgroupManager) Driver() string {
+	return "cgroupfs"
+}
+
+func (g *genericCgroupManager) ApplyToConfig(cfg *kubeletv1beta1.KubeletConfiguration) {
+	if cfg == nil {
+		return
+	}
+	if cfg.CgroupDriver == "" {
+		cfg.CgroupDriver = "cgroupfs"
+	}
+	if cfg.KubeletCgroups == "" {
+		cfg.KubeletCgroups = "/system.slice/containerd.service"
+	}
+	if cfg.KubeReservedCgroup == "" {
+		cfg.KubeReservedCgroup = "system.slice"
+	}
+}

--- a/pkg/component/worker/cgroup/manager_stub.go
+++ b/pkg/component/worker/cgroup/manager_stub.go
@@ -1,0 +1,30 @@
+//go:build !linux && !windows
+// +build !linux,!windows
+
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cgroup
+
+import kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
+
+// Ensure implementation satisfies the interface
+var _ CgroupManager = (*stubCgroupManager)(nil)
+
+// CgroupManager stub for unsupported platforms (so the package always builds)
+// CgroupManager stub for unsupported platforms (so the package always builds)
+type stubCgroupManager struct{}
+
+// Driver implements CgroupManager.
+func (s *stubCgroupManager) Driver() string {
+	panic("unimplemented")
+}
+
+// NewCgroupManager returns a no-op manager for unsupported platforms.
+func NewCgroupManager(_ string) CgroupManager {
+	return &stubCgroupManager{}
+}
+
+func (s *stubCgroupManager) ApplyToConfig(cfg *kubeletv1beta1.KubeletConfiguration) {
+	// no-op for stub
+}

--- a/pkg/component/worker/cgroup/manager_windows.go
+++ b/pkg/component/worker/cgroup/manager_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cgroup
+
+import kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
+
+// Ensure implementation satisfies the interface
+var _ CgroupManager = (*windowsCgroupManager)(nil)
+
+// CgroupManager no-op implementation for Windows.
+type windowsCgroupManager struct{}
+
+// Driver implements CgroupManager.
+func (w *windowsCgroupManager) Driver() string {
+	panic("unimplemented")
+}
+
+func NewCgroupManager(_ string) CgroupManager {
+	return &windowsCgroupManager{}
+}
+
+func (w *windowsCgroupManager) ApplyToConfig(cfg *kubeletv1beta1.KubeletConfiguration) {
+	// no-op for windows
+}

--- a/pkg/config/cfgvars.go
+++ b/pkg/config/cfgvars.go
@@ -33,6 +33,7 @@ type CfgVars struct {
 	KineSocketPath             string              // The unix socket path for kine
 	KonnectivitySocketDir      string              // location of konnectivity's socket path
 	KubeletAuthConfigPath      string              // KubeletAuthConfigPath defines the default kubelet auth config path
+	KubeletConfigPath          string              // KubeletConfigPath defines the kubelet config path
 	ManifestsDir               string              // location for all stack manifests
 	RunDir                     string              // location of supervised pid files and sockets
 	KonnectivityKubeConfigPath string              // location for konnectivity kubeconfig
@@ -159,6 +160,7 @@ func NewCfgVars(cobraCmd command, dirs ...string) (*CfgVars, error) {
 		KineSocketPath:             filepath.Join(runDir, constant.KineSocket),
 		KonnectivitySocketDir:      filepath.Join(runDir, "konnectivity-server"),
 		KubeletAuthConfigPath:      filepath.Join(dataDir, "kubelet.conf"),
+		KubeletConfigPath:          filepath.Join(runDir, "kubelet", "kubelet.yaml"),
 		ManifestsDir:               filepath.Join(dataDir, "manifests"),
 		RunDir:                     runDir,
 		KonnectivityKubeConfigPath: filepath.Join(certDir, "konnectivity.conf"),


### PR DESCRIPTION
## Description

This PR introduces cgroups auto-detection to select the driver (systemd/cgroupsfs) based on the operating environment. The auto-detection respects an existing configuration on the node, so which ever driver was used will be still used after upgrade. This ensures we're not gonna change the driver "in-flight" as that would probably break containers and pods.

The scope has been solely the driver detection, so what ever hard-coded, and non-optimal, cgroups have been used will still be used by default.



<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #6278

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

This is borderline a bug fix and a feature. 😂 

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
