### PR TITLE
Add `--context-name` flag to kubeconfig create command

### DIFF
--- a/cmd/kubeconfig/create_test.go
+++ b/cmd/kubeconfig/create_test.go
@@ -44,6 +44,7 @@ func TestKubeconfigCreate(t *testing.T) {
 		"--config", "-",
 		"--data-dir", k0sVars.DataDir,
 		"kubeconfig", "create", "test-user",
+		"--context-name", "my-cluster",
 	})
 	var stdout, stderr bytes.Buffer
 	cmd.SetIn(bytes.NewReader(configData))
@@ -57,6 +58,11 @@ func TestKubeconfigCreate(t *testing.T) {
 	// Write kubeconfig to a file in order to load it afterwards
 	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
 	require.NoError(t, os.WriteFile(kubeconfigPath, stdout.Bytes(), 0644))
+
+	// Verify that the current context is set as requested
+	rawConfig, err := clientcmd.LoadFromFile(kubeconfigPath)
+	require.NoError(t, err)
+	assert.Equal(t, "my-cluster", rawConfig.CurrentContext)
 
 	// Load the kubeconfig from disk and verify that the API server host is right
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds a `--context-name` flag to the `k0s kubeconfig create` command to support custom context and cluster names in generated kubeconfigs. This enhancement enables better multi-cluster management workflows by allowing users to avoid naming conflicts when merging multiple k0s cluster configurations.

The implementation modifies the `createUserKubeconfig` function in `cmd/kubeconfig/create.go` to accept a configurable context name instead of using the hardcoded "k0s" constant. The username remains unchanged from the command argument, preserving existing behavior while adding the requested customization capability.

Fixes #6302

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
