### PR TITLE
Fix ipv6 tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,8 +266,8 @@ ipv6-image-bundle-linux-riscv64.tar: ipv6-test-images.txt
 	./k0s airgap bundle-artifacts -v --platform='$(TARGET_PLATFORM)' -o '$@' <ipv6-test-images.txt
 
 .PHONY: $(smoketests)
-$(air_gapped_smoketests): airgap-image-bundle-linux-$(HOST_ARCH).tar
-check-calico-ipv6 check-kuberouter-ipv6: ipv6-image-bundle-linux-$(HOST_ARCH).tar
+$(air_gapped_smoketests) $(ipv6_smoketests): airgap-image-bundle-linux-$(HOST_ARCH).tar
+$(ipv6_smoketests): ipv6-image-bundle-linux-$(HOST_ARCH).tar
 $(smoketests): k0s
 	$(MAKE) -C inttest \
 		K0S_IMAGES_BUNDLE='$(CURDIR)/airgap-image-bundle-linux-$(HOST_ARCH).tar' \

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -81,7 +81,9 @@ smoketests := \
 
 air_gapped_smoketests := \
 	check-airgap \
-	check-ap-airgap \
+	check-ap-airgap
+
+ipv6_smoketests := \
 	check-calico-ipv6 \
 	check-cplb-ipvs-ipv6 \
 	check-cplb-userspace-ipv6 \

--- a/inttest/network-conformance/network_test.go
+++ b/inttest/network-conformance/network_test.go
@@ -55,7 +55,7 @@ func (s *networkSuite) TestK0sGetsUp() {
 		s.WriteFileContent(s.ControllerNode(0), "/tmp/k0s.yaml", config)
 	}
 
-	s.Require().NoError(s.InitController(0, "--config=/tmp/k0s.yaml", "--disable-components=metrics-server"))
+	s.Require().NoError(s.InitController(0, "--config=/tmp/k0s.yaml", "--disable-components=metrics-server", "--feature-gates=IPv6SingleStack=true"))
 
 	if s.isIPv6Only {
 		common.ConfigureIPv6ResolvConf(&s.BootlooseSuite)


### PR DESCRIPTION
## Description

IPV6 tests were broken after merging the feature gates. This fixes it.

Also some tests weren't requiring the ipv6 image-bundle, so I added another PR to fix that too.

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
