### PR TITLE
Allow update-prober to be disabled

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/k0sproject/k0s/internal/sync/value"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/applier"
-	apclient "github.com/k0sproject/k0s/pkg/autopilot/client"
 	"github.com/k0sproject/k0s/pkg/build"
 	"github.com/k0sproject/k0s/pkg/certificate"
 	"github.com/k0sproject/k0s/pkg/component/controller"
@@ -563,9 +562,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 	})
 
 	clusterComponents.Add(ctx, controller.NewUpdateProber(
-		&apclient.ClientFactory{
-			ClientFactoryInterface: adminClientFactory,
-		},
+		adminClientFactory,
 		leaderElector,
 	))
 

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -561,10 +561,12 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 		Workloads:          controllerMode.WorkloadsEnabled(),
 	})
 
-	clusterComponents.Add(ctx, controller.NewUpdateProber(
-		adminClientFactory,
-		leaderElector,
-	))
+	if !slices.Contains(flags.DisableComponents, constant.UpdateProberComponentName) {
+		clusterComponents.Add(ctx, controller.NewUpdateProber(
+			adminClientFactory,
+			leaderElector,
+		))
+	}
 
 	// Add the config source as the last component, so that the reconciliation
 	// starts after all other components have been started.

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -52,7 +52,7 @@ Flags:
       --data-dir string                                Data Directory for k0s. DO NOT CHANGE for an existing setup, things will break! (default `+defaultDataDir+`)
   -d, --debug                                          Debug logging (implies verbose logging)
       --debugListenOn string                           Http listenOn for Debug pprof handler (default ":6060")
-      --disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,windows-node,worker-config)
+      --disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,update-prober,windows-node,worker-config)
       --enable-cloud-provider                          Whether or not to enable cloud provider support in kubelet
       --enable-dynamic-config                          enable cluster-wide dynamic config based on custom resource
       --enable-k0s-cloud-provider                      enables the k0s-cloud-provider (default false)

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -46,7 +46,7 @@ Flags:
   -c, --config string                                  config file, use '-' to read the config from stdin (default `+defaultConfigPath+`)
       --cri-socket string                              container runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]
       --data-dir string                                Data Directory for k0s. DO NOT CHANGE for an existing setup, things will break! (default `+defaultDataDir+`)
-      --disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,windows-node,worker-config)
+      --disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,update-prober,windows-node,worker-config)
       --enable-cloud-provider                          Whether or not to enable cloud provider support in kubelet
       --enable-dynamic-config                          enable cluster-wide dynamic config based on custom resource
       --enable-k0s-cloud-provider                      enables the k0s-cloud-provider (default false)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -583,7 +583,7 @@ they need to fulfill their need for the control plane. Disabling the system
 components happens through a command line flag for the controller process:
 
 ```text
---disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,windows-node,worker-config)
+--disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,update-prober,windows-node,worker-config)
 ```
 
 If you use k0sctl, just add the flag when installing the cluster for the first

--- a/pkg/component/controller/updateprober.go
+++ b/pkg/component/controller/updateprober.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/autopilot/channels"
-	apcli "github.com/k0sproject/k0s/pkg/autopilot/client"
 	"github.com/k0sproject/k0s/pkg/autopilot/controller/updates"
 	"github.com/k0sproject/k0s/pkg/build"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/manager"
+	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,13 +27,13 @@ import (
 var _ manager.Component = (*UpdateProber)(nil)
 
 type UpdateProber struct {
-	APClientFactory apcli.FactoryInterface
+	APClientFactory kubeutil.ClientFactoryInterface
 	ClusterConfig   *v1beta1.ClusterConfig
 	log             logrus.FieldLogger
 	leaderElector   leaderelector.Interface
 }
 
-func NewUpdateProber(apClientFactory apcli.FactoryInterface, leaderElector leaderelector.Interface) *UpdateProber {
+func NewUpdateProber(apClientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface) *UpdateProber {
 	return &UpdateProber{
 		APClientFactory: apClientFactory,
 		log:             logrus.WithFields(logrus.Fields{"component": "updateprober"}),

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -269,6 +269,7 @@ var availableComponents = []string{
 	constant.NetworkProviderComponentName,
 	constant.NodeRoleComponentName,
 	constant.SystemRBACComponentName,
+	constant.UpdateProberComponentName,
 	constant.WindowsNodeComponentName,
 	constant.WorkerConfigComponentName,
 }

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -107,6 +107,7 @@ const (
 	NodeRoleComponentName              = "node-role"
 	WindowsNodeComponentName           = "windows-node"
 	AutopilotComponentName             = "autopilot"
+	UpdateProberComponentName          = "update-prober"
 
 	// ClusterConfigNamespace is the namespace where we expect to find the ClusterConfig CRs
 	ClusterConfigNamespace  = "kube-system"


### PR DESCRIPTION
## Description

In airgapped environments with strict network observibility the update-prober contributes additional noise to egress denial logs.
    
By providing an option to disable it in the same way as other control-plane components we allow users of k0s in those environments to prevent unwanted network egress attempts.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
