### PR TITLE
Stack Applier: Strip namespaces from cluster resources

### DIFF
--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -72,7 +72,6 @@ func (s *Stack) Apply(ctx context.Context, prune bool) error {
 
 	var errs []error
 	for _, resource := range sortedResources {
-		s.prepareResource(resource)
 		mapping, err := getRESTMapping(mapper, ptr.To(resource.GroupVersionKind()))
 		if err != nil {
 			errs = append(errs, err)
@@ -82,8 +81,10 @@ func (s *Stack) Apply(ctx context.Context, prune bool) error {
 		if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
 			drClient = dynamicClient.Resource(mapping.Resource).Namespace(resource.GetNamespace())
 		} else {
+			resource.SetNamespace("")
 			drClient = dynamicClient.Resource(mapping.Resource)
 		}
+		s.prepareResource(resource)
 		serverResource, err := drClient.Get(ctx, resource.GetName(), metav1.GetOptions{})
 		if apiErrors.IsNotFound(err) {
 			created, err := drClient.Create(ctx, resource, metav1.CreateOptions{})

--- a/pkg/applier/stack_test.go
+++ b/pkg/applier/stack_test.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package applier_test
+
+import (
+	"testing"
+
+	"github.com/k0sproject/k0s/pkg/applier"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/k0sproject/k0s/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStack_StripsNamespaceFromClusterScopedResource(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ns-strip-test",
+			Namespace: "should-be-ignored",
+		},
+	}
+
+	resources, err := applier.ToUnstructured(nil, ns)
+	require.NoError(t, err)
+
+	fakes := testutil.NewFakeClientFactory()
+	s := applier.Stack{
+		Name:      "strip-ns",
+		Resources: []*unstructured.Unstructured{resources},
+		Clients:   fakes,
+	}
+
+	err = s.Apply(t.Context(), true)
+	require.NoError(t, err)
+
+	appliedNs, err := fakes.Client.CoreV1().Namespaces().Get(t.Context(), "ns-strip-test", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, appliedNs.Namespace)
+
+	lastAppliedAnn, ok := appliedNs.Annotations["k0s.k0sproject.io/last-applied-configuration"]
+	require.True(t, ok)
+	err = yaml.Unmarshal([]byte(lastAppliedAnn), &appliedNs)
+	require.NoError(t, err)
+	assert.Empty(t, appliedNs.Namespace)
+}


### PR DESCRIPTION
## Description

If there is a cluster-wide resource with a namespace set , the stack applier gets confused by it. Although the API server ignores the namespace, the applier takes it into account for resource pruning. This effectively resulted in the resource being applied and deleted again.

First, remove the namespace for cluster-wide resources. Then, prepare the resources for application. This ensures that the incorrect namespace won't end up in the cache key or the last applied configuration.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
