### PR TITLE
Revert "Use gh runners for arm64 instead of self-hosted"

### DIFF
--- a/.github/workflows/build-k0s.yml
+++ b/.github/workflows/build-k0s.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: >-
       ${{
            inputs.target-arch == 'arm'   && fromJSON('["self-hosted", "linux", "arm"]')
+        || inputs.target-arch == 'arm64' && fromJSON('["self-hosted", "linux", "arm64"]')
         || 'ubuntu-24.04'
       }}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -99,13 +99,8 @@ jobs:
   build-k0s:
     strategy:
       matrix:
-        include:
-          - target-os: linux
-            target-arch: amd64
-          - target-os: linux
-            target-arch: arm64
-          - target-os: windows
-            target-arch: amd64
+        target-os: [linux, windows]
+        target-arch: [amd64]
 
     name: "Build :: k0s :: ${{ matrix.target-os }}-${{ matrix.target-arch }}"
     uses: ./.github/workflows/build-k0s.yml
@@ -114,26 +109,20 @@ jobs:
       target-arch: ${{ matrix.target-arch }}
 
   build-airgap-image-bundle:
-    strategy:
-      matrix:
-        target-arch: [amd64, arm64]
-    name: "Build :: Airgap image bundle :: linux-${{ matrix.target-arch }}"
+    name: "Build :: Airgap image bundle"
     needs: [build-k0s]
     uses: ./.github/workflows/build-airgap-image-bundle.yml
     with:
       target-os: linux
-      target-arch: ${{ matrix.target-arch }}
+      target-arch: amd64
 
   build-ipv6-image-bundle:
-    strategy:
-      matrix:
-        target-arch: [amd64, arm64]
-    name: "Build :: IPv6 image bundle :: linux-${{ matrix.target-arch }}"
+    name: "Build :: IPv6 image bundle"
     needs: [build-k0s]
     uses: ./.github/workflows/build-ipv6-image-bundle.yml
     with:
       target-os: linux
-      target-arch: ${{ matrix.target-arch }}
+      target-arch: amd64
 
   generate-sbom:
     name: "Build :: SBOM"
@@ -163,10 +152,6 @@ jobs:
         include:
           - name: linux-amd64
             runs-on: ubuntu-24.04
-            target-arch: amd64
-          - name: linux-arm64
-            runs-on: ubuntu-24.04
-            target-arch: arm64
           - name: windows-amd64
             runs-on: windows-2022
             target-os: windows
@@ -237,8 +222,6 @@ jobs:
       fail-fast: false
       matrix:
         smoke-suite: ${{ fromJson(needs.prepare.outputs.smoketest-matrix) }}
-        target-arch:
-          - amd64
 
     name: "Smoke test :: ${{ matrix.smoke-suite }}"
     needs: [prepare, build-k0s, build-airgap-image-bundle, build-ipv6-image-bundle]
@@ -247,24 +230,6 @@ jobs:
     with:
       name: ${{ matrix.smoke-suite }}
 
-  smoketests-arm64:
-    strategy:
-      fail-fast: false
-      matrix:
-        smoke-suite:
-          - basic
-          - airgap
-          - network-conformance-calico
-          - network-conformance-kuberouter
-        target-arch:
-          - arm64
-
-    name: "Smoke test :: ${{ matrix.target-arch }} :: ${{ matrix.smoke-suite }}"
-    needs: [prepare, build-k0s, build-airgap-image-bundle, build-ipv6-image-bundle]
-
-    uses: ./.github/workflows/smoketest.yaml
-    with:
-      name: ${{ matrix.smoke-suite }}
   autopilot-tests:
     strategy:
       fail-fast: false
@@ -284,12 +249,14 @@ jobs:
       k0s-reference-version: ${{ matrix.version }}
 
   build-arm:
-    name: build on armv7
+    name: build on armv7/arm64
     if: github.repository == 'k0sproject/k0s'
     strategy:
       fail-fast: false
       matrix:
-        arch: [arm] # this is armv7
+        arch:
+          - arm # this is armv7
+          - arm64
     runs-on:
       - self-hosted
       - linux
@@ -390,13 +357,15 @@ jobs:
   # This way we could actually fully parallelize the build and smoketest steps. Currently we are limited by the fact that
   # smoke-test step only start after both arm and armv7 builds have finished.
   smoketest-arm:
-    name: Smoke test on armv7 -- ${{ matrix.test }}
+    name: Smoke test on armv7/arm64 -- ${{ matrix.test }}
     if: github.repository == 'k0sproject/k0s'
     needs: [build-arm]
     strategy:
       fail-fast: false
       matrix:
-        arch: [arm]
+        arch:
+          - arm # this is armv7
+          - arm64
         test:
           - check-basic
           - check-calico


### PR DESCRIPTION
This reverts commit 2b5c8e57724ba8aa126ebfaef253ef87170e74d0.

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
