### PR TITLE
Run Kube-Router only on Linux nodes

### DIFF
--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -243,6 +243,8 @@ spec:
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: kube-router
+      nodeSelector:
+        kubernetes.io/os: linux
       initContainers:
         - name: install-cni-bins
           image: {{ .CNIInstallerImage }}


### PR DESCRIPTION
## Description

This is just a cosmetic change. Kube-Router cannot be used as a CNI in clusters with Windows workers. Nevertheless, it feels right to do this anyway.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
