### PR TITLE
Avoid userspace polling in Supervisor proc handles if possible

### DIFF
--- a/internal/os/linux/pidfd.go
+++ b/internal/os/linux/pidfd.go
@@ -7,6 +7,7 @@ package linux
 
 import (
 	"cmp"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -15,7 +16,104 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+type PIDFD struct {
+	fd int
+}
+
+// Opens the process with the given PID.
+//
+// Since Linux 5.3. See [man 2 pidfd_open].
+//
+// [man 2 pidfd_open]: https://www.man7.org/linux/man-pages/man2/pidfd_open.2.html
+func OpenProcess(pid int) (*PIDFD, error) {
+	// https://www.man7.org/linux/man-pages/man2/pidfd_open.2.html
+	fd, err := unix.PidfdOpen(pid, 0)
+	if err != nil {
+		return nil, os.NewSyscallError("pidfd_open", err)
+	}
+	return &PIDFD{fd}, nil
+}
+
+func (p *PIDFD) Close() error {
+	return os.NewSyscallError("close", unix.Close(p.fd))
+}
+
 // Sends a signal to the process.
+//
+// See [man 2 pidfd_send_signal].
+//
+// [man 2 pidfd_send_signal]: https://man7.org/linux/man-pages/man2/pidfd_send_signal.2.html
+func (p *PIDFD) SendSignal(signal os.Signal) error {
+	sig, ok := signal.(syscall.Signal)
+	if !ok {
+		return fmt.Errorf("%w: %s", errors.ErrUnsupported, signal)
+	}
+
+	return pidfdSendSignal(p.fd, sig)
+}
+
+// Waits for the process to terminate.
+func (p *PIDFD) Wait(ctx context.Context) (err error) {
+	// Setup an eventfd object to wake up the poll call from a goroutine when
+	// the context gets canceled.
+	// https://www.man7.org/linux/man-pages/man2/eventfd.2.html
+	eventFD, err := unix.Eventfd(0, unix.EFD_CLOEXEC)
+	if err != nil {
+		return os.NewSyscallError("eventfd", err)
+	}
+	defer func() { err = errors.Join(err, os.NewSyscallError("close", unix.Close(eventFD))) }()
+
+	exit, done := make(chan struct{}), make(chan error, 1)
+	go func() {
+		defer close(done)
+		select {
+		case <-ctx.Done():
+			// eventfds accept an uint64 between 0 and 2^64-1.
+			one := [8]byte{7: 1}
+			_, err := unix.Write(eventFD, one[:])
+			done <- os.NewSyscallError("write", err)
+		case <-exit:
+		}
+	}()
+	defer func() {
+		close(exit)
+		if doneErr := <-done; doneErr != nil {
+			err = errors.Join(err, doneErr)
+		}
+	}()
+
+	for {
+		// https://www.man7.org/linux/man-pages/man2/poll.2.html
+		fds := [2]unix.PollFd{
+			{Fd: int32(p.fd), Events: unix.POLLIN},
+			{Fd: int32(eventFD), Events: unix.POLLIN},
+		}
+		_, err := unix.Poll(fds[:], -1)
+
+		switch {
+		case errors.Is(err, syscall.EINTR):
+			continue
+
+		case err != nil:
+			return os.NewSyscallError("poll", err)
+
+		case fds[0].Revents&unix.POLLIN != 0:
+			return nil // the process has terminated
+
+		case fds[1].Revents&unix.POLLIN != 0:
+			return context.Cause(ctx) // the context has been canceled
+
+		default:
+			return fmt.Errorf("woke up unexpectedly (0x%x / 0x%x)", fds[0].Revents, fds[1].Revents)
+		}
+	}
+}
+
+// Sends a signal to the process.
+//
+// Since Linux 5.1. See [man 2 pidfd_send_signal].
+//
+// [man 2 pidfd_send_signal]: https://man7.org/linux/man-pages/man2/pidfd_send_signal.2.html
 func SendSignal(pidfd syscall.Conn, signal os.Signal) error {
 	sig, ok := signal.(syscall.Signal)
 	if !ok {
@@ -39,8 +137,6 @@ func SendSignal(pidfd syscall.Conn, signal os.Signal) error {
 // The calling process must either be in the same PID namespace as the process
 // referred to by pidfd, or be in an ancestor of that namespace.
 //
-// Since Linux 5.1.
-// https://man7.org/linux/man-pages/man2/pidfd_send_signal.2.html
 // https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=3eb39f47934f9d5a3027fe00d906a45fe3a15fad
 func pidfdSendSignal(pidfd int, sig syscall.Signal) error {
 	// If the info argument is a NULL pointer, this is equivalent to specifying

--- a/pkg/supervisor/prochandle_windows.go
+++ b/pkg/supervisor/prochandle_windows.go
@@ -111,6 +111,11 @@ func (p *process) requestGracefulTermination() error {
 	return sendCtrlBreakOnTargetConsole(p.processID)
 }
 
+// awaitTermination implements [procHandle].
+func (p *process) awaitTermination(ctx context.Context) error {
+	return syscall.EWINDOWS
+}
+
 // Windows requires that processes be attached to the same console in order to
 // send console control events to each other. A process can only be attached to
 // one console at a time, and k0s cannot simply detach from its own console to


### PR DESCRIPTION
## Description

On newer kernels which support `pidfd_open`, it's actually possible to wait for arbitrary processes. Use pidfds in conjunction with eventfds to implement a cancellable procedure that waits for process termination without requiring userspace polling.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
