### PR TITLE
Don't block fsnotify watcher during stack application

### DIFF
--- a/pkg/applier/stackapplier.go
+++ b/pkg/applier/stackapplier.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/avast/retry-go"
-	"github.com/k0sproject/k0s/pkg/debounce"
 	"github.com/k0sproject/k0s/pkg/kubernetes"
 
 	"github.com/fsnotify/fsnotify"
@@ -55,57 +54,59 @@ func (s *StackApplier) Run(ctx context.Context) error {
 		return nil // The context is already done.
 	}
 
+	trigger := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return fmt.Errorf("failed to create watcher: %w", err)
 	}
-	defer watcher.Close()
 
-	debounceCtx, cancelDebouncer := context.WithCancel(ctx)
-	defer cancelDebouncer()
-
-	debouncer := debounce.Debouncer[fsnotify.Event]{
-		Input:    watcher.Events,
-		Timeout:  1 * time.Second,
-		Filter:   s.triggersApply,
-		Callback: func(fsnotify.Event) { s.apply(debounceCtx) },
-	}
-
-	// Send an artificial event to ensure that an initial apply will happen.
-	go func() { watcher.Events <- fsnotify.Event{} }()
-
-	// Consume and log any errors.
 	go func() {
-		for {
-			err, ok := <-watcher.Errors
-			if !ok {
-				return
-			}
-			s.log.WithError(err).Error("Error while watching stack")
-		}
+		defer watcher.Close()
+		defer close(trigger)
+		err = s.runWatcher(watcher, trigger, ctx.Done())
 	}()
 
-	err = watcher.Add(s.path)
-	if err != nil {
-		return fmt.Errorf("failed to watch %q: %w", s.path, err)
+	if addErr := watcher.Add(s.path); addErr != nil {
+		return fmt.Errorf("failed to watch %q: %w", s.path, addErr)
 	}
 
-	_ = debouncer.Run(debounceCtx)
-	return nil
+	for range trigger {
+		s.apply(ctx)
+	}
+
+	return err
 }
 
-func (*StackApplier) triggersApply(event fsnotify.Event) bool {
-	// Always let the initial apply happen
-	if event == (fsnotify.Event{}) {
-		return true
-	}
+func (s *StackApplier) runWatcher(watcher *fsnotify.Watcher, trigger chan<- struct{}, stop <-chan struct{}) error {
+	const timeout = 1 * time.Second // debounce events for one second
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 
-	// Only consider events on manifest files
-	if match, _ := filepath.Match(manifestFilePattern, filepath.Base(event.Name)); !match {
-		return false
-	}
+	for {
+		select {
+		case err := <-watcher.Errors:
+			return fmt.Errorf("while watching stack: %w", err)
 
-	return true
+		case event := <-watcher.Events:
+			// Only consider events on manifest files
+			if match, _ := filepath.Match(manifestFilePattern, filepath.Base(event.Name)); !match {
+				continue
+			}
+			timer.Reset(timeout)
+
+		case <-timer.C:
+			select {
+			case trigger <- struct{}{}:
+			default:
+			}
+
+		case <-stop:
+			return nil
+		}
+	}
 }
 
 func (s *StackApplier) apply(ctx context.Context) {


### PR DESCRIPTION
## Description

Decouple the stack application from the fsnotify watcher loop. This prevents the loop from stalling due to a long-running application and reduces the risk of the operating system buffer getting overflowed. Trigger applications via a separate channel with a buffer size of one item. This naturally implements debouncing.

Fixes a panic that could occur when the Run method exits before the initial apply event has been sent from the separate goroutine.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
