### PR TITLE
Use fake version in update server inttest

### DIFF
--- a/inttest/update-server/html/unstable/index.yaml
+++ b/inttest/update-server/html/unstable/index.yaml
@@ -1,5 +1,5 @@
 name: unstable
-version: v1.34.0+k0s.0
+version: v99.99.99+k0s.0
 downloadURLs:
   k0s:
     linux-amd64: ..../k0s-amd64


### PR DESCRIPTION
## Description

It doesn't need to be a real version number. Change this to be a fake one, so this file won't be changed when k0s/kubernetes versions are increased.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
