### PR TITLE
Use GitHub managed runners for linux-arm64

### DIFF
--- a/.github/workflows/build-k0s.yml
+++ b/.github/workflows/build-k0s.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: >-
       ${{
            inputs.target-arch == 'arm'   && fromJSON('["self-hosted", "linux", "arm"]')
-        || inputs.target-arch == 'arm64' && fromJSON('["self-hosted", "linux", "arm64"]')
+        || inputs.target-arch == 'arm64' && 'ubuntu-24.04-arm'
         || 'ubuntu-24.04'
       }}
 
@@ -31,11 +31,11 @@ jobs:
 
     steps:
       - name: Set up Docker Context for Buildx
-        if: inputs.target-arch != 'amd64'
+        if: inputs.target-arch == 'arm'
         run: docker context create builders
 
       - name: Set up Docker Buildx
-        if: inputs.target-arch != 'amd64'
+        if: inputs.target-arch == 'arm'
         uses: docker/setup-buildx-action@v3
         with:
           endpoint: builders

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -99,8 +99,13 @@ jobs:
   build-k0s:
     strategy:
       matrix:
-        target-os: [linux, windows]
-        target-arch: [amd64]
+        include:
+          - target-os: linux
+            target-arch: amd64
+          - target-os: linux
+            target-arch: arm64
+          - target-os: windows
+            target-arch: amd64
 
     name: "Build :: k0s :: ${{ matrix.target-os }}-${{ matrix.target-arch }}"
     uses: ./.github/workflows/build-k0s.yml
@@ -109,12 +114,17 @@ jobs:
       target-arch: ${{ matrix.target-arch }}
 
   build-airgap-image-bundle:
+    strategy:
+      fail-fast: false
+      matrix:
+        target-arch: [amd64, arm64]
+
     name: "Build :: Airgap image bundle"
     needs: [build-k0s]
     uses: ./.github/workflows/build-airgap-image-bundle.yml
     with:
       target-os: linux
-      target-arch: amd64
+      target-arch: ${{ matrix.target-arch }}
 
   build-ipv6-image-bundle:
     name: "Build :: IPv6 image bundle"
@@ -159,7 +169,7 @@ jobs:
             runs-on: macos-15
             target-os: darwin
 
-    name: "Unit tests :: k0s :: ${{ matrix.name }}"
+    name: "check-unit :: ${{ matrix.name }}"
     runs-on: "${{ matrix.runs-on }}"
 
     defaults:
@@ -223,11 +233,30 @@ jobs:
       matrix:
         smoke-suite: ${{ fromJson(needs.prepare.outputs.smoketest-matrix) }}
 
-    name: "Smoke test :: ${{ matrix.smoke-suite }}"
+    name: "check-${{ matrix.smoke-suite }} :: amd64"
     needs: [prepare, build-k0s, build-airgap-image-bundle, build-ipv6-image-bundle]
 
     uses: ./.github/workflows/smoketest.yaml
     with:
+      arch: amd64
+      name: ${{ matrix.smoke-suite }}
+
+  smoketests-linux-arm64:
+    strategy:
+      fail-fast: false
+      matrix:
+        smoke-suite:
+          - airgap
+          - basic
+          - network-conformance-calico
+          - network-conformance-kuberouter
+
+    name: "check-${{ matrix.smoke-suite }} :: arm64"
+    needs: [build-k0s, build-airgap-image-bundle]
+
+    uses: ./.github/workflows/smoketest.yaml
+    with:
+      arch: arm64
       name: ${{ matrix.smoke-suite }}
 
   autopilot-tests:
@@ -239,43 +268,26 @@ jobs:
           - controllerworker
           - ha3x3
 
-    name: "Autopilot test :: ${{ matrix.version }} :: ${{ matrix.smoke-suite }}"
+    name: "check-ap-${{ matrix.smoke-suite }} :: ${{ matrix.version }}"
     needs: [prepare, build-k0s]
 
     uses: ./.github/workflows/smoketest.yaml
     with:
+      arch: amd64
       name: ap-${{ matrix.smoke-suite }}
-      job-name: autopilot-test
       k0s-reference-version: ${{ matrix.version }}
 
   build-arm:
-    name: build on armv7/arm64
+    name: "Build :: k0s :: arm"
     if: github.repository == 'k0sproject/k0s'
-    strategy:
-      fail-fast: false
-      matrix:
-        arch:
-          - arm # this is armv7
-          - arm64
     runs-on:
       - self-hosted
       - linux
-      - ${{ matrix.arch }}
+      - arm
     steps:
       # https://github.com/actions/checkout/issues/273#issuecomment-642908752 (see below)
       - name: "Pre: Fixup directories"
-        if: matrix.arch == 'arm'
         run: find . -type d -not -perm /u+w -exec chmod u+w '{}' \;
-
-      - name: Set up Docker Context for Buildx
-        if: matrix.arch != 'arm'
-        run: docker context create builders
-
-      - name: Set up Docker Buildx
-        if: matrix.arch != 'arm'
-        uses: docker/setup-buildx-action@v3
-        with:
-          endpoint: builders
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -294,7 +306,7 @@ jobs:
       - name: Cache embedded binaries
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-embedded-bins-${{ matrix.arch }}-${{ hashFiles('**/embedded-bins/**/*') }}
+          key: ${{ runner.os }}-embedded-bins-arm-${{ hashFiles('**/embedded-bins/**/*') }}
           path: |
             .bins.linux.stamp
             embedded-bins/staging/linux/bin/
@@ -303,16 +315,16 @@ jobs:
       - name: Cache GOCACHE
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-smoketest-arm-gocache-${{ matrix.arch }}-${{ github.ref_name }}-${{ github.sha }}
+          key: ${{ runner.os }}-smoketest-arm-gocache-arm-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-smoketest-arm-gocache-${{ matrix.arch }}-${{ github.ref_name }}-
+            ${{ runner.os }}-smoketest-arm-gocache-arm-${{ github.ref_name }}-
           path: |
             build/cache/go/build
 
       - name: Cache GOMODCACHE
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-smoketest-arm-gomodcache-${{ matrix.arch }}-${{ hashFiles('go.sum') }}
+          key: ${{ runner.os }}-smoketest-arm-gomodcache-arm-${{ hashFiles('go.sum') }}
           path: |
             build/cache/go/mod
 
@@ -325,7 +337,7 @@ jobs:
       - name: Upload compiled executable
         uses: actions/upload-artifact@v4
         with:
-          name: k0s-${{ matrix.arch }}
+          name: k0s-arm
           path: k0s
 
       - name: Unit tests
@@ -338,34 +350,31 @@ jobs:
         id: cache-airgap-image-bundle
         uses: actions/cache@v4
         with:
-          key: airgap-image-bundle-linux-${{ matrix.arch }}-${{ hashFiles('Makefile', 'airgap-images.txt', 'cmd/airgap/*', 'pkg/airgap/*') }}
+          key: airgap-image-bundle-linux-arm-${{ hashFiles('Makefile', 'airgap-images.txt', 'cmd/airgap/*', 'pkg/airgap/*') }}
           path: |
             airgap-images.txt
-            airgap-image-bundle-linux-${{ matrix.arch }}.tar
+            airgap-image-bundle-linux-arm.tar
 
       - name: Create airgap image bundle if not cached
         if: steps.cache-airgap-image-bundle.outputs.cache-hit != 'true'
-        run: make airgap-image-bundle-linux-${{ matrix.arch }}.tar
+        run: make airgap-image-bundle-linux-arm.tar
 
       - name: Upload airgap bundle
         uses: actions/upload-artifact@v4
         with:
-          name: airgap-image-bundle-linux-${{ matrix.arch }}.tar
-          path: airgap-image-bundle-linux-${{ matrix.arch }}.tar
+          name: airgap-image-bundle-linux-arm.tar
+          path: airgap-image-bundle-linux-arm.tar
 
   # TODO We probably want to separate the smoketest into a separate callable workflow which we can call from the build step
   # This way we could actually fully parallelize the build and smoketest steps. Currently we are limited by the fact that
   # smoke-test step only start after both arm and armv7 builds have finished.
   smoketest-arm:
-    name: Smoke test on armv7/arm64 -- ${{ matrix.test }}
+    name: "${{ matrix.test }} :: arm"
     if: github.repository == 'k0sproject/k0s'
     needs: [build-arm]
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - arm # this is armv7
-          - arm64
         test:
           - check-basic
           - check-calico
@@ -373,20 +382,9 @@ jobs:
     runs-on:
       - self-hosted
       - linux
-      - ${{ matrix.arch }}
+      - arm
 
     steps:
-
-      - name: Set up Docker Context for Buildx
-        if: matrix.arch != 'arm'
-        run: docker context create builders
-
-      - name: Set up Docker Buildx
-        if: matrix.arch != 'arm'
-        uses: docker/setup-buildx-action@v3
-        with:
-          endpoint: builders
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -404,7 +402,7 @@ jobs:
       - name: Download compiled binary
         uses: actions/download-artifact@v5
         with:
-          name: k0s-${{ matrix.arch }}
+          name: k0s-arm
 
       - name: k0s sysinfo
         run: |
@@ -415,17 +413,16 @@ jobs:
         if: contains(matrix.test, 'airgap')
         uses: actions/download-artifact@v5
         with:
-          name: airgap-image-bundle-linux-${{ matrix.arch }}.tar
+          name: airgap-image-bundle-linux-arm.tar
 
       - name: Run smoketest
         run: make -C inttest ${{ matrix.test }}
-
 
       - name: Collect k0s logs and support bundle
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: smoketest-${{ matrix.arch }}-check-basic-files
+          name: smoketest-arm-check-basic-files
           path: |
             /tmp/*.log
             /tmp/support-bundle.tar.gz
@@ -438,9 +435,9 @@ jobs:
       # post build action. So, as a workaround, ensure that all subdirectories
       # are writable.
       - name: "Post: Fixup directories"
-        if: always() && matrix.arch == 'arm'
+        if: always()
         run: find . -type d -not -perm /u+w -exec chmod u+w '{}' \;
 
       - name: "Docker prune"
-        if: always() && matrix.arch == 'arm'
+        if: always()
         run: docker system prune --force --filter "until=$((24*7))h"

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -6,16 +6,14 @@ name: Smoke test
 on:
   workflow_call:
     inputs:
+      arch:
+        type: string
+        required: true
+        description: The architecture to test k0s on.
       name:
         type: string
         required: true
         description: The integration test name to be executed.
-      job-name:
-        type: string
-        default: smoketest
-        description: >-
-          The name to use for the test job.
-          Will be used as a prefix for artifact uploads.
       k0s-reference-version:
         type: string
         description: >-
@@ -27,8 +25,8 @@ permissions:
 
 jobs:
   smoketest:
-    name: ${{ inputs.job-name }}
-    runs-on: ubuntu-24.04
+    name: Test
+    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
 
     steps:
       - name: Check out code into the Go module directory
@@ -55,7 +53,7 @@ jobs:
       - name: Download compiled executable
         uses: actions/download-artifact@v5
         with:
-          name: k0s-linux-amd64
+          name: k0s-linux-${{ inputs.arch }}
 
       - name: k0s sysinfo
         run: |
@@ -66,21 +64,22 @@ jobs:
         if: contains(inputs.name, 'airgap') || contains(inputs.name, 'ipv6')
         uses: actions/download-artifact@v5
         with:
-          name: airgap-image-bundle-linux-amd64
+          name: airgap-image-bundle-linux-${{ inputs.arch }}
 
       - name: Download ipv6 image bundle
         if: inputs.name == 'calico-ipv6' || inputs.name == 'kuberouter-ipv6' || (startsWith(inputs.name, 'network-conformance-') && contains(inputs.name, '-ipv6'))
         uses: actions/download-artifact@v5
         with:
-          name: ipv6-image-bundle-linux-amd64
+          name: ipv6-image-bundle-linux-${{ inputs.arch }}
 
       - name: Download k0s reference release
         if: inputs.k0s-reference-version != ''
         env:
           K0S_VERSION: ${{ inputs.k0s-reference-version }}
         run: |
-          curl --proto '=https' --tlsv1.2 -sSLo "k0s-$K0S_VERSION" --retry 5 --retry-all-errors "https://github.com/k0sproject/k0s/releases/download/$K0S_VERSION/k0s-$K0S_VERSION-amd64"
+          curl --proto '=https' --tlsv1.2 -sSLo "k0s-$K0S_VERSION" --retry 5 --retry-all-errors "https://github.com/k0sproject/k0s/releases/download/$K0S_VERSION/k0s-$K0S_VERSION-${{ inputs.arch }}"
           chmod +x "k0s-$K0S_VERSION"
+          ./"k0s-$K0S_VERSION" version
           k0sRealPath="$(realpath "k0s-$K0S_VERSION")"
           echo K0S_UPDATE_FROM_PATH="$k0sRealPath" >>"$GITHUB_ENV"
 
@@ -93,7 +92,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.job-name }}-${{ inputs.name }}-files
+          name: ${{ inputs.name }}-${{ inputs.arch }}-files
           path: |
             /tmp/*.log
             /tmp/support-bundle.tar.gz


### PR DESCRIPTION
## Description

Now that GitHub supports arm64 for Linux, there's no longer the need to use self-hosted runners for this. This allows for running arm64 builds and tests on forks.

Also shorten the run names to match the make targets they're running. The old naming scheme was truncated when displayed on the GitHub webpage.

See:

* #6363

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
