### PR TITLE
[Backport release-1.33] Replace links to Medium with links to the community blog

### DIFF
--- a/docs/contributors/index.md
+++ b/docs/contributors/index.md
@@ -36,12 +36,15 @@ By contributing, you agree that your contributions will be licensed as followed:
 
 ## Community
 
-Some of you might have noticed we have official community blog hosted on
-[Medium][k0s@medium]. If you are not yet following us, we'd like to invite you
-to do so now! Make sure to [follow us on X][@k0sproject] as well 😊
+Some of you may have noticed that we have a [community blog]. If you're not
+following us [:fontawesome-solid-rss:][blog-rss] yet, we invite you to do so
+now! Make sure to [follow us on X][@k0sproject] as well 😊
 
-The main community communication channel is on [Kubernetes Slack][k8s Slack]. There you'll find like-minded people and reach out for assistance and discussions.
+The main community communication channel is on [Kubernetes Slack][k8s Slack].
+There you'll find like-minded people and reach out for assistance and
+discussions.
 
-[k0s@medium]: https://medium.com/k0sproject
+[community blog]: https://blog.k0sproject.io/
+[blog-rss]: https://blog.k0sproject.io/index.xml
 [@k0sproject]: https://x.com/k0sproject
 [k8s Slack]: https://kubernetes.slack.com/archives/C07VAPJUECS

--- a/docs/governance/cncf/security-self-assessment.md
+++ b/docs/governance/cncf/security-self-assessment.md
@@ -123,7 +123,13 @@ k0s follows the [CIS Kubernetes Benchmark](https://docs.k0sproject.io/stable/cis
 
 **Inbound:** [#k0s-users](https://kubernetes.slack.com/archives/C0809EA06QZ) in Kubernetes Slack and GitHGub issues. Stack Overflow has also a [k0s tag](https://stackoverflow.com/questions/tagged/k0s) for related questions.
 
-**External**: k0s does not currently have any mailing lists. There are Mirantis-operated social media accounts that are used for communicating things like new releases etc.. There’s also a [k0sproject](https://medium.com/k0sproject) Medium account which is used for blogs.
+**External**: k0s does not currently have any mailing lists. There are
+Mirantis-operated social media accounts that are used for communicating things
+like new releases etc. There’s also a [community blog] which is backed by a
+[GitHub repository][k0sproject/blog].
+
+[community blog]: https://blog.k0sproject.io/
+[k0sproject/blog]: https://github.com/k0sproject/blog
 
 ## Security issue resolution
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,9 @@ markdown_extensions:
   - pymdownx.highlight: {}
   - pymdownx.superfences: {}
   - pymdownx.inlinehilite: {}
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - mdx_truly_sane_lists: # https://github.com/mkdocs/mkdocs/issues/545#issuecomment-522196661
       nested_indent: 2
       truly_sane: true
@@ -164,9 +167,12 @@ extra:
     - icon: fontawesome/brands/x-twitter
       link: https://x.com/k0sproject
       name: k0s on X
-    - icon: fontawesome/brands/medium
-      link: https://medium.com/k0sproject
-      name: k0s on Medium
+    - icon: fontawesome/solid/blog
+      link: https://blog.k0sproject.io/
+      name: The k0sproject community blog
+    - icon: fontawesome/solid/rss
+      link: https://blog.k0sproject.io/index.xml
+      name: RSS feed of the k0sproject community blog
     - icon: fontawesome/brands/slack
       link: https://kubernetes.slack.com/archives/C07VAPJUECS
       name: k0s on the k8s slack


### PR DESCRIPTION
Backport to `release-1.33`:

* #6443