### PR TITLE
Let Supervisor return errors from its Stop method

### DIFF
--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -199,7 +199,7 @@ func (a *APIServer) writeKonnectivityConfig() error {
 // Stop stops APIServer
 func (a *APIServer) Stop() error {
 	if a.supervisor != nil {
-		a.supervisor.Stop()
+		return a.supervisor.Stop()
 	}
 	return nil
 }

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -137,7 +137,9 @@ func (a *Manager) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterCon
 	// Stop in case there's process running already and we need to change the config
 	if a.supervisor != nil {
 		logger.Info("reconcile has nothing to do")
-		a.supervisor.Stop()
+		if err := a.supervisor.Stop(); err != nil {
+			logger.WithError(err).Error("Failed to stop executable")
+		}
 		a.supervisor = nil
 	}
 
@@ -156,7 +158,7 @@ func (a *Manager) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterCon
 // Stop stops Manager
 func (a *Manager) Stop() error {
 	if a.supervisor != nil {
-		a.supervisor.Stop()
+		return a.supervisor.Stop()
 	}
 	return nil
 }

--- a/pkg/component/controller/cplb/cplb_linux.go
+++ b/pkg/component/controller/cplb/cplb_linux.go
@@ -183,7 +183,9 @@ func (k *Keepalived) Stop() error {
 	}
 
 	k.log.Info("Stopping keepalived")
-	k.supervisor.Stop()
+	if err := k.supervisor.Stop(); err != nil {
+		k.log.WithError(err).Error("Failed to stop executable")
+	}
 
 	if len(k.Config.VirtualServers) > 0 {
 		k.log.Info("Deleting dummy interface")

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -247,7 +247,7 @@ func (e *Etcd) Start(ctx context.Context) error {
 // Stop stops etcd
 func (e *Etcd) Stop() error {
 	if e.supervisor != nil {
-		e.supervisor.Stop()
+		return e.supervisor.Stop()
 	}
 	return nil
 }

--- a/pkg/component/controller/k0scontrolapi.go
+++ b/pkg/component/controller/k0scontrolapi.go
@@ -59,7 +59,7 @@ func (m *K0SControlAPI) Start(_ context.Context) error {
 // Stop stops k0s api
 func (m *K0SControlAPI) Stop() error {
 	if m.supervisor != nil {
-		m.supervisor.Stop()
+		return m.supervisor.Stop()
 	}
 	return nil
 }

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -130,7 +130,7 @@ func (k *Kine) Start(ctx context.Context) error {
 // Stop stops kine
 func (k *Kine) Stop() error {
 	if k.supervisor != nil {
-		k.supervisor.Stop()
+		return k.supervisor.Stop()
 	}
 	return nil
 }

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -170,7 +170,9 @@ func (k *Konnectivity) runServer(count uint) error {
 	if k.supervisor != nil {
 		k.EmitWithPayload("restarting konnectivity server due to server count change",
 			map[string]any{"serverCount": count})
-		k.supervisor.Stop()
+		if err := k.supervisor.Stop(); err != nil {
+			k.log.WithError(err).Error("Failed to stop executable")
+		}
 	}
 
 	k.supervisor = &supervisor.Supervisor{
@@ -217,8 +219,7 @@ func (k *Konnectivity) Stop() error {
 		return nil
 	}
 	logrus.Debug("about to stop konnectivity supervisor")
-	k.supervisor.Stop()
-	return nil
+	return k.supervisor.Stop()
 }
 
 func (k *Konnectivity) health(ctx context.Context, path string) error {

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -58,7 +58,7 @@ func (a *Scheduler) Start(_ context.Context) error {
 // Stop stops Scheduler
 func (a *Scheduler) Stop() error {
 	if a.supervisor != nil {
-		a.supervisor.Stop()
+		return a.supervisor.Stop()
 	}
 	return nil
 }
@@ -97,7 +97,9 @@ func (a *Scheduler) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterC
 	// Stop in case there's process running already and we need to change the config
 	if a.supervisor != nil {
 		logrus.WithField("component", kubeSchedulerComponentName).Info("reconcile has nothing to do")
-		a.supervisor.Stop()
+		if err := a.supervisor.Stop(); err != nil {
+			logrus.WithField("component", kubeSchedulerComponentName).WithError(err).Error("Failed to stop executable")
+		}
 		a.supervisor = nil
 	}
 

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -174,7 +174,7 @@ func (k *Kubelet) Start(ctx context.Context) error {
 // Stop stops kubelet
 func (k *Kubelet) Stop() error {
 	if k.supervisor != nil {
-		k.supervisor.Stop()
+		return k.supervisor.Stop()
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

Return an error instead of logging warnings internally. This renders the decision what to do with about a failed attempt to stop the Supervisor to the caller.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
