### PR TITLE
feat: Add konnectivity host network configuration

### DIFF
--- a/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
@@ -127,6 +127,41 @@ spec:
 	assert.Equal(t, addr, c.Spec.Storage.Etcd.PeerAddress)
 }
 
+func TestKonnectivityDefaults(t *testing.T) {
+	// Test default values
+	defaultSpec := DefaultKonnectivitySpec()
+	assert.Equal(t, int32(8132), defaultSpec.AgentPort)
+	assert.Equal(t, int32(8133), defaultSpec.AdminPort)
+	assert.False(t, defaultSpec.HostNetwork) // New field should default to false
+
+	// Test that defaults are applied in cluster config
+	yamlData := []byte(`
+apiVersion: k0s.k0sproject.io/v1beta1
+kind: ClusterConfig
+metadata:
+  name: test
+`)
+
+	c, err := ConfigFromBytes(yamlData)
+	assert.NoError(t, err)
+	assert.False(t, c.Spec.Konnectivity.HostNetwork)
+
+	// Test explicit HostNetwork configuration
+	yamlDataWithHostNetwork := []byte(`
+apiVersion: k0s.k0sproject.io/v1beta1
+kind: ClusterConfig
+metadata:
+  name: test
+spec:
+  konnectivity:
+    hostNetwork: true
+`)
+
+	c2, err := ConfigFromBytes(yamlDataWithHostNetwork)
+	assert.NoError(t, err)
+	assert.True(t, c2.Spec.Konnectivity.HostNetwork)
+}
+
 func TestNetworkValidation_Custom(t *testing.T) {
 	yamlData := []byte(`
 apiVersion: k0s.k0sproject.io/v1beta1

--- a/pkg/apis/k0s/v1beta1/konnectivity.go
+++ b/pkg/apis/k0s/v1beta1/konnectivity.go
@@ -27,13 +27,19 @@ type KonnectivitySpec struct {
 	// external address to advertise for the konnectivity agent to connect to
 	// +optional
 	ExternalAddress string `json:"externalAddress,omitempty"`
+
+	// HostNetwork controls whether the konnectivity agent should use host networking
+	// +kubebuilder:default=false
+	// +optional
+	HostNetwork bool `json:"hostNetwork,omitempty"`
 }
 
 // DefaultKonnectivitySpec builds default KonnectivitySpec
 func DefaultKonnectivitySpec() *KonnectivitySpec {
 	return &KonnectivitySpec{
-		AgentPort: 8132,
-		AdminPort: 8133,
+		AgentPort:   8132,
+		AdminPort:   8133,
+		HostNetwork: false,
 	}
 }
 

--- a/pkg/component/controller/konnectivityagent.go
+++ b/pkg/component/controller/konnectivityagent.go
@@ -111,6 +111,7 @@ func (k *KonnectivityAgent) writeKonnectivityAgent(clusterConfig *v1beta1.Cluste
 		Image:           clusterConfig.Spec.Images.Konnectivity.URI(),
 		ServerCount:     serverCount,
 		PullPolicy:      clusterConfig.Spec.Images.DefaultPullPolicy,
+		HostNetwork:     clusterConfig.Spec.Konnectivity.HostNetwork,
 	}
 
 	if clusterConfig.Spec.Network != nil {

--- a/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
+++ b/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
@@ -462,6 +462,11 @@ spec:
                     description: external address to advertise for the konnectivity
                       agent to connect to
                     type: string
+                  hostNetwork:
+                    default: false
+                    description: HostNetwork controls whether the konnectivity agent
+                      should use host networking
+                    type: boolean
                 type: object
               network:
                 description: Network defines the network related config options


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR adds configurable host network support for the Konnectivity agent by introducing a new `hostNetwork` field to the `KonnectivitySpec` configuration.

Fixes #6465 

**Motivation:**
Currently, the Konnectivity agent's host network configuration is only controlled internally when node-local load balancing is enabled. This change allows users to explicitly control whether the Konnectivity agent should use host networking independently, providing flexibility for scenarios such as:
- Preventing CNI installation deadlocks in restricted network environments
- Troubleshooting connectivity issues
- Meeting specific network policy or compliance requirements

The feature maintains backward compatibility with `hostNetwork: false` as the default value.


## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
