### PR TITLE
Fix typo in external runtime deps docs

### DIFF
--- a/docs/external-runtime-deps.md
+++ b/docs/external-runtime-deps.md
@@ -172,7 +172,7 @@ host, otherwise containerd will [disable][cd-aa] AppArmor support.
 #### iptables
 
 iptables may be executed to detect if there are any existing iptables rules and
-if those are in legacy of nft mode. If iptables is not found, k0s will assume
+if those are in legacy or nft mode. If iptables is not found, k0s will assume
 that there are no pre-existing iptables rules.
 
 #### useradd / adduser


### PR DESCRIPTION
## Description

Fix typo in external runtime deps docs (of -> or)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
