### PR TITLE
Don't unmount kubelet-root-dir on k0s reset

### DIFF
--- a/inttest/reset/reset_test.go
+++ b/inttest/reset/reset_test.go
@@ -13,23 +13,45 @@ import (
 
 	testifysuite "github.com/stretchr/testify/suite"
 
+	"github.com/k0sproject/bootloose/pkg/config"
 	"github.com/k0sproject/k0s/inttest/common"
 )
 
+const dataDir = "/var/lib/k0s"
+
 type suite struct {
 	common.BootlooseSuite
+
+	// kubeletRootDir is the directory passed to the worker and to k0s reset
+	// via --kubelet-root-dir.
+	kubeletRootDir string
 }
 
 //go:embed clutter-data-dir.sh
 var clutterScript []byte
 
+// kubeletRootDirSeparate reports whether the kubelet root dir lives outside the
+// data dir. A separate kubelet root dir is its own mount point that reset must
+// keep in place (only emptying it); one under the data dir gets removed
+// together with the data dir.
+func (s *suite) kubeletRootDirSeparate() bool {
+	return !strings.HasPrefix(s.kubeletRootDir, dataDir+"/")
+}
+
 func (s *suite) TestReset() {
 	ctx := s.Context()
 	workerNode := s.WorkerNode(0)
+	separate := s.kubeletRootDirSeparate()
+
+	// A mount nested under the kubelet root dir, and the source it's bound
+	// from. Reset must unmount and remove the nested mount, but leave the
+	// (out-of-tree) bind source alone.
+	nestedMount := s.kubeletRootDir + "/k0s_reset_inttest_nested_mount"
+	nestedMountSource := "/k0s_reset_inttest_nested_source"
 
 	if !s.Run("k0s gets up", func() {
 		s.Require().NoError(s.InitController(0, "--disable-components=konnectivity-server,metrics-server"))
-		s.Require().NoError(s.RunWorkers("--kubelet-root-dir=/var/lib/kubelet"))
+		s.Require().NoError(s.RunWorkers("--kubelet-root-dir=" + s.kubeletRootDir))
 
 		kc, err := s.KubeClient(s.ControllerNode(0))
 		s.Require().NoError(err)
@@ -44,9 +66,9 @@ func (s *suite) TestReset() {
 		s.Require().NoError(err)
 		defer ssh.Disconnect()
 
-		s.NoError(ssh.Exec(ctx, "test -d /var/lib/k0s", common.SSHStreams{}), "/var/lib/k0s is not a directory")
+		s.NoError(ssh.Exec(ctx, "test -d "+dataDir, common.SSHStreams{}), "%s is not a directory", dataDir)
 		s.NoError(ssh.Exec(ctx, "test -d /run/k0s", common.SSHStreams{}), "/run/k0s is not a directory")
-		s.NoError(ssh.Exec(ctx, "test -d /var/lib/kubelet", common.SSHStreams{}), "/var/lib/kubelet is not a directory")
+		s.NoError(ssh.Exec(ctx, "test -d "+s.kubeletRootDir, common.SSHStreams{}), "%s is not a directory", s.kubeletRootDir)
 
 		s.NoError(ssh.Exec(ctx, "pidof containerd-shim-runc-v2 >&2", common.SSHStreams{}), "Expected some running containerd shims")
 	}) {
@@ -62,12 +84,26 @@ func (s *suite) TestReset() {
 		s.Require().NoError(err)
 		defer ssh.Disconnect()
 
+		// Clutter the data dir with files and (recursive/over-) mounts that
+		// reset has to clean up.
 		streams, flushStreams := common.TestLogStreams(s.T(), "clutter data dir")
 		streams.In = bytes.NewReader(clutterScript)
 		streams.Out = io.MultiWriter(&clutteringPaths, streams.Out)
-		err = ssh.Exec(ctx, "sh -s -- /var/lib/k0s", streams)
+		err = ssh.Exec(ctx, "sh -s -- "+dataDir, streams)
 		flushStreams()
 		s.Require().NoError(err)
+
+		// The worker's kubelet already bind-mounts its root dir, so the kubelet
+		// root dir is itself a (busy) mount point at this point. Add another
+		// mount nested under it, so reset has to unmount and remove the nested
+		// mount while coping with the kubelet root dir being a busy mount point:
+		// leaving it in place when it's separate from the data dir, and
+		// unmounting it when it lives under the data dir.
+		setup := strings.Join([]string{
+			fmt.Sprintf("mkdir -p %s %s", nestedMount, nestedMountSource),
+			fmt.Sprintf("mount --bind %s %s", nestedMountSource, nestedMount),
+		}, " && ")
+		s.Require().NoError(ssh.Exec(ctx, setup, common.SSHStreams{}), "failed to set up kubelet root dir mounts")
 	}) {
 		return
 	}
@@ -78,31 +114,71 @@ func (s *suite) TestReset() {
 		defer ssh.Disconnect()
 
 		streams, flushStreams := common.TestLogStreams(s.T(), "reset")
-		err = ssh.Exec(ctx, "k0s reset --debug --kubelet-root-dir=/var/lib/kubelet", streams)
+		err = ssh.Exec(ctx, "k0s reset --debug --kubelet-root-dir="+s.kubeletRootDir, streams)
 		flushStreams()
 		s.NoError(err, "k0s reset didn't exit cleanly")
 
+		// Everything cluttered under the data dir must be gone (mounts
+		// unmounted, contents removed); the bind-mount sources live outside the
+		// data dir and must still be there.
 		for path := range strings.SplitSeq(string(bytes.TrimSpace(clutteringPaths.Bytes())), "\n") {
-			if strings.HasPrefix(path, "/var/lib/k0s") {
+			if strings.HasPrefix(path, dataDir) {
 				s.NoError(ssh.Exec(ctx, fmt.Sprintf("! test -e %q", path), common.SSHStreams{}), "Failed to verify non-existence of %s", path)
 			} else {
 				s.NoError(ssh.Exec(ctx, fmt.Sprintf("test -e %q", path), common.SSHStreams{}), "Failed to verify existence of %s", path)
 			}
 		}
 
-		// /var/lib/k0s is a mount point in the Docker container and can't be deleted, so it must be empty
-		s.NoError(ssh.Exec(ctx, `x="$(ls -A /var/lib/k0s)" && echo "$x" >&2 && [ -z "$x" ]`, common.SSHStreams{}), "/var/lib/k0s is not empty")
-		s.NoError(ssh.Exec(ctx, "! test -e /var/lib/kubelet", common.SSHStreams{}), "/var/lib/kubelet still exists")
+		// A mount nested under the kubelet root dir must be unmounted and
+		// removed, while its out-of-tree bind source is left untouched.
+		s.NoError(ssh.Exec(ctx, "! test -e "+nestedMount, common.SSHStreams{}), "%s still exists", nestedMount)
+		s.NoError(ssh.Exec(ctx, "test -d "+nestedMountSource, common.SSHStreams{}), "%s should have survived reset", nestedMountSource)
+
+		// The data dir is a mount point in the Docker container and can't be
+		// deleted, so it must be emptied.
+		s.NoError(ssh.Exec(ctx, fmt.Sprintf(`x="$(ls -A %s)" && echo "$x" >&2 && [ -z "$x" ]`, dataDir), common.SSHStreams{}), "%s is not empty", dataDir)
+
+		if separate {
+			// A kubelet root dir outside the data dir is its own mount point:
+			// reset can't delete it, so it must survive but be emptied.
+			s.NoError(ssh.Exec(ctx, fmt.Sprintf(`x="$(ls -A %s)" && echo "$x" >&2 && [ -z "$x" ]`, s.kubeletRootDir), common.SSHStreams{}), "%s is not empty", s.kubeletRootDir)
+		} else {
+			// A kubelet root dir under the data dir is removed along with it.
+			s.NoError(ssh.Exec(ctx, "! test -e "+s.kubeletRootDir, common.SSHStreams{}), "%s still exists", s.kubeletRootDir)
+		}
+
 		s.NoError(ssh.Exec(ctx, "! test -e /run/k0s", common.SSHStreams{}), "/run/k0s still exists")
 		s.NoError(ssh.Exec(ctx, "! pidof containerd-shim-runc-v2 >&2", common.SSHStreams{}), "Expected no running containerd shims")
 	})
 }
 
+// TestResetSuite covers a kubelet root dir on its own mount, separate from the
+// data dir: reset must leave the mount point in place and only empty it.
 func TestResetSuite(t *testing.T) {
 	testifysuite.Run(t, &suite{
-		common.BootlooseSuite{
+		BootlooseSuite: common.BootlooseSuite{
+			ControllerCount: 1,
+			WorkerCount:     1,
+			ExtraVolumes: []config.Volume{
+				{
+					Type:        "volume",
+					Destination: "/var/lib/kubelet",
+				},
+			},
+		},
+		kubeletRootDir: "/var/lib/kubelet",
+	})
+}
+
+// TestResetKubeletRootDirUnderDataDirSuite covers a kubelet root dir under the
+// data dir (its default location): reset must unmount and remove it together
+// with the data dir.
+func TestResetKubeletRootDirUnderDataDirSuite(t *testing.T) {
+	testifysuite.Run(t, &suite{
+		BootlooseSuite: common.BootlooseSuite{
 			ControllerCount: 1,
 			WorkerCount:     1,
 		},
+		kubeletRootDir: dataDir + "/kubelet",
 	})
 }

--- a/pkg/cleanup/directories.go
+++ b/pkg/cleanup/directories.go
@@ -26,7 +26,14 @@ func (d *directories) Run() error {
 		return err
 	}
 
-	var dataDirMounted bool
+	var dataDirMounted, kubeletRootDirMounted bool
+
+	// The kubelet root dir only needs special handling when it lives outside
+	// the data dir. When it's under the data dir (the default location), it
+	// gets cleaned up together with the data dir below, so we must let its
+	// own mount be unmounted here just like any other mount under the data
+	// dir; otherwise the data dir cleanup would choke on the busy mount.
+	kubeletRootDirSeparate := !isUnderPath(d.kubeletRootDir, d.dataDir)
 
 	// ensure that we don't delete any persistent data volumes that may be
 	// mounted by kubernetes by unmount every mount point under DataDir.
@@ -43,11 +50,16 @@ func (d *directories) Run() error {
 	//  - https://man7.org/linux/man-pages/man2/mount.2.html
 	//  - https://man7.org/linux/man-pages/man2/umount.2.html#NOTES
 	for _, v := range slices.Backward(procMounts) {
-
-		// avoid unmount datadir if its mounted on separate partition
-		// k0s didn't mount it so leave it alone
+		// avoid unmounting the data dir or a separate kubelet root dir
+		// themselves if they are mounted on a separate partition/volume:
+		// k0s didn't mount them, so leave them alone and just empty their
+		// contents.
 		if v.Path == d.dataDir {
 			dataDirMounted = true
+			continue
+		}
+		if v.Path == d.kubeletRootDir && kubeletRootDirSeparate {
+			kubeletRootDirMounted = true
 			continue
 		}
 		if isUnderPath(v.Path, d.kubeletRootDir) || isUnderPath(v.Path, d.dataDir) {
@@ -66,7 +78,15 @@ func (d *directories) Run() error {
 
 	logrus.Debugf("removing kubelet root dir (%s)", d.kubeletRootDir)
 	if err := os.RemoveAll(d.kubeletRootDir); err != nil {
-		return fmt.Errorf("failed to delete k0s kubelet root direcotory: %w", err)
+		// if the kubelet root dir is itself a mount point (e.g. mounted on
+		// a separate volume), it can't be removed; emptying its contents is
+		// enough. Bail out only on other errors.
+		if !kubeletRootDirMounted {
+			return fmt.Errorf("failed to delete k0s kubelet root directory: %w", err)
+		}
+		if !errorIsUnlinkat(err, d.kubeletRootDir) {
+			return fmt.Errorf("failed to delete contents of mounted kubelet root directory: %w", err)
+		}
 	}
 
 	if dataDirMounted {


### PR DESCRIPTION
## Description

Fixes an issue where `k0s reset` was unmounting and deleting the kubelet-root-dir mount point when configured on a separate filesystem.

When `--kubelet-root-dir` is on a dedicated partition (common in production), `k0s reset` would unmount the filesystem and delete the mount point.

This PR applies the same mount point preservation logic to `kubelet-root-dir` that was already existing for `data-dir`.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

Tested scenarios:
- **Mounted filesystem**: Kubelet mount point preserved, only contents deleted
- **Default setup**: Directory completely removed as before

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
