### PR TITLE
Downgrade go to 1.24.8

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM $BUILDIMAGE
 ARG TARGETARCH
 RUN set -ex; \
 # Need to use the gold linker on ARM, Go really wants to have it.
-# https://github.com/golang/go/blob/go1.25.1/src/cmd/link/internal/ld/lib.go#L1678-L1697
+# https://github.com/golang/go/blob/go1.24.8/src/cmd/link/internal/ld/lib.go#L1674-L1694
   case "$TARGETARCH" in \
   arm*) binutils=binutils-gold ;; \
     *)    binutils=binutils ;; \

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -2,7 +2,7 @@
 alpine_patch_version = 3.22.1
 alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.25.1
+go_version = 1.24.8
 
 # renovate: datasource=github-releases depName=opencontainers/runc
 runc_version = 1.3.2

--- a/internal/pkg/file/atomic_test.go
+++ b/internal/pkg/file/atomic_test.go
@@ -215,7 +215,7 @@ func TestWriteAtomically(t *testing.T) {
 			)
 			assert.Equal(t, file, linkErr.New)
 			if runtime.GOOS == "windows" {
-				// https://github.com/golang/go/blob/go1.25.1/src/syscall/types_windows.go#L13
+				// https://github.com/golang/go/blob/go1.25.1/src/syscall/types_windows.go#L11
 				//revive:disable-next-line:var-naming
 				const ERROR_ACCESS_DENIED syscall.Errno = 5
 				var errno syscall.Errno


### PR DESCRIPTION
1.25.2 breaks the CI and kubernetes doesn't use 1.25 yet.

Fixes CVE-2025-58188