### PR TITLE
CIS benchmark 1.1.15 and 1.1.17: change file permissions to 0600 for ccm.conf and scheduler.conf

### DIFF
--- a/cmd/controller/certificates.go
+++ b/cmd/controller/certificates.go
@@ -140,7 +140,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 			return err
 		}
 
-		return kubeConfig(filepath.Join(c.K0sVars.CertRootDir, "ccm.conf"), kubeConfigAPIUrl, c.CACert, ccmCert.Cert, ccmCert.Key, apiServerUID, constant.CertSecureMode)
+		return kubeConfig(filepath.Join(c.K0sVars.CertRootDir, "ccm.conf"), kubeConfigAPIUrl, c.CACert, ccmCert.Cert, ccmCert.Key, apiServerUID, constant.OwnerOnlyMode)
 	})
 
 	eg.Go(func() error {
@@ -164,7 +164,7 @@ func (c *Certificates) Init(ctx context.Context) error {
 			return err
 		}
 
-		return kubeConfig(filepath.Join(c.K0sVars.CertRootDir, "scheduler.conf"), kubeConfigAPIUrl, c.CACert, schedulerCert.Cert, schedulerCert.Key, uid, constant.CertSecureMode)
+		return kubeConfig(filepath.Join(c.K0sVars.CertRootDir, "scheduler.conf"), kubeConfigAPIUrl, c.CACert, schedulerCert.Cert, schedulerCert.Key, uid, constant.OwnerOnlyMode)
 	})
 
 	eg.Go(func() error {

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -138,7 +138,7 @@ func (s *BasicSuite) checkCertPerms(ctx context.Context, node string) error {
 		return fmt.Errorf("some private key files having non 640 permissions: %s", keyOutput)
 	}
 
-	// Check that .conf files have either 640 or 600 permissions (admin.conf uses 600, others use 640)
+	// Check that .conf files have either 640 or 600 permissions (admin.conf, scheduler.conf, and ccm.conf use 600, others use 640)
 	confOutput, err := ssh.ExecWithOutput(ctx, `find /var/lib/k0s/custom-data-dir/pki/ -name '*.conf' -a \! -perm 0640 -a \! -perm 0600`)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

This PR updates file permissions to be more restrictive (0600) as required by the [CIS Kubernetes Benchmark (v1.11)](https://github.com/aquasecurity/kube-bench/tree/main/cfg/cis-1.11):

 /var/lib/k0s/pki/scheduler.conf (CIS 1.1.15)
 /var/lib/k0s/pki/ccm.conf (CIS 1.1.17)

Fixes # (issue)
CIS benchmark control IDs

1.1.15 – /var/lib/k0s/pki/scheduler.conf → currently 640 kube-scheduler:root (CIS requires 600)
1.1.17 – /var/lib/k0s/pki/ccm.conf → currently 640 kube-apiserver:root (CIS requires 600)


## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

### Testing details:
- Built k0s locally and installed with sudo k0s install controller --single.
- Verified k0scontroller service is running with all components
- Checked file permissions:

/var/lib/k0s/pki/scheduler.conf → 600 kube-scheduler:root

```
sudo stat -c "%a %U:%G %n" /var/lib/k0s/pki/scheduler.conf
600 kube-scheduler:root /var/lib/k0s/pki/scheduler.conf
```

/var/lib/k0s/pki/ccm.conf → 600 kube-apiserver:root
```
sudo stat -c "%a %U:%G %n" /var/lib/k0s/pki/ccm.conf
600 kube-apiserver:root /var/lib/k0s/pki/ccm.conf
```

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
