### PR TITLE
Bridge GRPC logs to logrus

### DIFF
--- a/internal/pkg/log/k0s.go
+++ b/internal/pkg/log/k0s.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bombsimon/logrusr/v4"
 	cfssllog "github.com/cloudflare/cfssl/log"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/grpclog"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -24,6 +25,7 @@ func InitLogging() (Backend, ShutdownLoggingFunc) {
 
 	cfssllog.SetLogger((*cfsslAdapter)(logrus.WithField("component", "cfssl")))
 	crlog.SetLogger(logrusr.New(logrus.WithField("component", "controller-runtime")))
+	grpclog.SetLoggerV2(&grpcAdapter{logrus.WithField("component", "grpc")})
 
 	SetWarnLevel()
 
@@ -44,3 +46,7 @@ func SetWarnLevel() {
 	logrus.SetLevel(logrus.WarnLevel)
 	cfssllog.Level = cfssllog.LevelWarning
 }
+
+type grpcAdapter struct{ *logrus.Entry }
+
+func (*grpcAdapter) V(level int) bool { return false }


### PR DESCRIPTION
## Description

By default, grpc-go only logs errors. However, the Kubernetes API server installs a klog backend for GRPC logs. In k0s, this means that GRPC warnings will be printed to stderr. Install our own logrus backend instead. Set the default log level to "error," as vanilla grpc-go does. Support the same environment variables to change that behavior.

Note that to see GRPC info logs, one must set the GRPC log level to info and run k0s with either the --verbose or --debug flag.

See:

* https://github.com/kubernetes/kubernetes/blob/v1.34.1/staging/src/k8s.io/apiserver/pkg/storage/etcd3/logger.go#L27
* k0sproject/k0sctl#953

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
