### PR TITLE
[Backport release-1.32] Allow update-prober to be disabled

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -590,16 +590,17 @@ func (c *command) start(ctx context.Context) error {
 		EnableWorker:       c.EnableWorker,
 	})
 
-	restConfig, err := adminClientFactory.GetRESTConfig()
-	if err != nil {
-		return err
+	if !slices.Contains(c.DisableComponents, constant.UpdateProberComponentName) {
+		restConfig, err := adminClientFactory.GetRESTConfig()
+		if err != nil {
+			return err
+		}
+		apClientFactory, err := apclient.NewClientFactory(restConfig)
+		if err != nil {
+			return err
+		}
+		clusterComponents.Add(ctx, controller.NewUpdateProber(apClientFactory, leaderElector))
 	}
-	apClientFactory, err := apclient.NewClientFactory(restConfig)
-	if err != nil {
-		return err
-	}
-	clusterComponents.Add(ctx, controller.NewUpdateProber(apClientFactory, leaderElector))
-
 	// Add the config source as the last component, so that the reconciliation
 	// starts after all other components have been started.
 	clusterComponents.Add(ctx, configSource)

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -66,7 +66,7 @@ Flags:
       --data-dir string                                Data Directory for k0s. DO NOT CHANGE for an existing setup, things will break! (default `+defaultDataDir+`)
   -d, --debug                                          Debug logging (default: false)
       --debugListenOn string                           Http listenOn for Debug pprof handler (default ":6060")
-      --disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,windows-node,worker-config)
+      --disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,update-prober,windows-node,worker-config)
       --enable-cloud-provider                          Whether or not to enable cloud provider support in kubelet
       --enable-dynamic-config                          enable cluster-wide dynamic config based on custom resource
       --enable-k0s-cloud-provider                      enables the k0s-cloud-provider (default false)

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -62,7 +62,7 @@ Flags:
       --data-dir string                                Data Directory for k0s. DO NOT CHANGE for an existing setup, things will break! (default `+defaultDataDir+`)
   -d, --debug                                          Debug logging (default: false)
       --debugListenOn string                           Http listenOn for Debug pprof handler (default ":6060")
-      --disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,windows-node,worker-config)
+      --disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,update-prober,windows-node,worker-config)
       --enable-cloud-provider                          Whether or not to enable cloud provider support in kubelet
       --enable-dynamic-config                          enable cluster-wide dynamic config based on custom resource
       --enable-k0s-cloud-provider                      enables the k0s-cloud-provider (default false)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -566,7 +566,7 @@ they need to fulfill their need for the control plane. Disabling the system
 components happens through a command line flag for the controller process:
 
 ```text
---disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,windows-node,worker-config)
+--disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,update-prober,windows-node,worker-config)
 ```
 
 **Note:** As of k0s 1.26, the kubelet-config component has been replaced by the

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -263,6 +263,7 @@ var availableComponents = []string{
 	constant.NetworkProviderComponentName,
 	constant.NodeRoleComponentName,
 	constant.SystemRbacComponentName,
+	constant.UpdateProberComponentName,
 	constant.WindowsNodeComponentName,
 	constant.WorkerConfigComponentName,
 }

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -122,6 +122,7 @@ const (
 	NodeRoleComponentName              = "node-role"
 	WindowsNodeComponentName           = "windows-node"
 	AutopilotComponentName             = "autopilot"
+	UpdateProberComponentName          = "update-prober"
 
 	// ClusterConfigNamespace is the namespace where we expect to find the ClusterConfig CRs
 	ClusterConfigNamespace  = "kube-system"


### PR DESCRIPTION
Backport to `release-1.32`:

* #6328

See:

* #6326
