### PR TITLE
Fix image bundle hash key calculation

### DIFF
--- a/.github/workflows/build-image-bundle.yml
+++ b/.github/workflows/build-image-bundle.yml
@@ -56,7 +56,7 @@ jobs:
       - name: "Cache :: Image bundle :: Calculate cache key"
         id: cache-image-bundle-calc-key
         env:
-          HASH_VALUE: ${{ hashFiles('Makefile', '${{ inputs.image-bundle-name }}-images.txt', 'cmd/airgap/*', 'pkg/airgap/*') }}
+          HASH_VALUE: ${{ hashFiles('Makefile', format('{0}-images.txt', inputs.image-bundle-name), 'cmd/airgap/*', 'pkg/airgap/*') }}
         run: |
           printf 'cache-key=build-%s-image-bundle-%s-%s-%s\n' "$IMAGE_BUNDLE_NAME" "$TARGET_OS" "$TARGET_ARCH" "$HASH_VALUE" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Description

The hash calculation did not take the image bundle list into account.

String interpolation only works in "YAML" mode. If you are already in "script" mode, you need to use different techniques. This explains why the image bundle list was never picked up and why image bundles with the wrong content were shared between builds.

Fixes:

* #6405

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
