### PR TITLE
Optimize GitHub Actions cache usage

### DIFF
--- a/.github/workflows/build-k0s.yml
+++ b/.github/workflows/build-k0s.yml
@@ -58,34 +58,35 @@ jobs:
           echo executable-suffix="$executableSuffix" >>"$GITHUB_OUTPUT"
 
       - name: "Cache :: embedded binaries"
+        id: cache-embedded-bins
         uses: actions/cache@v4
         with:
-          key: build-k0s-${{ inputs.target-os }}-${{ inputs.target-arch }}-embedded-bins-${{ hashFiles('embedded-bins/**/*') }}
-          path: |
-            .bins.${{ inputs.target-os }}.stamp
-            bindata_${{ inputs.target-os }}
-            embedded-bins/staging/${{ inputs.target-os }}/bin/
-            embedded-bins/Makefile.variables
-            pkg/assets/zz_generated_offsets_${{ inputs.target-os }}.go
+          key: "build-k0s-${{ inputs.target-os }}-${{ inputs.target-arch }}-embedded-bins-${{ hashFiles('embedded-bins/**/*') }}"
+          path: embedded-bins/staging/${{ inputs.target-os }}/bin/
 
-      - name: "Cache :: GOCACHE"
+      - name: "Cache :: Go cache"
         id: cache-gocache
         uses: actions/cache@v4
         with:
-          key: build-k0s-${{ inputs.target-os }}-${{ inputs.target-arch }}-gocache-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            build-k0s-${{ inputs.target-os }}-${{ inputs.target-arch }}-gocache-${{ github.ref_name }}-
-          path: |
-            build/cache/go/build
+          key: "build-k0s-${{ inputs.target-os }}-${{ inputs.target-arch }}-gocache-go${{ env.GO_VERSION }}-${{ github.sha }}"
+          restore-keys: "build-k0s-${{ inputs.target-os }}-${{ inputs.target-arch }}-gocache-go${{ env.GO_VERSION }}-"
+          path: build/cache/go/build
 
-      - name: "Cache :: GOCACHE :: Prepare"
+      - name: "Cache :: Go cache :: Prepare"
         if: steps.cache-gocache.outputs.cache-hit
         run: |
           touch -t "$(TZ=UTC+24 date +%Y%m%d%H%M.%S)" build/cache/_cache_sentinel
           find build/cache/go/build -type f \( -name '*-a' -o -name '*-d' \) -exec touch -r build/cache/_cache_sentinel {} +
 
       - name: "Build :: k0s"
+        env:
+          EMBEDDED_BINS_CACHED: "${{ steps.cache-embedded-bins.outputs.cache-hit }}"
         run: |
+          make .k0sbuild.docker-image.k0s
+          touch go.sum
+          if [ "$EMBEDDED_BINS_CACHED" == true ]; then
+            make --touch ".bins.$TARGET_OS.stamp"
+          fi
           make bindata
           make --touch codegen
           make build
@@ -129,7 +130,7 @@ jobs:
           name: ipv6-test-image-list-${{ inputs.target-os }}-${{ inputs.target-arch }}
           path: ipv6-test-images.txt
 
-      - name: "Cache :: GOCACHE :: Trim"
+      - name: "Cache :: Go cache :: Trim"
         if: steps.cache-gocache.outputs.cache-hit
         run: |
           find build/cache/go/build -type f \( -name '*-a' -o -name '*-d' \) -not -newer build/cache/_cache_sentinel -delete

--- a/.github/workflows/go-completed.yaml
+++ b/.github/workflows/go-completed.yaml
@@ -1,0 +1,46 @@
+name: Go build completed
+
+on:
+  workflow_run:
+    workflows: [Go build]
+    types: [completed]
+
+jobs:
+  # Based on https://github.com/actions/cache/blob/v4.2.0/tips-and-workarounds.md#force-deletion-of-caches-overriding-default-cache-eviction-policy
+  cleanup-actions-caches:
+    name: Cleanup GitHub Actions caches
+    runs-on: ubuntu-latest
+    permissions:
+      # `actions:write` permission is required to delete caches
+      #   See also: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id
+      actions: write
+
+    steps:
+      # Group all caches that end with a Git commit hash by branch and keep only the most recently created one.
+      - name: Cleanup
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_REPO: "${{ github.repository }}"
+          QUERY: |
+            [ .actions_caches[]
+              | . + { key_prefix: .key | sub("-[0-9a-f]{40}$"; "") } # Calculate cache prefix
+              | select(.key_prefix != .key)                          # Only keep caches which have the right suffix
+            ]
+            | [
+              group_by([.ref, .key_prefix])[] # Look at all the caches per branch with the same prefix
+              | sort_by(.created_at)          # Sort by creation date ...
+              | reverse                       # ... so that the newest cache is the first in the array
+              | del(.[0])                     # Remove that newest cache, i.e. don't delete it
+            ]
+            | flatten           # Remove the grouping
+            | .[]               # Unpack the resulting flat array
+            | [.id, .ref, .key] # Extract the values to be returned
+            | @sh               # Escape them to be used in POSIX shells
+
+        run: |
+          set -euo pipefail
+          gh api -X GET repos/{owner}/{repo}/actions/caches -q "$QUERY" | while read -r args; do
+            eval "set -- $args"
+            echo Deleting cache with id "$1" from "$2": "$3"
+            gh api -X DELETE repos/{owner}/{repo}/actions/caches/"$1" || :
+          done

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -179,6 +179,8 @@ jobs:
 
     env:
       EMBEDDED_BINS_BUILDMODE: none
+      # Set SOURCE_DATE_EPOCH to optimize cache usage
+      MAKEFLAGS: -j SOURCE_DATE_EPOCH=315532800
 
     steps:
       - name: Check out code into the Go module directory
@@ -209,15 +211,13 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
-      - name: Cache GOCACHE
+      - name: Cache Go cache
         id: cache-gocache
         uses: actions/cache@v4
         with:
-          key: unittests-k0s-${{ matrix.name }}-gocache-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            unittests-k0s-${{ matrix.name }}-gocache-${{ github.ref_name }}-
-          path: |
-            build/cache/go/build
+          key: "unittests-k0s-${{ matrix.name }}-gocache-go${{ env.GO_VERSION }}-${{ github.sha }}"
+          restore-keys: "unittests-k0s-${{ matrix.name }}-gocache-go${{ env.GO_VERSION }}-"
+          path: build/cache/go/build
 
       - name: Run unit tests
         env:
@@ -317,35 +317,40 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Cache embedded binaries
+        id: cache-embedded-bins
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-embedded-bins-arm-${{ hashFiles('**/embedded-bins/**/*') }}
-          path: |
-            .bins.linux.stamp
-            embedded-bins/staging/linux/bin/
-            embedded-bins/Makefile.variables
+          key: "build-k0s-linux-arm-embedded-bins-${{ hashFiles('embedded-bins/**/*') }}"
+          path: embedded-bins/staging/linux/bin/
 
-      - name: Cache GOCACHE
+      - name: Cache Go cache
         id: cache-gocache
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-smoketest-arm-gocache-arm-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-smoketest-arm-gocache-arm-${{ github.ref_name }}-
-          path: |
-            build/cache/go/build
+          key: "build-k0s-linux-arm-gocache-go${{ env.GO_VERSION }}-${{ github.sha }}"
+          restore-keys: "build-k0s-linux-arm-gocache-go${{ env.GO_VERSION }}-"
+          path: build/cache/go/build
 
-      - name: Cache GOCACHE - Prepare
+      - name: Prepare Go cache
         if: steps.cache-gocache.outputs.cache-hit
         run: |
           touch -t "$(TZ=UTC+24 date +%Y%m%d%H%M.%S)" build/cache/_cache_sentinel
           find build/cache/go/build -type f \( -name '*-a' -o -name '*-d' \) -exec touch -r build/cache/_cache_sentinel {} +
 
       - name: Build
+        env:
+          EMBEDDED_BINS_CACHED: "${{ steps.cache-embedded-bins.outputs.cache-hit }}"
         run: |
+          gh --version || echo No gh installed
+          make .k0sbuild.docker-image.k0s
+          touch go.sum
+          if [ "$EMBEDDED_BINS_CACHED" == true ]; then
+            make --touch .bins.linux.stamp
+          fi
           make bindata
           make --touch codegen
           make build
+          echo "k0s binary size: **$(du -sh k0s | cut -f1)**" >>$GITHUB_STEP_SUMMARY
 
       - name: Upload compiled executable
         uses: actions/upload-artifact@v4
@@ -378,7 +383,7 @@ jobs:
           name: airgap-image-bundle-linux-arm.tar
           path: airgap-image-bundle-linux-arm.tar
 
-      - name: Cache GOCACHE - Trim
+      - name: Trim Go cache
         if: steps.cache-gocache.outputs.cache-hit
         run: |
           find build/cache/go/build -type f \( -name '*-a' -o -name '*-d' \) -not -newer build/cache/_cache_sentinel -delete

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,6 +30,9 @@ env:
   MAKEFLAGS: -j
   EMBEDDED_BINS_BUILDMODE: none
 
+permissions:
+  contents: read
+
 jobs:
   lint-go:
     strategy:
@@ -67,14 +70,13 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
-      - name: "Cache :: golangci-lint"
+      - name: Cache golangci-lint cache
         id: cache-golangci
         uses: actions/cache@v4
         with:
-          key: lint-${{ matrix.target-os }}-amd64-golangci-${{ github.ref_name }}-${{ github.sha }}
+          key: "lint-${{ matrix.target-os }}-amd64-golangci-${{ env.GOLANGCI_LINT_VERSION }}-go-${{ env.GO_VERSION }}-${{ github.sha }}"
           restore-keys: |
-            lint-${{ matrix.target-os }}-amd64-golangci-${{ github.ref_name }}-
-            lint-${{ matrix.target-os }}-amd64-golangci-main-
+            lint-${{ matrix.target-os }}-amd64-golangci-${{ env.GOLANGCI_LINT_VERSION }}-go-${{ env.GO_VERSION }}-
           path: |
             build/cache/go/build
             build/cache/golangci-lint
@@ -103,16 +105,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          preserve-credentials: false
 
-      - name: "Cache :: GOCACHE"
+      - name: Prepare build environment
+        run: .github/workflows/prepare-build-env.sh
+
+      - name: Restore Go cache
         uses: actions/cache/restore@v4
         with:
-          key: build-k0s-linux-amd64-gocache-${{ github.ref_name }}-${{ github.sha }}
+          key: "build-k0s-linux-amd64-gocache-go${{ env.GO_VERSION }}-${{ github.sha }}"
           restore-keys: |
-            build-k0s-linux-amd64-gocache-${{ github.ref_name }}-
-            build-k0s-linux-amd64-gocache-main-
-          path: |
-            build/cache/go/build
+            build-k0s-linux-amd64-gocache-go${{ env.GO_VERSION }}-
+          path: build/cache/go/build
 
       - name: Check go.mod/go.sum to be consistent
         run: make --always-make go.sum && git diff --exit-code

--- a/.github/workflows/ostests-nightly.yaml
+++ b/.github/workflows/ostests-nightly.yaml
@@ -134,7 +134,7 @@ jobs:
         # Message format described here: https://api.slack.com/surfaces/messages#payloads
         # The block structure can be tested online: https://app.slack.com/block-kit-builder
         run: |
-          gh api "/repos/{owner}/{repo}/actions/runs/$GITHUB_RUN_ID/jobs" -q '
+          gh api "repos/{owner}/{repo}/actions/runs/$GITHUB_RUN_ID/jobs" -q '
             def fmt_duration:
               if . >= 3600 then "\(./3600|floor) h \((.%3600/60|floor)) min"
               elif . >= 60 then "\(./60|floor) min \(.%60) sec"

--- a/.github/workflows/pr-closed.yaml
+++ b/.github/workflows/pr-closed.yaml
@@ -23,11 +23,11 @@ jobs:
           BRANCH: "refs/pull/${{ github.event.pull_request.number }}/merge"
         run: |
           set -euo pipefail
-          gh api -X GET /repos/{owner}/{repo}/actions/caches -f ref="$BRANCH" --paginate -q '.actions_caches[] | "\(.id) \(.key)"' | {
+          gh api -X GET repos/{owner}/{repo}/actions/caches -f ref="$BRANCH" --paginate -q '.actions_caches[] | "\(.id) \(.key)"' | {
             fail=0
             while read -r id key; do
               echo Deleting cache with ID $id: $key
-              gh api -X DELETE /repos/{owner}/{repo}/actions/caches/"$id" || fail=1
+              gh api -X DELETE repos/{owner}/{repo}/actions/caches/"$id" || fail=1
             done
             [ $fail -eq 0 ]
           }


### PR DESCRIPTION
## Description

The Go cache has fixed trim settings. It updates mtimes hourly and trims daily, deleting anything older than five days. This is too conservative for CI caches. We only want to retain caches used in the current run. We can achieve this by setting the mtime of all cache files to a time between one hour and five days ago. After the build, all used cache entries will have a newer mtime. Everything else can be trimmed.

Remove the caching of the Go module cache. It only provides an approximate 20-second speed boost, while eating up a couple of 100MB per GitHub cache. We can add it back later on if we think it's really worth it.

Simplify the caching of the embedded executables. Makes the cache size smaller, at the cost of some extra packaging time spent to build the gzipped blob during build time. This requires some tricks to tell make what needs to be built and what doesn't.

Only keep the most recent cache per branch. All caches ending in a hash will be pruned so that only the newest cache is retained on a per-branch and per-key-prefix basis.

Don't use leading slashes for URLs passed to the gh CLI. Leading slashes would otherwise trigger file path normalization in bash on Windows, which would render the URL fragment illegal.

Use a fixed source date epoch in unit tests to better leverage cache usage.

Trying to mitigate this:

[
<img width="522" height="87" alt="k0s-cache-usage" src="https://github.com/user-attachments/assets/4d3f6e1b-7dea-48e2-8a12-ec82507d09b7" />
](url)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
