### PR TITLE
Disable update prober interval with ENV variable value `DISABLED`

### DIFF
--- a/pkg/component/controller/updateprober.go
+++ b/pkg/component/controller/updateprober.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	// "github.com/k0sproject/k0s/pkg/component/manager"
@@ -47,6 +48,11 @@ func (u *UpdateProber) Init(ctx context.Context) error {
 
 func (u *UpdateProber) Start(ctx context.Context) error {
 	u.log.Debug("starting up")
+	// Check if it's disabled by env variable and return immediately
+	if isCheckUpdatesDisabled() {
+		u.log.Debug("update check interval disabled")
+		return nil
+	}
 	// Check for updates in 30min intervals from default update server
 	// ENV var only to be used for testing purposes
 	updateCheckInterval := 30 * time.Minute
@@ -76,6 +82,10 @@ func (u *UpdateProber) Start(ctx context.Context) error {
 
 func (u *UpdateProber) Stop() error {
 	return nil
+}
+
+func isCheckUpdatesDisabled() bool {
+	return strings.ToUpper(os.Getenv("K0S_UPDATE_CHECK_INTERVAL")) == "DISABLED"
 }
 
 func (u *UpdateProber) checkUpdates(ctx context.Context) {
@@ -176,6 +186,7 @@ func (u *UpdateProber) checkUpdates(ctx context.Context) {
 			return
 		}
 	} else {
-		u.log.Debugf("no newer version availablen")
+		u.log.Debugf("no newer version available")
 	}
 }
+

--- a/pkg/component/controller/updateprober_test.go
+++ b/pkg/component/controller/updateprober_test.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2023 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"os"
+	"testing"
+	assert "github.com/stretchr/testify/assert"
+)
+
+func TestUpdateCheckIntervalIsEnabled(t *testing.T) {
+	os.Setenv("K0S_UPDATE_CHECK_INTERVAL", "10s")
+	defer os.Unsetenv("K0S_UPDATE_CHECK_INTERVAL")
+	
+	assert.Equal(t, "10s", os.Getenv("K0S_UPDATE_CHECK_INTERVAL"))
+	assert.False(t, isCheckUpdatesDisabled())
+}
+
+func TestUpdateCheckIntervalIsEnbledByDefault(t *testing.T) {
+	os.Unsetenv("K0S_UPDATE_CHECK_INTERVAL")
+	assert.False(t, isCheckUpdatesDisabled())
+}
+
+func TestUpdateCheckIntervalIsDisabled(t *testing.T) {
+	t.Run("lower case", func (t *testing.T) {
+		os.Setenv("K0S_UPDATE_CHECK_INTERVAL", "disabled")
+		defer os.Unsetenv("K0S_UPDATE_CHECK_INTERVAL")
+		assert.True(t, isCheckUpdatesDisabled())
+	})
+
+	t.Run("mixed case", func (t *testing.T) {
+		os.Setenv("K0S_UPDATE_CHECK_INTERVAL", "Disabled")
+		defer os.Unsetenv("K0S_UPDATE_CHECK_INTERVAL")
+		assert.True(t, isCheckUpdatesDisabled())
+	})
+
+	t.Run("upper case", func (t *testing.T) {
+		os.Setenv("K0S_UPDATE_CHECK_INTERVAL", "DISABLED")
+		defer os.Unsetenv("K0S_UPDATE_CHECK_INTERVAL")
+		assert.True(t, isCheckUpdatesDisabled())
+	})
+
+	assert.False(t, isCheckUpdatesDisabled())
+}


### PR DESCRIPTION
## Description

In some scenarios it makes sense to disable the updateprober (f.i. highly monitored network traffic environment) and this PR is disabling the interval (so that the checkUpdates method is never called). By setting the `K0S_UPDATE_CHECK_INTERVAL="disabled"` the check is completely disabled.

The default behavior *does not change* with this PRs. The value must be explicitly set to "disabled".

https://github.com/k0sproject/k0s/issues/6561


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

- Checking for the log entries which confirm that the update check interval has been disabled

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
