### PR TITLE
Enable dependency bumps on release-1.34

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   ],
   "baseBranchPatterns": [
     "main",
-    "/^release-1\\.3[0-3]$/"
+    "/^release-1\\.3[1-4]$/"
   ],
   "prTitleStrict": true,
   "enabledManagers": [
@@ -89,6 +89,17 @@
       "matchBaseBranches": [
         "!main"
       ]
+    },
+    {
+      "description": "Bump Go for release-1.34",
+      "enabled": true,
+      "matchBaseBranches": [
+        "release-1.34"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "allowedVersions": "<=1.24"
     },
     {
       "description": "Bump Envoy for release-1.33",


### PR DESCRIPTION
## Description

And exclude `release-1.30` from bumps.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
