### PR TITLE
Disable kine's automatic compaction

### DIFF
--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -117,6 +117,8 @@ func (k *Kine) Start(ctx context.Context) error {
 			"--listen-address=unix://" + k.K0sVars.KineSocketPath,
 			// Enable metrics on port 2380. The default is 8080, which clashes with kube-router.
 			"--metrics-bind-address=:2380",
+			// https://github.com/k3s-io/kine/pull/513
+			"--compact-interval=0",
 		},
 		UID: k.uid,
 		GID: kineGID,


### PR DESCRIPTION
## Description

As of Kubernetes v1.34, the kube-apiserver expects to manage etcd-style compaction itself and observes a "compaction revision" key to coordinate cache pruning.

If Kine continues compacting independently, it can race the API server's own compaction logic. Disable Kine's automatic compaction by passing `--compact-interval=0` so that the API server has full control.

See:

* [KEP-4988 Snapshottable API server cache](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/4988-snapshottable-api-server-cache/README.md)
* k3s-io/kine#513

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
