### PR TITLE
Implement k0s etcd member-update command

### DIFF
--- a/cmd/etcd/etcd.go
+++ b/cmd/etcd/etcd.go
@@ -49,6 +49,7 @@ func NewEtcdCmd() *cobra.Command {
 	pflags.AddFlagSet(config.GetPersistentFlagSet())
 
 	cmd.AddCommand(etcdLeaveCmd())
+	cmd.AddCommand(etcdUpdateCmd())
 	cmd.AddCommand(etcdListCmd())
 
 	return cmd

--- a/cmd/etcd/update.go
+++ b/cmd/etcd/update.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package etcd
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+
+	"github.com/asaskevich/govalidator"
+	"github.com/k0sproject/k0s/pkg/config"
+	"github.com/k0sproject/k0s/pkg/etcd"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func etcdUpdateCmd() *cobra.Command {
+	var peerAddressArg string
+	var memberName string
+
+	cmd := &cobra.Command{
+		Use:   "member-update",
+		Short: "Update specific member of the cluster",
+		// accept peer address list as the first flag
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, peerAddr []string) error {
+			for _, peer := range peerAddr {
+				if !govalidator.IsIP(peer) && !govalidator.IsDNSName(peer) {
+					return fmt.Errorf("%q neither an IP address nor a DNS name", peer)
+				}
+			}
+
+			opts, err := config.GetCmdOpts(cmd)
+			if err != nil {
+				return err
+			}
+			nodeConfig, err := opts.K0sVars.NodeConfig()
+			if err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+
+			peerAddress := cmp.Or(peerAddressArg, nodeConfig.Spec.Storage.Etcd.PeerAddress)
+			if memberName == "" && peerAddress == "" {
+				return errors.New("can't update member: no member name or peer address specified")
+			}
+
+			etcdClient, err := etcd.NewClient(opts.K0sVars.CertRootDir, opts.K0sVars.EtcdCertDir, nodeConfig.Spec.Storage.Etcd)
+			if err != nil {
+				return fmt.Errorf("can't connect to the etcd: %w", err)
+			}
+
+			var peerID uint64
+			if memberName != "" {
+				peerID, err = etcdClient.GetPeerIDByName(ctx, memberName)
+				if err != nil {
+					logrus.WithField("memberName", memberName).Errorf("Failed to get peer ID")
+					return err
+				}
+			} else if peerAddress != "" {
+				peerURL := (&url.URL{Scheme: "https", Host: net.JoinHostPort(peerAddress, "2380")}).String()
+				peerID, err = etcdClient.GetPeerIDByAddress(ctx, peerURL)
+				if err != nil {
+					logrus.WithField("peerURL", peerURL).Errorf("Failed to get peer ID")
+					return err
+				}
+			}
+
+			if err := etcdClient.UpdateMember(ctx, peerID, peerAddr); err != nil {
+				logrus.
+					WithField("peerID", strconv.FormatUint(peerID, 16)).
+					Errorf("Failed to update cluster member")
+				return err
+			}
+
+			logrus.
+				WithField("peerID", strconv.FormatUint(peerID, 16)).
+				Info("Successfully updated")
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.AddFlag(&pflag.Flag{
+		Name:  "peer-address",
+		Usage: "etcd peer address to update (default <this node's peer address>)",
+		Value: (*ipOrDNSName)(&peerAddressArg),
+	})
+	flags.AddFlag(&pflag.Flag{
+		Name:  "member-name",
+		Usage: "etcd member name to update",
+		Value: (*ipOrDNSName)(&memberName),
+	})
+
+	return cmd
+}

--- a/cmd/etcd/update_test.go
+++ b/cmd/etcd/update_test.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package etcd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEtcdUpdateCmd(t *testing.T) {
+	t.Run("rejects_invalid_peer_argument", func(t *testing.T) {
+		updateCmd := etcdUpdateCmd()
+		updateCmd.SetArgs([]string{"some/path"})
+		err := updateCmd.Execute()
+		assert.ErrorContains(t, err, `"some/path" neither an IP address nor a DNS name`)
+	})
+
+	t.Run("requires_minimum_arguments", func(t *testing.T) {
+		updateCmd := etcdUpdateCmd()
+		updateCmd.SetArgs([]string{})
+		err := updateCmd.Execute()
+		assert.ErrorContains(t, err, "requires at least 1 arg(s)")
+	})
+
+	t.Run("rejects_invalid_peer_address_flag", func(t *testing.T) {
+		updateCmd := etcdUpdateCmd()
+		updateCmd.SetArgs([]string{"--peer-address=neither/ip/nor/name", "peer1"})
+		err := updateCmd.Execute()
+		assert.ErrorContains(t, err, `invalid argument "neither/ip/nor/name" for "--peer-address" flag: neither an IP address nor a DNS name`)
+	})
+
+	t.Run("rejects_invalid_member_name_flag", func(t *testing.T) {
+		updateCmd := etcdUpdateCmd()
+		updateCmd.SetArgs([]string{"--member-name=neither/ip/nor/name", "peer1"})
+		err := updateCmd.Execute()
+		assert.ErrorContains(t, err, `invalid argument "neither/ip/nor/name" for "--member-name" flag: neither an IP address nor a DNS name`)
+	})
+
+	t.Run("usage_string_contains_flag_help", func(t *testing.T) {
+		updateCmd := etcdUpdateCmd()
+		usageLines := strings.Split(updateCmd.UsageString(), "\n")
+		assert.Contains(t, usageLines, "      --peer-address ip-or-dns-name   etcd peer address to update (default <this node's peer address>)")
+		assert.Contains(t, usageLines, "      --member-name ip-or-dns-name    etcd member name to update")
+	})
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -105,7 +105,11 @@ func TestUnknownSubCommandsAreRejected(t *testing.T) {
 			for _, cmd := range underTest.Commands() {
 				name, _, _ := strings.Cut(cmd.Use, " ")
 				require.NotEmpty(t, name)
-				t.Run(name, testCommand(cmd, slices.Concat(args, []string{name})))
+				switch name {
+				case "member-update": // Don't test comands with positional args
+				default:
+					t.Run(name, testCommand(cmd, slices.Concat(args, []string{name})))
+				}
 			}
 
 			subCommand := strings.Join(args, " ")

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -115,6 +115,26 @@ func (c *Client) GetPeerIDByAddress(ctx context.Context, peerAddress string) (ui
 	return 0, fmt.Errorf("peer not found: %s", peerAddress)
 }
 
+// GetPeerIDByName looks up peer id by peer name
+func (c *Client) GetPeerIDByName(ctx context.Context, peerName string) (uint64, error) {
+	resp, err := c.client.MemberList(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("etcd member list failed: %w", err)
+	}
+	for _, m := range resp.Members {
+		if m.Name == peerName {
+			return m.ID, nil
+		}
+	}
+	return 0, fmt.Errorf("peer not found: %s", peerName)
+}
+
+// UpdateMember updates member by peer ID
+func (c *Client) UpdateMember(ctx context.Context, peerID uint64, peerAddr []string) error {
+	_, err := c.client.MemberUpdate(ctx, peerID, peerAddr)
+	return err
+}
+
 // DeleteMember deletes member by peer name
 func (c *Client) DeleteMember(ctx context.Context, peerID uint64) error {
 	_, err := c.client.MemberRemove(ctx, peerID)


### PR DESCRIPTION
## Description

Having this command in place would allow to perform member `peerURL` update without using `etcdctl` when such operation is required.

It can be used as:

```bash
k0s etcd member-update --member-name <hostname> <peerURLs>
```

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #6582 

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
