### PR TITLE
Add short roadmap page to point to GH projects

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,9 @@
+# k0s roadmap
+
+k0s maintainers work in a KanBan-ish style, with a [public board] available defining the roadmap items. As always, a roadmap is a living entity and subject to change based on user feedback, maintainer interests, and other factors.
+
+Reach out on [Slack] or [GitHub issues] if you have any questions or suggestions regarding the roadmap or k0s in general!
+
+[Slack]: https://kubernetes.slack.com/archives/C0809EA06QZ/p1730993027457849
+[GitHub Issues]: https://github.com/k0sproject/k0s/issues
+[public board]: https://github.com/orgs/k0sproject/projects/4


### PR DESCRIPTION
CNCF suggests projects to document how the roadmap is defined and where it is managed