### PR TITLE
Demote CoreDNS configuration log message

### DIFF
--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -427,7 +427,7 @@ func (c *CoreDNS) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterC
 		return fmt.Errorf("error calculating coredns configs: %w, will retry", err)
 	}
 	if reflect.DeepEqual(c.previousConfig, cfg) {
-		c.log.Infof("current cfg matches existing, not gonna do anything")
+		c.log.Debug("Configuration is up to date, not gonna do anything")
 		return nil
 	}
 	tw := templatewriter.TemplateWriter{


### PR DESCRIPTION
## Description

The `Reconcile` method of the CoreDNS component is called every ten seconds by a timer task. This means that the log message indicating that the configuration has not been updated will be logged every ten seconds. That's really excessive for a message that simply states that nothing has been done.

Demote it to the debug log level.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
