### PR TITLE
[Backport release-1.33] Bump Go to 1.24.10

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM $BUILDIMAGE
 ARG TARGETARCH
 RUN set -ex; \
 # Need to use the gold linker on ARM, Go really wants to have it.
-# https://github.com/golang/go/blob/go1.24.9/src/cmd/link/internal/ld/lib.go#L1674-L1693
+# https://github.com/golang/go/blob/go1.24.10/src/cmd/link/internal/ld/lib.go#L1674-L1693
   case "$TARGETARCH" in \
   arm*) binutils=binutils-gold ;; \
     *)    binutils=binutils ;; \

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,7 +1,7 @@
 alpine_version = 3.21
 alpine_patch_version = $(alpine_version).3
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
-go_version = 1.24.9
+go_version = 1.24.10
 
 runc_version = 1.2.6
 runc_buildimage = $(golang_buildimage)

--- a/internal/pkg/file/atomic_test.go
+++ b/internal/pkg/file/atomic_test.go
@@ -214,7 +214,7 @@ func TestWriteAtomically(t *testing.T) {
 			)
 			assert.Equal(t, file, linkErr.New)
 			if runtime.GOOS == "windows" {
-				// https://github.com/golang/go/blob/go1.24.9/src/syscall/types_windows.go#L11
+				// https://github.com/golang/go/blob/go1.24.10/src/syscall/types_windows.go#L11
 				//revive:disable-next-line:var-naming
 				const ERROR_ACCESS_DENIED syscall.Errno = 5
 				var errno syscall.Errno


### PR DESCRIPTION
Backport to `release-1.33`:

* #6571
* #6601

See:

* #6564