### PR TITLE
Add --feature-gates flag to the k0s config subcommand

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -4,17 +4,28 @@
 package config
 
 import (
+	"github.com/k0sproject/k0s/pkg/featuregate"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
 func NewConfigCmd() *cobra.Command {
+	var featureGates featuregate.FeatureGates
+
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Configuration related sub-commands",
 		Args:  cobra.NoArgs,
 		RunE:  func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("feature-gates") {
+				return featureGates.Set("")
+			}
+			return nil
+		},
 	}
+
+	cmd.PersistentFlags().Var(&featureGates, "feature-gates", "feature gates to enable (comma separated list of key=value pairs)")
 
 	cmd.AddCommand(NewCreateCmd())
 	cmd.AddCommand(NewEditCmd())

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/k0s/cmd"
+	"github.com/k0sproject/k0s/pkg/featuregate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_ValidateDefaultConfig(t *testing.T) {
+	t.Cleanup(func() { featuregate.FlushDefaultFeatureGates(t) })
+
+	var defaultConfigBytes bytes.Buffer
+	configCreateCmd := cmd.NewRootCmd()
+	configCreateCmd.SetArgs([]string{"config", "create"})
+	configCreateCmd.SetOut(&defaultConfigBytes)
+	require.NoError(t, configCreateCmd.Execute())
+
+	configValidateCmd := cmd.NewRootCmd()
+	configValidateCmd.SetArgs([]string{"config", "validate", "-c", "-"})
+	configValidateCmd.SetIn(bytes.NewReader(defaultConfigBytes.Bytes()))
+	require.NoError(t, configValidateCmd.Execute())
+}
+
+func TestConfig_ValidateIPV6SingleStack(t *testing.T) {
+	config := []byte(`apiVersion: k0s.k0sproject.io/v1beta1
+kind: ClusterConfig
+metadata:
+  name: k0s
+spec:
+  network:
+    podCIDR: fd00::/108
+    serviceCIDR: fd01::/108
+`)
+
+	t.Run("WithoutFeatureGates", func(t *testing.T) {
+		t.Cleanup(func() { featuregate.FlushDefaultFeatureGates(t) })
+
+		expected := `spec: network: podCIDR: Invalid value: "fd00::/108": feature gate IPv6SingleStack must be explicitly enabled to use IPv6 single stack`
+
+		var stderr strings.Builder
+		underTest := cmd.NewRootCmd()
+		underTest.SetArgs([]string{"config", "validate", "-c", "-"})
+		underTest.SetIn(bytes.NewReader(config))
+		underTest.SetErr(&stderr)
+		assert.ErrorContains(t, underTest.Execute(), expected)
+		assert.Equal(t, "Error: "+expected+"\n", stderr.String())
+	})
+
+	t.Run("WithFeatureGate", func(t *testing.T) {
+		t.Cleanup(func() { featuregate.FlushDefaultFeatureGates(t) })
+
+		var stderr strings.Builder
+		underTest := cmd.NewRootCmd()
+		underTest.SetArgs([]string{"config", "validate", "-c", "-", "--feature-gates", "IPv6SingleStack=true"})
+		underTest.SetIn(bytes.NewReader(config))
+		underTest.SetErr(&stderr)
+		assert.NoError(t, underTest.Execute())
+		assert.Empty(t, stderr.String())
+	})
+}

--- a/cmd/config/validate.go
+++ b/cmd/config/validate.go
@@ -25,8 +25,11 @@ func NewValidateCmd() *cobra.Command {
 		Short: "Validate k0s configuration",
 		Long: `Example:
    k0s config validate --config path_to_config.yaml`,
-		Args:             cobra.NoArgs,
-		PersistentPreRun: debugFlags.Run,
+		Args: cobra.NoArgs,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			debugFlags.Run(cmd, args)
+			return internal.CallParentPersistentPreRun(cmd, args)
+		},
 		RunE: func(cmd *cobra.Command, _ []string) (err error) {
 			var bytes []byte
 

--- a/cmd/internal/cobra.go
+++ b/cmd/internal/cobra.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Runs the parent command's persistent pre-run. Cobra can do this either always
+// for the whole command chain from root to leaf, or never. This function allows
+// for more flexibility around this on a case by case basis.
+//
+// See: https://github.com/spf13/cobra/issues/216
+func CallParentPersistentPreRun(cmd *cobra.Command, args []string) error {
+	for p := cmd.Parent(); p != nil; p = p.Parent() {
+		preRunE := p.PersistentPreRunE
+		preRun := p.PersistentPreRun
+
+		p.PersistentPreRunE = nil
+		p.PersistentPreRun = nil
+
+		defer func() {
+			p.PersistentPreRunE = preRunE
+			p.PersistentPreRun = preRun
+		}()
+
+		if preRunE != nil {
+			return preRunE(cmd, args)
+		}
+
+		if preRun != nil {
+			preRun(cmd, args)
+			return nil
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description

This prevents a panic when validating an IPv6-only k0s config.

NB: `CallPersistentPreRun` has been resurrected from commit f9773809e.

Fixes:

* #6611
* #6130

See:

* #5390

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
