### PR TITLE
Fix go mod directive renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -143,11 +143,12 @@
         "**/go.mod"
       ],
       "matchStrings": [
-        "^go (?<currentValue>\\d+\\.\\d+)\\.0\\b"
+        "\\bgo (?<currentValue>\\d+\\.\\d+)\\.\\d+\\b"
       ],
       "depNameTemplate": "go",
       "datasourceTemplate": "golang-version",
       "extractVersionTemplate": "^(?<version>\\d+\\.\\d+)",
+      "autoReplaceStringTemplate": "go {{{newValue}}}.0",
       "versioningTemplate": "loose"
     },
     {


### PR DESCRIPTION
## Description

The previous configuration assumed that the go.mod files in k0s would always remain at the .0 patch level. However, if a dependency declares a higher patch level for any reason, k0s must follow that.

Fixing this requires rewriting the go directive from "go 1.xx.y" to "go 1.zz.0". Additionally, the regular expression was broken. Apparently, it's not a good idea to use line beginning and line end markers for Renovate regular expressions. Replace those with the word boundary marker.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
