### PR TITLE
Don't restart additional controllers using --enable-worker in backup inttest

### DIFF
--- a/inttest/backup/backup_test.go
+++ b/inttest/backup/backup_test.go
@@ -72,6 +72,7 @@ func (s *BackupSuite) TestK0sGetsUp() {
 		}
 	}
 
+	s.Require().NoError(s.WaitForNodeReady(s.ControllerNode(0), kc))
 	for i := range s.WorkerCount {
 		s.Require().NoError(s.WaitForNodeReady(s.WorkerNode(i), kc))
 	}
@@ -99,10 +100,11 @@ func (s *BackupSuite) TestK0sGetsUp() {
 		for i := range s.ControllerCount - 1 {
 			i := i + 1
 			s.PutFile(s.ControllerNode(i), "/etc/k0s/k0s.yaml", config)
-			s.Require().NoError(s.InitController(i, "--enable-worker", token))
+			s.Require().NoError(s.InitController(i, token))
 		}
 	}
 
+	s.Require().NoError(s.WaitForNodeReady(s.ControllerNode(0), kc))
 	for i := range s.WorkerCount {
 		s.Require().NoError(s.WaitForNodeReady(s.WorkerNode(i), kc))
 	}


### PR DESCRIPTION
## Description

This _actually_ fixes the test failures mentioned in #6618.

Fixes:

* #6618
* #6568


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
