### PR TITLE
Disable RenovateBot vulnerability alerts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,9 @@
   "prTitleStrict": true,
   "commitMessageAction": "Bump",
   "commitMessageTopic": "{{depName}}",
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
   "enabledManagers": [
     "gomod",
     "custom.regex"


### PR DESCRIPTION
## Description

Those are breaking apart the mandatory grouping for some dependency bumps, preventing pull requests from passing CI. There's currently no way to change that behavior in RenovateBot.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
