### PR TITLE
Add honorLabels to pushgateway ServiceMonitor example in the Docs

### DIFF
--- a/docs/system-monitoring.md
+++ b/docs/system-monitoring.md
@@ -46,6 +46,7 @@ metadata:
 spec:
   endpoints:
   - port: http
+    honorLabels: true 
   selector:
     matchLabels:
       app: k0s-observability


### PR DESCRIPTION
## Description

Without `honorLabels: true` the labels of the scraped metrics from the Pushgateway will have a `exported_` prefix.

With that the query in the docs (`absent(apiserver_audit_event_total{job="kube-scheduler"})`) would still not work as it would be `absent(apiserver_audit_event_total{exported_job="kube-scheduler"})`.

With `honorLabels: true`, everything works as expected and also other queries are working in the same way as they are on other distributions without isolated CP.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## How Has This Been Tested?

- [X] Manual test
- [ ] Auto test added
