### PR TITLE
Implement token fetch from URL

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -187,9 +187,9 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 		if c.TokenArg != "" {
 			tokenData = c.TokenArg
 		} else {
-			data, err := os.ReadFile(c.TokenFile)
+			data, err := token.Load(ctx, c.TokenFile, c.InsecureTokenFetch)
 			if err != nil {
-				return fmt.Errorf("read token file %q: %w", c.TokenFile, err)
+				return fmt.Errorf("read token from %q: %w", c.TokenFile, err)
 			}
 			tokenData = string(data)
 		}

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -62,6 +62,7 @@ Flags:
   -h, --help                                           help for controller
       --ignore-pre-flight-checks                       continue even if pre-flight checks fail
       --init-only                                      only initialize controller and exit
+      --insecure-token-fetch                           Skip TLS certificate verification when fetching token from HTTPS URL
       --iptables-mode string                           iptables mode (valid values: nft, legacy, auto). default: auto
       --k0s-cloud-provider-port int                    the port that k0s-cloud-provider binds on (default 10258)
       --k0s-cloud-provider-update-frequency duration   the frequency of k0s-cloud-provider node updates (default 2m0s)
@@ -75,7 +76,7 @@ Flags:
       --single                                         enable single node (implies --enable-worker, default false)
       --status-socket string                           Full file path to the socket file. (default: <rundir>/status.sock)
       --taints strings                                 Node taints, list of key=value:effect strings
-      --token-file string                              Path to the file containing join-token.
+      --token-file string                              Path to the file containing join-token or URL to fetch it from.
   -v, --verbose                                        Verbose logging (default true)
 `, out.String())
 }

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -55,6 +55,7 @@ Flags:
       --feature-gates mapStringBool                    feature gates to enable (comma separated list of key=value pairs)
   -h, --help                                           help for controller
       --init-only                                      only initialize controller and exit
+      --insecure-token-fetch                           Skip TLS certificate verification when fetching token from HTTPS URL
       --iptables-mode string                           iptables mode (valid values: nft, legacy, auto). default: auto
       --k0s-cloud-provider-port int                    the port that k0s-cloud-provider binds on (default 10258)
       --k0s-cloud-provider-update-frequency duration   the frequency of k0s-cloud-provider node updates (default 2m0s)
@@ -68,7 +69,7 @@ Flags:
       --single                                         enable single node (implies --enable-worker, default false)
       --status-socket string                           Full file path to the socket file. (default: <rundir>/status.sock)
       --taints strings                                 Node taints, list of key=value:effect strings
-      --token-file string                              Path to the file containing join-token.
+      --token-file string                              Path to the file containing join-token or URL to fetch it from.
 
 Global Flags:
   -d, --debug                  Debug logging (implies verbose logging)

--- a/cmd/install/util.go
+++ b/cmd/install/util.go
@@ -26,12 +26,22 @@ func cmdFlagsToArgs(cmd *cobra.Command) ([]string, error) {
 			switch f.Name {
 			case "env", "force":
 				return
-			case "data-dir", "kubelet-root-dir", "token-file", "config":
+			case "data-dir", "kubelet-root-dir", "config":
 				if absVal, err := filepath.Abs(val); err != nil {
 					err = fmt.Errorf("failed to convert --%s=%s to an absolute path: %w", f.Name, val, err)
 					errs = append(errs, err)
 				} else {
 					val = absVal
+				}
+			case "token-file":
+				// Only convert to absolute path if it's not a URL
+				if !strings.HasPrefix(val, "http://") && !strings.HasPrefix(val, "https://") {
+					if absVal, err := filepath.Abs(val); err != nil {
+						err = fmt.Errorf("failed to convert --%s=%s to an absolute path: %w", f.Name, val, err)
+						errs = append(errs, err)
+					} else {
+						val = absVal
+					}
 				}
 			}
 			flagsAndVals = append(flagsAndVals, fmt.Sprintf("--%s=%s", f.Name, val))

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -80,7 +80,7 @@ func NewWorkerCmd() *cobra.Command {
 				c.TokenArg = args[0]
 			}
 
-			getBootstrapKubeconfig, err := kubeconfigGetterFromJoinToken(c.TokenFile, c.TokenArg)
+			getBootstrapKubeconfig, err := kubeconfigGetterFromJoinToken(ctx, c.TokenFile, c.TokenArg, c.InsecureTokenFetch)
 			if err != nil {
 				return err
 			}
@@ -150,7 +150,7 @@ func GetNodeName(opts *config.WorkerOptions) (apitypes.NodeName, stringmap.Strin
 	return nodeName, kubeletExtraArgs, nil
 }
 
-func kubeconfigGetterFromJoinToken(tokenFile, tokenArg string) (clientcmd.KubeconfigGetter, error) {
+func kubeconfigGetterFromJoinToken(ctx context.Context, tokenFile, tokenArg string, insecure bool) (clientcmd.KubeconfigGetter, error) {
 	if tokenArg != "" {
 		if tokenFile != "" {
 			return nil, errors.New("you can only pass one token argument either as a CLI argument 'k0s worker [token]' or as a flag 'k0s worker --token-file [path]'")
@@ -171,7 +171,7 @@ func kubeconfigGetterFromJoinToken(tokenFile, tokenArg string) (clientcmd.Kubeco
 	}
 
 	return func() (*clientcmdapi.Config, error) {
-		return loadKubeconfigFromTokenFile(tokenFile)
+		return loadKubeconfigFromToken(ctx, tokenFile, insecure)
 	}, nil
 }
 
@@ -193,21 +193,24 @@ func loadKubeconfigFromJoinToken(tokenData string) (*clientcmdapi.Config, error)
 	return kubeconfig, nil
 }
 
-func loadKubeconfigFromTokenFile(path string) (*clientcmdapi.Config, error) {
-	var problem string
-	tokenBytes, err := os.ReadFile(path)
-	if errors.Is(err, os.ErrNotExist) {
-		problem = "not found"
-	} else if err != nil {
-		return nil, fmt.Errorf("failed to read token file: %w", err)
-	} else if len(tokenBytes) == 0 {
-		problem = "is empty"
-	}
-	if problem != "" {
-		return nil, fmt.Errorf("token file %q %s"+
+func loadKubeconfigFromToken(ctx context.Context, pathOrURL string, insecure bool) (*clientcmdapi.Config, error) {
+	tokenErr := func(problem string) error {
+		return fmt.Errorf("token file %q %s"+
 			`: obtain a new token via "k0s token create ..." and store it in the file`+
 			` or reinstall this node via "k0s install --force ..." or "k0sctl apply --force ..."`,
-			path, problem)
+			pathOrURL, problem)
+	}
+
+	tokenBytes, err := token.Load(ctx, pathOrURL, insecure)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, tokenErr("not found")
+		}
+		return nil, fmt.Errorf("failed to load token from %q: %w", pathOrURL, err)
+	}
+
+	if len(tokenBytes) == 0 {
+		return nil, tokenErr("is empty")
 	}
 
 	return loadKubeconfigFromJoinToken(string(tokenBytes))

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -63,16 +63,17 @@ type ControllerOptions struct {
 
 // Shared worker cli flags
 type WorkerOptions struct {
-	CloudProvider    bool
-	LogLevels        LogLevels
-	CriSocket        string
-	KubeletExtraArgs string
-	Labels           map[string]string
-	Taints           []string
-	TokenFile        string
-	TokenArg         string
-	WorkerProfile    string
-	IPTablesMode     string
+	CloudProvider      bool
+	LogLevels          LogLevels
+	CriSocket          string
+	KubeletExtraArgs   string
+	Labels             map[string]string
+	Taints             []string
+	TokenFile          string
+	InsecureTokenFetch bool
+	TokenArg           string
+	WorkerProfile      string
+	IPTablesMode       string
 }
 
 func (m ControllerMode) WorkloadsEnabled() bool {
@@ -250,7 +251,8 @@ func GetWorkerFlags() *pflag.FlagSet {
 	flagset.String("kubelet-root-dir", "", "Kubelet root directory for k0s")
 	flagset.StringVar(&workerOpts.WorkerProfile, "profile", defaultWorkerProfile, "worker profile to use on the node")
 	flagset.BoolVar(&workerOpts.CloudProvider, "enable-cloud-provider", false, "Whether or not to enable cloud provider support in kubelet")
-	flagset.StringVar(&workerOpts.TokenFile, "token-file", "", "Path to the file containing join-token.")
+	flagset.StringVar(&workerOpts.TokenFile, "token-file", "", "Path to the file containing join-token or URL to fetch it from.")
+	flagset.BoolVar(&workerOpts.InsecureTokenFetch, "insecure-token-fetch", false, "Skip TLS certificate verification when fetching token from HTTPS URL")
 	flagset.VarP((*logLevelsFlag)(&workerOpts.LogLevels), "logging", "l", "Logging Levels for the different components")
 	flagset.Var((*cliflag.ConfigurationMap)(&workerOpts.Labels), "labels", "Node labels, list of key=value pairs")
 	flagset.StringSliceVarP(&workerOpts.Taints, "taints", "", []string{}, "Node taints, list of key=value:effect strings")

--- a/pkg/token/loader.go
+++ b/pkg/token/loader.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package token
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	// httpClientTimeout is the maximum time allowed for HTTP requests when fetching tokens
+	httpClientTimeout = 90 * time.Second
+)
+
+// Load loads token content from a file path or URL.
+// Supports plain file paths, file://, http://, and https:// protocols.
+// The file:// prefix is automatically stripped and treated as a plain file path.
+func Load(ctx context.Context, pathOrURL string, insecure bool) ([]byte, error) {
+	// Check if it's an HTTP/HTTPS URL
+	if isHTTPURL(pathOrURL) {
+		return fetchFromURL(ctx, pathOrURL, insecure)
+	}
+
+	// Handle file:// protocol by stripping prefix and treating as file path
+	pathOrURL = strings.TrimPrefix(pathOrURL, "file://")
+
+	// Treat as file path
+	return os.ReadFile(pathOrURL)
+}
+
+// isHTTPURL checks if the given string is an HTTP or HTTPS URL
+func isHTTPURL(pathOrURL string) bool {
+	return strings.HasPrefix(pathOrURL, "http://") ||
+		strings.HasPrefix(pathOrURL, "https://")
+}
+
+// fetchFromURL fetches token content from HTTP or HTTPS URL
+func fetchFromURL(ctx context.Context, urlStr string, insecure bool) ([]byte, error) {
+	// Parse the URL to add hostname query parameter
+	parsedURL, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	// Get the hostname of the current node
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get hostname: %w", err)
+	}
+
+	// Add hostname as query parameter
+	query := parsedURL.Query()
+	query.Set("hostname", hostname)
+
+	// Add architecture
+	query.Set("arch", runtime.GOARCH)
+
+	// Add machine-id if available
+	if machineID, err := os.ReadFile("/etc/machine-id"); err == nil {
+		// Trim whitespace (machine-id files typically have a trailing newline)
+		trimmedID := strings.TrimSpace(string(machineID))
+		if trimmedID != "" {
+			query.Set("machine-id", trimmedID)
+		}
+	}
+
+	parsedURL.RawQuery = query.Encode()
+	urlStr = parsedURL.String()
+
+	client := &http.Client{
+		Timeout: httpClientTimeout,
+	}
+	if insecure && strings.HasPrefix(urlStr, "https://") {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch from URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("%w: HTTP 404 Not Found", os.ErrNotExist)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected HTTP status: %d %s", resp.StatusCode, resp.Status)
+	}
+
+	tokenBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	return tokenBytes, nil
+}

--- a/pkg/token/loader_test.go
+++ b/pkg/token/loader_test.go
@@ -1,0 +1,431 @@
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package token_test
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/k0s/pkg/token"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad_PlainFilePath(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary file with token content
+	tmpDir := t.TempDir()
+	tokenFile := filepath.Join(tmpDir, "token")
+	tokenContent := []byte("test-token-content")
+	require.NoError(t, os.WriteFile(tokenFile, tokenContent, 0o600))
+
+	// Test loading from plain file path
+	result, err := token.Load(context.Background(), tokenFile, false)
+	require.NoError(t, err)
+	assert.Equal(t, tokenContent, result)
+}
+
+func TestLoad_FileProtocol(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary file with token content
+	tmpDir := t.TempDir()
+	tokenFile := filepath.Join(tmpDir, "token")
+	tokenContent := []byte("test-token-content")
+	require.NoError(t, os.WriteFile(tokenFile, tokenContent, 0o600))
+
+	// Test loading with file:// protocol
+	result, err := token.Load(context.Background(), "file://"+tokenFile, false)
+	require.NoError(t, err)
+	assert.Equal(t, tokenContent, result)
+}
+
+func TestLoad_FileNotFound(t *testing.T) {
+	t.Parallel()
+
+	// Test loading from non-existent file
+	_, err := token.Load(context.Background(), "/nonexistent/path/to/token", false)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestLoad_HTTPSuccess(t *testing.T) {
+	t.Parallel()
+
+	tokenContent := []byte("http-token-content")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(tokenContent)
+	}))
+	defer server.Close()
+
+	result, err := token.Load(context.Background(), server.URL, false)
+	require.NoError(t, err)
+	assert.Equal(t, tokenContent, result)
+}
+
+func TestLoad_HTTPQueryParameters_AutomaticParams(t *testing.T) {
+	t.Parallel()
+
+	// Get expected values
+	expectedHostname, err := os.Hostname()
+	require.NoError(t, err)
+	expectedArch := runtime.GOARCH
+
+	// Check if machine-id is available
+	machineIDBytes, err := os.ReadFile("/etc/machine-id")
+	hasMachineID := err == nil && len(strings.TrimSpace(string(machineIDBytes))) > 0
+	var expectedMachineID string
+	if hasMachineID {
+		expectedMachineID = strings.TrimSpace(string(machineIDBytes))
+	}
+
+	tokenContent := []byte("http-token-content")
+	receivedParams := make(map[string]string)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedParams["hostname"] = r.URL.Query().Get("hostname")
+		receivedParams["arch"] = r.URL.Query().Get("arch")
+		receivedParams["machine-id"] = r.URL.Query().Get("machine-id")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(tokenContent)
+	}))
+	defer server.Close()
+
+	result, err := token.Load(context.Background(), server.URL, false)
+	require.NoError(t, err)
+	assert.Equal(t, tokenContent, result)
+
+	// Verify hostname and arch parameters are automatically added
+	assert.Equal(t, expectedHostname, receivedParams["hostname"])
+	assert.Equal(t, expectedArch, receivedParams["arch"])
+
+	// Verify machine-id is added when available
+	if hasMachineID {
+		assert.Equal(t, expectedMachineID, receivedParams["machine-id"])
+	} else {
+		assert.Empty(t, receivedParams["machine-id"])
+	}
+}
+
+func TestLoad_HTTPS_Success(t *testing.T) {
+	t.Parallel()
+
+	tokenContent := []byte("https-token-content")
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(tokenContent)
+	}))
+	defer server.Close()
+
+	// Test with insecure=true (skips cert verification)
+	result, err := token.Load(context.Background(), server.URL, true)
+	require.NoError(t, err)
+	assert.Equal(t, tokenContent, result)
+}
+
+func TestLoad_HTTPS_CertVerificationFails(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("content"))
+	}))
+	defer server.Close()
+
+	// Test with insecure=false (enforces cert verification)
+	// This should fail because httptest uses self-signed certs
+	_, err := token.Load(context.Background(), server.URL, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch from URL")
+}
+
+func TestLoad_HTTP404(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, err := token.Load(context.Background(), server.URL, false)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, os.ErrNotExist, "HTTP 404 should be mapped to os.ErrNotExist")
+	assert.Contains(t, err.Error(), "HTTP 404 Not Found")
+}
+
+func TestLoad_HTTPOtherError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	_, err := token.Load(context.Background(), server.URL, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected HTTP status: 500")
+}
+
+func TestLoad_HTTPConnectionRefused(t *testing.T) {
+	t.Parallel()
+
+	// Use a URL that will definitely fail to connect
+	_, err := token.Load(context.Background(), "http://localhost:1", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch from URL")
+}
+
+func TestLoad_EmptyFile(t *testing.T) {
+	t.Parallel()
+
+	// Create an empty file
+	tmpDir := t.TempDir()
+	tokenFile := filepath.Join(tmpDir, "empty-token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte{}, 0o600))
+
+	// Loading empty file should succeed but return empty content
+	result, err := token.Load(context.Background(), tokenFile, false)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestLoad_HTTPEmptyResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Don't write any content
+	}))
+	defer server.Close()
+
+	result, err := token.Load(context.Background(), server.URL, false)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestLoad_InsecureFlagOnlyAppliesToHTTPS(t *testing.T) {
+	t.Parallel()
+
+	tokenContent := []byte("http-token")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(tokenContent)
+	}))
+	defer server.Close()
+
+	// insecure flag should not affect HTTP (only HTTPS)
+	result, err := token.Load(context.Background(), server.URL, true)
+	require.NoError(t, err)
+	assert.Equal(t, tokenContent, result)
+}
+
+func TestLoad_URLValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		input        string
+		isHTTP       bool
+		errorMessage string
+	}{
+		// Valid HTTP/HTTPS URLs
+		{"http URL", "http://localhost:1", true, "failed to fetch from URL"},
+		{"https URL", "https://localhost:1", true, "failed to fetch from URL"},
+
+		// Invalid/malformed HTTP URLs
+		{"http no host", "http://", true, "failed to fetch from URL"},
+		{"https no host", "https://", true, "failed to fetch from URL"},
+		{"http invalid bracket", "http://[invalid", true, "failed to parse URL"},
+		{"https invalid port", "https://example.com:invalid-port", true, "failed to parse URL"},
+
+		// Non-HTTP URLs (case sensitive, treated as file paths)
+		{"HTTP uppercase", "HTTP://localhost:1", false, ""},
+		{"HTTPS uppercase", "HTTPS://localhost:1", false, ""},
+		{"file path", "/path/to/file", false, ""},
+		{"file protocol", "file:///path/to/file", false, ""},
+		{"ftp protocol", "ftp://localhost:1", false, ""},
+		{"empty string", "", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := token.Load(context.Background(), tt.input, false)
+
+			if tt.isHTTP {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMessage)
+			} else if tt.input != "" && tt.input != "/path/to/file" {
+				require.Error(t, err)
+				assert.NotContains(t, err.Error(), "failed to fetch from URL")
+			}
+		})
+	}
+}
+
+func TestLoad_HTTPSWithCustomTransport(t *testing.T) {
+	t.Parallel()
+
+	tokenContent := []byte("secure-token")
+
+	// Create a server with a custom TLS config
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the client is using TLS
+		assert.NotNil(t, r.TLS, "Request should use TLS")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(tokenContent)
+	}))
+	server.TLS = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	// Test with insecure=true (should skip cert verification)
+	result, err := token.Load(context.Background(), server.URL, true)
+	require.NoError(t, err)
+	assert.Equal(t, tokenContent, result)
+}
+
+func TestLoad_FileProtocolWithRelativePath(t *testing.T) {
+	// Create a temporary file
+	tmpDir := t.TempDir()
+	tokenFile := filepath.Join(tmpDir, "token")
+	tokenContent := []byte("relative-path-token")
+	require.NoError(t, os.WriteFile(tokenFile, tokenContent, 0o600))
+
+	// Change to temp directory
+	t.Chdir(tmpDir)
+
+	// Test with file:// and relative path
+	result, err := token.Load(context.Background(), "file://token", false)
+	require.NoError(t, err)
+	assert.Equal(t, tokenContent, result)
+}
+
+func TestLoad_HTTPRedirect(t *testing.T) {
+	t.Parallel()
+
+	tokenContent := []byte("redirected-token")
+
+	// Create the target server
+	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(tokenContent)
+	}))
+	defer targetServer.Close()
+
+	// Create a redirect server
+	redirectServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, targetServer.URL, http.StatusMovedPermanently)
+	}))
+	defer redirectServer.Close()
+
+	// HTTP client should follow redirects by default
+	result, err := token.Load(context.Background(), redirectServer.URL, false)
+	require.NoError(t, err)
+	assert.Equal(t, tokenContent, result)
+}
+
+func TestLoad_HTTPStatusCodes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		statusCode   int
+		expectError  bool
+		errorMessage string
+		isNotExist   bool
+	}{
+		{"200 OK", http.StatusOK, false, "", false},
+		{"201 Created", http.StatusCreated, true, "unexpected HTTP status: 201", false},
+		{"204 No Content", http.StatusNoContent, true, "unexpected HTTP status: 204", false},
+		{"301 Moved Permanently", http.StatusMovedPermanently, true, "unexpected HTTP status: 301", false},
+		{"400 Bad Request", http.StatusBadRequest, true, "unexpected HTTP status: 400", false},
+		{"401 Unauthorized", http.StatusUnauthorized, true, "unexpected HTTP status: 401", false},
+		{"403 Forbidden", http.StatusForbidden, true, "unexpected HTTP status: 403", false},
+		{"404 Not Found", http.StatusNotFound, true, "HTTP 404 Not Found", true},
+		{"500 Internal Server Error", http.StatusInternalServerError, true, "unexpected HTTP status: 500", false},
+		{"503 Service Unavailable", http.StatusServiceUnavailable, true, "unexpected HTTP status: 503", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				if tc.statusCode == http.StatusOK {
+					_, _ = w.Write([]byte("token-content"))
+				}
+			}))
+			defer server.Close()
+
+			result, err := token.Load(context.Background(), server.URL, false)
+			if tc.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errorMessage)
+				if tc.isNotExist {
+					assert.ErrorIs(t, err, os.ErrNotExist)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, []byte("token-content"), result)
+			}
+		})
+	}
+}
+
+func TestLoad_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	// Create a server that blocks until client cancels
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Wait for the request context to be canceled
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	// Create a context that we'll cancel
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel the context immediately
+	cancel()
+
+	// This should fail with context cancellation error
+	_, err := token.Load(ctx, server.URL, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context canceled")
+}
+
+func TestLoad_ContextTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Create a server that delays response
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("too-late"))
+	}))
+	defer server.Close()
+
+	// Create a context with a short timeout (less than server delay)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	// This should fail with context deadline exceeded
+	_, err := token.Load(ctx, server.URL, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+}


### PR DESCRIPTION
Enables fetching join tokens from HTTP/HTTPS URLs in addition to local file paths. The `--token-file` flag now accepts URLs, allowing tokens to be served dynamically from a token server (`--insecure-token-fetch` flag skips TLS certificate verification when needed).

When fetching from a URL, the following query parameters are automatically appended:
  - hostname - current node hostname
  - arch - system architecture (e.g., amd64, arm64)
  - machine-id - contents of /etc/machine-id (if available)

Implements client-side part of https://github.com/k0sproject/k0s/issues/6693