### PR TITLE
[Backport release-1.33] List RISC-V as supported architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ k0s is distributed as a single binary with zero host OS dependencies besides the
 - Supports custom [Container Runtime Interface (CRI)](docs/runtime.md) plugins (containerd is the default)
 - Supports all Kubernetes storage options with [Container Storage Interface (CSI)](docs/storage.md)
 - Supports a variety of [datastore backends](docs/configuration.md#specstorage): etcd (default for multi-node clusters), SQLite (default for single node clusters), MySQL, and PostgreSQL
-- Supports x86-64, ARM64 and ARMv7
+- Supports x86-64, ARM64, ARMv7 and RISC-V
 - Includes [Konnectivity service](docs/networking.md#controller-worker-communication), CoreDNS and Metrics Server
 <!-- End Key Features -->
 

--- a/docs/system-requirements.md
+++ b/docs/system-requirements.md
@@ -55,6 +55,7 @@ The specific storage consumption for k0s is as follows:
 - x86-64
 - ARM64
 - ARMv7
+- RISC-V (No pre-compiled binaries, no CI coverage)
 
 ## Networking
 


### PR DESCRIPTION
Backport to `release-1.33`:

* #6659

See:

* #6615