### PR TITLE
Tune Renovate OCI image version detection regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -282,7 +282,7 @@
         "**/Makefile*"
       ],
       "matchStrings": [
-        "\\b(?<depName>(docker|quay)\\.io/[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*)(:|.*\\n.*= \")v?(?<currentValue>[a-z0-9_][\\w.-]{0,127})"
+        "\\b(?<depName>(docker|k8s\\.gcr|quay)\\.io/(?:[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*)(:|.*\\n.*= \")v?(?<currentValue>[0-9_][\\w.-]{0,127})"
       ],
       "datasourceTemplate": "docker",
       "extractVersionTemplate": "^v?(?<version>[\\w][\\w.-]{0,127})"


### PR DESCRIPTION
## Description

* Add k8s.gcr.io as a known OCI registry
* Allow single URL segment OCI images (i.e. k8s.gcr.io/pause)
* Require versions to start with a number, optionally prefixed with a v
  Renovate will have a hard time to deal with non-numeric versions, and this eliminates some false positives

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
