### PR TITLE
Add ability to use `ENVIRON` for passing bootstrap token

### DIFF
--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -75,6 +75,7 @@ Flags:
       --single                                         enable single node (implies --enable-worker, default false)
       --status-socket string                           Full file path to the socket file. (default: <rundir>/status.sock)
       --taints strings                                 Node taints, list of key=value:effect strings
+      --token-env string                               Environment variable name containing the join-token.
       --token-file string                              Path to the file containing join-token.
   -v, --verbose                                        Verbose logging (default true)
 `, out.String())

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -68,6 +68,7 @@ Flags:
       --single                                         enable single node (implies --enable-worker, default false)
       --status-socket string                           Full file path to the socket file. (default: <rundir>/status.sock)
       --taints strings                                 Node taints, list of key=value:effect strings
+      --token-env string                               Environment variable name containing the join-token.
       --token-file string                              Path to the file containing join-token.
 
 Global Flags:
@@ -75,6 +76,7 @@ Global Flags:
       --debugListenOn string   Http listenOn for Debug pprof handler (default ":6060")
   -e, --env stringArray        set environment variable
       --force                  force init script creation
+      --start                  start the service immediately after installation
   -v, --verbose                Verbose logging
 `, out.String())
 }

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -6,6 +6,8 @@ package install
 import (
 	"github.com/k0sproject/k0s/cmd/internal"
 	"github.com/k0sproject/k0s/pkg/config"
+	"github.com/k0sproject/k0s/pkg/install"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -13,6 +15,7 @@ import (
 type installFlags struct {
 	force   bool
 	envVars []string
+	start   bool
 }
 
 func NewInstallCmd() *cobra.Command {
@@ -38,9 +41,15 @@ func NewInstallCmd() *cobra.Command {
 	})
 	pflags.BoolVar(&installFlags.force, "force", false, "force init script creation")
 	pflags.StringArrayVarP(&installFlags.envVars, "env", "e", nil, "set environment variable")
+	pflags.BoolVar(&installFlags.start, "start", false, "start the service immediately after installation")
 
 	cmd.AddCommand(installWorkerCmd(&installFlags))
 	addPlatformSpecificCommands(cmd, &installFlags)
 
 	return cmd
+}
+
+// startInstalledService starts (or restarts with force) the installed k0s service.
+func startInstalledService(force bool) error {
+	return install.StartInstalledService(force)
 }

--- a/cmd/install/worker.go
+++ b/cmd/install/worker.go
@@ -27,14 +27,35 @@ All default values of worker command will be passed to the service stub unless o
 				return errors.New("this command must be run as root")
 			}
 
+			k0sVars, err := config.NewCfgVars(cmd)
+			if err != nil {
+				return fmt.Errorf("failed to initialize configuration variables: %w", err)
+			}
+
+			// Convert --token-env to --token-file
+			tokenFilePath, err := handleTokenEnv(cmd, k0sVars.DataDir)
+			if err != nil {
+				return err
+			}
+
 			flagsAndVals, err := cmdFlagsToArgs(cmd)
 			if err != nil {
 				return err
 			}
 
+			if tokenFilePath != "" {
+				flagsAndVals = append(flagsAndVals, "--token-file="+tokenFilePath)
+			}
+
 			args := append([]string{"worker"}, flagsAndVals...)
 			if err := install.InstallService(args, installFlags.envVars, installFlags.force); err != nil {
 				return fmt.Errorf("failed to install worker service: %w", err)
+			}
+
+			if installFlags.start {
+				if err := startInstalledService(installFlags.force); err != nil {
+					return fmt.Errorf("failed to start worker service: %w", err)
+				}
 			}
 
 			return nil

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -70,6 +70,7 @@ type WorkerOptions struct {
 	Labels           map[string]string
 	Taints           []string
 	TokenFile        string
+	TokenEnv         string
 	TokenArg         string
 	WorkerProfile    string
 	IPTablesMode     string
@@ -251,6 +252,7 @@ func GetWorkerFlags() *pflag.FlagSet {
 	flagset.StringVar(&workerOpts.WorkerProfile, "profile", defaultWorkerProfile, "worker profile to use on the node")
 	flagset.BoolVar(&workerOpts.CloudProvider, "enable-cloud-provider", false, "Whether or not to enable cloud provider support in kubelet")
 	flagset.StringVar(&workerOpts.TokenFile, "token-file", "", "Path to the file containing join-token.")
+	flagset.StringVar(&workerOpts.TokenEnv, "token-env", "", "Environment variable name containing the join-token.")
 	flagset.VarP((*logLevelsFlag)(&workerOpts.LogLevels), "logging", "l", "Logging Levels for the different components")
 	flagset.Var((*cliflag.ConfigurationMap)(&workerOpts.Labels), "labels", "Node labels, list of key=value pairs")
 	flagset.StringSliceVarP(&workerOpts.Taints, "taints", "", []string{}, "Node taints, list of key=value:effect strings")

--- a/pkg/install/service.go
+++ b/pkg/install/service.go
@@ -5,6 +5,7 @@ package install
 
 import (
 	"errors"
+	"fmt"
 	"runtime"
 
 	"github.com/kardianos/service"
@@ -121,4 +122,23 @@ func GetServiceConfig(role string) *service.Config {
 		DisplayName: k0sDisplayName,
 		Description: k0sDescription,
 	}
+}
+
+// StartInstalledService starts (or restarts with force) the installed k0s service.
+func StartInstalledService(force bool) error {
+	svc, err := InstalledService()
+	if err != nil {
+		return err
+	}
+	status, _ := svc.Status()
+	if status == service.StatusRunning {
+		if force {
+			if err := svc.Restart(); err != nil {
+				return fmt.Errorf("failed to restart service: %w", err)
+			}
+			return nil
+		}
+		return errors.New("already running")
+	}
+	return svc.Start()
 }


### PR DESCRIPTION
Adds two new flags to improve k0s installation and token management for both worker and controller:

  - `--start`: Automatically starts the k0s service immediately after installation
  - `--token-env`: Allows specifying the join token via an environment variable name instead of passing it via file

Example Usage

Install and start controller with token from environment
```
export K0S_TOKEN="your-token-here"
k0s install controller --token-env K0S_TOKEN --start
```

Install and start worker with token from environment
```
k0s install worker --token-env K0S_TOKEN --start
```