### PR TITLE
Tighten Autpoilot node RBAC

### DIFF
--- a/pkg/component/controller/systemrbac-ap.yaml
+++ b/pkg/component/controller/systemrbac-ap.yaml
@@ -4,15 +4,32 @@ kind: ClusterRole
 metadata:
   name: system:nodes:autopilot
 rules:
-  - apiGroups: ["autopilot.k0sproject.io"]
-    resources: ["*"]
-    verbs: ["*"]
+  # Allow Autopilot to read/patch their own Node object for signal annotations
+  # and cordon/uncordon state.
   - apiGroups: [""]
-    resources: ["nodes", "pods", "pods/eviction", "namespaces"]
-    verbs: ["*"]
-  - apiGroups: ["apps"]
-    resources: ["*"]
-    verbs: ["*"]
+    resources: [nodes]
+    verbs: [get, list, watch, update, patch]
+  # Needed by drain to list/delete pods scheduled to the node.
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [get, list, watch, delete]
+  # Drain uses the eviction subresource when available.
+  - apiGroups: [""]
+    resources: [pods/eviction]
+    verbs: [create]
+  # Required to fetch the cluster UID from kube-system.
+  - apiGroups: [""]
+    resources: [namespaces]
+    resourceNames: [kube-system]
+    verbs: [get]
+  # Required by the drain helper to skip DaemonSet-managed pods.
+  - apiGroups: [apps]
+    resources: [daemonsets]
+    verbs: [get, list]
+  # Autopilot signalling uses the plan resources for communication.
+  - apiGroups: [autopilot.k0sproject.io]
+    resources: [plans]
+    verbs: [get, list, watch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Description

Restrict the `system:nodes:autopilot` ClusterRole to the minimal verbs needed by Autopilot and add a short docstring to each rule which explains why it's needed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
