### PR TITLE
Add `k0s payload extract` command

### DIFF
--- a/cmd/payload/extract.go
+++ b/cmd/payload/extract.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package payload
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/k0sproject/k0s/cmd/internal"
+	"github.com/k0sproject/k0s/pkg/assets"
+	"github.com/k0sproject/k0s/pkg/constant"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func NewExtractCmd() *cobra.Command {
+	var dataDir string
+	debugFlags := (&internal.DebugFlags{}).LongRunning()
+
+	cmd := &cobra.Command{
+		Use:   "extract",
+		Short: "Extract embedded binaries",
+		Args:  cobra.NoArgs,
+		Long: `Extract all embedded binaries to the bin directory.
+
+This command extracts all binaries embedded in the k0s executable to the
+bin directory. By default, binaries are extracted to /var/lib/k0s/bin.
+
+When a custom data-dir is specified, binaries are extracted to <data-dir>/bin.
+
+This is useful for pre-staging binaries before starting k0s, especially in
+airgapped environments or when the k0s binary is stored on a read-only
+filesystem.
+
+Examples:
+  # Extract to default location (/var/lib/k0s/bin)
+  k0s payload extract
+
+  # Extract to custom location
+  k0s payload extract --data-dir /custom/path
+`,
+		PersistentPreRun: debugFlags.Run,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return extractPayload(dataDir)
+		},
+	}
+
+	cmd.Flags().StringVar(&dataDir, "data-dir", constant.DataDirDefault, "Data directory for k0s")
+	debugFlags.AddToFlagSet(cmd.Flags())
+
+	return cmd
+}
+
+func extractPayload(dataDir string) error {
+	// Resolve absolute path
+	absDataDir, err := filepath.Abs(dataDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve data directory path: %w", err)
+	}
+
+	binDir := filepath.Join(absDataDir, "bin")
+	logrus.Infof("Extracting embedded binaries to %s", binDir)
+
+	// Create bin directory if it doesn't exist
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return fmt.Errorf("failed to create bin directory: %w", err)
+	}
+
+	// Get list of all embedded binaries
+	binaries := assets.GetEmbeddedBinaries()
+	if len(binaries) == 0 {
+		return errors.New("no payload found")
+	}
+
+	// Extract each binary
+	for _, binaryName := range binaries {
+		_, err := assets.StageExecutable(binDir, binaryName)
+		if err != nil {
+			return fmt.Errorf("failed to stage %s: %w", binaryName, err)
+		}
+
+		logrus.Infof("Extracted %s", binaryName)
+	}
+
+	return nil
+}

--- a/cmd/payload/payload.go
+++ b/cmd/payload/payload.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package payload
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func NewPayloadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "payload",
+		Short: "Manage embedded payload",
+		Args:  cobra.NoArgs,
+		Long:  `Commands for managing embedded payload in k0s`,
+		RunE:  func(*cobra.Command, []string) error { return pflag.ErrHelp }, // Enforce arg validation
+	}
+
+	cmd.AddCommand(NewExtractCmd())
+
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/k0sproject/k0s/cmd/install"
 	"github.com/k0sproject/k0s/cmd/kubeconfig"
 	"github.com/k0sproject/k0s/cmd/kubectl"
+	"github.com/k0sproject/k0s/cmd/payload"
 	"github.com/k0sproject/k0s/cmd/start"
 	"github.com/k0sproject/k0s/cmd/stop"
 	"github.com/k0sproject/k0s/cmd/sysinfo"
@@ -44,6 +45,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(install.NewInstallCmd())
 	cmd.AddCommand(kubeconfig.NewKubeConfigCmd())
 	cmd.AddCommand(kubectl.NewK0sKubectlCmd())
+	cmd.AddCommand(payload.NewPayloadCmd())
 	cmd.AddCommand(start.NewStartCmd())
 	cmd.AddCommand(stop.NewStopCmd())
 	cmd.AddCommand(sysinfo.NewSysinfoCmd())

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -73,6 +73,7 @@ smoketests := \
 	check-noderole \
 	check-noderole-no-taints \
 	check-noderole-single \
+	check-payload-extract \
 	check-psp \
 	check-reset \
 	check-singlenode \

--- a/inttest/payload-extract/payloadextract_test.go
+++ b/inttest/payload-extract/payloadextract_test.go
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package payloadextract
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/stretchr/testify/suite"
+)
+
+type PayloadExtractSuite struct {
+	common.BootlooseSuite
+}
+
+// TestPayloadExtract tests extraction functionality and that k0s uses pre-extracted binaries
+func (s *PayloadExtractSuite) TestPayloadExtract() {
+	ssh, err := s.SSH(s.Context(), s.ControllerNode(0))
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	dataDir := "/var/lib/k0s"
+
+	s.Run("extract", func() {
+		s.T().Log("Extracting binaries to", dataDir)
+		output, err := ssh.ExecWithOutput(s.Context(), fmt.Sprintf("%s payload extract --data-dir %s", s.K0sFullPath, dataDir))
+		s.Require().NoError(err, "payload extract command failed")
+		s.T().Logf("Extract output:\n%s", output)
+
+		// Verify the bin directory was created
+		_, err = ssh.ExecWithOutput(s.Context(), fmt.Sprintf("test -d %s/bin", dataDir))
+		s.Require().NoError(err, "bin directory was not created")
+
+		// Get actual list of binaries that were extracted by listing the directory
+		lsOutput, err := ssh.ExecWithOutput(s.Context(), fmt.Sprintf("ls -1 %s/bin", dataDir))
+		s.Require().NoError(err, "failed to list bin directory")
+		actualBinaries := strings.Split(strings.TrimSpace(lsOutput), "\n")
+		s.T().Logf("Found %d actual binaries: %v", len(actualBinaries), actualBinaries)
+		s.Require().NotEmpty(actualBinaries, "no binaries found in bin directory")
+
+		s.T().Log("Verifying all binaries were extracted")
+		for _, binary := range actualBinaries {
+			binaryPath := fmt.Sprintf("%s/bin/%s", dataDir, binary)
+
+			// Check if file exists
+			_, err = ssh.ExecWithOutput(s.Context(), "test -f "+binaryPath)
+			s.Require().NoError(err, "binary %s not found", binary)
+
+			// Check if file is executable
+			_, err = ssh.ExecWithOutput(s.Context(), "test -x "+binaryPath)
+			s.Require().NoError(err, "binary %s is not executable", binary)
+
+			// Check file size is reasonable (> 100KB, embedded binaries should be substantial)
+			sizeOutput, err := ssh.ExecWithOutput(s.Context(), "stat -c %%s "+binaryPath)
+			s.Require().NoError(err, "failed to get size of %s", binary)
+			s.T().Logf("Binary %s size: %s bytes", binary, strings.TrimSpace(sizeOutput))
+		}
+
+		s.T().Log("Verifying all binaries can be executed")
+		// Try to execute each binary with --help (most binaries support this)
+		// Some may fail but we just log those - the important thing is they're valid executables
+		for _, binary := range actualBinaries {
+			binaryPath := fmt.Sprintf("%s/bin/%s", dataDir, binary)
+
+			// Try --help first, if that fails try --version, if that fails just run it to see if it's executable
+			output, err := ssh.ExecWithOutput(s.Context(), fmt.Sprintf("%s --help 2>&1 || %s --version 2>&1 || true", binaryPath, binaryPath))
+			if err == nil && output != "" {
+				s.T().Logf("%s is executable (output: %s)", binary, strings.Split(output, "\n")[0])
+			} else {
+				s.T().Logf("Warning: %s may not support --help or --version, but file is executable", binary)
+			}
+		}
+	})
+
+	s.Run("start_with_preextracted_binaries", func() {
+		// Get list of extracted binaries and their timestamps
+		lsOutput, err := ssh.ExecWithOutput(s.Context(), fmt.Sprintf("ls -1 %s/bin", dataDir))
+		s.Require().NoError(err, "failed to list bin directory")
+		extractedBinaries := strings.Split(strings.TrimSpace(lsOutput), "\n")
+		s.T().Logf("Found %d pre-extracted binaries", len(extractedBinaries))
+		s.Require().NotEmpty(extractedBinaries, "no binaries found after extraction")
+
+		// Get the timestamps of all binaries to verify k0s doesn't re-extract them
+		timestampsBefore := make(map[string]string)
+		for _, binary := range extractedBinaries {
+			timestamp, err := ssh.ExecWithOutput(s.Context(), fmt.Sprintf("stat -c %%Y %s/bin/%s", dataDir, binary))
+			s.Require().NoError(err, "failed to get timestamp for %s", binary)
+			timestampsBefore[binary] = strings.TrimSpace(timestamp)
+		}
+		s.T().Logf("Recorded timestamps for %d binaries before k0s start", len(timestampsBefore))
+
+		s.T().Log("Starting k0s controller")
+		s.Require().NoError(s.InitController(0, "--enable-worker"))
+		s.Require().NoError(s.WaitForKubeAPI(s.ControllerNode(0)))
+
+		kc, err := s.KubeClient(s.ControllerNode(0))
+		s.Require().NoError(err)
+
+		err = s.WaitForNodeReady(s.ControllerNode(0), kc)
+		s.Require().NoError(err)
+
+		s.AssertSomeKubeSystemPods(kc)
+
+		// Check that no binaries were re-extracted (timestamps should be the same)
+		s.T().Log("Verifying binaries were not re-extracted")
+		for _, binary := range extractedBinaries {
+			timestampAfter, err := ssh.ExecWithOutput(s.Context(), fmt.Sprintf("stat -c %%Y %s/bin/%s", dataDir, binary))
+			s.Require().NoError(err, "failed to get timestamp for %s after start", binary)
+
+			s.Equal(timestampsBefore[binary], strings.TrimSpace(timestampAfter),
+				"binary %s was re-extracted when it should have used the pre-extracted version", binary)
+		}
+		s.T().Logf("Verified all %d binaries were not re-extracted", len(extractedBinaries))
+	})
+}
+
+func TestPayloadExtractSuite(t *testing.T) {
+	s := PayloadExtractSuite{
+		common.BootlooseSuite{
+			ControllerCount: 1,
+			WorkerCount:     0,
+			LaunchMode:      common.LaunchModeOpenRC,
+		},
+	}
+	suite.Run(t, &s)
+}

--- a/pkg/assets/stage.go
+++ b/pkg/assets/stage.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/k0sproject/k0s/internal/pkg/file"
@@ -131,4 +132,18 @@ type notEmbeddedError string
 
 func (e notEmbeddedError) Error() string {
 	return "not an embedded asset: " + string(e)
+}
+
+// GetEmbeddedBinaries returns a list of all embedded binary names (without the bin/ prefix and .gz suffix)
+func GetEmbeddedBinaries() []string {
+	var binaries []string
+	
+	for name := range BinData {
+		// Remove "bin/" prefix and ".gz" suffix
+		binaryName := strings.TrimPrefix(name, "bin/")
+		binaryName = strings.TrimSuffix(binaryName, ".gz")
+		binaries = append(binaries, binaryName)
+	}
+	
+	return binaries
 }


### PR DESCRIPTION
## Description

Add command to pre-extract embedded binaries to <data-dir>/bin before starting k0s. The command extracts all embedded binaries (containerd, kubelet, etcd, etc.) to <data-dir>/bin, defaulting to /var/lib/k0s/bin. When k0s starts, it will use the pre-extracted binaries instead of extracting them again.

Part of #6733

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
