### PR TITLE
Ensure that Autopilot can be disabled for real

### DIFF
--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -298,7 +298,7 @@ func (c *Command) Start(ctx context.Context, nodeName apitypes.NodeName, kubelet
 
 	certManager := worker.NewCertificateManager(kubeletKubeconfigPath)
 
-	addPlatformSpecificComponents(ctx, componentManager, c.K0sVars, controller, certManager)
+	addPlatformSpecificComponents(ctx, componentManager, c.K0sVars, workerConfig, controller, certManager)
 
 	if controller == nil {
 		// if running inside a controller, status component is already running

--- a/cmd/worker/worker_unix.go
+++ b/cmd/worker/worker_unix.go
@@ -10,14 +10,17 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/component/worker"
+	workerconfig "github.com/k0sproject/k0s/pkg/component/worker/config"
 	"github.com/k0sproject/k0s/pkg/config"
 )
 
 func initLogging(context.Context, string) error { return nil }
 
-func addPlatformSpecificComponents(ctx context.Context, m *manager.Manager, k0sVars *config.CfgVars, controller EmbeddingController, certManager *worker.CertificateManager) {
-	m.Add(ctx, &worker.Autopilot{
-		K0sVars:     k0sVars,
-		CertManager: certManager,
-	})
+func addPlatformSpecificComponents(ctx context.Context, m *manager.Manager, k0sVars *config.CfgVars, workerConfig *workerconfig.Profile, controller EmbeddingController, certManager *worker.CertificateManager) {
+	if !workerConfig.AutopilotDisabled {
+		m.Add(ctx, &worker.Autopilot{
+			K0sVars:     k0sVars,
+			CertManager: certManager,
+		})
+	}
 }

--- a/cmd/worker/worker_windows.go
+++ b/cmd/worker/worker_windows.go
@@ -14,6 +14,7 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/log"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/component/worker"
+	workerconfig "github.com/k0sproject/k0s/pkg/component/worker/config"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/k0scontext"
@@ -45,6 +46,6 @@ func initLogging(ctx context.Context, logDir string) error {
 	return nil
 }
 
-func addPlatformSpecificComponents(ctx context.Context, m *manager.Manager, k0sVars *config.CfgVars, controller EmbeddingController, certManager *worker.CertificateManager) {
+func addPlatformSpecificComponents(ctx context.Context, m *manager.Manager, k0sVars *config.CfgVars, workerConfig *workerconfig.Profile, controller EmbeddingController, certManager *worker.CertificateManager) {
 	// no-op
 }

--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -54,6 +54,7 @@ type Reconciler struct {
 	clientFactory       kubeutil.ClientFactoryInterface
 	leaderElector       leaderelector.Interface
 	konnectivityEnabled bool
+	autopilotDisabled   bool
 
 	mu    sync.Mutex
 	state reconcilerState
@@ -82,7 +83,7 @@ var (
 )
 
 // NewReconciler creates a new reconciler for worker configurations.
-func NewReconciler(k0sVars *config.CfgVars, nodeSpec *v1beta1.ClusterSpec, clientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface, konnectivityEnabled bool) (*Reconciler, error) {
+func NewReconciler(k0sVars *config.CfgVars, nodeSpec *v1beta1.ClusterSpec, clientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface, konnectivityEnabled, autopilotDisabled bool) (*Reconciler, error) {
 	log := logrus.WithFields(logrus.Fields{"component": "workerconfig.Reconciler"})
 
 	clusterDNSIPString, err := nodeSpec.Network.DNSAddress()
@@ -102,6 +103,7 @@ func NewReconciler(k0sVars *config.CfgVars, nodeSpec *v1beta1.ClusterSpec, clien
 		clientFactory:       clientFactory,
 		leaderElector:       leaderElector,
 		konnectivityEnabled: konnectivityEnabled,
+		autopilotDisabled:   autopilotDisabled,
 
 		state: reconcilerCreated,
 	}
@@ -602,7 +604,8 @@ func (r *Reconciler) buildProfile(snapshot *snapshot) *workerconfig.Profile {
 			Enabled:   r.konnectivityEnabled,
 			AgentPort: snapshot.konnectivityAgentPort,
 		},
-		DualStackEnabled: snapshot.dualStackEnabled,
+		DualStackEnabled:  snapshot.dualStackEnabled,
+		AutopilotDisabled: r.autopilotDisabled,
 	}
 
 	if workerProfile.NodeLocalLoadBalancing != nil &&

--- a/pkg/component/controller/workerconfig/reconciler_test.go
+++ b/pkg/component/controller/workerconfig/reconciler_test.go
@@ -59,6 +59,7 @@ func TestReconciler_Lifecycle(t *testing.T) {
 			clients,
 			&leaderelector.Dummy{Leader: true},
 			true,
+			false,
 		)
 		require.NoError(t, err)
 		underTest.log = newTestLogger(t)
@@ -314,6 +315,7 @@ func TestReconciler_ResourceGeneration(t *testing.T) {
 		clients,
 		&leaderelector.Dummy{Leader: true},
 		true,
+		false,
 	)
 	require.NoError(t, err)
 	underTest.log = newTestLogger(t)
@@ -497,6 +499,7 @@ func TestReconciler_ReconcilesOnChangesOnly(t *testing.T) {
 		clients,
 		&leaderelector.Dummy{Leader: true},
 		true,
+		false,
 	)
 	require.NoError(t, err)
 	underTest.log = newTestLogger(t)
@@ -647,6 +650,7 @@ func TestReconciler_LeaderElection(t *testing.T) {
 		clients,
 		&le,
 		true,
+		false,
 	)
 	require.NoError(t, err)
 

--- a/pkg/component/worker/config/config.go
+++ b/pkg/component/worker/config/config.go
@@ -27,6 +27,7 @@ type Profile struct {
 	Konnectivity           Konnectivity
 	PauseImage             *v1beta1.ImageSpec
 	DualStackEnabled       bool
+	AutopilotDisabled      bool
 }
 
 func (p *Profile) DeepCopy() *Profile {
@@ -143,6 +144,7 @@ func forEachConfigMapEntry(profile *Profile, f func(fieldName string, ptr any)) 
 		"konnectivity":           &profile.Konnectivity,
 		"pauseImage":             &profile.PauseImage,
 		"dualStackEnabled":       &profile.DualStackEnabled,
+		"autopilotDisabled":      &profile.AutopilotDisabled,
 	} {
 		f(fieldName, ptr)
 	}


### PR DESCRIPTION
## Description

The disable component flag only guarded the CRD and RBAC application, but the actual Autopilot components were still started.

Add the new field `autopilotDisabled` to the worker profiles config map to transport this information over to the workers.

See:

* #6726

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
