### PR TITLE
Apply CRDs directly without the applier manager

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -345,7 +345,9 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 			K0sVars:           c.K0sVars,
 			KubeClientFactory: adminClientFactory,
 			IgnoredStacks: []string{
+				controller.AutopilotStackName,
 				controller.ClusterConfigStackName,
+				controller.EtcdMemberStackName,
 				controller.SystemRBACStackName,
 				controller.WindowsStackName,
 			},
@@ -451,7 +453,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 	))
 
 	if !slices.Contains(flags.DisableComponents, constant.HelmComponentName) {
-		clusterComponents.Add(ctx, controller.NewCRD(c.K0sVars.ManifestsDir, "helm"))
+		clusterComponents.Add(ctx, controller.NewCRD(c.K0sVars.ManifestsDir, controller.HelmExtensionStackName))
 		clusterComponents.Add(ctx, controller.NewExtensionsController(
 			c.K0sVars,
 			adminClientFactory,
@@ -611,7 +613,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 			return fmt.Errorf("failed to parse API address: %w", err)
 		}
 
-		clusterComponents.Add(ctx, controller.NewCRD(c.K0sVars.ManifestsDir, "autopilot"))
+		clusterComponents.Add(ctx, controller.NewCRDStack(adminClientFactory, leaderElector, controller.AutopilotStackName))
 		clusterComponents.Add(ctx, &controller.Autopilot{
 			APIAddress:         apiAddress,
 			K0sVars:            c.K0sVars,

--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -10,7 +10,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"slices"
 	"sync"
 	"time"
@@ -25,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/restmapper"
@@ -36,22 +34,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func ApplyStack(ctx context.Context, clients kubernetes.ClientFactoryInterface, src io.Reader, srcName, stackName string) error {
-	infos, err := resource.NewLocalBuilder().
-		Unstructured().
-		Stream(src, srcName).
-		Flatten().
-		Do().
-		Infos()
-	if err != nil {
-		return err
-	}
-
-	resources := make([]*unstructured.Unstructured, len(infos))
-	for i := range infos {
-		resources[i] = infos[i].Object.(*unstructured.Unstructured)
-	}
-
+func ApplyStack(ctx context.Context, clients kubernetes.ClientFactoryInterface, resources []*unstructured.Unstructured, stackName string) error {
 	var lastErr error
 	if err := retry.Do(
 		func() error {

--- a/pkg/component/controller/autopilot.go
+++ b/pkg/component/controller/autopilot.go
@@ -20,6 +20,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const AutopilotStackName = "autopilot"
+
 var _ manager.Component = (*Autopilot)(nil)
 
 type Autopilot struct {

--- a/pkg/component/controller/crd.go
+++ b/pkg/component/controller/crd.go
@@ -5,24 +5,43 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/file"
+	"github.com/k0sproject/k0s/pkg/applier"
+	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/constant"
+	"github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/k0sproject/k0s/pkg/leaderelection"
 	"github.com/k0sproject/k0s/static"
+	"github.com/sirupsen/logrus"
 )
 
 var _ manager.Component = (*CRD)(nil)
 
 // CRD unpacks bundled CRD definitions to the filesystem
+//
+// Deprecated: Use [CRDStack] instead.
 type CRD struct {
 	bundle       string
 	manifestsDir string
+
+	crdOpts
+}
+
+// CRDStack applies bundled CRDs.
+type CRDStack struct {
+	clients       kubernetes.ClientFactoryInterface
+	leaderElector leaderelector.Interface
+	bundle        string
+	stop          func()
 
 	crdOpts
 }
@@ -34,6 +53,8 @@ type crdOpts struct {
 type CRDOption func(*crdOpts)
 
 // NewCRD build new CRD
+//
+// Deprecated: Use [NewCRDStack] instead.
 func NewCRD(manifestsDir, bundle string, opts ...CRDOption) *CRD {
 	var options crdOpts
 	for _, opt := range opts {
@@ -49,6 +70,28 @@ func NewCRD(manifestsDir, bundle string, opts ...CRDOption) *CRD {
 		bundle:       bundle,
 		manifestsDir: manifestsDir,
 		crdOpts:      options,
+	}
+}
+
+var _ manager.Component = (*CRDStack)(nil)
+
+// Creates a new CRD stack for the given bundle.
+func NewCRDStack(clients kubernetes.ClientFactoryInterface, leaderElector leaderelector.Interface, bundle string, opts ...CRDOption) *CRDStack {
+	var options crdOpts
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	if options.assetsDir == "" {
+		options.stackName = bundle
+		options.assetsDir = bundle
+	}
+
+	return &CRDStack{
+		clients:       clients,
+		leaderElector: leaderElector,
+		bundle:        bundle,
+		crdOpts:       options,
 	}
 }
 
@@ -91,5 +134,60 @@ func (c CRD) Start(context.Context) error {
 }
 
 func (c CRD) Stop() error {
+	return nil
+}
+
+// Init implements [manager.Component]. It does nothing.
+func (c *CRDStack) Init(ctx context.Context) error {
+	return nil
+}
+
+// Applies this CRD stack when becoming the leader. Implements [manager.Component].
+func (c *CRDStack) Start(context.Context) error {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		leaderelection.RunLeaderTasks(ctx, c.leaderElector.CurrentStatus, func(ctx context.Context) {
+			resources, err := applier.ReadUnstructuredDir(static.CRDs, c.assetsDir)
+			if err != nil {
+				logrus.WithError(err).Errorf("Failed to read %s CRD stack", c.bundle)
+				return
+			}
+
+			stack := applier.Stack{
+				Name:      c.stackName,
+				Resources: resources,
+				Clients:   c.clients,
+			}
+
+			for {
+				err := stack.Apply(ctx, true)
+				if err == nil {
+					break
+				}
+
+				logrus.WithError(err).Errorf("Failed to apply %s CRD stack, retrying in 30 seconds", c.bundle)
+
+				select {
+				case <-time.After(30 * time.Second):
+				case <-ctx.Done():
+					return
+				}
+			}
+		})
+	}()
+
+	c.stop = func() { cancel(errors.New("CRD stack is stopping")); <-done }
+
+	return nil
+}
+
+// Stop implements [manager.Component].
+func (c *CRDStack) Stop() error {
+	if stop := c.stop; stop != nil {
+		stop()
+	}
 	return nil
 }

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -36,6 +36,8 @@ const (
 	shutdownLabelName        = "k0s.k0sproject.io/shutdown"
 )
 
+const EtcdMemberStackName = "etcd-member"
+
 var _ manager.Component = (*EtcdMemberReconciler)(nil)
 
 func NewEtcdMemberReconciler(kubeClientFactory kubeutil.ClientFactoryInterface, k0sVars *config.CfgVars, etcdConfig *v1beta1.EtcdConfig, leaderElector leaderelector.Interface, controllerCount func() uint, shutdown context.CancelCauseFunc) (*EtcdMemberReconciler, error) {

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -49,6 +49,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const HelmExtensionStackName = "helm"
+
 // Helm watch for Chart crd
 type ExtensionsController struct {
 	L             *logrus.Entry

--- a/pkg/component/controller/systemrbac.go
+++ b/pkg/component/controller/systemrbac.go
@@ -32,7 +32,9 @@ func (s *SystemRBAC) Init(ctx context.Context) error {
 		in = io.MultiReader(in, bytes.NewReader(apSystemRBAC))
 	}
 
-	if err := applier.ApplyStack(ctx, s.Clients, in, SystemRBACStackName, SystemRBACStackName); err != nil {
+	if resources, err := applier.ReadUnstructuredStream(in, SystemRBACStackName); err != nil {
+		return fmt.Errorf("failed to read system RBAC stack: %w", err)
+	} else if err := applier.ApplyStack(ctx, s.Clients, resources, SystemRBACStackName); err != nil {
 		return fmt.Errorf("failed to apply system RBAC stack: %w", err)
 	}
 


### PR DESCRIPTION
## Description

There's no need to write them to the filesystem.

Add the etcd member reconciler as a cluster component, just as its CRD stack.

Move unstructured stack application into public function The system RBAC component fed an io.Reader into a resource builder to extract unstructured objects and apply them as a stack in a retry loop. This is a pattern that is reusable across components: Move this into its own function in the applier package.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
