### PR TITLE
Apply Helm Stack in-memory

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -44,6 +44,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/k0sproject/k0s/pkg/leaderelection"
 	"github.com/k0sproject/k0s/pkg/performance"
 	"github.com/k0sproject/k0s/pkg/telemetry"
 	"github.com/k0sproject/k0s/pkg/token"
@@ -329,7 +330,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 
 	// One leader elector per controller
 	if singleController {
-		leaderElector = &leaderelector.Dummy{Leader: true}
+		leaderElector = leaderelector.Off()
 	} else {
 		// The name used to be hardcoded in the component itself
 		// At some point we need to rename this.
@@ -431,7 +432,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 	if flags.EnableDynamicConfig {
 		clusterComponents.Add(ctx, controller.NewClusterConfigInitializer(
 			adminClientFactory,
-			leaderElector,
+			func() leaderelection.Status { status, _ := leaderElector.CurrentStatus(); return status },
 			nodeConfig,
 		))
 
@@ -461,7 +462,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 	if enableK0sEndpointReconciler {
 		clusterComponents.Add(ctx, controller.NewEndpointReconciler(
 			nodeConfig,
-			leaderElector,
+			func() leaderelection.Status { status, _ := leaderElector.CurrentStatus(); return status },
 			adminClientFactory,
 			net.DefaultResolver,
 			nodeConfig.PrimaryAddressFamily(),

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -346,6 +346,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 				controller.AutopilotStackName,
 				controller.ClusterConfigStackName,
 				controller.EtcdMemberStackName,
+				controller.HelmExtensionStackName,
 				controller.SystemRBACStackName,
 				controller.WindowsStackName,
 			},
@@ -451,9 +452,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 	))
 
 	if !slices.Contains(flags.DisableComponents, constant.HelmComponentName) {
-		clusterComponents.Add(ctx, controller.NewCRD(c.K0sVars.ManifestsDir, controller.HelmExtensionStackName))
 		clusterComponents.Add(ctx, controller.NewExtensionsController(
-			c.K0sVars.ManifestsDir,
 			adminClientFactory,
 			leaderElector,
 		))
@@ -593,7 +592,8 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 		if err != nil {
 			return err
 		}
-		clusterComponents.Add(ctx, controller.NewCRD(c.K0sVars.ManifestsDir, "etcd", controller.WithStackName("etcd-member")))
+
+		clusterComponents.Add(ctx, controller.NewCRDStack(adminClientFactory, leaderElector, "etcd", controller.WithStackName(controller.EtcdMemberStackName)))
 		clusterComponents.Add(ctx, etcdReconciler)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.43.0
 	golang.org/x/text v0.36.0
-	golang.org/x/time v0.15.0
 	golang.org/x/tools v0.44.0
 	google.golang.org/grpc v1.80.0
 	helm.sh/helm/v3 v3.20.2
@@ -267,6 +266,7 @@ require (
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260120221211-b8f7ae30c516 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect

--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -12,6 +12,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -33,7 +34,6 @@ import (
 	"github.com/cloudflare/cfssl/initca"
 	"github.com/cloudflare/cfssl/signer"
 	"github.com/cloudflare/cfssl/signer/local"
-	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/inttest/common"
 	helmv1beta1 "github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
@@ -48,11 +48,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	k8s "k8s.io/client-go/kubernetes"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -153,6 +155,7 @@ func (as *AddonsSuite) SetupTest() {
 }
 
 func (as *AddonsSuite) TestHelmBasedAddons() {
+	ctx := as.TContext()
 	crlog.SetLogger(testr.New(as.T()))
 
 	addonName := "test-addon"
@@ -189,17 +192,11 @@ func (as *AddonsSuite) TestHelmBasedAddons() {
 	as.Run("Controller restart recovery", func() { as.testControllerRestartRecovery(kc) })
 	as.Run("Chart ordering", func() { as.testChartOrdering() })
 
-	values := map[string]any{
-		"replicaCount": 2,
-		"image": map[string]any{
-			"pullPolicy": "Always",
-		},
-	}
-	as.doTestAddonUpdate(addonName, values)
+	as.doTestAddonUpdate(ctx, addonName)
 	chart := as.waitForTestRelease(addonName, "0.6.0", metav1.NamespaceDefault, 2)
 	as.Require().NoError(as.checkCustomValues(chart.Status.ReleaseName))
 	as.deleteRelease(chart)
-	as.deleteUninstalledChart(as.TContext())
+	as.deleteUninstalledChart(ctx)
 }
 
 func (as *AddonsSuite) pullHelmChart(node string) {
@@ -397,19 +394,22 @@ func (as *AddonsSuite) waitForChartError(addonName, expectedError string) {
 func (as *AddonsSuite) deleteRelease(chart *helmv1beta1.Chart) {
 	ctx := as.Context()
 	as.T().Logf("Deleting chart %s/%s", chart.Namespace, chart.Name)
-	ssh, err := as.SSH(ctx, as.ControllerNode(0))
+	kubeconfig, err := as.GetKubeConfig(as.ControllerNode(0))
 	as.Require().NoError(err)
-	defer ssh.Disconnect()
-	_, err = ssh.ExecWithOutput(ctx, "rm /var/lib/k0s/manifests/helm/0_helm_extension_test-addon.yaml")
+	dyn, err := dynamic.NewForConfig(kubeconfig)
 	as.Require().NoError(err)
-	cfg, err := as.GetKubeConfig(as.ControllerNode(0))
-	as.Require().NoError(err)
-	k8sclient, err := k8s.NewForConfig(cfg)
+
+	_, err = patchResource(
+		ctx, dyn.Resource(k0sv1beta1.SchemeGroupVersion.WithResource("clusterconfigs")).Namespace(metav1.NamespaceSystem), "k0s",
+		patchOp{"test", "/spec/extensions/helm/charts/0/name", chart.Status.ReleaseName},
+		patchOp{"remove", "/spec/extensions/helm/charts/0", nil},
+	)
 	as.Require().NoError(err)
 	as.Require().NoError(wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(pollCtx context.Context) (done bool, err error) {
 		as.T().Logf("Expecting have no secrets left for release %s/%s", chart.Status.Namespace, chart.Status.ReleaseName)
-		items, err := k8sclient.CoreV1().Secrets(chart.Status.Namespace).List(pollCtx, metav1.ListOptions{
-			LabelSelector: "name=" + chart.Status.ReleaseName,
+		secrets := dyn.Resource(corev1.SchemeGroupVersion.WithResource("secrets"))
+		items, err := secrets.Namespace(chart.Status.Namespace).List(pollCtx, metav1.ListOptions{
+			LabelSelector: fields.OneTermEqualSelector("name", chart.Status.ReleaseName).String(),
 		})
 		if err != nil {
 			if ctxErr := context.Cause(ctx); ctxErr != nil {
@@ -425,19 +425,16 @@ func (as *AddonsSuite) deleteRelease(chart *helmv1beta1.Chart) {
 		return true, nil
 	}))
 
-	chartClient, err := client.New(cfg, client.Options{Scheme: k0sscheme.Scheme})
-	as.Require().NoError(err)
-
 	as.T().Logf("Expecting chart %s/%s to be deleted", chart.Namespace, chart.Name)
 	var lastResourceVersion string
 	as.Require().NoError(wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
-		var found helmv1beta1.Chart
-		err := chartClient.Get(ctx, client.ObjectKey{Namespace: chart.Namespace, Name: chart.Name}, &found)
+		charts := dyn.Resource(helmv1beta1.SchemeGroupVersion.WithResource("charts"))
+		found, err := charts.Namespace(chart.Namespace).Get(ctx, chart.Name, metav1.GetOptions{})
 		switch {
 		case err == nil:
-			if lastResourceVersion == "" || lastResourceVersion != found.ResourceVersion {
+			if lastResourceVersion == "" || lastResourceVersion != found.GetResourceVersion() {
 				as.T().Log("Chart not yet deleted")
-				lastResourceVersion = found.ResourceVersion
+				lastResourceVersion = found.GetResourceVersion()
 			}
 			return false, nil
 
@@ -602,33 +599,25 @@ func (as *AddonsSuite) checkCustomValues(releaseName string) error {
 	})
 }
 
-func (as *AddonsSuite) doTestAddonUpdate(addonName string, values map[string]any) {
-	path := fmt.Sprintf("/var/lib/k0s/manifests/helm/0_helm_extension_%s.yaml", addonName)
-	valuesBytes, err := yaml.Marshal(values)
+func (as *AddonsSuite) doTestAddonUpdate(ctx context.Context, addonName string) {
+	kubeconfig, err := as.GetKubeConfig(as.ControllerNode(0))
 	as.Require().NoError(err)
-	tw := templatewriter.TemplateWriter{
-		Name:     "testChartUpdate",
-		Template: chartCrdTemplate,
-		Data: struct {
-			Name         string
-			ChartName    string
-			Values       string
-			Version      string
-			TargetNS     string
-			ForceUpgrade *bool
-		}{
-			Name:         "test-addon",
-			ChartName:    "ealenn/echo-server",
-			Values:       string(valuesBytes),
-			Version:      "0.5.0",
-			TargetNS:     metav1.NamespaceDefault,
-			ForceUpgrade: ptr.To(false),
-		},
-	}
-	buf := bytes.NewBuffer([]byte{})
-	as.Require().NoError(tw.WriteToBuffer(buf))
+	dyn, err := dynamic.NewForConfig(kubeconfig)
+	as.Require().NoError(err)
 
-	as.PutFile(as.ControllerNode(0), path, buf.String())
+	_, err = patchResource(
+		ctx, dyn.Resource(k0sv1beta1.SchemeGroupVersion.WithResource("clusterconfigs")).Namespace(metav1.NamespaceSystem), "k0s",
+		patchOp{"test", "/spec/extensions/helm/charts/0/name", addonName},
+		patchOp{"replace", "/spec/extensions/helm/charts/0", map[string]any{
+			"name":         addonName,
+			"chartname":    "ealenn/echo-server",
+			"values":       `{"replicaCount": 2, "image": {"pullPolicy": "Always"}}`,
+			"version":      "0.5.0",
+			"namespace":    metav1.NamespaceDefault,
+			"forceUpgrade": false,
+		}},
+	)
+	as.Require().NoError(err)
 }
 
 // testControllerRestartRecovery tests that charts stuck in pending-install state
@@ -919,6 +908,21 @@ func TestAddonsSuite(t *testing.T) {
 	suite.Run(t, &s)
 }
 
+type patchOp = struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value,omitempty"`
+}
+
+//nolint:unparam // returned object not yet used
+func patchResource(ctx context.Context, c dynamic.ResourceInterface, name string, ops ...patchOp) (*unstructured.Unstructured, error) {
+	if patch, err := json.Marshal(ops); err != nil {
+		return nil, err
+	} else {
+		return c.Patch(ctx, name, types.JSONPatchType, patch, metav1.PatchOptions{})
+	}
+}
+
 type k0sConfigParams struct {
 	BasicAddonName string
 
@@ -965,25 +969,3 @@ spec:
 `
 
 var k0sConfigWithAddonTemplate = template.Must(template.New("k0sConfigWithAddon").Parse(k0sConfigWithAddonRawTemplate))
-
-// TODO: this actually duplicates logic from the controller code
-// better to somehow handle it by programmatic api
-const chartCrdTemplate = `
-apiVersion: helm.k0sproject.io/v1beta1
-kind: Chart
-metadata:
-  name: k0s-addon-chart-{{ .Name }}
-  namespace: ` + metav1.NamespaceSystem + `
-  finalizers:
-    - helm.k0sproject.io/uninstall-helm-release 
-spec:
-  chartName: {{ .ChartName }}
-  releaseName: {{ .Name }}
-  values: |
-{{ .Values | nindent 4 }}
-  version: {{ .Version }}
-  namespace: {{ .TargetNS }}
-{{- if ne .ForceUpgrade nil }}
-  forceUpgrade: {{ .ForceUpgrade }}
-{{- end }}
-`

--- a/pkg/applier/manager_test.go
+++ b/pkg/applier/manager_test.go
@@ -38,13 +38,13 @@ import (
 func TestManager_AppliesStacks(t *testing.T) {
 	k0sVars, err := config.NewCfgVars(nil, t.TempDir())
 	require.NoError(t, err)
-	leaderElector := leaderelector.Dummy{Leader: true}
+	leaderElector := leaderelector.Off()
 	clients := testutil.NewFakeClientFactory()
 
 	underTest := applier.Manager{
 		K0sVars:           k0sVars,
 		KubeClientFactory: clients,
-		LeaderElector:     &leaderElector,
+		LeaderElector:     leaderElector,
 	}
 
 	// A stack that exists on disk before the manager is started.
@@ -100,14 +100,14 @@ data: {}
 func TestManager_IgnoresStacks(t *testing.T) {
 	k0sVars, err := config.NewCfgVars(nil, t.TempDir())
 	require.NoError(t, err)
-	leaderElector := leaderelector.Dummy{Leader: true}
+	leaderElector := leaderelector.Off()
 	clients := testutil.NewFakeClientFactory()
 
 	underTest := applier.Manager{
 		K0sVars:           k0sVars,
 		IgnoredStacks:     []string{"ignored"},
 		KubeClientFactory: clients,
-		LeaderElector:     &leaderElector,
+		LeaderElector:     leaderElector,
 	}
 
 	ignored := filepath.Join(k0sVars.ManifestsDir, "ignored")

--- a/pkg/component/controller/apiendpointreconciler_test.go
+++ b/pkg/component/controller/apiendpointreconciler_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
-	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
+	"github.com/k0sproject/k0s/pkg/leaderelection"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,7 +36,8 @@ func TestBasicReconcilerWithNoLeader(t *testing.T) {
 
 	config := getFakeConfig()
 
-	r := NewEndpointReconciler(config, &leaderelector.Dummy{Leader: false}, fakeFactory, fakeResolver{}, v1beta1.PrimaryFamilyIPv4)
+	leaderStatus := func() leaderelection.Status { return leaderelection.StatusPending }
+	r := NewEndpointReconciler(config, leaderStatus, fakeFactory, fakeResolver{}, v1beta1.PrimaryFamilyIPv4)
 
 	ctx := t.Context()
 	assert.NoError(t, r.Init(ctx))
@@ -70,7 +71,8 @@ func TestBasicReconcilerWithNoExistingEndpoint(t *testing.T) {
 		fakeFactory := testutil.NewFakeClientFactory()
 		config := getFakeConfig()
 
-		r := NewEndpointReconciler(config, &leaderelector.Dummy{Leader: true}, fakeFactory, fakeResolver{}, test.afnet)
+		leaderStatus := func() leaderelection.Status { return leaderelection.StatusLeading }
+		r := NewEndpointReconciler(config, leaderStatus, fakeFactory, fakeResolver{}, test.afnet)
 
 		ctx := t.Context()
 		assert.NoError(t, r.Init(ctx))
@@ -100,7 +102,8 @@ func TestBasicReconcilerWithEmptyEndpointSubset(t *testing.T) {
 	assert.NoError(t, err)
 	config := getFakeConfig()
 
-	r := NewEndpointReconciler(config, &leaderelector.Dummy{Leader: true}, fakeFactory, fakeResolver{}, v1beta1.PrimaryFamilyIPv4)
+	leaderStatus := func() leaderelection.Status { return leaderelection.StatusLeading }
+	r := NewEndpointReconciler(config, leaderStatus, fakeFactory, fakeResolver{}, v1beta1.PrimaryFamilyIPv4)
 
 	assert.NoError(t, r.Init(ctx))
 
@@ -136,7 +139,8 @@ func TestReconcilerWithNoNeedForUpdate(t *testing.T) {
 
 	config := getFakeConfig()
 
-	r := NewEndpointReconciler(config, &leaderelector.Dummy{Leader: true}, fakeFactory, fakeResolver{}, v1beta1.PrimaryFamilyIPv4)
+	leaderStatus := func() leaderelection.Status { return leaderelection.StatusLeading }
+	r := NewEndpointReconciler(config, leaderStatus, fakeFactory, fakeResolver{}, v1beta1.PrimaryFamilyIPv4)
 
 	assert.NoError(t, r.Init(ctx))
 
@@ -173,7 +177,8 @@ func TestReconcilerWithNeedForUpdate(t *testing.T) {
 
 	config := getFakeConfig()
 
-	r := NewEndpointReconciler(config, &leaderelector.Dummy{Leader: true}, fakeFactory, fakeResolver{}, v1beta1.PrimaryFamilyIPv4)
+	leaderStatus := func() leaderelection.Status { return leaderelection.StatusLeading }
+	r := NewEndpointReconciler(config, leaderStatus, fakeFactory, fakeResolver{}, v1beta1.PrimaryFamilyIPv4)
 	assert.NoError(t, r.Init(ctx))
 
 	assert.NoError(t, r.reconcileEndpoints(ctx))

--- a/pkg/component/controller/clusterconfig_test.go
+++ b/pkg/component/controller/clusterconfig_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/k0sproject/k0s/internal/testutil"
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component/controller"
-	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/constant"
+	"github.com/k0sproject/k0s/pkg/leaderelection"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,12 +29,12 @@ import (
 func TestClusterConfigInitializer_Create(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		clients := testutil.NewFakeClientFactory()
-		leaderElector := leaderelector.Dummy{Leader: true}
+		leaderStatus := func() leaderelection.Status { return leaderelection.StatusLeading }
 		initialConfig := k0sv1beta1.DefaultClusterConfig()
 		initialConfig.ResourceVersion = "42"
 
 		underTest := controller.NewClusterConfigInitializer(
-			clients, &leaderElector, initialConfig.DeepCopy(),
+			clients, leaderStatus, initialConfig.DeepCopy(),
 		)
 
 		require.NoError(t, underTest.Init(t.Context()))
@@ -65,11 +65,11 @@ func TestClusterConfigInitializer_Create(t *testing.T) {
 func TestClusterConfigInitializer_NoConfig(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		clients := testutil.NewFakeClientFactory()
-		leaderElector := leaderelector.Dummy{Leader: false}
+		leaderStatus := func() leaderelection.Status { return leaderelection.StatusPending }
 		initialConfig := k0sv1beta1.DefaultClusterConfig()
 
 		underTest := controller.NewClusterConfigInitializer(
-			clients, &leaderElector, initialConfig.DeepCopy(),
+			clients, leaderStatus, initialConfig.DeepCopy(),
 		)
 
 		ctx, cancel := context.WithCancelCause(t.Context())
@@ -96,16 +96,15 @@ func TestClusterConfigInitializer_NoConfig(t *testing.T) {
 }
 
 func TestClusterConfigInitializer_Exists(t *testing.T) {
-	test := func(t *testing.T, leader bool) *testutil.FakeClientFactory {
+	test := func(t *testing.T, leaderStatus leaderelection.Status) *testutil.FakeClientFactory {
 		existingConfig := k0sv1beta1.DefaultClusterConfig()
 		existingConfig.ResourceVersion = "42"
 		clients := testutil.NewFakeClientFactory(existingConfig)
-		leaderElector := leaderelector.Dummy{Leader: leader}
 		initialConfig := existingConfig.DeepCopy()
 		initialConfig.ResourceVersion = "1337"
 
 		underTest := controller.NewClusterConfigInitializer(
-			clients, &leaderElector, initialConfig,
+			clients, func() leaderelection.Status { return leaderStatus }, initialConfig,
 		)
 
 		require.NoError(t, underTest.Init(t.Context()))

--- a/pkg/component/controller/csrapprover_test.go
+++ b/pkg/component/controller/csrapprover_test.go
@@ -57,7 +57,7 @@ func TestBasicCRSApprover(t *testing.T) {
 			},
 		},
 	}
-	c := NewCSRApprover(config, &leaderelector.Dummy{Leader: true}, fakeFactory)
+	c := NewCSRApprover(config, leaderelector.Off(), fakeFactory)
 
 	assert.NoError(t, c.Init(ctx))
 	assert.NoError(t, c.approveCSR(ctx))

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -170,6 +170,8 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.Hel
 
 	if err := filepath.WalkDir(ec.manifestsDir, func(path string, entry fs.DirEntry, err error) error {
 		switch {
+		case err != nil:
+			errs = append(errs, fmt.Errorf("while walking through Helm chart manifest directory: %w", err))
 		case !entry.Type().IsRegular():
 			ec.L.Debugf("Keeping %v as it is not a regular file", entry)
 		case slices.Contains(fileNamesToKeep, entry.Name()):

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"bytes"
 	"cmp"
 	"context"
 	"crypto/sha256"
@@ -11,37 +12,38 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
 	"net/url"
-	"os"
 	"path/filepath"
-	"regexp"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 
-	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
+	"github.com/k0sproject/k0s/internal/sync/value"
 	helmv1beta1 "github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	"github.com/k0sproject/k0s/pkg/applier"
 	k0sscheme "github.com/k0sproject/k0s/pkg/client/clientset/scheme"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/helm"
 	"github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/pkg/leaderelection"
+	"github.com/k0sproject/k0s/static"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	apiretry "k8s.io/client-go/util/retry"
 
+	"github.com/Masterminds/sprig"
 	"github.com/bombsimon/logrusr/v4"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/time/rate"
 	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
@@ -54,6 +56,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
 )
 
 const HelmExtensionStackName = "helm"
@@ -107,26 +110,26 @@ func (rc *repositoryCache) update(repositories []k0sv1beta1.Repository) {
 
 }
 
-// Helm watch for Chart crd
+// ExtensionsController reconciles Helm extension repositories and charts, and
+// keeps the Helm stack up to date as long as leadership is held.
 type ExtensionsController struct {
 	L               *logrus.Entry
 	clients         kubernetes.ClientFactoryInterface
 	leaderElector   leaderelector.Interface
-	manifestsDir    string
-	stop            context.CancelFunc
+	stop            func()
 	repositoryCache *repositoryCache
+	helmConfig      value.Latest[*k0sv1beta1.HelmExtensions]
 }
 
 var _ manager.Component = (*ExtensionsController)(nil)
 var _ manager.Reconciler = (*ExtensionsController)(nil)
 
 // NewExtensionsController builds new HelmAddons
-func NewExtensionsController(manifestsDir string, kubeClientFactory kubernetes.ClientFactoryInterface, leaderElector leaderelector.Interface) *ExtensionsController {
+func NewExtensionsController(kubeClientFactory kubernetes.ClientFactoryInterface, leaderElector leaderelector.Interface) *ExtensionsController {
 	return &ExtensionsController{
 		L:               logrus.WithFields(logrus.Fields{"component": "extensions_controller"}),
 		clients:         kubeClientFactory,
 		leaderElector:   leaderElector,
-		manifestsDir:    filepath.Join(manifestsDir, "helm"),
 		repositoryCache: &repositoryCache{},
 	}
 }
@@ -137,100 +140,124 @@ const (
 
 // Run runs the extensions controller
 func (ec *ExtensionsController) Reconcile(ctx context.Context, clusterConfig *k0sv1beta1.ClusterConfig) error {
-	ec.L.Info("Extensions reconciliation started")
-	defer ec.L.Info("Extensions reconciliation finished")
-	return ec.reconcileHelmExtensions(clusterConfig.Spec.Extensions.Helm)
+	helmConfig := clusterConfig.Spec.Extensions.Helm.DeepCopy()
+	if helmConfig == nil {
+		helmConfig = new(k0sv1beta1.HelmExtensions)
+	}
+	ec.helmConfig.Set(helmConfig)
+	return nil
 }
 
-// reconcileHelmExtensions creates instance of Chart CR for each chart of the config file
-// it also reconciles repositories settings
-// the actual helm install/update/delete management is done by ChartReconciler structure
-func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.HelmExtensions) error {
-	if helmSpec == nil {
-		return nil
-	}
+func (ec *ExtensionsController) reconcileConfig(ctx context.Context, stackReconciledOnceCh chan<- struct{}) {
+	var (
+		stackReconciledOnce bool
+		currentRepositories k0sv1beta1.RepositoriesSettings
+		currentCharts       k0sv1beta1.ChartsSettings
+	)
 
-	// Update repository cache
-	ec.repositoryCache.update(helmSpec.Repositories)
+	for {
+		config, configChanged := ec.helmConfig.Peek()
+		leaderStatus, statusChanged := ec.leaderElector.CurrentStatus()
 
-	var errs []error
-	var fileNamesToKeep []string
-	for _, chart := range helmSpec.Charts {
-		fileName := chartManifestFileName(&chart)
-		fileNamesToKeep = append(fileNamesToKeep, fileName)
-
-		path, err := ec.writeChartManifestFile(chart, fileName)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("can't write file for Helm chart manifest %q: %w", chart.ChartName, err))
-			continue
-		}
-
-		ec.L.Infof("Wrote Helm chart manifest file %q", path)
-	}
-
-	if err := filepath.WalkDir(ec.manifestsDir, func(path string, entry fs.DirEntry, err error) error {
-		switch {
-		case err != nil:
-			errs = append(errs, fmt.Errorf("while walking through Helm chart manifest directory: %w", err))
-		case !entry.Type().IsRegular():
-			ec.L.Debugf("Keeping %v as it is not a regular file", entry)
-		case slices.Contains(fileNamesToKeep, entry.Name()):
-			ec.L.Debugf("Keeping %v as it belongs to a known Helm extension", entry)
-		case !isChartManifestFileName(entry.Name()):
-			ec.L.Debugf("Keeping %v as it is not a Helm chart manifest file", entry)
-		default:
-			if err := os.Remove(path); err != nil {
-				if !errors.Is(err, os.ErrNotExist) {
-					errs = append(errs, fmt.Errorf("failed to remove Helm chart manifest file, the Chart resource will remain in the cluster: %w", err))
-				}
+		var retry <-chan time.Time
+		if config != nil && leaderStatus == leaderelection.StatusLeading {
+			if stackReconciledOnce && reflect.DeepEqual(currentRepositories, config.Repositories) && reflect.DeepEqual(currentCharts, config.Charts) {
+				ec.L.Debug("Helm configuration unchanged")
 			} else {
-				ec.L.Infof("Removed Helm chart manifest file %q", path)
+				ec.L.Debug("Reconciling ", HelmExtensionStackName, " stack")
+
+				// Update repository cache
+				ec.repositoryCache.update(config.Repositories)
+
+				ctx, cancel := context.WithCancelCause(ctx)
+				go func() {
+					select {
+					case <-statusChanged:
+						cancel(leaderelection.ErrLostLead)
+					case <-ctx.Done():
+					}
+				}()
+
+				if ec.reconcileStack(ctx, config.Charts) {
+					stackReconciledOnce = true
+					currentRepositories, currentCharts = config.Repositories, config.Charts
+					ec.L.Info("Reconciled ", HelmExtensionStackName, " stack")
+					if stackReconciledOnceCh != nil {
+						close(stackReconciledOnceCh)
+						stackReconciledOnceCh = nil
+					}
+				} else {
+					if stackReconciledOnce {
+						retry = time.After(wait.Jitter(1*time.Minute, 0.3))
+					} else {
+						retry = time.After(wait.Jitter(7*time.Second, 1))
+					}
+				}
 			}
 		}
 
-		return nil
-	}); err != nil {
-		errs = append(errs, fmt.Errorf("failed to walk Helm chart manifest directory: %w", err))
-	}
+		select {
+		case <-configChanged:
+			ec.L.Debug("Processing configuration change")
 
-	return errors.Join(errs...)
+		case <-statusChanged:
+			stackReconciledOnce = false
+			ec.L.Debug("Processing leader change")
+
+		case <-retry:
+			retry = nil
+			ec.L.Info("Retrying configuration reconciliation")
+
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
-func (ec *ExtensionsController) writeChartManifestFile(chart k0sv1beta1.Chart, fileName string) (string, error) {
-	// Find matching repository for this chart
-	var repository *k0sv1beta1.Repository
-	if repoID := extractRepositoryIdentifier(chart.ChartName); repoID != "" {
-		repository = ec.repositoryCache.get(repoID)
+func (ec *ExtensionsController) reconcileStack(ctx context.Context, charts k0sv1beta1.ChartsSettings) bool {
+	var fail bool
+
+	resources, err := applier.ReadUnstructuredDir(static.CRDs, HelmExtensionStackName)
+	if err != nil {
+		ec.L.WithError(err).Error("Failed to fetch Helm CRDs")
+		return false
 	}
 
-	tw := templatewriter.TemplateWriter{
-		Path:     filepath.Join(ec.manifestsDir, fileName),
-		Name:     "addon_crd_manifest",
-		Template: chartCrdTemplate,
-		Data: struct {
-			k0sv1beta1.Chart
-			Finalizer  string
+	chartTemplate := template.Must(template.New("addon_crd_manifest").Funcs(sprig.TxtFuncMap()).Parse(chartCrdTemplate))
+	for _, chart := range charts {
+		data := struct {
+			*k0sv1beta1.Chart
 			Repository *k0sv1beta1.Repository
 		}{
-			Chart:      chart,
-			Finalizer:  finalizerName,
-			Repository: repository,
-		},
-	}
-	if err := tw.Write(); err != nil {
-		return "", err
-	}
-	return tw.Path, nil
-}
+			Chart: &chart,
+		}
 
-// Determines the file name to use when storing a chart as a manifest on disk.
-func chartManifestFileName(c *k0sv1beta1.Chart) string {
-	return fmt.Sprintf("%d_helm_extension_%s.yaml", c.Order, c.Name)
-}
+		// Find matching repository for this chart
+		if repoID := extractRepositoryIdentifier(chart.ChartName); repoID != "" {
+			data.Repository = ec.repositoryCache.get(repoID)
+		}
 
-// Determines if the given file name is in the format for chart manifest file names.
-func isChartManifestFileName(fileName string) bool {
-	return regexp.MustCompile(`^-?[0-9]+_helm_extension_.+\.yaml$`).MatchString(fileName)
+		var rendered bytes.Buffer
+		if err := chartTemplate.Execute(&rendered, &data); err != nil {
+			ec.L.WithError(err).Error("Failed to render Helm chart manifest ", chart.Name)
+			return false
+		}
+
+		var object unstructured.Unstructured
+		if err := yaml.Unmarshal(rendered.Bytes(), &object.Object); err != nil {
+			ec.L.WithError(err).Error("Failed to render Helm chart manifest ", chart.Name)
+			return false
+		}
+
+		resources = append(resources, &object)
+	}
+
+	if err := applier.ApplyStack(ctx, ec.clients, resources, HelmExtensionStackName); err != nil {
+		fail = true
+		ec.L.WithError(err).Error("Failed to apply ", HelmExtensionStackName, " stack")
+	}
+
+	return !fail
 }
 
 type ChartReconciler struct {
@@ -684,13 +711,14 @@ func (cr *ChartReconciler) updateStatus(ctx context.Context, chart helmv1beta1.C
 }
 
 const chartCrdTemplate = `
+---
 apiVersion: helm.k0sproject.io/v1beta1
 kind: Chart
 metadata:
   name: k0s-addon-chart-{{ .Name }}
   namespace: ` + metav1.NamespaceSystem + `
   finalizers:
-    - {{ .Finalizer }}
+    - ` + finalizerName + `
 spec:
   chartName: {{ .ChartName }}
   releaseName: {{ .Name }}
@@ -737,38 +765,46 @@ func (ec *ExtensionsController) Init(_ context.Context) error {
 }
 
 // Start
-func (ec *ExtensionsController) Start(ctx context.Context) error {
+func (ec *ExtensionsController) Start(context.Context) error {
 	ec.L.Debug("Starting")
 
-	mgr, err := ec.instantiateManager(ctx)
+	mgr, err := ec.instantiateManager()
 	if err != nil {
 		return fmt.Errorf("can't instantiate controller-runtime manager: %w", err)
 	}
 
+	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
+	stackReconciledOnce := make(chan struct{})
 
-	go func() {
-		defer close(done)
+	wg.Go(func() { ec.reconcileConfig(ctx, stackReconciledOnce) })
+	wg.Go(func() {
 		leaderelection.RunLeaderTasks(ctx, ec.leaderElector.CurrentStatus, func(ctx context.Context) {
+			select {
+			case <-stackReconciledOnce:
+			case <-ctx.Done():
+				return
+			}
+
 			ec.L.Info("Running controller-runtime manager")
 			if err := mgr.Start(ctx); err != nil {
 				ec.L.WithError(err).Error("Failed to run controller-runtime manager")
+			} else {
+				ec.L.Info("Controller-runtime manager exited")
 			}
-			ec.L.Info("Controller-runtime manager exited")
 		})
 
-	}()
+	})
 
 	ec.stop = func() {
 		cancel()
-		<-done
+		wg.Wait()
 	}
 
 	return nil
 }
 
-func (ec *ExtensionsController) instantiateManager(ctx context.Context) (crman.Manager, error) {
+func (ec *ExtensionsController) instantiateManager() (crman.Manager, error) {
 	clientConfig, err := ec.clients.GetRESTConfig()
 	if err != nil {
 		return nil, fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
@@ -792,28 +828,6 @@ func (ec *ExtensionsController) instantiateManager(ctx context.Context) (crman.M
 	})
 	if err != nil {
 		return nil, fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
-	}
-
-	for chart, sometimes := (schema.GroupKind{Group: helmv1beta1.GroupName, Kind: "Chart"}), (&rate.Sometimes{Every: 5}); ; {
-		_, err := mgr.GetRESTMapper().RESTMapping(chart)
-		if err == nil {
-			ec.L.Info(chart, " CRD is ready, going nuts")
-			break
-		}
-
-		sometimes.Do(func() {
-			if meta.IsNoMatchError(err) {
-				ec.L.Warn(chart, " CRD is not yet ready, waiting before starting ExtensionsController")
-			} else {
-				ec.L.WithError(err).Error("Failed to check for ", chart, " CRD readiness")
-			}
-		})
-
-		select {
-		case <-time.After(2 * time.Second):
-		case <-ctx.Done():
-			return nil, fmt.Errorf("while waiting for %s CRD: %w (last error: %w)", chart, context.Cause(ctx), err)
-		}
 	}
 
 	if err := builder.

--- a/pkg/component/controller/extensions_controller_test.go
+++ b/pkg/component/controller/extensions_controller_test.go
@@ -4,18 +4,27 @@
 package controller
 
 import (
-	"os"
 	"path/filepath"
-	"strings"
+	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
+	"sigs.k8s.io/yaml"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	"github.com/k0sproject/k0s/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
+	clientgotesting "k8s.io/client-go/testing"
 )
 
 func TestChartNeedsUpgrade(t *testing.T) {
@@ -151,136 +160,147 @@ func TestChartNeedsUpgrade(t *testing.T) {
 	}
 }
 
-func TestChartManifestFileName(t *testing.T) {
-	chart := k0sv1beta1.Chart{
-		Name:      "release",
-		ChartName: "k0s/chart",
-		TargetNS:  metav1.NamespaceDefault,
-	}
-
-	chart1 := k0sv1beta1.Chart{
-		Name:      "release",
-		ChartName: "k0s/chart",
-		TargetNS:  metav1.NamespaceDefault,
-		Order:     1,
-	}
-
-	chart2 := k0sv1beta1.Chart{
-		Name:      "release",
-		ChartName: "k0s/chart",
-		TargetNS:  metav1.NamespaceDefault,
-		Order:     2,
-	}
-
-	assert.Equal(t, "0_helm_extension_release.yaml", chartManifestFileName(&chart))
-	assert.Equal(t, "1_helm_extension_release.yaml", chartManifestFileName(&chart1))
-	assert.Equal(t, "2_helm_extension_release.yaml", chartManifestFileName(&chart2))
-	assert.True(t, isChartManifestFileName("0_helm_extension_release.yaml"))
-}
-
-func TestExtensionsController_writeChartManifestFile(t *testing.T) {
-	type args struct {
-		chart    k0sv1beta1.Chart
-		fileName string
-	}
+func TestExtensionsController_reconcilesCharts(t *testing.T) {
 	tests := []struct {
-		name string
-		args args
-		want string
+		name  string
+		chart k0sv1beta1.Chart
+		want  string
 	}{
 		{
 			name: "forceUpgrade is nil should omit from manifest",
-			args: args{
-				chart: k0sv1beta1.Chart{
-					Name:      "release",
-					ChartName: "k0s/chart",
-					Version:   "0.0.1",
-					Values:    "values",
-					TargetNS:  metav1.NamespaceDefault,
-					Timeout: k0sv1beta1.BackwardCompatibleDuration(
-						metav1.Duration{Duration: 5 * time.Minute},
-					),
-				},
-				fileName: "0_helm_extension_release.yaml",
+			chart: k0sv1beta1.Chart{
+				Name:      "release",
+				ChartName: "k0s/chart",
+				Version:   "0.0.1",
+				Values:    "values",
+				TargetNS:  metav1.NamespaceDefault,
+				Timeout: k0sv1beta1.BackwardCompatibleDuration(
+					metav1.Duration{Duration: 5 * time.Minute},
+				),
 			},
 			want: `apiVersion: helm.k0sproject.io/v1beta1
 kind: Chart
 metadata:
+  finalizers:
+  - helm.k0sproject.io/uninstall-helm-release
+  labels:
+    k0s.k0sproject.io/stack: helm
   name: k0s-addon-chart-release
   namespace: ` + metav1.NamespaceSystem + `
-  finalizers:
-    - helm.k0sproject.io/uninstall-helm-release
 spec:
   chartName: k0s/chart
+  namespace: default
   releaseName: release
+  repository:
+    url: https://charts.k0sproject.io/release
   timeout: 5m0s
-  values: |
+  values: |2
 
     values
   version: 0.0.1
-  namespace: default
-  repository:
-    url: https://charts.k0sproject.io/release
+status: {}
 `,
 		},
 		{
 			name: "forceUpgrade is false should be included in manifest",
-			args: args{
-				chart: k0sv1beta1.Chart{
-					Name:         "release",
-					ChartName:    "k0s/chart",
-					Version:      "0.0.1",
-					Values:       "values",
-					TargetNS:     metav1.NamespaceDefault,
-					ForceUpgrade: ptr.To(false),
-					Timeout: k0sv1beta1.BackwardCompatibleDuration(
-						metav1.Duration{Duration: 5 * time.Minute},
-					),
-				},
-				fileName: "0_helm_extension_release.yaml",
+			chart: k0sv1beta1.Chart{
+				Name:         "release",
+				ChartName:    "k0s/chart",
+				Version:      "0.0.1",
+				Values:       "values",
+				TargetNS:     metav1.NamespaceDefault,
+				ForceUpgrade: ptr.To(false),
+				Timeout: k0sv1beta1.BackwardCompatibleDuration(
+					metav1.Duration{Duration: 5 * time.Minute},
+				),
 			},
 			want: `apiVersion: helm.k0sproject.io/v1beta1
 kind: Chart
 metadata:
+  finalizers:
+  - helm.k0sproject.io/uninstall-helm-release
+  labels:
+    k0s.k0sproject.io/stack: helm
   name: k0s-addon-chart-release
   namespace: ` + metav1.NamespaceSystem + `
-  finalizers:
-    - helm.k0sproject.io/uninstall-helm-release
 spec:
   chartName: k0s/chart
+  forceUpgrade: false
+  namespace: default
   releaseName: release
+  repository:
+    url: https://charts.k0sproject.io/release
   timeout: 5m0s
-  values: |
+  values: |2
 
     values
   version: 0.0.1
-  namespace: default
-  forceUpgrade: false
-  repository:
-    url: https://charts.k0sproject.io/release
+status: {}
 `,
 		},
 	}
 	for _, tt := range tests {
-		// With cache, make these behave as in the old style where config has the repo details,
-		// ensuring backwards compatibility with the old style
-		repoCache := repositoryCache{cache: make(map[string]k0sv1beta1.Repository)}
-		repoCache.update([]k0sv1beta1.Repository{
-			{
-				Name: "k0s",
-				URL:  "https://charts.k0sproject.io/release",
-			},
-		})
 		t.Run(tt.name, func(t *testing.T) {
-			ec := &ExtensionsController{
-				manifestsDir:    t.TempDir(),
-				repositoryCache: &repoCache,
-			}
-			path, err := ec.writeChartManifestFile(tt.args.chart, tt.args.fileName)
-			require.NoError(t, err)
-			contents, err := os.ReadFile(path)
-			require.NoError(t, err)
-			assert.Equal(t, strings.TrimSpace(tt.want), strings.TrimSpace(string(contents)))
+			synctest.Test(t, func(t *testing.T) {
+				cf := testutil.NewFakeClientFactory()
+
+				// Automatically mark all added CRDs as established.
+				cf.DynamicClient.PrependReactor("create", "customresourcedefinitions", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+					crd := action.(clientgotesting.CreateAction).GetObject().(*unstructured.Unstructured)
+					if err := unstructured.SetNestedSlice(crd.Object, []any{
+						map[string]any{
+							"type":   string(apiextensionsv1.Established),
+							"status": string(apiextensionsv1.ConditionTrue),
+						},
+					}, "status", "conditions"); !assert.NoError(t, err) {
+						return true, nil, err
+					}
+
+					return false, nil, nil
+				})
+
+				underTest := NewExtensionsController(cf, leaderelector.Off())
+
+				// Spawn the config reconciliation goroutine.
+				ctx := t.Context()
+				reconciled := make(chan struct{})
+				var wg sync.WaitGroup
+				t.Cleanup(wg.Wait)
+				wg.Go(func() { underTest.reconcileConfig(ctx, reconciled) })
+
+				// Reconcile the chart via the cluster config.
+				require.NoError(t, underTest.Reconcile(ctx, &k0sv1beta1.ClusterConfig{
+					Spec: &k0sv1beta1.ClusterSpec{
+						Extensions: &k0sv1beta1.ClusterExtensions{
+							Helm: &k0sv1beta1.HelmExtensions{
+								// With cache, make these behave as in the old style
+								// where config has the repo details,
+								// ensuring backwards compatibility with the old style
+								Repositories: k0sv1beta1.RepositoriesSettings{{
+									Name: "k0s",
+									URL:  "https://charts.k0sproject.io/release",
+								}},
+								Charts: k0sv1beta1.ChartsSettings{tt.chart},
+							},
+						},
+					},
+				}))
+
+				// Wait for the reconciliation goroutine to do its job.
+				<-reconciled
+				synctest.Wait()
+
+				// Check that the chart has been written to the API server.
+				charts, err := cf.K0sClient.HelmV1beta1().Charts(metav1.NamespaceSystem).List(ctx, metav1.ListOptions{})
+				require.NoError(t, err)
+				require.Len(t, charts.Items, 1)
+
+				chart := &charts.Items[0]
+				chart.Annotations = nil // we don't assert on annotations
+				b, err := yaml.Marshal(chart)
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, string(b))
+			})
 		})
 	}
 }

--- a/pkg/component/controller/workerconfig/reconciler_test.go
+++ b/pkg/component/controller/workerconfig/reconciler_test.go
@@ -59,7 +59,7 @@ func TestReconciler_Lifecycle(t *testing.T) {
 				},
 			},
 			clients,
-			&leaderelector.Dummy{Leader: true},
+			leaderelector.Off(),
 			true,
 			false,
 		)
@@ -317,7 +317,7 @@ func TestReconciler_ResourceGeneration(t *testing.T) {
 			},
 		},
 		clients,
-		&leaderelector.Dummy{Leader: true},
+		leaderelector.Off(),
 		true,
 		false,
 	)
@@ -503,7 +503,7 @@ func TestReconciler_ReconcilesOnChangesOnly(t *testing.T) {
 			},
 		},
 		clients,
-		&leaderelector.Dummy{Leader: true},
+		leaderelector.Off(),
 		true,
 		false,
 	)
@@ -589,7 +589,7 @@ func TestReconciler_ReconcilesOnChangesOnly(t *testing.T) {
 func TestReconciler_runReconcileLoop(t *testing.T) {
 	underTest := Reconciler{
 		log:           newTestLogger(t),
-		leaderElector: &leaderelector.Dummy{Leader: true},
+		leaderElector: leaderelector.Off(),
 	}
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)


### PR DESCRIPTION
## Description

Follow-up to #6739.

Instead of writing the chart manifests to disk, apply them directly from in-memory data. For historical reasons, the CRD and Helm chart resources generated from the k0s configuration reside in the same stack. Therefore, only apply the stack if all the chart resources can be rendered successfully. This ensures that charts are not accidentally removed because the initial config reconciliation is late.

Remove the CRD detection loop and start the controller-runtime manager only after the first successful stack application so CRDs are guaranteed to exist before informers come up.

- Use the standard client factory and remove the custom kubeconfig bootstrapping.
- Introduce an iterator function for embedded CRDs that allows for reading the CRDs without using the CRD component.
- Hardcode the dummy leader elector to always lead. A non-leading leader elector was only required during testing, when a simple function was sufficient.
- Patch the cluster config to modify the charts in the addons inttest instead of fiddling with the filesystem, which was an implementation detail.
- Drop the filesystem-based CRD component component. It's no longer in use. All CRDs are now applied in-memory.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
