### PR TITLE
Log a warning if the metrics server is likely to fail

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -501,6 +501,9 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 	}
 
 	if !slices.Contains(flags.DisableComponents, constant.MetricsServerComponentName) {
+		if !enableKonnectivity && !flags.Mode().WorkloadsEnabled() {
+			logrus.Warn("In order to run metrics-server without konnectivity, this controller must be able to connect to the cluster network")
+		}
 		clusterComponents.Add(ctx, controller.NewMetricServer(c.K0sVars, adminClientFactory))
 	}
 


### PR DESCRIPTION
## Description

When konnectivity is disabled, the controller nodes must be able to connect directly to the cluster network; otherwise, kube-apiserver will not be able to connect to the metrics-server pod. When workloads are enabled, the controller usually runs a CNI anyway, but if not, it's unlikely.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
