### PR TITLE
Add `--token-env` flag to install command

### DIFF
--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -75,6 +75,7 @@ Flags:
       --single                                         enable single node (implies --enable-worker, default false)
       --status-socket string                           Full file path to the socket file. (default: <rundir>/status.sock)
       --taints strings                                 Node taints, list of key=value:effect strings
+      --token-env string                               Environment variable name containing the join-token.
       --token-file string                              Path to the file containing join-token.
   -v, --verbose                                        Verbose logging (default true)
 `, out.String())

--- a/cmd/install/controller.go
+++ b/cmd/install/controller.go
@@ -49,9 +49,19 @@ With the controller subcommand you can setup a single node cluster by running:
 				return fmt.Errorf("invalid node config: %w", errors.Join(errs...))
 			}
 
+			// Convert --token-env to --token-file
+			tokenFilePath, err := handleTokenEnv(cmd, k0sVars.DataDir)
+			if err != nil {
+				return err
+			}
+
 			flagsAndVals, err := cmdFlagsToArgs(cmd)
 			if err != nil {
 				return err
+			}
+
+			if tokenFilePath != "" {
+				flagsAndVals = append(flagsAndVals, "--token-file="+tokenFilePath)
 			}
 
 			systemUsers := nodeConfig.Spec.Install.SystemUsers

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -68,6 +68,7 @@ Flags:
       --single                                         enable single node (implies --enable-worker, default false)
       --status-socket string                           Full file path to the socket file. (default: <rundir>/status.sock)
       --taints strings                                 Node taints, list of key=value:effect strings
+      --token-env string                               Environment variable name containing the join-token.
       --token-file string                              Path to the file containing join-token.
 
 Global Flags:

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -6,6 +6,7 @@ package install
 import (
 	"github.com/k0sproject/k0s/cmd/internal"
 	"github.com/k0sproject/k0s/pkg/config"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/cmd/install/util.go
+++ b/cmd/install/util.go
@@ -6,6 +6,7 @@ package install
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -24,7 +25,7 @@ func cmdFlagsToArgs(cmd *cobra.Command) ([]string, error) {
 			flagsAndVals = append(flagsAndVals, fmt.Sprintf(`--%s=%s`, f.Name, strings.Trim(val, "[]")))
 		default:
 			switch f.Name {
-			case "env", "force":
+			case "env", "force", "token-env":
 				return
 			case "data-dir", "kubelet-root-dir", "token-file", "config":
 				if absVal, err := filepath.Abs(val); err != nil {
@@ -43,4 +44,29 @@ func cmdFlagsToArgs(cmd *cobra.Command) ([]string, error) {
 	}
 
 	return flagsAndVals, nil
+}
+
+// handleTokenEnv converts --token-env to a token file and returns its path.
+func handleTokenEnv(cmd *cobra.Command, dataDir string) (string, error) {
+	tokenEnvFlag := cmd.Flags().Lookup("token-env")
+	if tokenEnvFlag == nil || !tokenEnvFlag.Changed {
+		return "", nil
+	}
+
+	envVarName := tokenEnvFlag.Value.String()
+	tokenValue := os.Getenv(envVarName)
+	if tokenValue == "" {
+		return "", fmt.Errorf("environment variable %q is not set or is empty", envVarName)
+	}
+
+	tokenFilePath := filepath.Join(dataDir, ".token")
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create data directory: %w", err)
+	}
+
+	if err := os.WriteFile(tokenFilePath, []byte(tokenValue), 0600); err != nil {
+		return "", fmt.Errorf("failed to write token file: %w", err)
+	}
+
+	return tokenFilePath, nil
 }

--- a/cmd/install/worker.go
+++ b/cmd/install/worker.go
@@ -27,9 +27,24 @@ All default values of worker command will be passed to the service stub unless o
 				return errors.New("this command must be run as root")
 			}
 
+			k0sVars, err := config.NewCfgVars(cmd)
+			if err != nil {
+				return fmt.Errorf("failed to initialize configuration variables: %w", err)
+			}
+
+			// Convert --token-env to --token-file
+			tokenFilePath, err := handleTokenEnv(cmd, k0sVars.DataDir)
+			if err != nil {
+				return err
+			}
+
 			flagsAndVals, err := cmdFlagsToArgs(cmd)
 			if err != nil {
 				return err
+			}
+
+			if tokenFilePath != "" {
+				flagsAndVals = append(flagsAndVals, "--token-file="+tokenFilePath)
 			}
 
 			args := append([]string{"worker"}, flagsAndVals...)

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -70,6 +70,7 @@ type WorkerOptions struct {
 	Labels           map[string]string
 	Taints           []string
 	TokenFile        string
+	TokenEnv         string
 	TokenArg         string
 	WorkerProfile    string
 	IPTablesMode     string
@@ -251,6 +252,7 @@ func GetWorkerFlags() *pflag.FlagSet {
 	flagset.StringVar(&workerOpts.WorkerProfile, "profile", defaultWorkerProfile, "worker profile to use on the node")
 	flagset.BoolVar(&workerOpts.CloudProvider, "enable-cloud-provider", false, "Whether or not to enable cloud provider support in kubelet")
 	flagset.StringVar(&workerOpts.TokenFile, "token-file", "", "Path to the file containing join-token.")
+	flagset.StringVar(&workerOpts.TokenEnv, "token-env", "", "Environment variable name containing the join-token.")
 	flagset.VarP((*logLevelsFlag)(&workerOpts.LogLevels), "logging", "l", "Logging Levels for the different components")
 	flagset.Var((*cliflag.ConfigurationMap)(&workerOpts.Labels), "labels", "Node labels, list of key=value pairs")
 	flagset.StringSliceVarP(&workerOpts.Taints, "taints", "", []string{}, "Node taints, list of key=value:effect strings")


### PR DESCRIPTION
Adds new flags to improve k0s token management experience for both worker and controller:

`--token-env`: Allows specifying the join token via an environment variable name instead of passing it via file

Related: https://github.com/k0sproject/k0s/pull/6727