### PR TITLE
Allow to copy env var values in install subcommand

### DIFF
--- a/cmd/install/controller.go
+++ b/cmd/install/controller.go
@@ -34,6 +34,11 @@ With the controller subcommand you can setup a single node cluster by running:
 				return errors.New("this command must be run as root")
 			}
 
+			envVars, err := resolveEnvVars(installFlags.envVars)
+			if err != nil {
+				return err
+			}
+
 			cmd.SetIn(iotest.ErrReader(errors.New("cannot read configuration from standard input when installing k0s")))
 			k0sVars, err := config.NewCfgVars(cmd)
 			if err != nil {
@@ -61,7 +66,7 @@ With the controller subcommand you can setup a single node cluster by running:
 			}
 
 			args := append([]string{"controller"}, flagsAndVals...)
-			if err := install.InstallService(args, installFlags.envVars, installFlags.force); err != nil {
+			if err := install.InstallService(args, envVars, installFlags.force); err != nil {
 				return fmt.Errorf("failed to install controller service: %w", err)
 			}
 

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -73,9 +73,9 @@ Flags:
 Global Flags:
   -d, --debug                  Debug logging (implies verbose logging)
       --debugListenOn string   Http listenOn for Debug pprof handler (default ":6060")
-  -e, --env stringArray        set environment variable
-      --force                  force init script creation
-      --start                  start the service immediately after installation
+  -e, --env stringArray        Set environment variables (<name>=<value> or just <name>)
+      --force                  Force init script creation
+      --start                  Start the service immediately after installation
   -v, --verbose                Verbose logging
 `, out.String())
 }

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -38,9 +38,9 @@ func NewInstallCmd() *cobra.Command {
 		f.Deprecated = "it has no effect and will be removed in a future release"
 		pflags.AddFlag(f)
 	})
-	pflags.BoolVar(&installFlags.force, "force", false, "force init script creation")
-	pflags.StringArrayVarP(&installFlags.envVars, "env", "e", nil, "set environment variable")
-	pflags.BoolVar(&installFlags.start, "start", false, "start the service immediately after installation")
+	pflags.BoolVar(&installFlags.force, "force", false, "Force init script creation")
+	pflags.StringArrayVarP(&installFlags.envVars, "env", "e", nil, "Set environment variables (<name>=<value> or just <name>)")
+	pflags.BoolVar(&installFlags.start, "start", false, "Start the service immediately after installation")
 
 	cmd.AddCommand(installWorkerCmd(&installFlags))
 	addPlatformSpecificCommands(cmd, &installFlags)

--- a/cmd/install/util.go
+++ b/cmd/install/util.go
@@ -6,12 +6,29 @@ package install
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+func resolveEnvVars(in []string) ([]string, error) {
+	out := make([]string, len(in))
+	for i, evar := range in {
+		if strings.Contains(evar, "\x00") {
+			return nil, errors.New("NUL byte in environment variable")
+		}
+		if name, _, hasValue := strings.Cut(evar, "="); hasValue {
+			out[i] = evar
+		} else {
+			out[i] = name + "=" + os.Getenv(name)
+		}
+	}
+
+	return out, nil
+}
 
 func cmdFlagsToArgs(cmd *cobra.Command) ([]string, error) {
 	var flagsAndVals []string

--- a/cmd/install/worker.go
+++ b/cmd/install/worker.go
@@ -27,13 +27,18 @@ All default values of worker command will be passed to the service stub unless o
 				return errors.New("this command must be run as root")
 			}
 
+			envVars, err := resolveEnvVars(installFlags.envVars)
+			if err != nil {
+				return err
+			}
+
 			flagsAndVals, err := cmdFlagsToArgs(cmd)
 			if err != nil {
 				return err
 			}
 
 			args := append([]string{"worker"}, flagsAndVals...)
-			if err := install.InstallService(args, installFlags.envVars, installFlags.force); err != nil {
+			if err := install.InstallService(args, envVars, installFlags.force); err != nil {
 				return fmt.Errorf("failed to install worker service: %w", err)
 			}
 


### PR DESCRIPTION
## Description

Previously, the `-e` flag required a fully specified environment variable, including the variable's name and value. Add functionality that copies the environment variable values from the current process if no value is provided. This is similar to what other tools, such as Docker and Podman, do.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
