### PR TITLE
Retry leave check in etcd member inttest a few times

### DIFF
--- a/inttest/etcdmember/etcdmember_test.go
+++ b/inttest/etcdmember/etcdmember_test.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -142,13 +143,17 @@ func (s *EtcdMemberSuite) TestDeregistration() {
 	// Final sanity -- ensure all nodes see each other according to etcd
 	members = s.getMembers(ctx, 0)
 	s.Require().Len(members, s.ControllerCount)
-	s.Require().Contains(members, "controller2")
-
-	// Check the CR is present again
-	em = s.getMember(ctx, "controller2")
-	s.Require().Equal(em.Status.PeerAddress, s.GetControllerIPAddress(2))
-	s.Require().False(em.Spec.Leave)
-	s.Require().Equal(etcdv1beta1.ConditionTrue, em.Status.GetCondition(etcdv1beta1.ConditionTypeJoined).Status)
+	s.Require().Contains(members, s.ControllerNode(2))
+	s.Require().EventuallyWithT(func(tt *assert.CollectT) {
+		s.Require().NoError(context.Cause(ctx), "Context done")
+		// Check the CR is present again
+		em = s.getMember(ctx, s.ControllerNode(2))
+		assert.Equal(tt, em.Status.PeerAddress, s.GetControllerIPAddress(2))
+		assert.False(tt, em.Spec.Leave, "Node is still flagged to be leaving")
+		if cond := em.Status.GetCondition(etcdv1beta1.ConditionTypeJoined); assert.NotNilf(tt, cond, "condition not found: %s", etcdv1beta1.ConditionTypeJoined) {
+			assert.Equal(tt, etcdv1beta1.ConditionTrue, cond.Status, "node not joined yet")
+		}
+	}, 30*time.Second, 1*time.Second)
 
 	// Check that after restarting the controller, the member is still present
 	s.Require().NoError(s.RestartController(s.ControllerNode(2)))


### PR DESCRIPTION
## Description

It's possible that the controller hasn't had the chance to update its etcd member yet when the test reaches the checks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
