### PR TITLE
Include k0s reference version in smoketest artifact names

### DIFF
--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -93,7 +93,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v5
         with:
-          name: ${{ inputs.name }}-${{ inputs.arch }}-files
+          name: ${{ inputs.name }}${{ inputs.k0s-reference-version && format('-{0}', inputs.k0s-reference-version) || '' }}-${{ inputs.arch }}-files
           path: |
             /tmp/*.log
             /tmp/support-bundle.tar.gz


### PR DESCRIPTION
## Description

Some upgrade-related integration tests are executed using multiple k0s reference versions. When more than one of these tests fail, the uploaded diagnostic artifacts had conflicting names. Mitigate this by also including the k0s reference version in these names, if any.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
