### PR TITLE
Omit calico windows installer host prefic for CNI_NET_DIR

### DIFF
--- a/static/manifests/calico/DaemonSet/calico-node-windows.yaml
+++ b/static/manifests/calico/DaemonSet/calico-node-windows.yaml
@@ -54,7 +54,7 @@ spec:
         - name: CNI_CONF_NAME
           value: 10-calico.conflist
         - name: CNI_NET_DIR
-          value: /host/etc/cni/net.d
+          value: /etc/cni/net.d
         - name: SLEEP
           value: "false"
         volumeMounts:
@@ -71,7 +71,7 @@ spec:
         - name: CNI_BIN_DIR
           value: /host/opt/cni/bin
         - name: CNI_NET_DIR
-          value: /host/etc/cni/net.d
+          value: /etc/cni/net.d
         # Name of the CNI config file to create.
         - name: CNI_CONF_NAME
           value: "10-calico.conflist"


### PR DESCRIPTION
## Description

Some of the installer paths use the `/host` prefix and some don't. In this case the path is used in the _actual_ CNI config file dropped into the host so it needs to be WITHOUT the prefix.

Fixes: 98727e458 ("Revamp Calico manifests for Windows")

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added (will be added in #6756 )

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
