### PR TITLE
Add missing linux node selector to pushgateway

### DIFF
--- a/pkg/component/controller/metrics.go
+++ b/pkg/component/controller/metrics.go
@@ -348,6 +348,8 @@ spec:
         component: "pushgateway"
         app: k0s-observability
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
         - key: node-role.kubernetes.io/master
           operator: Exists


### PR DESCRIPTION
Currently the image is only built for Linux thus we need this selector. Without it it might get scheduled for Windows nodes.

Dunno if it's worth to look if the image could be built for Windows too :thinking:

Fixes #6794


## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
