### PR TITLE
Share code during Autopilot (un-)cordoning

### DIFF
--- a/pkg/autopilot/controller/signal/k0s/uncordon.go
+++ b/pkg/autopilot/controller/signal/k0s/uncordon.go
@@ -6,15 +6,12 @@
 package k0s
 
 import (
-	"context"
-	"fmt"
 	"strings"
 
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	apsigcomm "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common"
 	apsigpred "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common/predicate"
-	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -49,10 +46,6 @@ func unCordoningEventFilter(hostname string, handler apsigpred.ErrorHandler) crp
 	)
 }
 
-type uncordoning struct {
-	cordonUncordon
-}
-
 // registerUncordoning registers the 'uncordoning' controller to the
 // controller-runtime manager.
 //
@@ -74,43 +67,15 @@ func registerUncordoning(logger *logrus.Entry, mgr crman.Manager, eventFilter cr
 		For(delegate.CreateObject()).
 		WithEventFilter(eventFilter).
 		Complete(
-			&uncordoning{cordonUncordon{
+			&cordonUncordon{
 				log:       logger.WithFields(logrus.Fields{"reconciler": "k0s-uncordoning", "object": delegate.Name()}),
 				client:    mgr.GetClient(),
 				delegate:  delegate,
 				clientset: clientset,
 				do:        uncordonNode,
 				nextState: apsigcomm.Completed,
-			}},
+			},
 		)
-}
-
-// Reconcile for the 'cordoning' reconciler will cordon and drain a node
-func (r *uncordoning) Reconcile(ctx context.Context, req cr.Request) (cr.Result, error) {
-	signalNode := r.delegate.CreateObject()
-	if err := r.client.Get(ctx, req.NamespacedName, signalNode); err != nil {
-		return cr.Result{}, fmt.Errorf("unable to get signal for node='%s': %w", req.Name, err)
-	}
-
-	logger := r.log.WithField("signalnode", signalNode.GetName())
-
-	var signalData apsigv2.SignalData
-	if err := signalData.Unmarshal(signalNode.GetAnnotations()); err != nil {
-		return cr.Result{}, fmt.Errorf("unable to unmarshal signal data for node='%s': %w", req.Name, err)
-	}
-
-	if !needsCordoning(signalNode) {
-		logger.Infof("ignoring non worker node")
-
-		return cr.Result{}, r.moveToNextState(ctx, signalNode)
-	}
-
-	logger.Infof("starting to un-cordon node %s", signalNode.GetName())
-	if err := r.run(ctx, signalNode); err != nil {
-		return cr.Result{}, err
-	}
-
-	return cr.Result{}, r.moveToNextState(ctx, signalNode)
 }
 
 func uncordonNode(drainer *drain.Helper, node *corev1.Node) error {


### PR DESCRIPTION
## Description

The cordoning and uncordoning code in Autopilot was essentially identical. Refactor them into truly shared code. Replace the (despite their methods) identical `cordoning` and `uncordoning` structs with a shared `cordonUncordon` struct and add a few fields to support both use cases. Remove all the duplicate code from `uncordon.go`, and use the code from `cordon.go` for both cordoning and uncordoning.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
