### PR TITLE
[Backport release-1.33] Bump calico to v3.29.7

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -95,7 +95,7 @@ const (
 	EnvoyProxyImage                    = "quay.io/k0sproject/envoy-distroless"
 	EnvoyProxyImageVersion             = "v1.32.8"
 	CalicoImage                        = "quay.io/k0sproject/calico-cni"
-	CalicoComponentImagesVersion       = "v3.29.6-0"
+	CalicoComponentImagesVersion       = "v3.29.7-0"
 	CalicoNodeImage                    = "quay.io/k0sproject/calico-node"
 	KubeControllerImage                = "quay.io/k0sproject/calico-kube-controllers"
 	KubeRouterCNIImage                 = "quay.io/k0sproject/kube-router"

--- a/static/manifests/calico/ClusterRole/calico-cni-plugin.yaml
+++ b/static/manifests/calico/ClusterRole/calico-cni-plugin.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/charts/calico/templates/calico-node-rbac.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/charts/calico/templates/calico-node-rbac.yaml
 # CNI cluster role
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/static/manifests/calico/ClusterRole/calico-kube-controllers.yaml
+++ b/static/manifests/calico/ClusterRole/calico-kube-controllers.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/charts/calico/templates/calico-kube-controllers-rbac.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/charts/calico/templates/calico-kube-controllers-rbac.yaml
 # assuming datastore == "kubernetes"
 #
 # Include a clusterrole for the kube-controllers component,

--- a/static/manifests/calico/ClusterRole/calico-node.yaml
+++ b/static/manifests/calico/ClusterRole/calico-node.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/charts/calico/templates/calico-node-rbac.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/charts/calico/templates/calico-node-rbac.yaml
 # Include a clusterrole for the calico-node DaemonSet,
 # and bind it to the calico-node serviceaccount.
 kind: ClusterRole

--- a/static/manifests/calico/ClusterRoleBinding/calico-cni-plugin.yaml
+++ b/static/manifests/calico/ClusterRoleBinding/calico-cni-plugin.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/charts/calico/templates/calico-node-rbac.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/charts/calico/templates/calico-node-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/static/manifests/calico/ClusterRoleBinding/calico-kube-controllers.yaml
+++ b/static/manifests/calico/ClusterRoleBinding/calico-kube-controllers.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/charts/calico/templates/calico-kube-controllers-rbac.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/charts/calico/templates/calico-kube-controllers-rbac.yaml
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/static/manifests/calico/ClusterRoleBinding/calico-node.yaml
+++ b/static/manifests/calico/ClusterRoleBinding/calico-node.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/charts/calico/templates/calico-node-rbac.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/charts/calico/templates/calico-node-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/static/manifests/calico/ConfigMap/calico-config.yaml
+++ b/static/manifests/calico/ConfigMap/calico-config.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/charts/calico/templates/calico-config.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/charts/calico/templates/calico-config.yaml
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
 apiVersion: v1

--- a/static/manifests/calico/CustomResourceDefinition/adminnetworkpolicies.crd.policy.networking.k8s.io.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/adminnetworkpolicies.crd.policy.networking.k8s.io.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/policy.networking.k8s.io_adminnetworkpolicies.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/policy.networking.k8s.io_adminnetworkpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/bgpconfigurations.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/bgpconfigurations.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_bgpconfigurations.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_bgpconfigurations.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/bgpfilters.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/bgpfilters.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_bgpfilters.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_bgpfilters.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/bgppeers.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/bgppeers.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_bgppeers.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_bgppeers.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/blockaffinities.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/blockaffinities.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_blockaffinities.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_blockaffinities.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/caliconodestatuses.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/caliconodestatuses.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_caliconodestatuses.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_caliconodestatuses.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/clusterinformations.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/clusterinformations.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_clusterinformations.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_clusterinformations.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/felixconfigurations.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/felixconfigurations.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/globalnetworkpolicies.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/globalnetworkpolicies.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_globalnetworkpolicies.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_globalnetworkpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/globalnetworksets.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/globalnetworksets.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_globalnetworksets.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_globalnetworksets.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/hostendpoints.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/hostendpoints.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_hostendpoints.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_hostendpoints.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/ipamblocks.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/ipamblocks.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_ipamblocks.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_ipamblocks.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/ipamconfigs.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/ipamconfigs.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_ipamconfigs.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_ipamconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/ipamhandles.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/ipamhandles.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_ipamhandles.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_ipamhandles.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/ippools.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/ippools.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_ippools.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_ippools.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/ipreservations.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/ipreservations.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_ipreservations.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_ipreservations.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/kubecontrollersconfigurations.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/kubecontrollersconfigurations.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/networkpolicies.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/networkpolicies.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_networkpolicies.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_networkpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/networksets.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/networksets.crd.projectcalico.org.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_networksets.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_networksets.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/CustomResourceDefinition/tiers.crd.projectcalico.org.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/tiers.crd.projectcalico.org.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_tiers.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/libcalico-go/config/crd/crd.projectcalico.org_tiers.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/static/manifests/calico/DaemonSet/calico-node.yaml
+++ b/static/manifests/calico/DaemonSet/calico-node.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/charts/calico/templates/calico-node.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/charts/calico/templates/calico-node.yaml
 # This manifest installs the calico-node container, as well
 # as the CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.

--- a/static/manifests/calico/Deployment/calico-kube-controllers.yaml
+++ b/static/manifests/calico/Deployment/calico-kube-controllers.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/charts/calico/templates/calico-kube-controllers.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/charts/calico/templates/calico-kube-controllers.yaml
 # See https://github.com/projectcalico/kube-controllers
 apiVersion: apps/v1
 kind: Deployment

--- a/static/manifests/calico/PodDisruptionBudget/calico-kube-controllers.yaml
+++ b/static/manifests/calico/PodDisruptionBudget/calico-kube-controllers.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/charts/calico/templates/calico-kube-controllers.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/charts/calico/templates/calico-kube-controllers.yaml
 # This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
 
 apiVersion: policy/v1

--- a/static/manifests/calico/ServiceAccount/calico-cni-plugin.yaml
+++ b/static/manifests/calico/ServiceAccount/calico-cni-plugin.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/charts/calico/templates/calico-node.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/charts/calico/templates/calico-node.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/static/manifests/calico/ServiceAccount/calico-kube-controllers.yaml
+++ b/static/manifests/calico/ServiceAccount/calico-kube-controllers.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/charts/calico/templates/calico-kube-controllers.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/charts/calico/templates/calico-kube-controllers.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/static/manifests/calico/ServiceAccount/calico-node.yaml
+++ b/static/manifests/calico/ServiceAccount/calico-node.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: https://github.com/projectcalico/calico/blob/v3.29.6/charts/calico/templates/calico-node.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.29.7/charts/calico/templates/calico-node.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Backport to `release-1.33`:

* #6850

See:

* #6843