### PR TITLE
Add validation for IPv6 ServiceCIDR prefix size

### DIFF
--- a/pkg/apis/k0s/v1beta1/network_test.go
+++ b/pkg/apis/k0s/v1beta1/network_test.go
@@ -325,6 +325,21 @@ func (s *NetworkSuite) TestValidation() {
 		}
 	})
 
+	s.Run("invalid_ipv6_service_cidr_prefix_too_large", func() {
+		fg := featuregate.FeatureGates{}
+		s.NoError(fg.Set("IPv6SingleStack=true"))
+		defer func() { featuregate.FlushDefaultFeatureGates(s.T()) }()
+
+		n := DefaultNetwork()
+		n.PodCIDR = "fd00::/108"
+		n.ServiceCIDR = "fd01::/120"
+
+		errors := n.Validate()
+		if s.Len(errors, 1) {
+			s.ErrorContains(errors[0], "IPv6 service CIDR prefix must be <= 108")
+		}
+	})
+
 	s.Run("invalid_ipv6_pod_cidr", func() {
 		n := DefaultNetwork()
 		n.Calico = DefaultCalico()


### PR DESCRIPTION
## Description
Adds validation for IPv6 ServiceCIDR prefix length (<= /108) per k8s requirement.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #6545

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Manual test
- [x] Auto test added

## Checklist
- [x] My code follows the style guidelines of this project
- [x] My commit messages are signed-off
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

