### PR TITLE
Close etcd clients after use

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -202,6 +202,7 @@ func etcdHandler(log logrus.FieldLogger, certRootDir, etcdCertDir string) http.H
 			sendError(err, resp)
 			return
 		}
+		defer etcdClient.Close()
 
 		memberList, err := etcdClient.AddMember(ctx, etcdReq.Node, etcdReq.PeerAddress)
 		if err != nil {

--- a/cmd/etcd/leave.go
+++ b/cmd/etcd/leave.go
@@ -51,6 +51,7 @@ func etcdLeaveCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("can't connect to the etcd: %w", err)
 			}
+			defer etcdClient.Close()
 
 			peerID, err := etcdClient.GetPeerIDByAddress(ctx, peerURL)
 			if err != nil {

--- a/cmd/etcd/list.go
+++ b/cmd/etcd/list.go
@@ -32,6 +32,7 @@ func etcdListCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("can't list etcd cluster members: %w", err)
 			}
+			defer etcdClient.Close()
 			members, err := etcdClient.ListMembers(ctx)
 			if err != nil {
 				return fmt.Errorf("can't list etcd cluster members: %w", err)

--- a/pkg/backup/etcd_unix.go
+++ b/pkg/backup/etcd_unix.go
@@ -47,6 +47,7 @@ func (e etcdStep) Backup() (StepResult, error) {
 	if err != nil {
 		return StepResult{}, err
 	}
+	defer etcdClient.Close()
 	path := filepath.Join(e.tmpDir, etcdBackup)
 
 	// disable etcd's logging

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -264,6 +264,7 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context, client et
 	if err != nil {
 		return err
 	}
+	defer etcdClient.Close()
 
 	memberID, err := etcdClient.GetPeerIDByAddress(ctx, e.etcdConfig.GetPeerURL())
 	if err != nil {
@@ -395,6 +396,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 
 		return false
 	}
+	defer etcdClient.Close()
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -122,8 +122,8 @@ func (c *Client) DeleteMember(ctx context.Context, peerID uint64) error {
 }
 
 // Close closes the etcd client
-func (c *Client) Close() {
-	c.client.Close()
+func (c *Client) Close() error {
+	return c.client.Close()
 }
 
 // Health return err if the etcd peer is not reported as healthy

--- a/pkg/etcd/health.go
+++ b/pkg/etcd/health.go
@@ -18,6 +18,7 @@ func CheckEtcdReady(ctx context.Context, certDir string, etcdCertDir string, etc
 		logrus.Errorf("failed to initialize etcd client: %v", err)
 		return err
 	}
+	defer c.Close()
 
 	return c.Health(ctx)
 }


### PR DESCRIPTION
## Description

This has been forgotten in every case.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
