### PR TITLE
Cleanup GitHub Workflow path-ignore

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,6 @@ on:
       - .github/dependabot.yml
       - docs/**
       - hack/ostests/**
-      - hack/tool/**
       - LICENSE
       - mkdocs.yml
       - renovate.json
@@ -42,7 +41,6 @@ on:
       - .github/dependabot.yml
       - docs/**
       - hack/ostests/**
-      - hack/tool/**
       - LICENSE
       - mkdocs.yml
       - renovate.json


### PR DESCRIPTION
The hack/tool directory was removed in commit 9487e25a5c02 (Remove hack/tool folder). Remove references in workflow.

Fixes: https://github.com/k0sproject/k0s/issues/6904

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
