### PR TITLE
Add IPv6-only validation for dual-stack CIDRs

### DIFF
--- a/pkg/apis/k0s/v1beta1/network_test.go
+++ b/pkg/apis/k0s/v1beta1/network_test.go
@@ -356,6 +356,32 @@ func (s *NetworkSuite) TestValidation() {
 		}
 	})
 
+	s.Run("dualstack_ipv6_podcidr_rejects_ipv4", func() {
+		n := DefaultNetwork()
+		n.DualStack.Enabled = true
+		n.PodCIDR = "10.244.0.0/16"
+		n.ServiceCIDR = "10.96.0.0/12"
+		n.DualStack.IPv6PodCIDR = "10.0.0.0/24"
+		n.DualStack.IPv6ServiceCIDR = "fd01::/108"
+
+		errs := n.Validate()
+		s.NotEmpty(errs)
+		s.ErrorContains(errs[0], "must be an IPv6 CIDR")
+	})
+
+	s.Run("dualstack_ipv6_servicecidr_rejects_ipv4", func() {
+		n := DefaultNetwork()
+		n.DualStack.Enabled = true
+		n.PodCIDR = "10.244.0.0/16"
+		n.ServiceCIDR = "10.96.0.0/12"
+		n.DualStack.IPv6PodCIDR = "fd00::/108"
+		n.DualStack.IPv6ServiceCIDR = "10.96.0.0/12"
+
+		errs := n.Validate()
+		s.NotEmpty(errs)
+		s.ErrorContains(errs[0], "must be an IPv6 CIDR")
+	})
+
 	s.Run("invalid_mode_for_kube_proxy", func() {
 		n := DefaultNetwork()
 		n.KubeProxy.Mode = "foobar"


### PR DESCRIPTION
## Description

Validates to ensure that IPv6-only CIDR fields in dual-stack configuration do not accept IPv4 CIDRs.

Fixes #6887

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
