### PR TITLE
Fix health prober unit test flakes

### DIFF
--- a/pkg/component/prober/events_test.go
+++ b/pkg/component/prober/events_test.go
@@ -17,7 +17,7 @@ const maxEvents = 100
 func TestEvents(t *testing.T) {
 	t.Run("prober_collects_emitted_events", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			prober := testProber(5)
+			prober := testProber()
 			component := newMockWithEvents(100)
 			eventsSent := []Event{
 				{
@@ -59,7 +59,7 @@ func TestEvents(t *testing.T) {
 			emitter.Emit("message1")
 			emitter.Emit("message2")
 			emitter.Emit("message3")
-			prober := testProber(10)
+			prober := testProber()
 			prober.Register("component_with_events", comp)
 			runProberToCompletion(t, prober, 0)
 			state := prober.State(maxEvents)
@@ -81,7 +81,7 @@ func TestEvents(t *testing.T) {
 
 	t.Run("emitter_observes_events_emitted_by_components_registred_after_run_is_called", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			prober := testProber(0)
+			prober := testProber()
 			component := newMockWithEvents(3)
 			prober.Register("component_with_events", component)
 			component.sendEvents(
@@ -127,7 +127,7 @@ func TestEvents(t *testing.T) {
 			_ = comp2
 			emitter2.Emit("message4")
 			emitter2.Emit("message5")
-			prober := testProber(10)
+			prober := testProber()
 			prober.Register("component_with_events", comp)
 			prober.Register("component_with_events2", comp2)
 			runProberToCompletion(t, prober, 0)


### PR DESCRIPTION
## Description

Use synctest to make event collection deterministic. Also remove all test-only knobs from the health prober, as the synctest package gives full control over the clock, so there's no need to have extra knobs to tune behavior for tests anymore.

Addresses test failures like [these](https://github.com/k0sproject/k0s/actions/runs/20855004983/job/59919184089#step:7:407):

<details>
<summary>CI log snippet</summary>

```text
--- FAIL: TestEvents (0.03s)
    --- FAIL: TestEvents/prober_collects_emitted_events (0.01s)
        events_test.go:46:
            	Error Trace:	/Users/runner/work/k0s/k0s/pkg/component/prober/events_test.go:46
            	Error:      	"[]" should have 3 item(s), but has 0
            	Test:       	TestEvents/prober_collects_emitted_events
            	Messages:   	should have 3 events in the state due to ring buffer size
        events_test.go:47:
            	Error Trace:	/Users/runner/work/k0s/k0s/pkg/component/prober/events_test.go:47
            	Error:      	Not equal:
            	            	expected: []prober.Event{prober.Event{At:time.Date(2026, time.January, 9, 14, 32, 58, 893670000, time.Local), Message:"Test event 2", Payload:interface {}(nil)}, prober.Event{At:time.Date(2026, time.January, 9, 14, 32, 58, 893670000, time.Local), Message:"Test event 3", Payload:interface {}(nil)}, prober.Event{At:time.Date(2026, time.January, 9, 14, 32, 58, 893670000, time.Local), Message:"Test event 4", Payload:interface {}(nil)}}
            	            	actual  : []prober.Event{}

            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,53 +1,2 @@
            	            	-([]prober.Event) (len=3) {
            	            	- (prober.Event) {
            	            	-  At: (time.Time) {
            	            	-   wall: (uint64) 14001799297323258480,
            	            	-   ext: (int64) 4064418,
            	            	-   loc: (*time.Location)({
            	            	-    name: (string) "",
            	            	-    zone: ([]time.zone) <nil>,
            	            	-    tx: ([]time.zoneTrans) <nil>,
            	            	-    extend: (string) "",
            	            	-    cacheStart: (int64) 0,
            	            	-    cacheEnd: (int64) 0,
            	            	-    cacheZone: (*time.zone)(<nil>)
            	            	-   })
            	            	-  },
            	            	-  Message: (string) (len=12) "Test event 2",
            	            	-  Payload: (interface {}) <nil>
            	            	- },
            	            	- (prober.Event) {
            	            	-  At: (time.Time) {
            	            	-   wall: (uint64) 14001799297323258480,
            	            	-   ext: (int64) 4064585,
            	            	-   loc: (*time.Location)({
            	            	-    name: (string) "",
            	            	-    zone: ([]time.zone) <nil>,
            	            	-    tx: ([]time.zoneTrans) <nil>,
            	            	-    extend: (string) "",
            	            	-    cacheStart: (int64) 0,
            	            	-    cacheEnd: (int64) 0,
            	            	-    cacheZone: (*time.zone)(<nil>)
            	            	-   })
            	            	-  },
            	            	-  Message: (string) (len=12) "Test event 3",
            	            	-  Payload: (interface {}) <nil>
            	            	- },
            	            	- (prober.Event) {
            	            	-  At: (time.Time) {
            	            	-   wall: (uint64) 14001799297323258480,
            	            	-   ext: (int64) 4064668,
            	            	-   loc: (*time.Location)({
            	            	-    name: (string) "",
            	            	-    zone: ([]time.zone) <nil>,
            	            	-    tx: ([]time.zoneTrans) <nil>,
            	            	-    extend: (string) "",
            	            	-    cacheStart: (int64) 0,
            	            	-    cacheEnd: (int64) 0,
            	            	-    cacheZone: (*time.zone)(<nil>)
            	            	-   })
            	            	-  },
            	            	-  Message: (string) (len=12) "Test event 4",
            	            	-  Payload: (interface {}) <nil>
            	            	- }
            	            	+([]prober.Event) {
            	            	 }
            	Test:       	TestEvents/prober_collects_emitted_events
            	Messages:   	should have 3 last events in the state due to ring buffer size
FAIL
```

</details>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
