### PR TITLE
Add note about unsupported raw git/github chart URLs in Helm repos

### DIFF
--- a/docs/helm-charts.md
+++ b/docs/helm-charts.md
@@ -41,6 +41,8 @@ See [Chart configuration](#chart-configuration) below for more details on how to
 | `username` | -             | Username for Basic HTTP authentication                                                            |
 | `password` | -             | Password for Basic HTTP authentication                                                            |
 
+**Note:** k0s supports only classic Helm chart repositories that provide a valid `index.yaml`. Direct links to chart folders or files (for example raw GitHub URLs) are not recognized as Helm repositories and will not work unless they follow the full Helm repository structure. For details on how a valid Helm chart repository must be structured, see: https://helm.sh/docs/topics/chart_repository/#create-a-chart-repository
+
 ### Chart configuration
 
 | Field          | Default value | Description                                                                               |
@@ -75,9 +77,10 @@ spec:
       - name: oci-registry-with-private-ca
         # OCI registry URL must not include any path elements
         url: oci://registry-with-private-ca.com:8080
-        # Currently, only caFile is supported for TLS transport
-        # Setting certFile or keyFile will result in an error
+        # certFile and keyFile can be provided to enable mTLS
         caFile: /path/to/ca.crt
+        certFile: /path/to/client.crt
+        keyFile: /path/to/client.key
       charts:
       - name: prometheus-stack
         chartname: prometheus-community/prometheus


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Added a note to the Helm Charts docs  that explains, raw git/gitHub chart directories can’t be used as chart sources.
Fixes #6341

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
