### PR TITLE
Use --master <api-url> for kube-router always

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -505,7 +505,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 			return fmt.Errorf("failed to create Calico component: %w", err)
 		}
 		clusterComponents.Add(ctx, calico)
-		clusterComponents.Add(ctx, controller.NewKubeRouter(c.K0sVars))
+		clusterComponents.Add(ctx, controller.NewKubeRouter(nodeConfig, c.K0sVars.ManifestsDir))
 	}
 
 	if !slices.Contains(flags.DisableComponents, constant.MetricsServerComponentName) {

--- a/pkg/apis/k0s/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types.go
@@ -426,6 +426,20 @@ func (s *ClusterSpec) Validate() (errs []error) {
 	return
 }
 
+// APIServerURLForHostNetworkPods returns the effective API server URL for
+// host-network components running on worker nodes (like kube-proxy and kube-router).
+// When node-local load balancing is enabled, it returns the localhost URL;
+// otherwise, it returns the standard API server URL.
+func (s *ClusterSpec) APIServerURLForHostNetworkPods() string {
+	if s.Network != nil {
+		nllb := s.Network.NodeLocalLoadBalancing
+		if nllb.IsEnabled() && nllb.Type == NllbTypeEnvoyProxy {
+			return fmt.Sprintf("https://localhost:%d", nllb.EnvoyProxy.APIServerBindPort)
+		}
+	}
+	return s.API.APIAddressURL()
+}
+
 func (s *ClusterSpec) ValidateNodeLocalLoadBalancing() (errs field.ErrorList) {
 	if s.Network == nil || !s.Network.NodeLocalLoadBalancing.IsEnabled() {
 		return

--- a/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
@@ -527,4 +527,15 @@ func TestAPIServerURLForHostNetworkPods(t *testing.T) {
 		}
 		assert.Equal(t, "https://10.0.0.1:6443", spec.APIServerURLForHostNetworkPods())
 	})
+
+	t.Run("handles_custom_ports", func(t *testing.T) {
+		spec := &ClusterSpec{
+			API: &APISpec{
+				Address: "10.0.0.1",
+				Port:    7443,
+			},
+			Network: nil,
+		}
+		assert.Equal(t, "https://10.0.0.1:7443", spec.APIServerURLForHostNetworkPods())
+	})
 }

--- a/pkg/apis/k0s/v1beta1/network.go
+++ b/pkg/apis/k0s/v1beta1/network.go
@@ -182,6 +182,16 @@ func (n *Network) Validate() []error {
 		errors = append(errors, err)
 	}
 
+	// Validate that both kube-proxy and kube-router service proxy are not enabled simultaneously
+	if n.KubeRouter != nil && n.KubeRouter.ExtraArgs != nil {
+		if n.KubeRouter.ExtraArgs["run-service-proxy"] == "true" && (n.KubeProxy == nil || !n.KubeProxy.Disabled) {
+			errors = append(errors, field.Forbidden(
+				field.NewPath("kuberouter", "extraArgs", "run-service-proxy"),
+				"cannot enable kube-router service proxy when kube-proxy is enabled",
+			))
+		}
+	}
+
 	return errors
 }
 

--- a/pkg/component/controller/kuberouter_test.go
+++ b/pkg/component/controller/kuberouter_test.go
@@ -259,6 +259,145 @@ func TestRawArgs(t *testing.T) {
 	}
 }
 
+func TestKubeRouterWithServiceProxy(t *testing.T) {
+	k0sVars, err := config.NewCfgVars(nil, t.TempDir())
+	require.NoError(t, err)
+	cfg := v1beta1.DefaultClusterConfig()
+	cfg.Spec.Network.Calico = nil
+	cfg.Spec.Network.Provider = "kuberouter"
+	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
+	cfg.Spec.Network.KubeRouter.ExtraArgs = map[string]string{
+		"run-service-proxy": "true",
+	}
+	cfg.Spec.Network.KubeProxy.Disabled = true
+	cfg.Spec.API.Address = "10.0.0.1"
+	cfg.Spec.API.Port = 6443
+
+	ctx := t.Context()
+	kr := NewKubeRouter(k0sVars)
+	require.NoError(t, kr.Init(ctx))
+	require.NoError(t, kr.Start(ctx))
+	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
+	require.NoError(t, kr.Reconcile(ctx, cfg))
+
+	manifestData, err := os.ReadFile(filepath.Join(k0sVars.ManifestsDir, "kuberouter", "kube-router.yaml"))
+	assert.NoError(t, err, "must have manifests for kube-router")
+
+	resources, err := testutil.ParseManifests(manifestData)
+	require.NoError(t, err)
+	ds, err := findDaemonset(resources)
+	require.NoError(t, err)
+	require.NotNil(t, ds)
+
+	// Verify that --master flag is injected with the API server URL
+	require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--run-service-proxy=true")
+	require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--master=https://10.0.0.1:6443")
+}
+
+func TestKubeRouterWithServiceProxyAndExternalAddress(t *testing.T) {
+	k0sVars, err := config.NewCfgVars(nil, t.TempDir())
+	require.NoError(t, err)
+	cfg := v1beta1.DefaultClusterConfig()
+	cfg.Spec.Network.Calico = nil
+	cfg.Spec.Network.Provider = "kuberouter"
+	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
+	cfg.Spec.Network.KubeRouter.ExtraArgs = map[string]string{
+		"run-service-proxy": "true",
+	}
+	cfg.Spec.Network.KubeProxy.Disabled = true
+	cfg.Spec.API.Address = "10.0.0.1"
+	cfg.Spec.API.ExternalAddress = "api.example.com"
+	cfg.Spec.API.Port = 6443
+
+	ctx := t.Context()
+	kr := NewKubeRouter(k0sVars)
+	require.NoError(t, kr.Init(ctx))
+	require.NoError(t, kr.Start(ctx))
+	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
+	require.NoError(t, kr.Reconcile(ctx, cfg))
+
+	manifestData, err := os.ReadFile(filepath.Join(k0sVars.ManifestsDir, "kuberouter", "kube-router.yaml"))
+	assert.NoError(t, err, "must have manifests for kube-router")
+
+	resources, err := testutil.ParseManifests(manifestData)
+	require.NoError(t, err)
+	ds, err := findDaemonset(resources)
+	require.NoError(t, err)
+	require.NotNil(t, ds)
+
+	// Verify that --master flag uses external address when available
+	require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--run-service-proxy=true")
+	require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--master=https://api.example.com:6443")
+}
+
+func TestKubeRouterAlwaysSetsMaxter(t *testing.T) {
+	k0sVars, err := config.NewCfgVars(nil, t.TempDir())
+	require.NoError(t, err)
+	cfg := v1beta1.DefaultClusterConfig()
+	cfg.Spec.Network.Calico = nil
+	cfg.Spec.Network.Provider = "kuberouter"
+	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
+	// No run-service-proxy set
+	cfg.Spec.API.Address = "10.0.0.1"
+	cfg.Spec.API.Port = 6443
+
+	ctx := t.Context()
+	kr := NewKubeRouter(k0sVars)
+	require.NoError(t, kr.Init(ctx))
+	require.NoError(t, kr.Start(ctx))
+	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
+	require.NoError(t, kr.Reconcile(ctx, cfg))
+
+	manifestData, err := os.ReadFile(filepath.Join(k0sVars.ManifestsDir, "kuberouter", "kube-router.yaml"))
+	assert.NoError(t, err, "must have manifests for kube-router")
+
+	resources, err := testutil.ParseManifests(manifestData)
+	require.NoError(t, err)
+	ds, err := findDaemonset(resources)
+	require.NoError(t, err)
+	require.NotNil(t, ds)
+
+	// Verify that --master flag is always set, even without service-proxy
+	require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--master=https://10.0.0.1:6443")
+}
+
+func TestKubeRouterWithNLLB(t *testing.T) {
+	k0sVars, err := config.NewCfgVars(nil, t.TempDir())
+	require.NoError(t, err)
+	cfg := v1beta1.DefaultClusterConfig()
+	cfg.Spec.Network.Calico = nil
+	cfg.Spec.Network.Provider = "kuberouter"
+	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
+	cfg.Spec.API.Address = "10.0.0.1"
+	cfg.Spec.API.Port = 6443
+	cfg.Spec.Network.NodeLocalLoadBalancing = &v1beta1.NodeLocalLoadBalancing{
+		Enabled: true,
+		Type:    v1beta1.NllbTypeEnvoyProxy,
+		EnvoyProxy: &v1beta1.EnvoyProxy{
+			APIServerBindPort: 7443,
+		},
+	}
+
+	ctx := t.Context()
+	kr := NewKubeRouter(k0sVars)
+	require.NoError(t, kr.Init(ctx))
+	require.NoError(t, kr.Start(ctx))
+	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
+	require.NoError(t, kr.Reconcile(ctx, cfg))
+
+	manifestData, err := os.ReadFile(filepath.Join(k0sVars.ManifestsDir, "kuberouter", "kube-router.yaml"))
+	assert.NoError(t, err, "must have manifests for kube-router")
+
+	resources, err := testutil.ParseManifests(manifestData)
+	require.NoError(t, err)
+	ds, err := findDaemonset(resources)
+	require.NoError(t, err)
+	require.NotNil(t, ds)
+
+	// Verify that --master flag uses localhost when NLLB is enabled
+	require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--master=https://localhost:7443")
+}
+
 func findConfig(resources []*unstructured.Unstructured) (corev1.ConfigMap, error) {
 	var cm corev1.ConfigMap
 	for _, r := range resources {

--- a/pkg/component/controller/kuberouter_test.go
+++ b/pkg/component/controller/kuberouter_test.go
@@ -22,52 +22,201 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func TestKubeRouterConfig(t *testing.T) {
+func TestKubeRouterManifests(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupNodeCfg    func(*v1beta1.ClusterConfig)
+		setupClusterCfg func(*v1beta1.ClusterConfig)
+		assertDS        func(*testing.T, *appsv1.DaemonSet)
+		assertCM        func(*testing.T, *corev1.ConfigMap)
+	}{
+		{
+			name: "custom config with MTU, peering, hairpin, and ipmasq",
+			setupClusterCfg: func(cfg *v1beta1.ClusterConfig) {
+				cfg.Spec.Network.KubeRouter.AutoMTU = ptr.To(false)
+				cfg.Spec.Network.KubeRouter.MTU = 1450
+				cfg.Spec.Network.KubeRouter.PeerRouterASNs = "12345,67890"
+				cfg.Spec.Network.KubeRouter.PeerRouterIPs = "1.2.3.4,4.3.2.1"
+				cfg.Spec.Network.KubeRouter.Hairpin = v1beta1.HairpinAllowed
+				cfg.Spec.Network.KubeRouter.IPMasq = true
+			},
+			assertDS: func(t *testing.T, ds *appsv1.DaemonSet) {
+				require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--peer-router-ips=1.2.3.4,4.3.2.1")
+				require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--peer-router-asns=12345,67890")
+				require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--hairpin-mode=false")
+			},
+			assertCM: func(t *testing.T, cm *corev1.ConfigMap) {
+				p, err := getKubeRouterPlugin(*cm, "bridge")
+				require.NoError(t, err)
+				assert.InEpsilon(t, 1450, p["mtu"], 0)
+				assert.Equal(t, true, p["hairpinMode"])
+				assert.Equal(t, true, p["ipMasq"])
+			},
+		},
+		{
+			name: "default manifests",
+			assertDS: func(t *testing.T, ds *appsv1.DaemonSet) {
+				assert.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--hairpin-mode=true")
+			},
+			assertCM: func(t *testing.T, cm *corev1.ConfigMap) {
+				p, err := getKubeRouterPlugin(*cm, "bridge")
+				require.NoError(t, err)
+				assert.NotContains(t, p, "mtu")
+				assert.Equal(t, true, p["hairpinMode"])
+				assert.Equal(t, false, p["ipMasq"])
+			},
+		},
+		{
+			name: "manual MTU",
+			setupClusterCfg: func(cfg *v1beta1.ClusterConfig) {
+				cfg.Spec.Network.KubeRouter.AutoMTU = ptr.To(false)
+				cfg.Spec.Network.KubeRouter.MTU = 1234
+			},
+			assertDS: func(t *testing.T, ds *appsv1.DaemonSet) {
+				assert.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--auto-mtu=false")
+			},
+			assertCM: func(t *testing.T, cm *corev1.ConfigMap) {
+				p, err := getKubeRouterPlugin(*cm, "bridge")
+				require.NoError(t, err)
+				assert.InEpsilon(t, 1234, p["mtu"], 0)
+			},
+		},
+		{
+			name: "extra args",
+			setupClusterCfg: func(cfg *v1beta1.ClusterConfig) {
+				cfg.Spec.Network.KubeRouter.ExtraArgs = map[string]string{
+					"foo":          "bar",
+					"run-firewall": "false",
+				}
+			},
+			assertDS: func(t *testing.T, ds *appsv1.DaemonSet) {
+				assert.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--run-firewall=false")
+				assert.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--foo=bar")
+			},
+		},
+		{
+			name: "raw args",
+			setupClusterCfg: func(cfg *v1beta1.ClusterConfig) {
+				cfg.Spec.Network.KubeRouter.ExtraArgs = map[string]string{
+					"log-level": "debug",
+				}
+				cfg.Spec.Network.KubeRouter.RawArgs = []string{
+					"--log-level=debug",
+					"--log-level=debug",
+				}
+			},
+			assertDS: func(t *testing.T, ds *appsv1.DaemonSet) {
+				// Verify that both extraArgs and rawArgs are present
+				args := ds.Spec.Template.Spec.Containers[0].Args[len(ds.Spec.Template.Spec.Containers[0].Args)-2:]
+				for _, arg := range args {
+					assert.Equal(t, "--log-level=debug", arg)
+				}
+			},
+		},
+		{
+			name: "with service proxy",
+			setupClusterCfg: func(cfg *v1beta1.ClusterConfig) {
+				cfg.Spec.Network.KubeRouter.ExtraArgs = map[string]string{
+					"run-service-proxy": "true",
+				}
+				cfg.Spec.Network.KubeProxy.Disabled = true
+			},
+			assertDS: func(t *testing.T, ds *appsv1.DaemonSet) {
+				require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--run-service-proxy=true")
+				require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--master=https://10.0.0.1:6443")
+			},
+		},
+		{
+			name: "with service proxy and external address",
+			setupNodeCfg: func(cfg *v1beta1.ClusterConfig) {
+				cfg.Spec.API.ExternalAddress = "api.example.com"
+			},
+			setupClusterCfg: func(cfg *v1beta1.ClusterConfig) {
+				cfg.Spec.Network.KubeRouter.ExtraArgs = map[string]string{
+					"run-service-proxy": "true",
+				}
+				cfg.Spec.Network.KubeProxy.Disabled = true
+				cfg.Spec.API.ExternalAddress = "api.example.com"
+			},
+			assertDS: func(t *testing.T, ds *appsv1.DaemonSet) {
+				require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--run-service-proxy=true")
+				require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--master=https://api.example.com:6443")
+			},
+		},
+		{
+			name: "always sets master",
+			assertDS: func(t *testing.T, ds *appsv1.DaemonSet) {
+				require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--master=https://10.0.0.1:6443")
+			},
+		},
+		{
+			name: "with NLLB",
+			setupNodeCfg: func(cfg *v1beta1.ClusterConfig) {
+				cfg.Spec.Network.NodeLocalLoadBalancing = &v1beta1.NodeLocalLoadBalancing{
+					Enabled: true,
+					Type:    v1beta1.NllbTypeEnvoyProxy,
+					EnvoyProxy: &v1beta1.EnvoyProxy{
+						APIServerBindPort: 7443,
+					},
+				}
+			},
+			assertDS: func(t *testing.T, ds *appsv1.DaemonSet) {
+				require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--master=https://localhost:7443")
+			},
+		},
+	}
 
-	cfg := v1beta1.DefaultClusterConfig()
-	cfg.Spec.Network.Calico = nil
-	cfg.Spec.Network.Provider = "kuberouter"
-	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
-	cfg.Spec.Network.KubeRouter.AutoMTU = ptr.To(false)
-	cfg.Spec.Network.KubeRouter.MTU = 1450
-	cfg.Spec.Network.KubeRouter.PeerRouterASNs = "12345,67890"
-	cfg.Spec.Network.KubeRouter.PeerRouterIPs = "1.2.3.4,4.3.2.1"
-	cfg.Spec.Network.KubeRouter.Hairpin = v1beta1.HairpinAllowed
-	cfg.Spec.Network.KubeRouter.IPMasq = true
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifestDir := t.TempDir()
 
-	manifestDir := t.TempDir()
-	nodeConfig := v1beta1.DefaultClusterConfig()
-	nodeConfig.Spec.API.Port = 6443
-	nodeConfig.Spec.API.Address = "10.0.0.1"
+			nodeConfig := v1beta1.DefaultClusterConfig()
+			// Set default API configuration
+			nodeConfig.Spec.API.Port = 6443
+			nodeConfig.Spec.API.Address = "10.0.0.1"
+			if tt.setupNodeCfg != nil {
+				tt.setupNodeCfg(nodeConfig)
+			}
 
-	ctx := t.Context()
-	kr := NewKubeRouter(nodeConfig, manifestDir)
-	require.NoError(t, kr.Init(ctx))
-	require.NoError(t, kr.Start(ctx))
-	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
-	require.NoError(t, kr.Reconcile(ctx, cfg))
+			cfg := v1beta1.DefaultClusterConfig()
+			cfg.Spec.Network.Calico = nil
+			cfg.Spec.Network.Provider = "kuberouter"
+			cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
+			// Set default API configuration
+			cfg.Spec.API.Port = 6443
+			cfg.Spec.API.Address = "10.0.0.1"
+			if tt.setupClusterCfg != nil {
+				tt.setupClusterCfg(cfg)
+			}
 
-	manifestData, err := os.ReadFile(filepath.Join(manifestDir, "kuberouter", "kube-router.yaml"))
-	assert.NoError(t, err, "must have manifests for kube-router")
+			ctx := t.Context()
+			kr := NewKubeRouter(nodeConfig, manifestDir)
+			require.NoError(t, kr.Init(ctx))
+			require.NoError(t, kr.Start(ctx))
+			t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
+			require.NoError(t, kr.Reconcile(ctx, cfg))
 
-	resources, err := testutil.ParseManifests(manifestData)
-	require.NoError(t, err)
-	ds, err := findDaemonset(resources)
-	require.NoError(t, err)
-	require.NotNil(t, ds)
-	require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--peer-router-ips=1.2.3.4,4.3.2.1")
-	require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--peer-router-asns=12345,67890")
-	require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--hairpin-mode=false")
+			manifestData, err := os.ReadFile(filepath.Join(manifestDir, "kuberouter", "kube-router.yaml"))
+			assert.NoError(t, err, "must have manifests for kube-router")
 
-	cm, err := findConfig(resources)
-	require.NoError(t, err)
-	require.NotNil(t, cm)
+			resources, err := testutil.ParseManifests(manifestData)
+			require.NoError(t, err)
 
-	p, err := getKubeRouterPlugin(cm, "bridge")
-	require.NoError(t, err)
-	assert.InEpsilon(t, 1450, p["mtu"], 0)
-	assert.Equal(t, true, p["hairpinMode"])
-	assert.Equal(t, true, p["ipMasq"])
+			if tt.assertDS != nil {
+				ds, err := findDaemonset(resources)
+				require.NoError(t, err)
+				require.NotNil(t, ds)
+				tt.assertDS(t, &ds)
+			}
+
+			if tt.assertCM != nil {
+				cm, err := findConfig(resources)
+				require.NoError(t, err)
+				require.NotNil(t, cm)
+				tt.assertCM(t, &cm)
+			}
+		})
+	}
 }
 
 type hairpinTest struct {
@@ -116,310 +265,6 @@ func TestGetHairpinConfig(t *testing.T) {
 		}
 
 	}
-}
-
-func TestKubeRouterDefaultManifests(t *testing.T) {
-
-	manifestDir := t.TempDir()
-	nodeConfig := v1beta1.DefaultClusterConfig()
-	nodeConfig.Spec.API.Port = 6443
-	nodeConfig.Spec.API.Address = "10.0.0.1"
-	cfg := v1beta1.DefaultClusterConfig()
-	cfg.Spec.Network.Calico = nil
-	cfg.Spec.Network.Provider = "kuberouter"
-	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
-	ctx := t.Context()
-	kr := NewKubeRouter(nodeConfig, manifestDir)
-	require.NoError(t, kr.Init(ctx))
-	require.NoError(t, kr.Start(ctx))
-	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
-	require.NoError(t, kr.Reconcile(ctx, cfg))
-
-	manifestData, err := os.ReadFile(filepath.Join(manifestDir, "kuberouter", "kube-router.yaml"))
-	assert.NoError(t, err, "must have manifests for kube-router")
-
-	resources, err := testutil.ParseManifests(manifestData)
-	require.NoError(t, err)
-	ds, err := findDaemonset(resources)
-	require.NoError(t, err)
-	require.NotNil(t, ds)
-
-	assert.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--hairpin-mode=true")
-
-	cm, err := findConfig(resources)
-	require.NoError(t, err)
-	require.NotNil(t, cm)
-
-	p, err := getKubeRouterPlugin(cm, "bridge")
-	require.NoError(t, err)
-	assert.NotContains(t, p, "mtu")
-	assert.Equal(t, true, p["hairpinMode"])
-	assert.Equal(t, false, p["ipMasq"])
-}
-
-func TestKubeRouterManualMTUManifests(t *testing.T) {
-
-	manifestDir := t.TempDir()
-	nodeConfig := v1beta1.DefaultClusterConfig()
-	nodeConfig.Spec.API.Port = 6443
-	nodeConfig.Spec.API.Address = "10.0.0.1"
-	cfg := v1beta1.DefaultClusterConfig()
-	cfg.Spec.Network.Calico = nil
-	cfg.Spec.Network.Provider = "kuberouter"
-	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
-	cfg.Spec.Network.KubeRouter.AutoMTU = ptr.To(false)
-	cfg.Spec.Network.KubeRouter.MTU = 1234
-	ctx := t.Context()
-	kr := NewKubeRouter(nodeConfig, manifestDir)
-	require.NoError(t, kr.Init(ctx))
-	require.NoError(t, kr.Start(ctx))
-	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
-	require.NoError(t, kr.Reconcile(ctx, cfg))
-
-	manifestData, err := os.ReadFile(filepath.Join(manifestDir, "kuberouter", "kube-router.yaml"))
-	assert.NoError(t, err, "must have manifests for kube-router")
-
-	resources, err := testutil.ParseManifests(manifestData)
-	require.NoError(t, err)
-	ds, err := findDaemonset(resources)
-	require.NoError(t, err)
-	require.NotNil(t, ds)
-
-	assert.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--auto-mtu=false")
-
-	cm, err := findConfig(resources)
-	require.NoError(t, err)
-	require.NotNil(t, cm)
-
-	p, err := getKubeRouterPlugin(cm, "bridge")
-	require.NoError(t, err)
-	assert.InEpsilon(t, 1234, p["mtu"], 0)
-}
-
-func TestExtraArgs(t *testing.T) {
-	manifestDir := t.TempDir()
-	nodeConfig := v1beta1.DefaultClusterConfig()
-	nodeConfig.Spec.API.Port = 6443
-	nodeConfig.Spec.API.Address = "10.0.0.1"
-	cfg := v1beta1.DefaultClusterConfig()
-	cfg.Spec.Network.Calico = nil
-	cfg.Spec.Network.Provider = "kuberouter"
-	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
-	cfg.Spec.Network.KubeRouter.ExtraArgs = map[string]string{
-		// Add some random arg
-		"foo": "bar",
-		// Override the default arg
-		"run-firewall": "false",
-	}
-
-	ctx := t.Context()
-	kr := NewKubeRouter(nodeConfig, manifestDir)
-	require.NoError(t, kr.Init(ctx))
-	require.NoError(t, kr.Start(ctx))
-	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
-	require.NoError(t, kr.Reconcile(ctx, cfg))
-
-	manifestData, err := os.ReadFile(filepath.Join(manifestDir, "kuberouter", "kube-router.yaml"))
-	assert.NoError(t, err, "must have manifests for kube-router")
-
-	resources, err := testutil.ParseManifests(manifestData)
-	require.NoError(t, err)
-	ds, err := findDaemonset(resources)
-	require.NoError(t, err)
-	require.NotNil(t, ds)
-
-	assert.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--run-firewall=false")
-	assert.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--foo=bar")
-}
-
-func TestRawArgs(t *testing.T) {
-	manifestDir := t.TempDir()
-	nodeConfig := v1beta1.DefaultClusterConfig()
-	nodeConfig.Spec.API.Port = 6443
-	nodeConfig.Spec.API.Address = "10.0.0.1"
-	cfg := v1beta1.DefaultClusterConfig()
-	cfg.Spec.Network.Calico = nil
-	cfg.Spec.Network.Provider = "kuberouter"
-	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
-	cfg.Spec.Network.KubeRouter.ExtraArgs = map[string]string{
-		"log-level": "debug",
-	}
-	cfg.Spec.Network.KubeRouter.RawArgs = []string{
-		"--log-level=debug",
-		"--log-level=debug",
-	}
-
-	ctx := t.Context()
-	kr := NewKubeRouter(nodeConfig, manifestDir)
-	require.NoError(t, kr.Init(ctx))
-	require.NoError(t, kr.Start(ctx))
-	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
-	require.NoError(t, kr.Reconcile(ctx, cfg))
-
-	manifestData, err := os.ReadFile(filepath.Join(manifestDir, "kuberouter", "kube-router.yaml"))
-	assert.NoError(t, err, "must have manifests for kube-router")
-
-	resources, err := testutil.ParseManifests(manifestData)
-	require.NoError(t, err)
-	ds, err := findDaemonset(resources)
-	require.NoError(t, err)
-	require.NotNil(t, ds)
-
-	// Verify that both extraArgs and rawArgs are present
-	args := ds.Spec.Template.Spec.Containers[0].Args[len(ds.Spec.Template.Spec.Containers[0].Args)-2:]
-	for _, arg := range args {
-		assert.Equal(t, "--log-level=debug", arg)
-	}
-}
-
-func TestKubeRouterWithServiceProxy(t *testing.T) {
-
-	nodeConfig := v1beta1.DefaultClusterConfig()
-	nodeConfig.Spec.API.Port = 6443
-	nodeConfig.Spec.API.Address = "10.0.0.1"
-
-	cfg := v1beta1.DefaultClusterConfig()
-	cfg.Spec.Network.Calico = nil
-	cfg.Spec.Network.Provider = "kuberouter"
-	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
-	cfg.Spec.Network.KubeRouter.ExtraArgs = map[string]string{
-		"run-service-proxy": "true",
-	}
-	cfg.Spec.Network.KubeProxy.Disabled = true
-	cfg.Spec.API.Address = "10.0.0.1"
-	cfg.Spec.API.Port = 6443
-
-	manifestDir := t.TempDir()
-	ctx := t.Context()
-	kr := NewKubeRouter(nodeConfig, manifestDir)
-	require.NoError(t, kr.Init(ctx))
-	require.NoError(t, kr.Start(ctx))
-	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
-	require.NoError(t, kr.Reconcile(ctx, cfg))
-
-	manifestData, err := os.ReadFile(filepath.Join(manifestDir, "kuberouter", "kube-router.yaml"))
-	assert.NoError(t, err, "must have manifests for kube-router")
-
-	resources, err := testutil.ParseManifests(manifestData)
-	require.NoError(t, err)
-	ds, err := findDaemonset(resources)
-	require.NoError(t, err)
-	require.NotNil(t, ds)
-
-	// Verify that --master flag is injected with the API server URL
-	require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--run-service-proxy=true")
-	require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--master=https://10.0.0.1:6443")
-}
-
-func TestKubeRouterWithServiceProxyAndExternalAddress(t *testing.T) {
-
-	cfg := v1beta1.DefaultClusterConfig()
-	cfg.Spec.Network.Calico = nil
-	cfg.Spec.Network.Provider = "kuberouter"
-	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
-	cfg.Spec.Network.KubeRouter.ExtraArgs = map[string]string{
-		"run-service-proxy": "true",
-	}
-	cfg.Spec.Network.KubeProxy.Disabled = true
-	cfg.Spec.API.Address = "10.0.0.1"
-	cfg.Spec.API.ExternalAddress = "api.example.com"
-	cfg.Spec.API.Port = 6443
-
-	ctx := t.Context()
-	manifestDir := t.TempDir()
-	nodeConfig := v1beta1.DefaultClusterConfig()
-	nodeConfig.Spec.API.Port = 6443
-	nodeConfig.Spec.API.ExternalAddress = "api.example.com"
-	kr := NewKubeRouter(nodeConfig, manifestDir)
-	require.NoError(t, kr.Init(ctx))
-	require.NoError(t, kr.Start(ctx))
-	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
-	require.NoError(t, kr.Reconcile(ctx, cfg))
-
-	manifestData, err := os.ReadFile(filepath.Join(manifestDir, "kuberouter", "kube-router.yaml"))
-	assert.NoError(t, err, "must have manifests for kube-router")
-
-	resources, err := testutil.ParseManifests(manifestData)
-	require.NoError(t, err)
-	ds, err := findDaemonset(resources)
-	require.NoError(t, err)
-	require.NotNil(t, ds)
-
-	// Verify that --master flag uses external address when available
-	require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--run-service-proxy=true")
-	require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--master=https://api.example.com:6443")
-}
-
-func TestKubeRouterAlwaysSetsMaxter(t *testing.T) {
-	cfg := v1beta1.DefaultClusterConfig()
-	cfg.Spec.Network.Calico = nil
-	cfg.Spec.Network.Provider = "kuberouter"
-	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
-	// No run-service-proxy set
-	cfg.Spec.API.Address = "10.0.0.1"
-	cfg.Spec.API.Port = 6443
-
-	ctx := t.Context()
-	manifestDir := t.TempDir()
-	nodeConfig := v1beta1.DefaultClusterConfig()
-	nodeConfig.Spec.API.Port = 6443
-	nodeConfig.Spec.API.Address = "10.0.0.1"
-	kr := NewKubeRouter(nodeConfig, manifestDir)
-	require.NoError(t, kr.Init(ctx))
-	require.NoError(t, kr.Start(ctx))
-	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
-	require.NoError(t, kr.Reconcile(ctx, cfg))
-
-	manifestData, err := os.ReadFile(filepath.Join(manifestDir, "kuberouter", "kube-router.yaml"))
-	assert.NoError(t, err, "must have manifests for kube-router")
-
-	resources, err := testutil.ParseManifests(manifestData)
-	require.NoError(t, err)
-	ds, err := findDaemonset(resources)
-	require.NoError(t, err)
-	require.NotNil(t, ds)
-
-	// Verify that --master flag is always set, even without service-proxy
-	require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--master=https://10.0.0.1:6443")
-}
-
-func TestKubeRouterWithNLLB(t *testing.T) {
-	manifestDir := t.TempDir()
-	nodeConfig := v1beta1.DefaultClusterConfig()
-	nodeConfig.Spec.API.Port = 6443
-	nodeConfig.Spec.API.Address = "10.0.0.1"
-	nodeConfig.Spec.Network.NodeLocalLoadBalancing = &v1beta1.NodeLocalLoadBalancing{
-		Enabled: true,
-		Type:    v1beta1.NllbTypeEnvoyProxy,
-		EnvoyProxy: &v1beta1.EnvoyProxy{
-			APIServerBindPort: 7443,
-		},
-	}
-	cfg := v1beta1.DefaultClusterConfig()
-	cfg.Spec.Network.Calico = nil
-	cfg.Spec.Network.Provider = "kuberouter"
-	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
-	cfg.Spec.API.Address = "10.0.0.1"
-	cfg.Spec.API.Port = 6443
-
-	ctx := t.Context()
-	kr := NewKubeRouter(nodeConfig, manifestDir)
-	require.NoError(t, kr.Init(ctx))
-	require.NoError(t, kr.Start(ctx))
-	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
-	require.NoError(t, kr.Reconcile(ctx, cfg))
-
-	manifestData, err := os.ReadFile(filepath.Join(manifestDir, "kuberouter", "kube-router.yaml"))
-	assert.NoError(t, err, "must have manifests for kube-router")
-
-	resources, err := testutil.ParseManifests(manifestData)
-	require.NoError(t, err)
-	ds, err := findDaemonset(resources)
-	require.NoError(t, err)
-	require.NotNil(t, ds)
-
-	// Verify that --master flag uses localhost when NLLB is enabled
-	require.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--master=https://localhost:7443")
 }
 
 func findConfig(resources []*unstructured.Unstructured) (corev1.ConfigMap, error) {


### PR DESCRIPTION
## Description


This way kube-router will connect directly to the API always or vie NLLB in case that is enabled. This mitigates the cases when kube-router is used also as service proxy.

Also add validation to prevent user enabling both kube-proxy AND kube-router with service proxy as that'll end in tears.

To properly pass in the node config and other stuff, small refactoring was needed to make those a args to the new function.

The unit test case started to have A LOT of duplication so refactored that into table-driven test.

Fixes #6940 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added
- [x] Existing test cases cover this functionality

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
