### PR TITLE
Downgrade setup-go to v5 on ARMv7

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -309,8 +309,7 @@ jobs:
         run: .github/workflows/prepare-build-env.sh
 
       - name: Set up Go
-        # https://github.com/actions/setup-go/pull/666
-        uses: actions/setup-go@b551c4cd70271da7ce09faf55f722b5e270c54d1
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -416,7 +415,7 @@ jobs:
         run: .github/workflows/prepare-build-env.sh
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,7 +399,7 @@ jobs:
           cat k0s.sig
 
       - name: Set up Go for smoke tests
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false


### PR DESCRIPTION
## Description

It has been accidentally bumped to v6 in some workflows for ARM, and it turns out that setup-go forgot to bump the node version to 24 until v6.2.0. This meant that the mistake wasn't discovered until that version was released yesterday.

Fixes:

* #6761

See:

* actions/setup-go#691

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
