### PR TITLE
Remove SANs auto-detection when defaulting the config

### DIFF
--- a/pkg/apis/k0s/v1beta1/api.go
+++ b/pkg/apis/k0s/v1beta1/api.go
@@ -66,7 +66,6 @@ type APISpec struct {
 func DefaultAPISpec() *APISpec {
 	a := new(APISpec)
 	a.setDefaults()
-	a.SANs, _ = iface.AllAddresses()
 	return a
 }
 


### PR DESCRIPTION
## Description

This serves really no purpose. We need the local interface addresses only when actually creating the certs which we already do with the `SANs()` func while we generate certs.

Alternative, probably better, way to fix #6952 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
