### PR TITLE
Make NLLB pods tolerate NoExecute taints

### DIFF
--- a/pkg/component/worker/nllb/envoy.go
+++ b/pkg/component/worker/nllb/envoy.go
@@ -303,6 +303,10 @@ func makePodManifest(params *envoyParams, podParams *envoyPodParams) corev1.Pod 
 					},
 				}},
 			},
+			// without this, kubernetes might try to evict the mirror pod
+			Tolerations: []corev1.Toleration{{
+				Operator: corev1.TolerationOpExists,
+			}},
 		},
 	}
 }


### PR DESCRIPTION
## Description

I introduced a toleration for all NoExecute taints on the static nllb pod as to prevent kubernetes from trying to evict the pod, which it can't do anyway.

Fixes #6955

## Type of change

<!-- check the related options -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [X] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [X] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [X] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
