### PR TITLE
Reclaim GH runner disk space when building k0s

### DIFF
--- a/.github/workflows/build-k0s.yml
+++ b/.github/workflows/build-k0s.yml
@@ -46,6 +46,10 @@ jobs:
           fetch-depth: 0 # for `git describe`
           persist-credentials: false
 
+      - name: "Build :: Reclaim runner disk space"
+        if: inputs.target-arch != 'arm'
+        run: .github/workflows/reclaim-runner-disk-space.bash
+
       - name: "Build :: Prepare"
         id: build-prepare
         run: |


### PR DESCRIPTION
## Description

There have been some CI build failures lately due to running out of disk space. It's unclear whether this is a temporary issue, but it's safer to free up some space before starting the build.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
