### PR TITLE
Add CNI Health Reporting to k0s status

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -385,8 +385,9 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 			K0sVars:       c.K0sVars,
 			ClusterConfig: nodeConfig,
 		},
-		Socket:      c.K0sVars.StatusSocketPath,
-		CertManager: worker.NewCertificateManager(c.K0sVars.KubeletAuthConfigPath),
+		Socket:             c.K0sVars.StatusSocketPath,
+		CertManager:        worker.NewCertificateManager(c.K0sVars.KubeletAuthConfigPath),
+		AdminClientFactory: adminClientFactory,
 	})
 
 	perfTimer.Checkpoint("starting-certificates-init")

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -127,17 +127,17 @@ func printStatus(w io.Writer, status *status.K0sStatus, output string) {
 		if status.StubFile != "" {
 			fmt.Fprintln(w, "Service file:", status.StubFile)
 		}
-		if status.CNI != nil {
+		if status.Conditions != nil {
 			fmt.Fprintln(w, "\nStatus:")
 
-			if len(status.CNI.Conditions) == 0 {
+			if len(status.Conditions) == 0 {
 				fmt.Fprintln(w, " No conditions reported.")
 				return
 			}
 
 			fmt.Fprintln(w, " conditions:")
 
-			for _, cond := range status.CNI.Conditions {
+			for _, cond := range status.Conditions {
 				fmt.Fprintf(w, "  - type:   %s\n", cond.Type)
 				fmt.Fprintf(w, "    status: %s\n", cond.Status)
 				fmt.Fprintf(w, "    reason: %s\n", cond.Reason)

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -127,6 +127,22 @@ func printStatus(w io.Writer, status *status.K0sStatus, output string) {
 		if status.StubFile != "" {
 			fmt.Fprintln(w, "Service file:", status.StubFile)
 		}
+		if status.CNI != nil {
+			fmt.Fprintln(w, "\nCNI Status:")
+			fmt.Fprintln(w, " Provider:", status.CNI.Provider)
+			fmt.Fprintln(w, " Health:", status.CNI.Health)
+
+			if len(status.CNI.Components) > 0 {
+				fmt.Fprintln(w, " Components:")
+				for _, c := range status.CNI.Components {
+					fmt.Fprintf(w, "   - %s\n", c)
+				}
+			}
+
+			if status.CNI.Error != "" {
+				fmt.Fprintln(w, "Error:", status.CNI.Error)
+			}
+		}
 
 	}
 }

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -128,19 +128,22 @@ func printStatus(w io.Writer, status *status.K0sStatus, output string) {
 			fmt.Fprintln(w, "Service file:", status.StubFile)
 		}
 		if status.CNI != nil {
-			fmt.Fprintln(w, "\nCNI Status:")
-			fmt.Fprintln(w, " Provider:", status.CNI.Provider)
-			fmt.Fprintln(w, " Health:", status.CNI.Health)
+			fmt.Fprintln(w, "\nStatus:")
 
-			if len(status.CNI.Components) > 0 {
-				fmt.Fprintln(w, " Components:")
-				for _, c := range status.CNI.Components {
-					fmt.Fprintf(w, "   - %s\n", c)
-				}
+			if len(status.CNI.Conditions) == 0 {
+				fmt.Fprintln(w, " No conditions reported.")
+				return
 			}
 
-			if status.CNI.Error != "" {
-				fmt.Fprintln(w, "Error:", status.CNI.Error)
+			fmt.Fprintln(w, " conditions:")
+
+			for _, cond := range status.CNI.Conditions {
+				fmt.Fprintf(w, "  - type:   %s\n", cond.Type)
+				fmt.Fprintf(w, "    status: %s\n", cond.Status)
+				fmt.Fprintf(w, "    reason: %s\n", cond.Reason)
+				if cond.Message != "" {
+					fmt.Fprintf(w, "    message: %s\n", cond.Message)
+				}
 			}
 		}
 

--- a/pkg/component/status/client.go
+++ b/pkg/component/status/client.go
@@ -36,16 +36,15 @@ type ProbeStatus struct {
 	Success bool
 }
 
-type CNI struct {
-	Provider   string
-	Health     string
-	Components []string
-	Error      string
+type Condition struct {
+	Type    string
+	Status  string
+	Reason  string
+	Message string
 }
 
-func (c *CNI) Fail(format string, a ...interface{}) {
-	c.Health = "Degraded"
-	c.Error = fmt.Sprintf(format, a...)
+type CNI struct {
+	Conditions []Condition
 }
 
 // GetStatus returns the status of the k0s process using the status socket

--- a/pkg/component/status/client.go
+++ b/pkg/component/status/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component/prober"
 	"github.com/k0sproject/k0s/pkg/config"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type K0sStatus struct {
@@ -29,7 +30,7 @@ type K0sStatus struct {
 	WorkerToAPIConnectionStatus ProbeStatus
 	ClusterConfig               *v1beta1.ClusterConfig
 	K0sVars                     *config.CfgVars
-	CNI                         *CNI
+	Conditions                  []Condition
 }
 type ProbeStatus struct {
 	Message string
@@ -38,13 +39,9 @@ type ProbeStatus struct {
 
 type Condition struct {
 	Type    string
-	Status  string
+	Status  corev1.ConditionStatus
 	Reason  string
 	Message string
-}
-
-type CNI struct {
-	Conditions []Condition
 }
 
 // GetStatus returns the status of the k0s process using the status socket

--- a/pkg/component/status/client.go
+++ b/pkg/component/status/client.go
@@ -29,10 +29,23 @@ type K0sStatus struct {
 	WorkerToAPIConnectionStatus ProbeStatus
 	ClusterConfig               *v1beta1.ClusterConfig
 	K0sVars                     *config.CfgVars
+	CNI                         *CNI
 }
 type ProbeStatus struct {
 	Message string
 	Success bool
+}
+
+type CNI struct {
+	Provider   string
+	Health     string
+	Components []string
+	Error      string
+}
+
+func (c *CNI) Fail(format string, a ...interface{}) {
+	c.Health = "Degraded"
+	c.Error = fmt.Sprintf(format, a...)
 }
 
 // GetStatus returns the status of the k0s process using the status socket


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This adds CNI health reporting to the k0s status command. It detects CNI provider (kube-router or Calico), overall CNI health, component readiness and error.

Fixes #5886

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test

1. Tested with kube-router

- Degraded State: when pods are in pending state : 

      CNI Status:
       Provider: kuberouter
       Health: Degraded
       Components:
         - kube-router-vwcl7 (Ready: false)
      Error: Component kube-router-vwcl7 is in Pending state

- Running state : 

      CNI Status:
       Provider: kuberouter
       Health: Healthy
       Components:
         - kube-router-vwcl7 (Ready: true)

2. Tested with calico 

- Degraded State: when pods are in pending state : 

      CNI Status:
        Provider: calico
        Health: Degraded
        Components:
          - calico-kube-controllers-74f9fd669d-2dcpd (Ready: false)
          - calico-node-lgrq8 (Ready: false)
        Error: Component calico-node-lgrq8 is in Pending state

- Running state : 

      CNI Status:
        Provider: calico
        Health: Healthy
        Components:
          - calico-kube-controllers-74f9fd669d-2dcpd (Ready: true)
          - calico-node-lgrq8 (Ready: true)

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
