### PR TITLE
feat: support multiple konnectivity server addresses for HA setups

### DIFF
--- a/pkg/apis/k0s/v1beta1/konnectivity.go
+++ b/pkg/apis/k0s/v1beta1/konnectivity.go
@@ -27,6 +27,13 @@ type KonnectivitySpec struct {
 	// external address to advertise for the konnectivity agent to connect to
 	// +optional
 	ExternalAddress string `json:"externalAddress,omitempty"`
+
+	// serverAddresses is a list of konnectivity server addresses for HA setups.
+	// When specified, agents will connect to all servers for proper load distribution.
+	// This is useful in multi-controller setups where using a single VIP would cause
+	// all agents to connect to only one server.
+	// +optional
+	ServerAddresses []string `json:"serverAddresses,omitempty"`
 }
 
 // DefaultKonnectivitySpec builds default KonnectivitySpec


### PR DESCRIPTION
## Summary

Add a new `serverAddresses` field to `KonnectivitySpec` that allows configuring multiple konnectivity server addresses for high availability setups.

## Problem

In multi-controller deployments using a single VIP (via keepalived, kube-vip, etc.), all konnectivity agents connect to the VIP which routes to only one active server. This leaves the konnectivity-servers on other controllers idle, causing **"No agent available"** errors when those API servers try to reach kubelets via `kubectl exec`, `kubectl logs`, etc.

## Solution

Allow operators to configure agents to connect to all control plane nodes directly:

```yaml
spec:
  konnectivity:
    serverAddresses:
      - 10.0.0.1:8132
      - 10.0.0.2:8132
      - 10.0.0.3:8132
```

The agents will connect to all servers simultaneously with `--sync-forever=true` enabled automatically for multi-server setups.

## Changes

- **`pkg/apis/k0s/v1beta1/konnectivity.go`**: Added `ServerAddresses []string` field to `KonnectivitySpec`
- **`pkg/component/controller/konnectivityagent.go`**: 
  - Changed `ProxyServerHost` (string) to `ProxyServerHosts` ([]string)
  - Added `SyncForever` field
  - Updated logic to check `ServerAddresses` first, then fall back to `ExternalAddress`
  - Updated template to render multiple `--proxy-server-host` flags

## Testing

- Verified template renders correctly for both single-server and multi-server configs
- Tested on 3-node HA cluster - agents successfully connect to all servers
- Backward compatible - existing configs continue to work

## Related

This feature works best with a corresponding k0sctl change that auto-populates `serverAddresses` with controller IPs in multi-controller setups.