### PR TITLE
Requeue Autopilot signal node updates on conflict

### DIFF
--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable.go
@@ -12,6 +12,8 @@ import (
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/sirupsen/logrus"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -64,6 +66,10 @@ func (aup *airgapupdate) Schedulable(ctx context.Context, planID string, cmd apv
 	// .. and update the node
 
 	if err := aup.client.Update(ctx, signalNodeCopy, &crcli.UpdateOptions{}); err != nil {
+		if apierrors.IsConflict(err) {
+			logger.WithError(err).Warn("Conflict updating signal node to ", nextForSignal.Name, ", retrying")
+			return status.State, true, nil
+		}
 		logger.Warnf("Unable to update signalnode with signaling: %v", err)
 		return status.State, false, fmt.Errorf("unable to update signalnode with signaling: %w", err)
 	}

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable.go
@@ -13,6 +13,8 @@ import (
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/sirupsen/logrus"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -90,6 +92,10 @@ func (kp *k0supdate) Schedulable(ctx context.Context, planID string, cmd apv1bet
 	// .. and update the node
 
 	if err := kp.client.Update(ctx, signalNodeCopy, &crcli.UpdateOptions{}); err != nil {
+		if apierrors.IsConflict(err) {
+			logger.WithError(err).Warn("Conflict updating signal node to ", nextForSignal.Name, ", retrying")
+			return status.State, true, nil
+		}
 		logger.Warnf("Unable to update signalnode with signaling: %v", err)
 		return status.State, false, fmt.Errorf("unable to update signalnode with signaling: %w", err)
 	}

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable_test.go
@@ -4,6 +4,9 @@
 package k0supdate
 
 import (
+	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/k0sproject/k0s/internal/testutil"
@@ -12,15 +15,20 @@ import (
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 	apscheme "github.com/k0sproject/k0s/pkg/client/clientset/scheme"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apimruntime "k8s.io/apimachinery/pkg/runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
-	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 // TestSchedulable tests the reconcile function of the `scheduleable` controller.
@@ -36,6 +44,7 @@ func TestSchedulable(t *testing.T) {
 		expectedRetry                 bool
 		expectedPlanStatusControllers []apv1beta2.PlanCommandTargetStatus
 		expectedPlanStatusWorkers     []apv1beta2.PlanCommandTargetStatus
+		conflictUpdate                bool
 	}{
 		// Ensures that if a controller is completed, no additional execution will occur.
 		{
@@ -86,6 +95,7 @@ func TestSchedulable(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("controller0", appc.SignalCompleted),
 			},
 			nil,
+			false,
 		},
 
 		// Ensures that a signal node can be sent a signal, and individually transition
@@ -139,6 +149,60 @@ func TestSchedulable(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("controller0", appc.SignalSent),
 			},
 			nil,
+			false,
+		},
+
+		// Ensures conflicts on update request a retry and preserve status.
+		{
+			"ConflictRequeues",
+			[]crcli.Object{
+				&apv1beta2.ControlNode{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ControlNode",
+						APIVersion: "autopilot.k0sproject.io/v1beta2",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "controller0",
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
+					},
+				},
+			},
+			apv1beta2.PlanCommand{
+				K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{
+					Version: "v99.99.99",
+					Platforms: apv1beta2.PlanPlatformResourceURLMap{
+						"theOS-theArch": {
+							URL:    "https://k0s.example.com/downloads/k0s-v99.99.99-theOS-theArch",
+							Sha256: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+						},
+					},
+					Targets: apv1beta2.PlanCommandTargets{
+						Controllers: apv1beta2.PlanCommandTarget{
+							Discovery: apv1beta2.PlanCommandTargetDiscovery{
+								Static: &apv1beta2.PlanCommandTargetDiscoveryStatic{
+									Nodes: []string{"controller0"},
+								},
+							},
+						},
+					},
+				},
+			},
+			apv1beta2.PlanCommandStatus{
+				ID:    123,
+				State: appc.PlanSchedulable,
+				K0sUpdate: &apv1beta2.PlanCommandK0sUpdateStatus{
+					Controllers: []apv1beta2.PlanCommandTargetStatus{
+						apv1beta2.NewPlanCommandTargetStatus("controller0", appc.SignalPending),
+					},
+				},
+			},
+			appc.PlanSchedulable,
+			true,
+			[]apv1beta2.PlanCommandTargetStatus{
+				apv1beta2.NewPlanCommandTargetStatus("controller0", appc.SignalPending),
+			},
+			nil,
+			true,
 		},
 	}
 
@@ -147,7 +211,23 @@ func TestSchedulable(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client := crfake.NewClientBuilder().WithObjects(test.objects...).WithScheme(scheme).Build()
+			builder := fake.NewClientBuilder().WithObjects(test.objects...).WithScheme(scheme)
+			if test.conflictUpdate {
+				var conflictOnce atomic.Bool
+				builder.WithInterceptorFuncs(interceptor.Funcs{
+					Update: func(ctx context.Context, client crcli.WithWatch, obj crcli.Object, opts ...crcli.UpdateOption) error {
+						if !conflictOnce.Swap(true) {
+							return apierrors.NewConflict(schema.GroupResource{
+								Group:    "autopilot.k0sproject.io",
+								Resource: "controlnodes",
+							}, obj.GetName(), errors.New("injected conflict"))
+						}
+						return client.Update(ctx, obj, opts...)
+					},
+				})
+				t.Cleanup(func() { assert.True(t, conflictOnce.Load(), "Conflict hasn't been injected.") })
+			}
+			client := builder.Build()
 
 			provider := NewK0sUpdatePlanCommandProvider(
 				logrus.NewEntry(logrus.StandardLogger()),


### PR DESCRIPTION
## Description

Plans execution can stall when the plan state handler fails to update a signal node. Detect such conflicts, log them, and flag them for retries instead.

Seen on CI: https://github.com/k0sproject/k0s/actions/runs/21172608922/job/60894010451

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
