### PR TITLE
Enable building airgap bundles via containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,8 @@ airgap-image-bundle-linux-amd64.tar \
 airgap-image-bundle-linux-arm64.tar \
 airgap-image-bundle-linux-arm.tar \
 airgap-image-bundle-linux-riscv64.tar: k0s airgap-images.txt
-	./k0s airgap bundle-artifacts --concurrency=1 -v --platform='$(TARGET_PLATFORM)' -o '$@' <airgap-images.txt
+	set -- $$(cat airgap-images.txt) && \
+	$(GO_ENV) ./k0s airgap bundle-artifacts --concurrency=1 -v --platform='$(TARGET_PLATFORM)' -o '$@' "$$@"
 
 ipv6-test-images.txt: $(GO_ENV_REQUISITES) embedded-bins/Makefile.variables hack/gen-test-images-list/main.go
 	{ \
@@ -280,7 +281,8 @@ ipv6-test-image-bundle-linux-amd64.tar \
 ipv6-test-image-bundle-linux-arm64.tar \
 ipv6-test-image-bundle-linux-arm.tar \
 ipv6-test-image-bundle-linux-riscv64.tar: k0s ipv6-test-images.txt
-	./k0s airgap bundle-artifacts -v --platform='$(TARGET_PLATFORM)' -o '$@' <ipv6-test-images.txt
+	set -- $$(cat ipv6-test-images.txt) && \
+	$(GO_ENV) ./k0s airgap bundle-artifacts -v --platform='$(TARGET_PLATFORM)' -o '$@' "$$@"
 
 .PHONY: $(smoketests)
 $(air_gapped_smoketests) $(ipv6_smoketests): airgap-image-bundle-linux-$(HOST_ARCH).tar


### PR DESCRIPTION
## Description

This way it is possible to build those e.g. on OSX.

Previously the build failed on OSX with
```
% make airgap-image-bundle-linux-arm64.tar
docker run --rm -v '/Users/jnummelin/projects/k0s/build/cache':/run/k0s-build -v '/Users/jnummelin/projects/k0s':/go/src/github.com/k0sproject/k0s -w /go/src/github.com/k0sproject/k0s -e GOOS -e CGO_ENABLED -e CGO_CFLAGS -e GOARCH -e XDG_CACHE_HOME=/run/k0s-build --user 503:20  -- 'sha256:54a63408880da9cb1741a45b9525306f31e38d2b455ffafbc6027457330ea472' ./k0s airgap list-images --all > 'airgap-images.txt'
./k0s airgap bundle-artifacts --concurrency=1 -v --platform='linux/arm64' -o 'airgap-image-bundle-linux-arm64.tar' <airgap-images.txt
/bin/sh: ./k0s: cannot execute binary file
make: *** [airgap-image-bundle-linux-arm64.tar] Error 126
```

To enable piping stdin, needed to add `-i` for the docker commands.



<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
