### PR TITLE
Make ap-airgap inttest pass with Kubernetes 1.35

### DIFF
--- a/inttest/ap-airgap/airgap_test.go
+++ b/inttest/ap-airgap/airgap_test.go
@@ -161,7 +161,7 @@ spec:
 
 	// At that moment we can assume that all pods have at least started.
 	// Inspect the Pulled events if there are some unexpected image pulls.
-	events, err := kc.CoreV1().Events("").List(ctx, metav1.ListOptions{
+	events, err := kc.CoreV1().Events(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
 		FieldSelector: fields.AndSelectors(
 			fields.OneTermEqualSelector("involvedObject.kind", "Pod"),
 			fields.OneTermEqualSelector("reason", "Pulled"),
@@ -171,7 +171,7 @@ spec:
 
 	for _, event := range events.Items {
 		if event.LastTimestamp.After(updateStart) {
-			if !strings.HasSuffix(event.Message, "already present on machine") {
+			if !strings.HasSuffix(event.Message, "already present on machine and can be accessed by the pod") {
 				s.Fail("Unexpected Pulled event", event.Message)
 			} else {
 				s.T().Log("Observed Pulled event:", event.Message)


### PR DESCRIPTION
## Description

For some reason, the ap-airgap inttest doesn't always fail because of the new Pulled event message. Anyhow, fix the condition to respect the new, longer Pulled event message suffix, and restore that behavior in the airgap inttest as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
