### PR TITLE
Add possibility to customize keepalived build flags

### DIFF
--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -99,6 +99,9 @@ build_docker_image = \
 	  --build-arg BUILD_SHIM_GO_CGO_ENABLED=$($(patsubst %/Dockerfile,%,$<)_build_shim_go_cgo_enabled) \
 	  --build-arg BUILD_GO_FLAGS=$($(patsubst %/Dockerfile,%,$<)_build_go_flags) \
 	  --build-arg BUILD_GO_LDFLAGS='$($(patsubst %/Dockerfile,%,$<)_build_go_ldflags) $($(patsubst %/Dockerfile,%,$<)_build_go_ldflags_extra)' \
+	  --build-arg BUILD_CFLAGS='$($(patsubst %/Dockerfile,%,$<)_build_cflags)' \
+	  --build-arg BUILD_LDFLAGS='$($(patsubst %/Dockerfile,%,$<)_build_ldflags)' \
+	  --build-arg BUILD_CONFIGURE_FLAGS='$($(patsubst %/Dockerfile,%,$<)_build_configure_flags)' \
 	  -- $(dir $<)
 
 .docker-image.%.stamp: %/Dockerfile Makefile.variables

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -75,6 +75,9 @@ iptables_buildimage = docker.io/library/alpine:$(alpine_patch_version)
 # renovate: datasource=github-tags depName=acassen/keepalived
 keepalived_version = 2.3.4
 keepalived_buildimage = docker.io/library/alpine:$(alpine_patch_version)
+keepalived_build_cflags = -static -s
+keepalived_build_ldflags = -static
+keepalived_build_configure_flags = --disable-dynamic-linking
 
 clean-iid-files = \
 	for i in $(IID_FILES); do \

--- a/embedded-bins/keepalived/Dockerfile
+++ b/embedded-bins/keepalived/Dockerfile
@@ -19,8 +19,11 @@ ARG VERSION
 RUN curl --proto '=https' --tlsv1.2 -L https://www.keepalived.org/software/keepalived-$VERSION.tar.gz \
 	| tar -C / -zx
 
+ARG BUILD_CFLAGS
+ARG BUILD_LDFLAGS
+ARG BUILD_CONFIGURE_FLAGS
 RUN cd /keepalived-$VERSION \
-	&& CFLAGS='-static -s' LDFLAGS=-static ./configure  --disable-dynamic-linking \
+	&& CFLAGS="${BUILD_CFLAGS}" LDFLAGS="${BUILD_LDFLAGS}" ./configure ${BUILD_CONFIGURE_FLAGS} \
 	&& make -j$(nproc)
 
 FROM scratch


### PR DESCRIPTION
## Description

There are some use cases where people might need to customize these, such as when building against system crypto libs for e.g. FIPS.

This also follows the same pattern we use for Golang based builds.


## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
