### PR TITLE
Refactor Helm reconciler to use ephemeral environments

### DIFF
--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -9,10 +9,13 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
@@ -36,6 +39,7 @@ import (
 	"github.com/avast/retry-go"
 	"github.com/bombsimon/logrusr/v4"
 	"github.com/sirupsen/logrus"
+	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
 
@@ -51,14 +55,63 @@ import (
 
 const HelmExtensionStackName = "helm"
 
+// repositoryCache provides thread-safe access to Helm repository configurations
+type repositoryCache struct {
+	cache map[string]k0sv1beta1.Repository
+	mutex sync.RWMutex
+}
+
+// get retrieves a repository configuration by key (repo name for traditional, hostname for OCI)
+// Returns nil if not found.
+func (rc *repositoryCache) get(key string) *k0sv1beta1.Repository {
+	rc.mutex.RLock()
+	defer rc.mutex.RUnlock()
+	repo, ok := rc.cache[key]
+	if !ok {
+		return nil
+	}
+	return &repo
+}
+
+// update replaces the entire cache contents with the provided repositories
+func (rc *repositoryCache) update(repositories []k0sv1beta1.Repository) {
+	// Build a new cache and swap it out under lock
+	newCache := make(map[string]k0sv1beta1.Repository)
+
+	// Populate with new repositories
+	// OCI repos are keyed by hostname, traditional repos by name
+	var repoName string
+	for _, repo := range repositories {
+		if registry.IsOCI(repo.URL) {
+			// Extract hostname from OCI URL and use as key
+			url, err := url.Parse(repo.URL)
+			// This shouldn't really happen at this point but just in case let's log it
+			if err != nil {
+				logrus.WithError(err).Warnf("Invalid repository URL %q, skipping", repo.URL)
+				continue
+			}
+			repoName = url.Host
+		} else {
+			// Traditional repo: use name as key
+			repoName = repo.Name
+		}
+		newCache[repoName] = repo
+	}
+
+	rc.mutex.Lock()
+	rc.cache = newCache
+	defer rc.mutex.Unlock()
+
+}
+
 // Helm watch for Chart crd
 type ExtensionsController struct {
-	L             *logrus.Entry
-	helm          *helm.Commands
-	kubeConfig    string
-	leaderElector leaderelector.Interface
-	manifestsDir  string
-	stop          context.CancelFunc
+	L               *logrus.Entry
+	kubeConfig      string
+	leaderElector   leaderelector.Interface
+	manifestsDir    string
+	stop            context.CancelFunc
+	repositoryCache *repositoryCache
 }
 
 var _ manager.Component = (*ExtensionsController)(nil)
@@ -67,11 +120,11 @@ var _ manager.Reconciler = (*ExtensionsController)(nil)
 // NewExtensionsController builds new HelmAddons
 func NewExtensionsController(k0sVars *config.CfgVars, kubeClientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface) *ExtensionsController {
 	return &ExtensionsController{
-		L:             logrus.WithFields(logrus.Fields{"component": "extensions_controller"}),
-		helm:          helm.NewCommands(k0sVars),
-		kubeConfig:    k0sVars.AdminKubeConfigPath,
-		leaderElector: leaderElector,
-		manifestsDir:  filepath.Join(k0sVars.ManifestsDir, "helm"),
+		L:               logrus.WithFields(logrus.Fields{"component": "extensions_controller"}),
+		kubeConfig:      k0sVars.AdminKubeConfigPath,
+		leaderElector:   leaderElector,
+		manifestsDir:    filepath.Join(k0sVars.ManifestsDir, "helm"),
+		repositoryCache: &repositoryCache{},
 	}
 }
 
@@ -94,13 +147,10 @@ func (ec *ExtensionsController) reconcileHelmExtensions(helmSpec *k0sv1beta1.Hel
 		return nil
 	}
 
-	var errs []error
-	for _, repo := range helmSpec.Repositories {
-		if err := ec.addRepo(repo); err != nil {
-			errs = append(errs, fmt.Errorf("can't init repository %q: %w", repo.URL, err))
-		}
-	}
+	// Update repository cache
+	ec.repositoryCache.update(helmSpec.Repositories)
 
+	var errs []error
 	var fileNamesToKeep []string
 	for _, chart := range helmSpec.Charts {
 		fileName := chartManifestFileName(&chart)
@@ -172,9 +222,10 @@ func isChartManifestFileName(fileName string) bool {
 
 type ChartReconciler struct {
 	client.Client
-	helm          *helm.Commands
-	leaderElector leaderelector.Interface
-	L             *logrus.Entry
+	kubeConfig      string
+	repositoryCache *repositoryCache
+	leaderElector   leaderelector.Interface
+	L               *logrus.Entry
 }
 
 func (cr *ChartReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
@@ -220,7 +271,14 @@ func (cr *ChartReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 }
 
 func (cr *ChartReconciler) uninstall(ctx context.Context, chart helmv1beta1.Chart) error {
-	if err := cr.helm.UninstallRelease(ctx, chart.Status.ReleaseName, chart.Status.Namespace); err != nil {
+	// Create ephemeral Helm commands without repository (uninstall doesn't need it)
+	helmCmd, cleanup, err := helm.NewCommands(cr.kubeConfig, nil)
+	if err != nil {
+		return fmt.Errorf("can't create Helm commands: %w", err)
+	}
+	defer cleanup()
+
+	if err := helmCmd.UninstallRelease(ctx, chart.Status.ReleaseName, chart.Status.Namespace); err != nil {
 		return fmt.Errorf("can't uninstall release `%s/%s`: %w", chart.Status.Namespace, chart.Status.ReleaseName, err)
 	}
 	return nil
@@ -272,10 +330,24 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart helmv
 			cr.L.WithError(err).Error("Failed to update status for chart release, give up", chart.Name)
 		}
 	}()
+
+	// Extract repository from chart name and look it up
+	repo, err := cr.extractAndLookupRepository(chart.Spec.ChartName)
+	if err != nil {
+		return fmt.Errorf("can't lookup repository for chart %q: %w", chart.Spec.ChartName, err)
+	}
+
+	// Create ephemeral Helm commands with repository
+	helmCmd, cleanup, err := helm.NewCommands(cr.kubeConfig, repo)
+	if err != nil {
+		return fmt.Errorf("can't create Helm commands for chart %q: %w", chart.GetName(), err)
+	}
+	defer cleanup()
+
 	if chart.Status.ReleaseName == "" {
 		// new chartRelease
 		cr.L.Tracef("Start update or install %s", chart.Spec.ChartName)
-		chartRelease, err = cr.helm.InstallChart(ctx,
+		chartRelease, err = helmCmd.InstallChart(ctx,
 			chart.Spec.ChartName,
 			chart.Spec.Version,
 			chart.Spec.ReleaseName,
@@ -291,7 +363,7 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart helmv
 			return nil
 		}
 		// update
-		chartRelease, err = cr.helm.UpgradeChart(ctx,
+		chartRelease, err = helmCmd.UpgradeChart(ctx,
 			chart.Spec.ChartName,
 			chart.Spec.Version,
 			chart.Status.ReleaseName,
@@ -310,6 +382,46 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart helmv
 		cr.L.WithError(err).Error("Failed to update status for chart release, give up", chart.Name)
 	}
 	return nil
+}
+
+// extractAndLookupRepository extracts the repository name or OCI hostname from chartName
+// and looks it up in the repository cache. Returns a pointer to the repository config or nil
+// if no repository configuration is needed (e.g., local path charts, OCI charts without auth).
+func (cr *ChartReconciler) extractAndLookupRepository(chartName string) (*k0sv1beta1.Repository, error) {
+	// Check if it's a local path (absolute or relative)
+	if filepath.IsAbs(chartName) || strings.HasPrefix(chartName, ".") {
+		// Local chart, no repository needed
+		return nil, nil
+	}
+
+	// Check if it's an OCI chart
+	if registry.IsOCI(chartName) {
+		// Extract hostname from OCI URL
+		chartURL, err := url.Parse(chartName)
+		if err != nil {
+			return nil, fmt.Errorf("invalid OCI chart URL %q: %w", chartName, err)
+		}
+		repoHostname := chartURL.Host
+		// Look up repository by hostname (OCI repos are keyed by hostname)
+		return cr.repositoryCache.get(repoHostname), nil
+
+	}
+
+	// Traditional format: "reponame/chartname"
+	repoName, chart, found := strings.Cut(chartName, "/")
+	if !found {
+		return nil, fmt.Errorf("invalid chart name %q: expected format 'repository/chart' for non-OCI charts", chartName)
+	}
+	if chart == "" {
+		return nil, fmt.Errorf("invalid chart name %q: chart name is empty", chartName)
+	}
+
+	repo := cr.repositoryCache.get(repoName)
+	if repo == nil {
+		return nil, fmt.Errorf("repository '%s' not found in cluster configuration", repoName)
+	}
+
+	return repo, nil
 }
 
 func (cr *ChartReconciler) chartNeedsUpgrade(chart helmv1beta1.Chart) bool {
@@ -349,10 +461,6 @@ func (cr *ChartReconciler) updateStatus(ctx context.Context, chart helmv1beta1.C
 		return updErr
 	}
 	return nil
-}
-
-func (ec *ExtensionsController) addRepo(repo k0sv1beta1.Repository) error {
-	return ec.helm.AddRepository(repo)
 }
 
 const chartCrdTemplate = `
@@ -461,10 +569,11 @@ func (ec *ExtensionsController) instantiateManager(ctx context.Context) (crman.M
 			),
 		).
 		Complete(&ChartReconciler{
-			Client:        mgr.GetClient(),
-			leaderElector: ec.leaderElector, // TODO: drop in favor of controller-runtime lease manager?
-			helm:          ec.helm,
-			L:             ec.L.WithField("extensions_type", "helm"),
+			Client:          mgr.GetClient(),
+			kubeConfig:      ec.kubeConfig,
+			repositoryCache: ec.repositoryCache,
+			leaderElector:   ec.leaderElector, // TODO: drop in favor of controller-runtime lease manager?
+			L:               ec.L.WithField("extensions_type", "helm"),
 		}); err != nil {
 		return nil, fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
 	}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
-	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
 )
 
@@ -58,14 +57,41 @@ var getters = getter.Providers{
 	},
 }
 
-// NewCommands builds new Commands instance with default values
-func NewCommands(k0sVars *config.CfgVars) *Commands {
-	return &Commands{
-		repoFile:        k0sVars.HelmRepositoryConfig,
-		registryManager: newOCIRegistryManager(),
-		helmCacheDir:    k0sVars.HelmRepositoryCache,
-		kubeConfig:      k0sVars.AdminKubeConfigPath,
+// NewCommands builds new Commands instance with ephemeral temporary directories.
+// If repo is provided, it will be initialized in the temporary environment.
+// Returns the Commands instance and a cleanup function that must be called to remove temporary files.
+func NewCommands(kubeConfig string, repo *v1beta1.Repository) (*Commands, func(), error) {
+	// Create temporary directory for ephemeral Helm environment
+	tmpDir, err := os.MkdirTemp("", "k0s-helm-*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create temporary Helm directory: %w", err)
 	}
+
+	cleanup := func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			logrus.WithError(err).WithField("path", tmpDir).Warn("Failed to clean up temporary Helm directory")
+		}
+	}
+
+	repoFile := filepath.Join(tmpDir, "repositories.yaml")
+	helmCacheDir := filepath.Join(tmpDir, "cache")
+
+	commands := &Commands{
+		repoFile:        repoFile,
+		registryManager: newOCIRegistryManager(),
+		helmCacheDir:    helmCacheDir,
+		kubeConfig:      kubeConfig,
+	}
+
+	// Initialize repository if provided
+	if repo != nil {
+		if err := commands.initRepository(*repo); err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("failed to initialize repository: %w", err)
+		}
+	}
+
+	return commands, cleanup, nil
 }
 
 func (hc *Commands) getActionCfg(namespace string) (*action.Configuration, error) {
@@ -95,7 +121,8 @@ func (hc *Commands) getActionCfg(namespace string) (*action.Configuration, error
 	return actionConfig, nil
 }
 
-func (hc *Commands) AddRepository(repoCfg v1beta1.Repository) error {
+// initRepository initializes a single repository in the ephemeral Helm environment
+func (hc *Commands) initRepository(repoCfg v1beta1.Repository) error {
 	if err := hc.registryManager.AddRegistry(repoCfg); !errors.Is(err, errors.ErrUnsupported) {
 		return err
 	}


### PR DESCRIPTION
## Description

Replace persistent Helm repository initialization with ephemeral, per-chart environments. This eliminates timing dependencies between repository setup and chart installation while simplifying the architecture.

Allows much easier implementation for things like #6915

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Existing cases cover this

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
