### PR TITLE
Fix SELinux labels for containerd binaries

### DIFF
--- a/pkg/component/worker/containerd/component_other.go
+++ b/pkg/component/worker/containerd/component_other.go
@@ -5,12 +5,20 @@
 
 package containerd
 
-import "github.com/k0sproject/k0s/pkg/assets"
+import (
+	"github.com/k0sproject/k0s/pkg/assets"
+)
 
 const (
 	defaultConfPath    = "/etc/k0s/containerd.toml"
 	defaultImportsPath = "/etc/k0s/containerd.d/"
 )
+
+// containerRuntimeExecLabel is the SELinux label for container runtime executables.
+// This label is required for containerd, runc, and related binaries to function
+// correctly on SELinux-enforcing systems. The label allows these binaries to
+// interact with container processes and manage container lifecycle.
+const containerRuntimeExecLabel = "system_u:object_r:container_runtime_exec_t:s0"
 
 var additionalExecutableNames = [...]string{
 	"containerd-shim",
@@ -19,5 +27,5 @@ var additionalExecutableNames = [...]string{
 }
 
 func stageExecutable(dir, name string) (string, error) {
-	return assets.StageExecutable(dir, name)
+	return assets.StageExecutable(dir, name, assets.WithSELinuxLabel(containerRuntimeExecLabel))
 }


### PR DESCRIPTION
## Description

Extend StageExecutable API to support SELinux labels via variadic options.

Apply container_runtime_exec_t label to containerd, runc, and shim binaries to fix SELinux integration broken by atomic file extraction.

Fixes #6577

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

Manually tested this on Rocky9 with SELinux in enforcing mode:

```
[root@lima-rocky9-test ~]# getenforce 
Enforcing
[root@lima-rocky9-test ~]# ls -lZ /var/lib/k0s/bin/{containerd*,runc}
-rwxr-x---. 1 root root system_u:object_r:container_runtime_exec_t:s0 42377856 Feb 11 13:40 /var/lib/k0s/bin/containerd
-rwxr-x---. 1 root root system_u:object_r:container_runtime_exec_t:s0  6881464 Feb 11 13:40 /var/lib/k0s/bin/containerd-shim
-rwxr-x---. 1 root root system_u:object_r:container_runtime_exec_t:s0 12910776 Feb 11 13:40 /var/lib/k0s/bin/containerd-shim-runc-v2
-rwxr-x---. 1 root root system_u:object_r:container_runtime_exec_t:s0 12378816 Feb 11 13:40 /var/lib/k0s/bin/runc
```

Running a privileged pod 
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: test-selinux
spec:
  containers:
  - name: test
    image: busybox
    command: ["sleep", "3600"]
    securityContext:
      privileged: true
```

results in:
```
[root@lima-rocky9-test ~]# ps -eZ | grep $(pidof sleep)
system_u:system_r:spc_t:s0      1406978 ?        00:00:00 sleep
```

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
