### PR TITLE
ci: don't build and lint docs on push to main

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,24 +1,12 @@
 name: Build docs
 
 on:
-  push:
-    branches:
-      - main
-      - release-*
-    paths:
-      - "**.md"
-      - docs/**
-      - embedded-bins/Makefile.variables
-      - pkg/constant/constant.go
-      - mkdocs.yml
-      - vars.sh
-
   pull_request:
     branches:
       - main
       - release-*
     paths:
-      - "**.md"
+      - '**.md'
       - docs/**
       - embedded-bins/Makefile.variables
       - pkg/constant/constant.go

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,14 +1,6 @@
 name: Lint docs
 
 on:
-  push:
-    branches:
-      - main
-      - release-*
-    paths:
-      - '**.md'
-      - .github/workflows/docs.yml
-      - .markdownlint.jsonc
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Description

I don't think it's necessary to build and lint documentation website after merge. PR triggers should be enough.
Because publishing docs is handled via https://github.com/k0sproject/k0s/actions/workflows/publish-docs.yml already.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
