### PR TITLE
Fix controller-tools post-upgrade command execution in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -176,7 +176,7 @@
       "postUpgradeTasks": {
         "executionMode": "branch",
         "commands": [
-          "install-tool golang $(./vars.sh go_version)",
+          "sh -c 'install-tool golang $(./vars.sh go_version)'",
           "make DOCKER='' EMBEDDED_BINS_BUILDMODE=none codegen"
         ]
       }


### PR DESCRIPTION
## Description

Recent Renovate versions execute `postUpgradeTasks` without shell expansion by default. This breaks the controller-tools upgrade, which relies on this to figure out the correct Go version to use. Wrap this command in `sh -c`, restoring the previous behavior for this command.

See:

* renovatebot/renovate#40230

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
