### PR TITLE
Use k0s-bot as author for Renovate commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     ":automergeMinor",
     ":semanticCommitsDisabled"
   ],
-  "gitAuthor": "Renovate Bot <renovate@whitesourcesoftware.com>",
+  "gitAuthor": "k0s-bot <110385897+k0s-bot@users.noreply.github.com>",
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
## Description

Set the gitAuthor used by Renovate to k0s-bot. This will prevent Renovate from using the default Mend-owned address, renovate@whitesourcesoftware.com, which triggers warnings in Renovate logs because upstream has enabled vigilant mode for that address on GitHub.

See:

* renovatebot/renovate#39309

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
