### PR TITLE
[renovate] Disable python datasource

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -182,6 +182,23 @@
       }
     },
     {
+      "description": "Disable Python managers",
+      "enabled": false,
+      "matchManagers": [
+        "pip_requirements",
+        "pip_setup",
+        "pipenv",
+        "poetry"
+      ]
+    },
+    {
+      "description": "Disable python datasource",
+      "enabled": false,
+      "matchDatasources": [
+        "python-version"
+      ]
+    },
+    {
       "description": "Only bump the main branch by default",
       "enabled": false,
       "prTitleStrict": false,


### PR DESCRIPTION
## Description

We're hitting rate limits on python API and the python dependencies are handled by dependabot so we don't really need this.

This is happening in most runs: https://github.com/k0sproject/k0s/actions/runs/22090661444/job/63834839388#step:3:22077

This causes that some PRs marked to retry/rebase aren't done, such as https://github.com/k0sproject/k0s/pull/7117

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
