### PR TITLE
Use a custom docker network in addons inttest

### DIFF
--- a/inttest/common/bootloosesuite.go
+++ b/inttest/common/bootloosesuite.go
@@ -328,6 +328,11 @@ func (s *BootlooseSuite) RegistryNode() string {
 	return fmt.Sprintf(registryNodeNameFormat, 0)
 }
 
+// Returns the registry port as seen from other bootloose nodes.
+func (s *BootlooseSuite) RegistryPort() int {
+	return registryContainerPort
+}
+
 func (s *BootlooseSuite) ExternalEtcdNode() string {
 	if !s.WithExternalEtcd {
 		s.FailNow("can't get external node name because it's not enabled for this suite")
@@ -1311,9 +1316,10 @@ func (s *BootlooseSuite) generateRegistryMachineSpec() *config.Machine {
 	extraArgs = append(extraArgs, fmt.Sprintf("--health-cmd=wget -q --no-check-certificate --spider %s://localhost:%d/v2", registryProtocol, registryContainerPort))
 
 	return &config.Machine{
-		Name:  registryNodeNameFormat,
-		Image: "registry:3.0.0",
-		Cmd:   "/etc/distribution/config.yml",
+		Name:     registryNodeNameFormat,
+		Image:    "docker.io/library/registry:3.0.0",
+		Cmd:      "/etc/distribution/config.yml",
+		Networks: s.Networks,
 		PortMappings: []config.PortMapping{
 			{
 				ContainerPort: uint16(registryContainerPort), // registry port


### PR DESCRIPTION
## Description

Instead of using the host-published DNS name and port, use the registry node's in-cluster address and port for self-signed OCI chart pulls. This makes the tests more robust and avoids host firewall/NAT/hairpin problems that could cause the tests to fail.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
