### PR TITLE
Switch Renovate data source for Python to containerbase

### DIFF
--- a/docs/Makefile.variables
+++ b/docs/Makefile.variables
@@ -1,2 +1,2 @@
-# renovate: datasource=python-version depName=python versioning=python
+# renovate: datasource=github-releases depName=containerbase/python-prebuild versioning=python
 python_version = 3.14.3


### PR DESCRIPTION
## Description

Recently, the official data source started to experience rate limiting. This breaks the entire Renovate run, preventing PRs from being created or updated. A proposed workaround is to use the GitHub releases of the `containerbase/python-prebuild` repo.

Hopefully, this gets addressed upstream soonish, so we can revert this PR again.

Alternative to:

* #7131

See:

* https://github.com/renovatebot/renovate/issues/27802#issuecomment-3902086982


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
