### PR TITLE
Revert "Bump quay.io/k0sproject/kube-router Docker tag to v2.7.1"

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -96,7 +96,7 @@ const (
 	CalicoNodeWindowsImageVersion         = "v3.31.3"
 	KubeControllerImage                   = "quay.io/k0sproject/calico-kube-controllers"
 	KubeRouterCNIImage                    = "quay.io/k0sproject/kube-router"
-	KubeRouterCNIImageVersion             = "v2.7.1-iptables1.8.11-0"
+	KubeRouterCNIImageVersion             = "v2.6.3-iptables1.8.11-0"
 	KubeRouterCNIInstallerImage           = "quay.io/k0sproject/cni-node"
 	KubeRouterCNIInstallerImageVersion    = "1.8.0-k0s.0"
 


### PR DESCRIPTION
Reverts k0sproject/k0s#7139

The conformance tests are failing on multiple tests due to flakyness on several network tests on kube-router: https://github.com/k0sproject/k0s/actions/runs/22143774742