### PR TITLE
Make renovate keep track of release-1.35

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -237,6 +237,18 @@
       "allowedVersions": "<=1.37"
     },
     {
+      "description": "Bump etcd for release-1.35",
+      "enabled": true,
+      "matchBaseBranches": [
+        "release-1.35"
+      ],
+      "matchPackageNames": [
+        "go.etcd.io/etcd/**/v3",
+        "etcd-io/etcd"
+      ],
+      "allowedVersions": "<=3.6"
+    },
+    {
       "description": "Bump Alpine for release-1.34",
       "enabled": true,
       "matchBaseBranches": [
@@ -280,6 +292,18 @@
         "quay.io/k0sproject/envoy-distroless"
       ],
       "allowedVersions": "<=1.34"
+    },
+    {
+      "description": "Bump etcd for release-1.34",
+      "enabled": true,
+      "matchBaseBranches": [
+        "release-1.34"
+      ],
+      "matchPackageNames": [
+        "go.etcd.io/etcd/**/v3",
+        "etcd-io/etcd"
+      ],
+      "allowedVersions": "<=3.6"
     },
     {
       "description": "Bump etcd for release-1.33",


### PR DESCRIPTION
## Description

- Removes support for release 1.32 as it's no longer maintained
- Adds support for 1.35
- Tracks etcd on 1.34 and 1.35, this should probably be another PR, but it's small so I slipped it here.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
