### PR TITLE
Remove Oracle Linux from nightly OS test matrix

### DIFF
--- a/.github/workflows/ostests-nightly.yaml
+++ b/.github/workflows/ostests-nightly.yaml
@@ -19,7 +19,6 @@ env:
       ["fcos_stable"],
       ["fedora_41"],
       ["flatcar"],
-      ["oracle_8_9", "oracle_9_3"],
       ["rhel_7", "rhel_8", "rhel_9"],
       ["rocky_8", "rocky_9"],
       ["sles_15"],

--- a/docs/system-requirements.md
+++ b/docs/system-requirements.md
@@ -65,7 +65,6 @@ The following operating systems are automatically tested as part of our CI:
 | Fedora CoreOS                 | stable stream                                                                           |
 | Fedora Linux                  | 41 (Cloud Edition)                                                                      |
 | Flatcar Container Linux       | by Kinvolk                                                                              |
-| Oracle Linux Server           | 8.9, 9.3                                                                                |
 | Red Hat Enterprise Linux      | 7.9 (Maipo), 8.10 (Ootpa), 9.7 (Plow)                                                   |
 | Rocky Linux                   | 8.10 (Green Obsidian), 9.5 (Blue Onyx)                                                  |
 | SUSE Linux Enterprise Server  | 15 SP6                                                                                  |


### PR DESCRIPTION
## Description

The official Oracle Linux AMIs seem to have disappeared from AWS.


```console
$ aws ec2 describe-images --owners 131827586825
{
    "Images": []
}
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
