### PR TITLE
[Backport release-1.33] Deduce alpine_version from alpine_patch_version

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,5 @@
-alpine_version = 3.21
-alpine_patch_version = $(alpine_version).6
+alpine_patch_version = 3.21.6
+alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine3.23
 go_version = 1.24.13
 


### PR DESCRIPTION
Backport to `release-1.33`:

* #5980  
  (without changes to `renovate.json`)