### PR TITLE
[Backport release-1.33] More Renovate version bumps

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -27,6 +27,7 @@ containerd_build_shim_go_cgo_enabled = 0
 containerd_build_go_ldflags = -w -s
 containerd_build_go_ldflags_extra = -extldflags=-static
 
+# renovate: datasource=github-releases depName=kubernetes/kubernetes
 kubernetes_version = 1.33.9
 kubernetes_buildimage = $(golang_buildimage)
 kubernetes_build_go_tags = "providerless"

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,8 @@ require (
 	google.golang.org/grpc v1.74.2
 	helm.sh/helm/v3 v3.18.6
 	oras.land/oras-go/v2 v2.6.0
+	sigs.k8s.io/controller-runtime v0.20.4
+	sigs.k8s.io/yaml v1.5.0
 )
 
 // Kubernetes
@@ -82,8 +84,6 @@ require (
 	k8s.io/kubernetes v1.33.9
 	k8s.io/mount-utils v0.33.9
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
-	sigs.k8s.io/controller-runtime v0.20.4
-	sigs.k8s.io/yaml v1.5.0
 )
 
 require (


### PR DESCRIPTION
Backport to `release-1.33`:

* #6759  
  (without changes to `renovate.json`)

See:

* #6427