### PR TITLE
Delay join token parsing on worker until it is known that it is needed

### DIFF
--- a/cmd/internal/tokendata.go
+++ b/cmd/internal/tokendata.go
@@ -61,7 +61,7 @@ func GetTokenData(tokenArg, tokenFile string) (string, error) {
 		problem = "is empty"
 	}
 	if problem != "" {
-		return "", fmt.Errorf("token file %q %s"+
+		return "", fmt.Errorf(`token file "%s" %s`+
 			`: obtain a new token via "k0s token create ..." and store it in the file`+
 			` or reinstall this node via "k0s install --force ..." or "k0sctl apply --force ..."`,
 			tokenFile, problem)

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -88,10 +88,7 @@ func NewWorkerCmd() *cobra.Command {
 				return err
 			}
 
-			getBootstrapKubeconfig, err := kubeconfigGetterFromJoinToken(c.TokenFile, c.TokenArg)
-			if err != nil {
-				return err
-			}
+			getBootstrapKubeconfig := kubeconfigGetterFromJoinToken(c.TokenFile, c.TokenArg)
 
 			nodeName, kubeletExtraArgs, err := GetNodeName(&c.WorkerOptions)
 			if err != nil {
@@ -158,24 +155,31 @@ func GetNodeName(opts *config.WorkerOptions) (apitypes.NodeName, stringmap.Strin
 	return nodeName, kubeletExtraArgs, nil
 }
 
-func kubeconfigGetterFromJoinToken(tokenFile, tokenArg string) (clientcmd.KubeconfigGetter, error) {
-	tokenData, err := internal.GetTokenData(tokenArg, tokenFile)
-	if err != nil {
-		return nil, err
+func kubeconfigGetterFromJoinToken(tokenFile, tokenArg string) clientcmd.KubeconfigGetter {
+	if tokenArg != "" {
+		return func() (*clientcmdapi.Config, error) {
+			return loadKubeconfigFromJoinToken(tokenArg)
+		}
 	}
 
-	if tokenData == "" {
-		return nil, nil
+	if envToken := os.Getenv(internal.EnvVarToken); envToken != "" {
+		return func() (*clientcmdapi.Config, error) {
+			return loadKubeconfigFromJoinToken(envToken)
+		}
 	}
 
-	kubeconfig, err := loadKubeconfigFromJoinToken(tokenData)
-	if err != nil {
-		return nil, err
+	if tokenFile == "" {
+		return nil
 	}
 
 	return func() (*clientcmdapi.Config, error) {
-		return kubeconfig, nil
-	}, nil
+		tokenData, err := internal.GetTokenData("", tokenFile)
+		if err != nil {
+			return nil, err
+		}
+
+		return loadKubeconfigFromJoinToken(tokenData)
+	}
 }
 
 func loadKubeconfigFromJoinToken(tokenData string) (*clientcmdapi.Config, error) {

--- a/cmd/worker/worker_test.go
+++ b/cmd/worker/worker_test.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package worker
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/k0sproject/k0s/cmd/internal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKubeconfigGetterFromJoinToken_NoSources(t *testing.T) {
+	t.Setenv(internal.EnvVarToken, "")
+
+	getter := kubeconfigGetterFromJoinToken("", "")
+	require.Nil(t, getter)
+}
+
+func TestKubeconfigGetterFromJoinToken_TokenFileLazy(t *testing.T) {
+	t.Setenv(internal.EnvVarToken, "")
+	tokenFile := filepath.Join(t.TempDir(), "missing.token")
+
+	getter := kubeconfigGetterFromJoinToken(tokenFile, "")
+	require.NotNil(t, getter)
+
+	_, err := getter()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), tokenFile)
+}
+
+func TestKubeconfigGetterFromJoinToken_EnvVarDeferred(t *testing.T) {
+	t.Setenv(internal.EnvVarToken, "not-base64")
+
+	getter := kubeconfigGetterFromJoinToken("", "")
+	require.NotNil(t, getter)
+
+	_, err := getter()
+	require.ErrorContains(t, err, "failed to decode join token")
+}
+
+func TestKubeconfigGetterFromJoinToken_InvalidArgDeferred(t *testing.T) {
+	t.Setenv(internal.EnvVarToken, "")
+
+	getter := kubeconfigGetterFromJoinToken("", "invalid")
+	require.NotNil(t, getter)
+
+	_, err := getter()
+	require.ErrorContains(t, err, "failed to decode join token")
+}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #7202 

Delays the parsing of join tokens on workers until it is known that the node needs to join and a token is needed.

## Type of change

<!-- check the related options -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [X] Manual test
- [X] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [X] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [X] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
