### PR TITLE
Enable Kubernetes version bumps for releases 1.33 and 1.34

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -260,6 +260,32 @@
       "allowedVersions": "<=1.34"
     },
     {
+      "description": "Bump Kubernetes for release-1.34",
+      "enabled": true,
+      "matchBaseBranches": [
+        "release-1.34"
+      ],
+      "matchPackageNames": [
+        "k8s.io/**",
+        "**/kubernetes",
+        "**/kube-proxy"
+      ],
+      "allowedVersions": "/^v?[01]\\.34\\./"
+    },
+    {
+      "description": "Disallow Kubernetes digest bumps for release-1.34",
+      "enabled": false,
+      "matchBaseBranches": [
+        "release-1.34"
+      ],
+      "matchPackageNames": [
+        "k8s.io/**"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ]
+    },
+    {
       "description": "Bump etcd for release-1.33",
       "enabled": true,
       "matchBaseBranches": [
@@ -281,6 +307,32 @@
         "quay.io/k0sproject/envoy-distroless"
       ],
       "allowedVersions": "<=1.32"
+    },
+    {
+      "description": "Bump Kubernetes for release-1.33",
+      "enabled": true,
+      "matchBaseBranches": [
+        "release-1.33"
+      ],
+      "matchPackageNames": [
+        "k8s.io/**",
+        "**/kubernetes",
+        "**/kube-proxy"
+      ],
+      "allowedVersions": "/^v?[01]\\.33\\./"
+    },
+    {
+      "description": "Disallow Kubernetes digest bumps for release-1.33",
+      "enabled": false,
+      "matchBaseBranches": [
+        "release-1.33"
+      ],
+      "matchPackageNames": [
+        "k8s.io/**"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Description

We need to explicitly disable digest version bumps, as some k8s.io dependencies don't have proper versions, and the allowedVersions regex won't apply to those.

Depends on:

* #7197
* #7198
* #7199
* #7200
* #7201

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
