### PR TITLE
Remove retry cap when waiting for Helm CRDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.41.0
 	golang.org/x/text v0.34.0
+	golang.org/x/time v0.14.0
 	golang.org/x/tools v0.42.0
 	google.golang.org/grpc v1.79.1
 	helm.sh/helm/v3 v3.20.0
@@ -266,7 +267,6 @@ require (
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/term v0.40.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -31,15 +31,16 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
 	apiretry "k8s.io/client-go/util/retry"
 
-	"github.com/avast/retry-go"
 	"github.com/bombsimon/logrusr/v4"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
 	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
@@ -712,10 +713,6 @@ func (ec *ExtensionsController) instantiateManager(ctx context.Context) (crman.M
 	if err != nil {
 		return nil, fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
 	}
-	gk := schema.GroupKind{
-		Group: helmv1beta1.GroupName,
-		Kind:  "Chart",
-	}
 
 	// Create a scheme with both k0s types and core Kubernetes types (needed for Secret access)
 	scheme := k0sscheme.Scheme
@@ -734,16 +731,27 @@ func (ec *ExtensionsController) instantiateManager(ctx context.Context) (crman.M
 	if err != nil {
 		return nil, fmt.Errorf("can't build controller-runtime controller for helm extensions: %w", err)
 	}
-	if err := retry.Do(func() error {
-		_, err := mgr.GetRESTMapper().RESTMapping(gk)
-		if err != nil {
-			ec.L.Warn("Extensions CRD is not yet ready, waiting before starting ExtensionsController")
-			return err
+
+	for chart, sometimes := (schema.GroupKind{Group: helmv1beta1.GroupName, Kind: "Chart"}), (&rate.Sometimes{Every: 5}); ; {
+		_, err := mgr.GetRESTMapper().RESTMapping(chart)
+		if err == nil {
+			ec.L.Info(chart, " CRD is ready, going nuts")
+			break
 		}
-		ec.L.Info("Extensions CRD is ready, going nuts")
-		return nil
-	}, retry.Context(ctx)); err != nil {
-		return nil, fmt.Errorf("can't start ExtensionsReconciler, helm CRD is not registered, check CRD registration reconciler: %w", err)
+
+		sometimes.Do(func() {
+			if meta.IsNoMatchError(err) {
+				ec.L.Warn(chart, " CRD is not yet ready, waiting before starting ExtensionsController")
+			} else {
+				ec.L.WithError(err).Error("Failed to check for ", chart, " CRD readiness")
+			}
+		})
+
+		select {
+		case <-time.After(2 * time.Second):
+		case <-ctx.Done():
+			return nil, fmt.Errorf("while waiting for %s CRD: %w (last error: %w)", chart, context.Cause(ctx), err)
+		}
 	}
 
 	if err := builder.


### PR DESCRIPTION
## Description

The extensions controller component relies on the availability of the Helm CRD. The component's startup is delayed until the CRD becomes available. The availability check is repeated using retry-go, which defaults to ten attempts with an exponential backoff. Overall, this will usually bail out in under a minute, resulting in a k0s restart.

This is problematic if it just takes longer for the CRD to become available. During initial cluster bootstrapping, the API server may receive a high volume of traffic, which takes time to process, especially for less powerful controllers. In these cases, k0s exits too early.

Another example is a borked leader lease: client-go's leader election waits for at least the lease duration before trying to acquire an abandoned lease, even if the last renewal time was way in the past. In such situations, bailing out too early effectively causes k0s to enter a crash loop.

Replace the capped retry/backoff with a context-cancellable endless loop that checks the CRD every two seconds, occasionally issues a log statement.

See:

* #5873

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
