### PR TITLE
Fix branch for Renovate's 1.35 release version bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -195,7 +195,7 @@
       "description": "Bump Calico for release-1.35",
       "enabled": true,
       "matchBaseBranches": [
-        "release-1.34"
+        "release-1.35"
       ],
       "matchDepNames": [
         "docker.io/calico/*",
@@ -207,7 +207,7 @@
       "description": "Bump Go for release-1.35",
       "enabled": true,
       "matchBaseBranches": [
-        "release-1.34"
+        "release-1.35"
       ],
       "matchDepNames": [
         "go"


### PR DESCRIPTION
## Description

Also, avoid bumping dependencies in the 1.35 release whose minor versions are still in sync with the main branch. It makes more sense to backport the bumps instead of duplicating them across release branches.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
