### PR TITLE
Fix EtcdMember lease name mismatch

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -579,6 +579,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 	if nodeConfig.Spec.Storage.Type == v1beta1.EtcdStorageType && !nodeConfig.Spec.Storage.Etcd.IsExternalClusterUsed() {
 		etcdReconciler, err := controller.NewEtcdMemberReconciler(
 			adminClientFactory,
+			nodeName,
 			c.K0sVars,
 			nodeConfig.Spec.Storage.Etcd,
 			leaderElector,

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -28,10 +28,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	nodeutil "k8s.io/component-helpers/node/util"
 )
 
 const (
+	controllerLeaseLabelName = "k0s.k0sproject.io/controller-lease"
 	shutdownOnLeaveLabelName = "k0s.k0sproject.io/shutdown-on-leave"
 	shutdownLabelName        = "k0s.k0sproject.io/shutdown"
 )
@@ -40,10 +42,11 @@ const EtcdMemberStackName = "etcd-member"
 
 var _ manager.Component = (*EtcdMemberReconciler)(nil)
 
-func NewEtcdMemberReconciler(kubeClientFactory kubeutil.ClientFactoryInterface, k0sVars *config.CfgVars, etcdConfig *v1beta1.EtcdConfig, leaderElector leaderelector.Interface, controllerCount func() uint, shutdown context.CancelCauseFunc) (*EtcdMemberReconciler, error) {
+func NewEtcdMemberReconciler(kubeClientFactory kubeutil.ClientFactoryInterface, nodeName apitypes.NodeName, k0sVars *config.CfgVars, etcdConfig *v1beta1.EtcdConfig, leaderElector leaderelector.Interface, controllerCount func() uint, shutdown context.CancelCauseFunc) (*EtcdMemberReconciler, error) {
 
 	return &EtcdMemberReconciler{
 		clientFactory:   kubeClientFactory,
+		nodeName:        nodeName,
 		k0sVars:         k0sVars,
 		etcdConfig:      etcdConfig,
 		leaderElector:   leaderElector,
@@ -58,6 +61,7 @@ type EtcdMemberReconciler struct {
 	etcdConfig      *v1beta1.EtcdConfig
 	leaderElector   leaderelector.Interface
 	controllerCount func() uint
+	nodeName        apitypes.NodeName
 	shutdown        context.CancelCauseFunc
 	stop            func()
 }
@@ -377,6 +381,8 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context, client et
 
 	log.WithField("name", name).WithField("memberID", memberID).Info("creating EtcdMember object")
 
+	controllerLeaseName := fmt.Sprintf("k0s-ctrl-%s", e.nodeName)
+
 	// Check if the object already exists
 	em, err = client.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
@@ -386,6 +392,7 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context, client et
 				ObjectMeta: metav1.ObjectMeta{
 					Name: name,
 					Labels: map[string]string{
+						controllerLeaseLabelName: controllerLeaseName,
 						shutdownOnLeaveLabelName: e.k0sVars.InvocationID,
 					},
 				},
@@ -413,7 +420,10 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context, client et
 		}
 	}
 
-	em.Labels = labels.Merge(em.Labels, labels.Set{shutdownOnLeaveLabelName: e.k0sVars.InvocationID})
+	em.Labels = labels.Merge(em.Labels, labels.Set{
+		controllerLeaseLabelName: controllerLeaseName,
+		shutdownOnLeaveLabelName: e.k0sVars.InvocationID,
+	})
 	delete(em.Labels, shutdownLabelName) // Clear any lingering shutdown request on re-join.
 	em.Spec.Leave = false
 
@@ -549,7 +559,11 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 			return false
 		}
 
-		if memberLease, err := clients.CoordinationV1().Leases(corev1.NamespaceNodeLease).Get(ctx, "k0s-ctrl-"+member.Name, metav1.GetOptions{}); err != nil {
+		memberLeaseName := member.Labels[controllerLeaseLabelName]
+		if memberLeaseName == "" {
+			memberLeaseName = "k0s-ctrl-" + member.Name
+		}
+		if memberLease, err := clients.CoordinationV1().Leases(corev1.NamespaceNodeLease).Get(ctx, memberLeaseName, metav1.GetOptions{}); err != nil {
 			log.WithError(err).Error("Failed to get etcd member lease")
 			msg := "Failed to get k0s controller lease: " + err.Error()
 			if apierrors.IsNotFound(err) {


### PR DESCRIPTION
## Description

We create lease with the hostname name and try to match them by EtcdMember object name, but they can be different

Fixes https://github.com/k0sproject/k0smotron/issues/1382

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
