### PR TITLE
Add cgroups v1 clarification to docs

### DIFF
--- a/docs/external-runtime-deps.md
+++ b/docs/external-runtime-deps.md
@@ -100,7 +100,18 @@ and, if enabled as a module, to load the `configs` module: `modprobe configs`.
 
 ### Control Groups (cgroups)
 
-Both [cgroup v1] and [cgroup v2] are supported.
+Both [cgroup v1] and [cgroup v2] are supported. Starting with Kubernetes 1.31 already, [cgroup v1] is in [maintenance mode] and starting in Kubernetes 1.35
+by default kubelet will fail to start if [cgroup v1] is detected on the system. If you want to run Kubernetes with [cgroup v1], you need to explicitly enable
+it by setting `failCgroupV1: false` in kubelet configuration, via k0s [worker profile](worker-node-config.md#kubelet-configuration):
+
+```yaml
+...
+spec:
+  workerProfiles:
+    - name: default # Applies to the default profile which all workers pick up if no profile is specified in the worker startup
+      values:
+        failCgroupV1: false
+```
 
 Required [cgroup] controllers:
 
@@ -124,6 +135,7 @@ Optional cgroup controllers:
 [cgroup v2]: https://www.kernel.org/doc/html/v5.16/admin-guide/cgroup-v2.html
 [kubernetes/kubeadm#2335 (comment)]: https://github.com/kubernetes/kubeadm/issues/2335#issuecomment-722405527
 [kubernetes/kubernetes#92287 (comment)]: https://github.com/kubernetes/kubernetes/issues/92287#issuecomment-1010723587
+[maintenance mode]: https://kubernetes.io/blog/2024/08/14/kubernetes-1-31-moving-cgroup-v1-support-maintenance-mode/
 
 ### No integration with Name Service Switch (NSS) APIs
 


### PR DESCRIPTION
## Description

The docs state that both v1 and v2 are supported but 1.35+ kubelet actually fails to start by default with v1. If v1 is actually used, there needs to be `failCgroupV1: false` added for kubelet config.



<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
