### PR TITLE
Replace filepath.Glob with a custom loop

### DIFF
--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -6,6 +6,7 @@ package applier
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/k0sproject/k0s/pkg/kubernetes"
@@ -20,7 +21,25 @@ import (
 const manifestFilePattern = "*.yaml"
 
 func FindManifestFilesInDir(dir string) ([]string, error) {
-	return filepath.Glob(filepath.Join(dir, manifestFilePattern))
+	// Don't use filepath.Glob directly, as that will swallow I/O errors.
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	matches := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if match, err := filepath.Match(manifestFilePattern, entry.Name()); err != nil {
+			return nil, err
+		} else if !match {
+			continue
+		}
+
+		matches = append(matches, filepath.Join(dir, entry.Name()))
+	}
+
+	return matches, nil
 }
 
 // Applier manages all the "static" manifests and applies them on the k8s API


### PR DESCRIPTION
## Description

The `filepath.Glob` function ignores many types of errors when listing directories and stat'ing files. This could lead to resources being erroneously deleted from the cluster under pathological circumstances.

Use a simple loop to iterate through the entries in the given directory, and manually use `filepath.Match`, passing on any errors instead of swallowing them.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
