### PR TITLE
Use filepath.Join for local filesystem paths

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -14,7 +14,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -241,27 +240,27 @@ func etcdHandler(log logrus.FieldLogger, certRootDir, etcdCertDir string) http.H
 func caHandler(certRootDir string) http.Handler {
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		caResp := v1beta1.CaResponse{}
-		key, err := os.ReadFile(path.Join(certRootDir, "ca.key"))
+		key, err := os.ReadFile(filepath.Join(certRootDir, "ca.key"))
 		if err != nil {
 			sendError(err, resp)
 			return
 		}
 		caResp.Key = key
-		crt, err := os.ReadFile(path.Join(certRootDir, "ca.crt"))
+		crt, err := os.ReadFile(filepath.Join(certRootDir, "ca.crt"))
 		if err != nil {
 			sendError(err, resp)
 			return
 		}
 		caResp.Cert = crt
 
-		saKey, err := os.ReadFile(path.Join(certRootDir, "sa.key"))
+		saKey, err := os.ReadFile(filepath.Join(certRootDir, "sa.key"))
 		if err != nil {
 			sendError(err, resp)
 			return
 		}
 		caResp.SAKey = saKey
 
-		saPub, err := os.ReadFile(path.Join(certRootDir, "sa.pub"))
+		saPub, err := os.ReadFile(filepath.Join(certRootDir, "sa.pub"))
 		if err != nil {
 			sendError(err, resp)
 			return

--- a/hack/gen-bindata/gen_bindata.go
+++ b/hack/gen-bindata/gen_bindata.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -27,6 +27,7 @@ type fileInfo struct {
 }
 
 func compressFiles(dirs []string, prefix string) ([]fileInfo, error) {
+	prefix = filepath.Clean(prefix)
 	var tmpFiles []fileInfo
 
 	// compress the files
@@ -46,8 +47,14 @@ func compressFiles(dirs []string, prefix string) ([]fileInfo, error) {
 			if err != nil {
 				return nil, err
 			}
-			filePath := path.Join(dir, f.Name())
-			name := strings.TrimPrefix(filePath, prefix) + ".gz"
+			filePath := filepath.Join(dir, f.Name())
+			name := filePath
+			if prefix != "" {
+				if name, err = filepath.Rel(prefix, filePath); err != nil {
+					return nil, err
+				}
+			}
+			name = filepath.ToSlash(name) + ".gz"
 			tmpFiles = append(tmpFiles, fileInfo{
 				Name:         name,
 				Path:         filePath,

--- a/internal/oci/download_test.go
+++ b/internal/oci/download_test.go
@@ -6,13 +6,14 @@ package oci_test
 import (
 	"bytes"
 	"cmp"
-	"embed"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -23,18 +24,15 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-//go:embed testdata/*
-var testData embed.FS
-
 // we define our tests as yaml files inside the testdata directory. this
 // function parses them and returns a map of the tests.
 func parseTestsYAML[T any](t *testing.T) map[string]T {
-	entries, err := testData.ReadDir("testdata")
+	entries, err := os.ReadDir("testdata")
 	require.NoError(t, err)
 	tests := make(map[string]T, 0)
 	for _, entry := range entries {
-		fpath := path.Join("testdata", entry.Name())
-		data, err := testData.ReadFile(fpath)
+		fpath := filepath.Join("testdata", entry.Name())
+		data, err := os.ReadFile(fpath)
 		require.NoError(t, err)
 
 		var onetest T

--- a/internal/pkg/sysinfo/probes/linux/cgroups_test.go
+++ b/internal/pkg/sysinfo/probes/linux/cgroups_test.go
@@ -8,7 +8,7 @@ package linux
 import (
 	"errors"
 	"fmt"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
@@ -78,7 +78,7 @@ func TestCgroupsProbes_Probe(t *testing.T) {
 }
 
 func TestCgroupsProbes_Probe_NonExistent(t *testing.T) {
-	nonExistent := path.Join(t.TempDir(), "non-existent")
+	nonExistent := filepath.Join(t.TempDir(), "non-existent")
 	path := probes.ProbePath{t.Name()}
 	reporter := new(test_sysinfo.MockReporter)
 	reporter.On("Reject", mock.Anything, mock.Anything, "").Return(nil)

--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -112,8 +113,8 @@ func issueServerCertsWithSelfSignedCA(t *testing.T, certsDir, registryHost strin
 	serverCert, err := s.Sign(signer.SignRequest{Request: string(serverCertCSR)})
 	require.NoError(t, err)
 
-	require.NoError(t, os.WriteFile(path.Join(certsDir, "tls.crt"), serverCert, 0644))
-	require.NoError(t, os.WriteFile(path.Join(certsDir, "tls.key"), serverKey, 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "tls.crt"), serverCert, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "tls.key"), serverKey, 0600))
 
 	return serverCert
 }
@@ -769,7 +770,7 @@ func tarFS(src fs.FS, path string, out io.Writer) (err error) {
 }
 
 func TestAddonsSuite(t *testing.T) {
-	registryTLSDir := path.Join(t.TempDir(), "registry-tls")
+	registryTLSDir := filepath.Join(t.TempDir(), "registry-tls")
 	require.NoError(t, os.MkdirAll(registryTLSDir, 0755))
 	networkName := "k0s-inttest-addons-" + utilrand.String(5)
 	out, err := exec.Command("docker", "network", "create", networkName).CombinedOutput()

--- a/inttest/common/bootloosesuite.go
+++ b/inttest/common/bootloosesuite.go
@@ -18,7 +18,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -424,7 +423,7 @@ func (s *BootlooseSuite) cleanupSuite(ctx context.Context, t *testing.T) {
 	}
 
 	if keepEnvironment(t) {
-		t.Logf("bootloose cluster left intact for debugging; needs to be manually cleaned up with: bootloose delete --config %s", path.Join(s.clusterDir, "bootloose.yaml"))
+		t.Logf("bootloose cluster left intact for debugging; needs to be manually cleaned up with: bootloose delete --config %s", filepath.Join(s.clusterDir, "bootloose.yaml"))
 		return
 	}
 
@@ -1204,7 +1203,7 @@ func (s *BootlooseSuite) initializeBootlooseClusterInDir(dir string) error {
 	cfg := config.Config{
 		Cluster: config.Cluster{
 			Name:       s.T().Name(),
-			PrivateKey: path.Join(dir, "id_rsa"),
+			PrivateKey: filepath.Join(dir, "id_rsa"),
 		},
 		Machines: []config.MachineReplicas{
 			{
@@ -1299,7 +1298,7 @@ func (s *BootlooseSuite) initializeBootlooseClusterInDir(dir string) error {
 		return fmt.Errorf("failed to marshal bootloose configuration: %w", err)
 	}
 
-	if err = os.WriteFile(path.Join(dir, "bootloose.yaml"), bootlooseYaml, 0700); err != nil {
+	if err = os.WriteFile(filepath.Join(dir, "bootloose.yaml"), bootlooseYaml, 0700); err != nil {
 		return fmt.Errorf("failed to write bootloose configuration to file: %w", err)
 	}
 

--- a/pkg/applier/manager.go
+++ b/pkg/applier/manager.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path"
 	"path/filepath"
 	"slices"
 	"time"
@@ -123,7 +122,7 @@ func (m *Manager) runWatchers(ctx context.Context) {
 	stacks := make(map[string]stack, len(dirs))
 
 	for _, dir := range dirs {
-		m.createStack(ctx, stacks, path.Join(m.bundleDir, dir))
+		m.createStack(ctx, stacks, filepath.Join(m.bundleDir, dir))
 	}
 
 	for {

--- a/pkg/autopilot/controller/signal/airgap/download.go
+++ b/pkg/autopilot/controller/signal/airgap/download.go
@@ -5,7 +5,7 @@ package airgap
 
 import (
 	"crypto/sha256"
-	"path"
+	"path/filepath"
 	"strings"
 
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
@@ -53,7 +53,7 @@ func (b downloadManfiestBuilderAirgap) Build(signalNode crcli.Object, signalData
 			URL:          signalData.Command.AirgapUpdate.URL,
 			ExpectedHash: signalData.Command.AirgapUpdate.Sha256,
 			Hasher:       sha256.New(),
-			DownloadDir:  path.Join(b.k0sDataDir, "images"),
+			DownloadDir:  filepath.Join(b.k0sDataDir, "images"),
 		},
 		SuccessState: apsigcomm.Completed,
 	}

--- a/pkg/autopilot/controller/signal/k0s/apply.go
+++ b/pkg/autopilot/controller/signal/k0s/apply.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -109,7 +108,7 @@ func (r *applyingUpdate) Reconcile(ctx context.Context, req cr.Request) (cr.Resu
 		return cr.Result{}, nil
 	}
 
-	updateFilenamePath := path.Join(r.k0sBinaryDir, apconst.K0sTempFilename)
+	updateFilenamePath := filepath.Join(r.k0sBinaryDir, apconst.K0sTempFilename)
 
 	// Ensure that the expected file exists
 	if _, err := os.Stat(updateFilenamePath); errors.Is(err, os.ErrNotExist) {

--- a/pkg/backup/manager_unix.go
+++ b/pkg/backup/manager_unix.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
@@ -155,7 +154,7 @@ func (bm *Manager) RunRestore(archivePath string, k0sVars *config.CfgVars, desir
 	if err != nil {
 		return fmt.Errorf("failed to parse backed-up configuration file, check the backup archive: %w", err)
 	}
-	bm.discoverSteps(bm.tmpDir+"/k0s.yaml", cfg.Spec, k0sVars, "restore", desiredRestoredConfigPath, out)
+	bm.discoverSteps(filepath.Join(bm.tmpDir, "k0s.yaml"), cfg.Spec, k0sVars, "restore", desiredRestoredConfigPath, out)
 	logrus.Info("Starting restore")
 
 	for _, step := range bm.steps {
@@ -168,7 +167,7 @@ func (bm *Manager) RunRestore(archivePath string, k0sVars *config.CfgVars, desir
 }
 
 func (bm Manager) getConfigForRestore() (*v1beta1.ClusterConfig, error) {
-	configFromBackup := path.Join(bm.tmpDir, "k0s.yaml")
+	configFromBackup := filepath.Join(bm.tmpDir, "k0s.yaml")
 	logrus.Debugf("Using k0s.yaml from: %s", configFromBackup)
 
 	bytes, err := os.ReadFile(configFromBackup)

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -95,26 +94,26 @@ func (a *APIServer) Start(ctx context.Context) error {
 		"advertise-address":                a.ClusterConfig.Spec.API.Address,
 		"secure-port":                      strconv.Itoa(a.ClusterConfig.Spec.API.Port),
 		"authorization-mode":               "Node,RBAC",
-		"client-ca-file":                   path.Join(a.K0sVars.CertRootDir, "ca.crt"),
+		"client-ca-file":                   filepath.Join(a.K0sVars.CertRootDir, "ca.crt"),
 		"enable-bootstrap-token-auth":      "true",
-		"kubelet-client-certificate":       path.Join(a.K0sVars.CertRootDir, "apiserver-kubelet-client.crt"),
-		"kubelet-client-key":               path.Join(a.K0sVars.CertRootDir, "apiserver-kubelet-client.key"),
+		"kubelet-client-certificate":       filepath.Join(a.K0sVars.CertRootDir, "apiserver-kubelet-client.crt"),
+		"kubelet-client-key":               filepath.Join(a.K0sVars.CertRootDir, "apiserver-kubelet-client.key"),
 		"kubelet-preferred-address-types":  "InternalIP,ExternalIP,Hostname",
-		"proxy-client-cert-file":           path.Join(a.K0sVars.CertRootDir, "front-proxy-client.crt"),
-		"proxy-client-key-file":            path.Join(a.K0sVars.CertRootDir, "front-proxy-client.key"),
+		"proxy-client-cert-file":           filepath.Join(a.K0sVars.CertRootDir, "front-proxy-client.crt"),
+		"proxy-client-key-file":            filepath.Join(a.K0sVars.CertRootDir, "front-proxy-client.key"),
 		"requestheader-allowed-names":      "front-proxy-client",
-		"requestheader-client-ca-file":     path.Join(a.K0sVars.CertRootDir, "front-proxy-ca.crt"),
-		"service-account-key-file":         path.Join(a.K0sVars.CertRootDir, "sa.pub"),
+		"requestheader-client-ca-file":     filepath.Join(a.K0sVars.CertRootDir, "front-proxy-ca.crt"),
+		"service-account-key-file":         filepath.Join(a.K0sVars.CertRootDir, "sa.pub"),
 		"service-cluster-ip-range":         a.ClusterConfig.Spec.Network.BuildServiceCIDR(a.ClusterConfig.PrimaryAddressFamily()),
 		"tls-min-version":                  "VersionTLS12",
-		"tls-cert-file":                    path.Join(a.K0sVars.CertRootDir, "server.crt"),
-		"tls-private-key-file":             path.Join(a.K0sVars.CertRootDir, "server.key"),
-		"service-account-signing-key-file": path.Join(a.K0sVars.CertRootDir, "sa.key"),
+		"tls-cert-file":                    filepath.Join(a.K0sVars.CertRootDir, "server.crt"),
+		"tls-private-key-file":             filepath.Join(a.K0sVars.CertRootDir, "server.key"),
+		"service-account-signing-key-file": filepath.Join(a.K0sVars.CertRootDir, "sa.key"),
 		"service-account-issuer":           "https://kubernetes.default.svc",
 		"service-account-jwks-uri":         "https://kubernetes.default.svc/openid/v1/jwks",
 		"profiling":                        "false",
 		"v":                                a.LogLevel,
-		"kubelet-certificate-authority":    path.Join(a.K0sVars.CertRootDir, "ca.crt"),
+		"kubelet-certificate-authority":    filepath.Join(a.K0sVars.CertRootDir, "ca.crt"),
 		"enable-admission-plugins":         "NodeRestriction",
 	}
 
@@ -129,7 +128,7 @@ func (a *APIServer) Start(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		args["egress-selector-config-file"] = path.Join(a.K0sVars.DataDir, "konnectivity.conf")
+		args["egress-selector-config-file"] = filepath.Join(a.K0sVars.DataDir, "konnectivity.conf")
 		apiAudiences = append(apiAudiences, "system:konnectivity-server")
 	}
 
@@ -184,9 +183,9 @@ func (a *APIServer) writeKonnectivityConfig() error {
 		Name:     "konnectivity",
 		Template: egressSelectorConfigTemplate,
 		Data: egressSelectorConfig{
-			UDSName: path.Join(a.K0sVars.KonnectivitySocketDir, "konnectivity-server.sock"),
+			UDSName: filepath.Join(a.K0sVars.KonnectivitySocketDir, "konnectivity-server.sock"),
 		},
-		Path: path.Join(a.K0sVars.DataDir, "konnectivity.conf"),
+		Path: filepath.Join(a.K0sVars.DataDir, "konnectivity.conf"),
 	}
 	err := tw.Write()
 	if err != nil {
@@ -207,14 +206,14 @@ func (a *APIServer) Stop() error {
 // Health-check interface
 func (a *APIServer) Ready() error {
 	// Load client cert so the api can authenticate the request.
-	certFile := path.Join(a.K0sVars.CertRootDir, "admin.crt")
-	keyFile := path.Join(a.K0sVars.CertRootDir, "admin.key")
+	certFile := filepath.Join(a.K0sVars.CertRootDir, "admin.crt")
+	keyFile := filepath.Join(a.K0sVars.CertRootDir, "admin.key")
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return err
 	}
 	// Load CA cert
-	caCert, err := os.ReadFile(path.Join(a.K0sVars.CertRootDir, "ca.crt"))
+	caCert, err := os.ReadFile(filepath.Join(a.K0sVars.CertRootDir, "ca.crt"))
 	if err != nil {
 		return err
 	}

--- a/pkg/component/controller/cniutil.go
+++ b/pkg/component/controller/cniutil.go
@@ -4,18 +4,18 @@
 package controller
 
 import (
-	"path"
+	"path/filepath"
 
 	"github.com/k0sproject/k0s/internal/pkg/file"
 )
 
 func existingCNIProvider(manifestDir string) string {
-	calicoManifestPath := path.Join(manifestDir, "calico", "calico-DaemonSet-calico-node.yaml")
+	calicoManifestPath := filepath.Join(manifestDir, "calico", "calico-DaemonSet-calico-node.yaml")
 	if file.Exists(calicoManifestPath) {
 		return "calico"
 	}
 
-	kubeRouterManifestPath := path.Join(manifestDir, "kuberouter", "kube-router.yaml")
+	kubeRouterManifestPath := filepath.Join(manifestDir, "kuberouter", "kube-router.yaml")
 	if file.Exists(kubeRouterManifestPath) {
 		return "kuberouter"
 	}

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -65,7 +64,7 @@ func (a *Manager) Init(_ context.Context) error {
 
 	// controller manager should be the only component that needs access to
 	// ca.key so let it own it.
-	if err := os.Chown(path.Join(a.K0sVars.CertRootDir, "ca.key"), a.uid, -1); err != nil && os.Geteuid() == 0 {
+	if err := os.Chown(filepath.Join(a.K0sVars.CertRootDir, "ca.key"), a.uid, -1); err != nil && os.Geteuid() == 0 {
 		logrus.Warn("failed to change permissions for the ca.key: ", err)
 	}
 	a.executablePath, err = assets.StageExecutable(a.K0sVars.BinDir, kubeControllerManagerComponent)
@@ -84,12 +83,12 @@ func (a *Manager) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterC
 		"authentication-kubeconfig":        ccmAuthConf,
 		"authorization-kubeconfig":         ccmAuthConf,
 		"kubeconfig":                       ccmAuthConf,
-		"client-ca-file":                   path.Join(a.K0sVars.CertRootDir, "ca.crt"),
-		"cluster-signing-cert-file":        path.Join(a.K0sVars.CertRootDir, "ca.crt"),
-		"cluster-signing-key-file":         path.Join(a.K0sVars.CertRootDir, "ca.key"),
-		"requestheader-client-ca-file":     path.Join(a.K0sVars.CertRootDir, "front-proxy-ca.crt"),
-		"root-ca-file":                     path.Join(a.K0sVars.CertRootDir, "ca.crt"),
-		"service-account-private-key-file": path.Join(a.K0sVars.CertRootDir, "sa.key"),
+		"client-ca-file":                   filepath.Join(a.K0sVars.CertRootDir, "ca.crt"),
+		"cluster-signing-cert-file":        filepath.Join(a.K0sVars.CertRootDir, "ca.crt"),
+		"cluster-signing-key-file":         filepath.Join(a.K0sVars.CertRootDir, "ca.key"),
+		"requestheader-client-ca-file":     filepath.Join(a.K0sVars.CertRootDir, "front-proxy-ca.crt"),
+		"root-ca-file":                     filepath.Join(a.K0sVars.CertRootDir, "ca.crt"),
+		"service-account-private-key-file": filepath.Join(a.K0sVars.CertRootDir, "sa.key"),
 		"cluster-cidr":                     clusterConfig.Spec.Network.BuildPodCIDR(),
 		"service-cluster-ip-range":         a.ServiceClusterIPRange,
 		"profiling":                        "false",

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"path"
 	"path/filepath"
 	"reflect"
 	"time"
@@ -314,7 +313,7 @@ func NewCoreDNS(k0sVars *config.CfgVars, clientFactory k8sutil.ClientFactoryInte
 		clusterDomain: nodeConfig.Spec.Network.ClusterDomain,
 		client:        client,
 		log:           logrus.WithField("component", "coredns"),
-		manifestDir:   path.Join(k0sVars.ManifestsDir, "coredns"),
+		manifestDir:   filepath.Join(k0sVars.ManifestsDir, "coredns"),
 	}, nil
 }
 

--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"time"
 
@@ -50,7 +49,7 @@ func NewKubeProxy(k0sVars *config.CfgVars, nodeConfig *v1beta1.ClusterConfig, ha
 
 		nodeConf:        nodeConfig,
 		K0sVars:         k0sVars,
-		manifestDir:     path.Join(k0sVars.ManifestsDir, "kubeproxy"),
+		manifestDir:     filepath.Join(k0sVars.ManifestsDir, "kubeproxy"),
 		hasWindowsNodes: hasWindowsNodes,
 	}
 }

--- a/pkg/component/controller/metrics.go
+++ b/pkg/component/controller/metrics.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"time"
 
@@ -182,8 +181,8 @@ type job struct {
 }
 
 func (m *Metrics) newEtcdJob() (*job, error) {
-	certFile := path.Join(m.K0sVars.CertRootDir, "apiserver-etcd-client.crt")
-	keyFile := path.Join(m.K0sVars.CertRootDir, "apiserver-etcd-client.key")
+	certFile := filepath.Join(m.K0sVars.CertRootDir, "apiserver-etcd-client.crt")
+	keyFile := filepath.Join(m.K0sVars.CertRootDir, "apiserver-etcd-client.key")
 
 	httpClient, err := getClient(certFile, keyFile)
 	if err != nil {
@@ -217,8 +216,8 @@ func (m *Metrics) newKineJob() (*job, error) {
 }
 
 func (m *Metrics) newJob(name, scrapeURL string) (*job, error) {
-	certFile := path.Join(m.K0sVars.CertRootDir, "admin.crt")
-	keyFile := path.Join(m.K0sVars.CertRootDir, "admin.key")
+	certFile := filepath.Join(m.K0sVars.CertRootDir, "admin.crt")
+	keyFile := filepath.Join(m.K0sVars.CertRootDir, "admin.key")
 
 	httpClient, err := getClient(certFile, keyFile)
 	if err != nil {

--- a/pkg/component/controller/metricserver.go
+++ b/pkg/component/controller/metricserver.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"path"
 	"path/filepath"
 	"time"
 
@@ -271,7 +270,7 @@ func (m *MetricServer) Init(_ context.Context) error {
 func (m *MetricServer) Start(ctx context.Context) error {
 	ctx, m.tickerDone = context.WithCancel(ctx)
 
-	msDir := path.Join(m.K0sVars.ManifestsDir, "metricserver")
+	msDir := filepath.Join(m.K0sVars.ManifestsDir, "metricserver")
 	err := dir.Init(msDir, constant.ManifestsDirMode)
 	if err != nil {
 		return err

--- a/pkg/helm/oci_test.go
+++ b/pkg/helm/oci_test.go
@@ -5,7 +5,7 @@ package helm
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/cloudflare/cfssl/csr"
@@ -34,8 +34,8 @@ func initCA(t *testing.T, certsDir string) {
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, os.WriteFile(path.Join(certsDir, caCertFilename), certData, 0644))
-	require.NoError(t, os.WriteFile(path.Join(certsDir, caKeyFilename), keyData, 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, caCertFilename), certData, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, caKeyFilename), keyData, 0600))
 }
 
 func TestOCIRegistryManager_AddRegistry(t *testing.T) {
@@ -231,7 +231,7 @@ func TestOCIRegistryManager_GetRegistryClient_Settings(t *testing.T) {
 			name: "Valid OCI Registry with self-signed CA cert",
 			repoCfg: Repository{
 				URL:    testOCIRegistryURL,
-				CAFile: path.Join(certsDir, caCertFilename),
+				CAFile: filepath.Join(certsDir, caCertFilename),
 			},
 		},
 	}
@@ -299,8 +299,8 @@ func TestOCIRegistryManager_mTLS_Success(t *testing.T) {
 	initCA(t, certsDir)
 
 	// reuse CA cert as dummy client cert
-	clientCert := path.Join(certsDir, caCertFilename)
-	clientKey := path.Join(certsDir, caKeyFilename)
+	clientCert := filepath.Join(certsDir, caCertFilename)
+	clientKey := filepath.Join(certsDir, caKeyFilename)
 
 	m := newOCIRegistryManager()
 


### PR DESCRIPTION
## Description

Most (all?) of these code paths are not used in production on Windows, but they represent local file system paths and should use `filepath.Join()` rather than `path.Join()`.

Leave `path.Join()` alone when operating on anything other than local file system paths.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
