### PR TITLE
Check Go module versions more thoroughly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -277,7 +277,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/controller-manager v0.35.2 // indirect
-	k8s.io/cri-client v0.35.0 // indirect
+	k8s.io/cri-client v0.35.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kms v0.35.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect

--- a/pkg/constant/constant_test.go
+++ b/pkg/constant/constant_test.go
@@ -69,16 +69,27 @@ func TestKubernetesModuleVersions(t *testing.T) {
 			}
 		},
 		func(t *testing.T, pkgPath string, module *packages.Module) bool {
-			modVer := module.Version
+			expected := "v" + kubernetesVersion
 			if module.Path != "k8s.io/kubernetes" {
 				// All modules besides Kubernetes itself use v0 instead of v1.
-				modVer = strings.Replace(modVer, "v0.", "v1.", 1)
+				if suffix, found := strings.CutPrefix(expected, "v1."); found {
+					expected = "v0." + suffix
+				}
 			}
 
-			return !assert.Equal(t, "v"+kubernetesVersion, modVer,
+			ok := assert.Equal(t, expected, module.Version,
 				"Module version for package %s doesn't match: %+#v",
-				pkgPath, module,
-			)
+				pkgPath, module)
+			if module.Replace == nil {
+				return ok
+			}
+
+			ok = assert.Nil(t, module.Replace.Replace) && ok
+			ok = assert.Equal(t, module.Path, module.Replace.Path) && ok
+			ok = assert.Equal(t, expected, module.Replace.Version,
+				"Replacing module version for package %s doesn't match: %+#v",
+				pkgPath, module.Replace) && ok
+			return ok
 		},
 	)
 }
@@ -94,9 +105,11 @@ func TestEtcdModuleVersions(t *testing.T) {
 				strings.HasSuffix(modulePath, "/v"+etcdVersionParts[0])
 		},
 		func(t *testing.T, pkgPath string, module *packages.Module) bool {
-			return !assert.Equal(t, "v"+etcdVersion, module.Version,
+			ok := assert.Equal(t, "v"+etcdVersion, module.Version,
 				"Module version for package %s doesn't match: %+#v",
 			)
+			ok = assert.Nil(t, module.Replace) && ok
+			return ok
 		},
 	)
 }
@@ -109,10 +122,11 @@ func TestContainerdModuleVersions(t *testing.T) {
 			return modulePath == "github.com/containerd/containerd/v2"
 		},
 		func(t *testing.T, pkgPath string, module *packages.Module) bool {
-			return !assert.Equal(t, "v"+containerdVersion, module.Version,
+			ok := assert.Equal(t, "v"+containerdVersion, module.Version,
 				"Module version for package %s doesn't match: %+#v",
-				pkgPath, module,
 			)
+			ok = assert.Nil(t, module.Replace) && ok
+			return ok
 		},
 	)
 }
@@ -125,10 +139,11 @@ func TestKonnectivityModuleVersions(t *testing.T) {
 			return strings.HasPrefix(modulePath, "sigs.k8s.io/apiserver-network-proxy/")
 		},
 		func(t *testing.T, pkgPath string, module *packages.Module) bool {
-			return !assert.Equal(t, "v"+konnectivityVersion, module.Version,
+			ok := assert.Equal(t, "v"+konnectivityVersion, module.Version,
 				"Module version for package %s doesn't match: %+#v",
-				pkgPath, module,
 			)
+			ok = assert.Nil(t, module.Replace) && ok
+			return ok
 		},
 	)
 }
@@ -161,15 +176,10 @@ func checkPackageModules(t *testing.T, filter func(modulePath string) bool, chec
 
 	packages.Visit(pkgs, func(p *packages.Package) bool {
 		if p.Module != nil && filter(p.Module.Path) {
-			actual := p.Module
-			for actual.Replace != nil {
-				actual = actual.Replace
-			}
-
-			if !failedModules[actual.Path] {
+			if !failedModules[p.Module.Path] {
 				numMatched++
-				if !check(t, p.PkgPath, actual) {
-					failedModules[actual.Path] = true
+				if !check(t, p.PkgPath, p.Module) {
+					failedModules[p.Module.Path] = true
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Instead of only looking at the effective module, also look at the original one. This will catch inconsistencies in go.mod where the versions seem out of sync when they are not. These inconsistencies aren't a real problem, but they've caused me to waste brain cycles more than once, only to realize that they're replaced later on.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
