### PR TITLE
fix(autopilot): airgapupdate plan stuck on controller+worker nodes

### DIFF
--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -8,7 +8,6 @@ smoketests := \
 	check-addons \
 	check-airgap \
 	check-ap-airgap \
-	check-ap-airgap-controllerworker \
 	check-ap-controllerworker \
 	check-ap-ha3x3 \
 	check-ap-platformselect \
@@ -83,8 +82,7 @@ smoketests := \
 
 air_gapped_smoketests := \
 	check-airgap \
-	check-ap-airgap \
-	check-ap-airgap-controllerworker
+	check-ap-airgap
 
 ipv6_smoketests := \
 	check-calico-ipv6 \

--- a/inttest/ap-airgap/airgap_controllerworker_test.go
+++ b/inttest/ap-airgap/airgap_controllerworker_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 k0s authors
 // SPDX-License-Identifier: Apache-2.0
 
-package airgapcontrollerworker
+package airgap
 
 import (
 	"testing"
@@ -24,7 +24,6 @@ type airgapControllerWorkerSuite struct {
 	common.BootlooseSuite
 }
 
-// SetupTest prepares the controller+worker node and waits for it to be ready.
 func (s *airgapControllerWorkerSuite) SetupTest() {
 	ctx := s.Context()
 


### PR DESCRIPTION
## Description

Fix airgap update plans getting stuck in `SchedulableWait` on controller+worker (hybrid) nodes.

When a node runs as both a controller and worker (`--enable-worker`), only the autopilot **controller** component is started — the autopilot **worker** component is not. Airgap update signals are written as annotations on `v1.Node` objects, and the worker component is the only consumer of those signals. Since the worker component is never started on controller+worker nodes, the airgap signal on the `v1.Node` object is never processed and the plan gets permanently stuck in `SchedulableWait`.

The fix registers the airgap Node signal controllers on the controller component itself when `--enable-worker` is set and the delegate is a `ControlNode`. This ensures the airgap signal on `v1.Node` is handled even without a running worker component.

Fixes #7303

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Auto test added

The `ap-airgap` inttest was modifies with a new test case that:
1. Starts a single controller+worker node with `--enable-worker`
2. Submits an airgap update `Plan` targeting the node
3. Asserts the plan reaches `PlanCompleted` state (previously it would time out stuck in `SchedulableWait`)
4. Verifies the airgap bundle was placed on the node at `/var/lib/k0s/images/bundle.tar`

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
