### PR TITLE
Pin upload-release-asset GH action to node 20 for ARMv7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,7 +420,7 @@ jobs:
             /tmp/support-bundle.tar.gz
 
       - name: Upload Release Assets - Binary
-        uses: shogo82148/actions-upload-release-asset@v1.10.0
+        uses: shogo82148/actions-upload-release-asset@v1.8.2 # node20
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./k0s
@@ -428,7 +428,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Upload Release Assets - Signature
-        uses: shogo82148/actions-upload-release-asset@v1.10.0
+        uses: shogo82148/actions-upload-release-asset@v1.8.2 # node20
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./k0s.sig
@@ -442,7 +442,7 @@ jobs:
           path: ./k0s
 
       - name: Upload Release Assets - Bundle
-        uses: shogo82148/actions-upload-release-asset@v1.10.0
+        uses: shogo82148/actions-upload-release-asset@v1.8.2 # node20
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./airgap-image-bundle-linux-arm.tar


### PR DESCRIPTION
## Description

The ARMv7 runners still have issues with newer GH actions targeting node 20.

See:

* #7297

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
