### PR TITLE
inttest/cli: test with systemd based docker image

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -33,6 +33,17 @@ bootloose_alpine_build_cmdline := \
 	$(DOCKER) build --progress=plain --build-arg TARGETARCH=$(ARCH) $(bootloose_alpine_build_cmdline)
 	touch $@
 
+bootloose_systemd_build_cmdline := \
+	--build-arg ETCD_VERSION=$(etcd_version) \
+	--build-arg HELM_VERSION=$(helm_version) \
+	-t bootloose-systemd \
+	-f bootloose-systemd/Dockerfile \
+	bootloose-systemd
+
+.bootloose-systemd.stamp: $(shell find bootloose-systemd -type f)
+	$(DOCKER) build --progress=plain --build-arg TARGETARCH=$(ARCH) $(bootloose_systemd_build_cmdline)
+	touch $@
+
 # This is a special target to test the bootloose alpine image locally for all supported platforms.
 .PHONY: check-bootloose-alpine-buildx
 check-bootloose-alpine-buildx:

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -129,6 +129,8 @@ $(smoketests): export K0S_EXTRA_IMAGES_BUNDLE ?= $(realpath ../ipv6-test-image-b
 $(smoketests): K0S_INTTEST_PACKAGE ?= $(shell $(determine_inttest_package))
 $(smoketests): .bootloose-alpine.stamp
 	K0S_INTTEST_TARGET=$(subst check-,,$@) go test -count=1 -v -timeout $(TIMEOUT) github.com/k0sproject/k0s/inttest/$(K0S_INTTEST_PACKAGE)
+
+check-cli: .bootloose-systemd.stamp
 .PHONY: clean
 
 clean:

--- a/inttest/bootloose-systemd/Dockerfile
+++ b/inttest/bootloose-systemd/Dockerfile
@@ -1,0 +1,59 @@
+ARG UBUNTU_VERSION=24.04
+ARG TARGETARCH
+ARG ETCD_VERSION
+ARG HELM_VERSION
+ARG TROUBLESHOOT_VERSION=0.125.0 # renovate: datasource=github-releases depName=replicatedhq/troubleshoot
+
+FROM quay.io/k0sproject/bootloose-ubuntu$UBUNTU_VERSION
+
+ARG TARGETARCH
+ARG ETCD_VERSION
+ARG HELM_VERSION
+ARG TROUBLESHOOT_VERSION
+
+ENV container=docker
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    coreutils \
+    curl \
+    haproxy \
+    inotify-tools \
+    iproute2 \
+    iptables \
+    ipvsadm \
+    nginx \
+    openssh-server \
+    procps \
+    systemd \
+    systemd-sysv \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY root/ /
+
+RUN systemctl enable k0s-seed.service
+
+RUN curl --proto '=https' --tlsv1.2 -L https://github.com/replicatedhq/troubleshoot/releases/download/v$TROUBLESHOOT_VERSION/support-bundle_linux_$TARGETARCH.tar.gz \
+  | tar xzO support-bundle >/usr/local/bin/kubectl-supportbundle \
+  && chmod +x /usr/local/bin/kubectl-supportbundle
+
+RUN curl --proto '=https' --tlsv1.2 -L https://get.helm.sh/helm-v$HELM_VERSION-linux-$TARGETARCH.tar.gz \
+  | tar xzO linux-$TARGETARCH/helm >/usr/local/bin/helm \
+  && chmod +x /usr/local/bin/helm
+
+RUN if [ "$TARGETARCH" != "arm" ] && [ "$TARGETARCH" != "riscv64" ]; then \
+    curl --proto '=https' --tlsv1.2 -L https://github.com/etcd-io/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-$TARGETARCH.tar.gz \
+      | tar xz -C /opt --strip-components=1; \
+  fi
+
+RUN chmod +x /usr/local/bin/troubleshoot-k0s-inttest.sh
+
+RUN for u in etcd kube-apiserver kube-scheduler konnectivity-server; do \
+    useradd --system --shell /usr/sbin/nologin --home-dir /var/lib/k0s --no-create-home "$u"; \
+  done
+
+STOPSIGNAL SIGRTMIN+3
+
+CMD ["/lib/systemd/systemd"]

--- a/inttest/bootloose-systemd/root/etc/nginx/sites-available/default
+++ b/inttest/bootloose-systemd/root/etc/nginx/sites-available/default
@@ -1,0 +1,8 @@
+server {
+	listen 80 default_server;
+	listen [::]:80 default_server;
+
+	location / {
+		root /;
+	}
+}

--- a/inttest/bootloose-systemd/root/etc/systemd/system/k0s-seed.service
+++ b/inttest/bootloose-systemd/root/etc/systemd/system/k0s-seed.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Copy seeded k0s to /usr/local/bin
+DefaultDependencies=no
+After=local-fs.target
+Before=multi-user.target ssh.service
+ConditionPathExists=/dist/k0s
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/install -D -t /usr/local/bin /dist/k0s
+
+[Install]
+WantedBy=multi-user.target

--- a/inttest/bootloose-systemd/root/etc/troubleshoot/k0s-inttest.yaml
+++ b/inttest/bootloose-systemd/root/etc/troubleshoot/k0s-inttest.yaml
@@ -1,0 +1,24 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: k0s-inttest
+spec:
+  collectors:
+    - clusterResources: {}
+    - clusterInfo: {}
+    - logs: {}
+    - configMap:
+        collectorName: autopilot
+        namespace: autopilot
+        selector: [""] # we want all ConfigMaps
+        includeAllData: true
+    - configMap:
+        collectorName: default
+        namespace: default
+        selector: [""] # we want all ConfigMaps
+        includeAllData: true
+    - configMap:
+        collectorName: kube-system
+        namespace: kube-system
+        selector: [""] # we want all ConfigMaps
+        includeAllData: true

--- a/inttest/bootloose-systemd/root/usr/local/bin/troubleshoot-k0s-inttest.sh
+++ b/inttest/bootloose-systemd/root/usr/local/bin/troubleshoot-k0s-inttest.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+set -eu
+
+export KUBECONFIG="$1/pki/admin.conf"
+
+[ -f "$KUBECONFIG" ] || {
+  echo "kubeconfig not present: $KUBECONFIG" 1>&2
+  exit 1
+}
+
+bundleDir="$(mktemp -d)"
+trap 'rm -rf -- "$bundleDir"' INT EXIT
+kubectl-supportbundle \
+  --debug \
+  --interactive=false \
+  --output="$bundleDir/support-bundle.tar.gz" \
+  /etc/troubleshoot/k0s-inttest.yaml 1>&2
+cat -- "$bundleDir/support-bundle.tar.gz"

--- a/inttest/cli/cli_test.go
+++ b/inttest/cli/cli_test.go
@@ -15,8 +15,18 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type CliSuite struct {
+// cliInstallStartStopSmokeSuite provides TestK0sCliInstallStartStopSmoke to
+// both CliSuite and CliSystemdSuite via embedding.
+type cliInstallStartStopSmokeSuite struct {
 	common.BootlooseSuite
+}
+
+type CliSuite struct {
+	cliInstallStartStopSmokeSuite
+}
+
+type CliSystemdSuite struct {
+	cliInstallStartStopSmokeSuite
 }
 
 func (s *CliSuite) TestK0sCliCommandNegative() {
@@ -41,7 +51,7 @@ func (s *CliSuite) TestK0sCliCommandNegative() {
 	s.Require().Error(err)
 }
 
-func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
+func (s *cliInstallStartStopSmokeSuite) TestK0sCliInstallStartStopSmoke() {
 	ssh, err := s.SSH(s.Context(), s.ControllerNode(0))
 	s.Require().NoError(err, "failed to SSH into controller")
 	defer ssh.Disconnect()
@@ -110,9 +120,17 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 	s.Require().NoError(err)
 	_, err = ssh.ExecWithOutput(s.Context(), "while pidof k0s containerd kubelet; do sleep 0.1s; done")
 	s.Require().NoError(err)
+}
 
+func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
+	// TestK0sCliInstallStartStopSmoke runs first (alphabetical order) and leaves
+	// k0s installed but stopped; this test just verifies reset from that state.
 	s.Run("k0sReset", func() {
 		assert := s.Assertions
+		ssh, err := s.SSH(s.Context(), s.ControllerNode(0))
+		s.Require().NoError(err, "failed to SSH into controller")
+		defer ssh.Disconnect()
+
 		resetOutput, err := ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s reset --debug")
 		s.T().Logf("Reset executed with output:\n%s", resetOutput)
 
@@ -130,12 +148,27 @@ func (s *CliSuite) TestK0sCliKubectlAndResetCommand() {
 
 func TestCliCommandSuite(t *testing.T) {
 	s := CliSuite{
-		common.BootlooseSuite{
-			ControllerCount: 1,
-			// The tests start and stop k0s manually. Setting the launch mode to
-			// OpenRC here anyways, so that the log collection will pick up the
-			// right paths.
-			LaunchMode: common.LaunchModeOpenRC,
+		cliInstallStartStopSmokeSuite{
+			common.BootlooseSuite{
+				ControllerCount: 1,
+				// The tests start and stop k0s manually. Setting the launch mode to
+				// OpenRC here anyways, so that the log collection will pick up the
+				// right paths.
+				LaunchMode: common.LaunchModeOpenRC,
+			},
+		},
+	}
+	suite.Run(t, &s)
+}
+
+func TestCliSystemdCommandSuite(t *testing.T) {
+	s := CliSystemdSuite{
+		cliInstallStartStopSmokeSuite{
+			common.BootlooseSuite{
+				ControllerCount: 1,
+				LaunchMode:      common.LaunchModeSystemd,
+				BootLooseImage:  "bootloose-systemd",
+			},
 		},
 	}
 	suite.Run(t, &s)

--- a/inttest/common/bootloosesuite.go
+++ b/inttest/common/bootloosesuite.go
@@ -140,11 +140,15 @@ func (s *BootlooseSuite) initializeDefaults() {
 		s.launchDelegate = &standaloneLaunchDelegate{s.K0sFullPath, s.ControllerUmask}
 	case LaunchModeOpenRC:
 		s.launchDelegate = &openRCLaunchDelegate{s.K0sFullPath}
+	case LaunchModeSystemd:
+		s.launchDelegate = &systemdLaunchDelegate{s.K0sFullPath}
 	default:
 		s.Require().Fail("Unknown launch mode", s.LaunchMode)
 	}
 
-	s.BootLooseImage = os.Getenv("BOOTLOOSE_IMAGE")
+	if s.BootLooseImage == "" {
+		s.BootLooseImage = os.Getenv("BOOTLOOSE_IMAGE")
+	}
 	if s.BootLooseImage == "" {
 		s.BootLooseImage = defaultBootLooseImage
 	}

--- a/inttest/common/launchdelegate.go
+++ b/inttest/common/launchdelegate.go
@@ -170,9 +170,9 @@ func (o *openRCLaunchDelegate) StartController(ctx context.Context, conn *SSHCon
 
 // StopController stops a k0s controller that was started using OpenRC.
 func (*openRCLaunchDelegate) StopController(ctx context.Context, conn *SSHConnection) error {
-	startCmd := "/etc/init.d/k0scontroller stop"
-	if err := conn.Exec(ctx, startCmd, SSHStreams{}); err != nil {
-		return fmt.Errorf("unable to execute %q: %w", startCmd, err)
+	cmd := "/etc/init.d/k0scontroller stop"
+	if err := conn.Exec(ctx, cmd, SSHStreams{}); err != nil {
+		return fmt.Errorf("unable to execute %q: %w", cmd, err)
 	}
 	return nil
 }
@@ -210,9 +210,9 @@ func (o *openRCLaunchDelegate) StartWorker(ctx context.Context, conn *SSHConnect
 
 // StopWorker stops a k0s worker that was started using OpenRC.
 func (*openRCLaunchDelegate) StopWorker(ctx context.Context, conn *SSHConnection) error {
-	startCmd := "/etc/init.d/k0sworker stop"
-	if err := conn.Exec(ctx, startCmd, SSHStreams{}); err != nil {
-		return fmt.Errorf("unable to execute %q: %w", startCmd, err)
+	cmd := "/etc/init.d/k0sworker stop"
+	if err := conn.Exec(ctx, cmd, SSHStreams{}); err != nil {
+		return fmt.Errorf("unable to execute %q: %w", cmd, err)
 	}
 	return nil
 }

--- a/inttest/common/launchdelegate.go
+++ b/inttest/common/launchdelegate.go
@@ -18,6 +18,7 @@ type LaunchMode string
 const (
 	LaunchModeStandalone LaunchMode = "standalone"
 	LaunchModeOpenRC     LaunchMode = "OpenRC"
+	LaunchModeSystemd    LaunchMode = "systemd"
 )
 
 // launchDelegate provides an indirection to the launch operations in
@@ -257,6 +258,99 @@ func configureK0sServiceArgs(ctx context.Context, conn *SSHConnection, k0sType s
 	_, err := conn.ExecWithOutput(ctx, cmd)
 	if err != nil {
 		return fmt.Errorf("failed to execute '%s' on %s: %w", cmd, conn.Address, err)
+	}
+
+	return nil
+}
+
+// systemdLaunchDelegate is a launchDelegate that starts controllers and workers
+// via a systemd service.
+type systemdLaunchDelegate struct {
+	k0sFullPath string
+}
+
+var _ launchDelegate = (*systemdLaunchDelegate)(nil)
+
+func (s *systemdLaunchDelegate) InitController(ctx context.Context, conn *SSHConnection, k0sArgs ...string) error {
+	if err := s.installK0sService(ctx, conn, "controller"); err != nil {
+		return fmt.Errorf("unable to install systemd k0s controller: %w", err)
+	}
+
+	controllerArgs := "controller --debug " + strings.Join(k0sArgs, " ")
+	if err := s.configureK0sServiceArgs(ctx, conn, "controller", controllerArgs); err != nil {
+		return fmt.Errorf("failed to configure k0s with %q: %w", controllerArgs, err)
+	}
+
+	return s.StartController(ctx, conn)
+}
+
+func (s *systemdLaunchDelegate) StartController(ctx context.Context, conn *SSHConnection) error {
+	return s.systemctl(ctx, conn, "start", "controller")
+}
+
+func (s *systemdLaunchDelegate) StopController(ctx context.Context, conn *SSHConnection) error {
+	return s.systemctl(ctx, conn, "stop", "controller")
+}
+
+func (s *systemdLaunchDelegate) InitWorker(ctx context.Context, conn *SSHConnection, token string, k0sArgs ...string) error {
+	if err := s.installK0sService(ctx, conn, "worker"); err != nil {
+		return fmt.Errorf("unable to install systemd k0s worker: %w", err)
+	}
+
+	workerArgs := fmt.Sprintf("worker --debug %s %s", strings.Join(k0sArgs, " "), token)
+	if err := s.configureK0sServiceArgs(ctx, conn, "worker", workerArgs); err != nil {
+		return fmt.Errorf("failed to configure k0s with %q: %w", workerArgs, err)
+	}
+
+	return s.StartWorker(ctx, conn)
+}
+
+func (s *systemdLaunchDelegate) StartWorker(ctx context.Context, conn *SSHConnection) error {
+	return s.systemctl(ctx, conn, "start", "worker")
+}
+
+func (s *systemdLaunchDelegate) StopWorker(ctx context.Context, conn *SSHConnection) error {
+	return s.systemctl(ctx, conn, "stop", "worker")
+}
+
+func (s *systemdLaunchDelegate) systemctl(ctx context.Context, conn *SSHConnection, action, k0sType string) error {
+	cmd := fmt.Sprintf("systemctl %s k0s%s.service", action, k0sType)
+	if err := conn.Exec(ctx, cmd, SSHStreams{}); err != nil {
+		return fmt.Errorf("unable to execute %q: %w", cmd, err)
+	}
+	return nil
+}
+
+func (*systemdLaunchDelegate) ReadK0sLogs(ctx context.Context, conn *SSHConnection, out, _ io.Writer) error {
+	const cmd = "journalctl --no-pager -u k0scontroller.service -u k0sworker.service"
+	return conn.Exec(ctx, cmd, SSHStreams{Out: out})
+}
+
+func (s *systemdLaunchDelegate) installK0sService(ctx context.Context, conn *SSHConnection, k0sType string) error {
+	serviceFile := "/etc/systemd/system/k0s" + k0sType + ".service"
+	existsCommand := "/usr/bin/file " + serviceFile
+	if _, err := conn.ExecWithOutput(ctx, existsCommand); err != nil {
+		cmd := fmt.Sprintf("%s install %s", s.k0sFullPath, k0sType)
+		if err := conn.Exec(ctx, cmd, SSHStreams{}); err != nil {
+			return fmt.Errorf("unable to execute %q: %w", cmd, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *systemdLaunchDelegate) configureK0sServiceArgs(ctx context.Context, conn *SSHConnection, k0sType string, args string) error {
+	serviceName := "k0s" + k0sType + ".service"
+	overrideDir := "/etc/systemd/system/" + serviceName + ".d"
+	overrideCmd := fmt.Sprintf(
+		"mkdir -p %[1]s && cat >%[1]s/override.conf <<'EOF'\n[Service]\nExecStart=\nExecStart=%[2]s %[3]s\nEOF\nsystemctl daemon-reload",
+		overrideDir,
+		s.k0sFullPath,
+		args,
+	)
+
+	if err := conn.Exec(ctx, overrideCmd, SSHStreams{}); err != nil {
+		return fmt.Errorf("failed to execute override update for %s on %s: %w", serviceName, conn.Address, err)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Add Ubuntu image for bootloose so we can test that k0s install/start/stop works with systemd units.

ref: https://github.com/k0sproject/k0s/pull/7053

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
