### PR TITLE
Docs: Remove minio from storage.md

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -22,7 +22,6 @@ Follow your storage driver's installation instructions. Note that by default the
 Different Kubernetes storage solutions are explained in the [official Kubernetes storage documentation](https://kubernetes.io/docs/concepts/storage/volumes/). All of them can be used with k0s. Here are some popular ones:
 
 - Rook-Ceph (Open Source)
-- MinIO (Open Source)
 - GlusterFS (Open Source)
 - Longhorn (Open Source)
 - Amazon EBS


### PR DESCRIPTION
## Description

[MinIO](https://github.com/minio/minio) is no longer maintained as an open-source distribution. It should not be recommended as a CSI backend, or at least not be listed as "open source".

No gh issue opened.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

Ran the local docs server and the change appears as expected.

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
