### PR TITLE
Fix kube-dns address on dualstack clusters

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -220,7 +220,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 	logrus.Infof("using listen port: %d", nodeConfig.Spec.API.Port)
 	logrus.Infof("using sans: %s", nodeConfig.Spec.API.SANs)
 
-	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress()
+	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.PrimaryAddressFamily())
 	if err != nil {
 		return err
 	}
@@ -530,7 +530,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 		workerConfigLeasePool := leaderelector.NewLeasePool(c.K0sVars.InvocationID, adminClientFactory, leaseName)
 		clusterComponents.Add(ctx, workerConfigLeasePool)
 
-		reconciler, err := workerconfig.NewReconciler(c.K0sVars, nodeConfig.Spec, adminClientFactory, workerConfigLeasePool, enableKonnectivity, disableAutopilot)
+		reconciler, err := workerconfig.NewReconciler(c.K0sVars, nodeConfig, adminClientFactory, workerConfigLeasePool, enableKonnectivity, disableAutopilot)
 		if err != nil {
 			return err
 		}

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -187,6 +187,9 @@ func (s *DualstackSuite) SetupSuite() {
 	s.Require().NoError(err)
 	s.client = client
 
+	s.T().Log("Validate the kube-dns service address")
+	s.validateKubeDNSIP(client)
+
 	s.T().Log("Verifying that pods didn't restart")
 	// CoreDNS may not be ready when we finish the test, which can break VerifyNoRestartedPods,
 	// so we need to wait for it first.
@@ -194,6 +197,18 @@ func (s *DualstackSuite) SetupSuite() {
 	// Verify that there aren't containers restarted on kube-system
 	for _, err := range common.VerifyNoRestartedPods(s.Context(), client) {
 		s.NoError(err)
+	}
+}
+
+func (s *DualstackSuite) validateKubeDNSIP(client *k8s.Clientset) {
+	svc, err := client.CoreV1().Services(metav1.NamespaceSystem).Get(s.Context(), "kube-dns", metav1.GetOptions{})
+	s.NoError(err, "failed to get service kube-dns")
+	svcIP := net.ParseIP(svc.Spec.ClusterIP)
+	if s.defaultIPv6 {
+		s.Require().Nil(svcIP.To4(), "kube-dns has an unexpected IPv4 address")
+		s.Require().NotNil(svcIP.To16(), "kube-dns has an invalid IP address")
+	} else {
+		s.Require().NotNil(svcIP.To4(), "kube-dns has an unexpected non IPv4 address")
 	}
 }
 

--- a/pkg/apis/k0s/v1beta1/network.go
+++ b/pkg/apis/k0s/v1beta1/network.go
@@ -186,10 +186,15 @@ func (n *Network) Validate() []error {
 }
 
 // DNSAddress calculates the 10th address of configured service CIDR block.
-func (n *Network) DNSAddress() (string, error) {
-	_, ipnet, err := net.ParseCIDR(n.ServiceCIDR)
+func (n *Network) DNSAddress(primaryAddressFamily PrimaryAddressFamilyType) (string, error) {
+	serviceCIDR := n.ServiceCIDR
+	if n.DualStack.Enabled && primaryAddressFamily == PrimaryFamilyIPv6 {
+		serviceCIDR = n.DualStack.IPv6ServiceCIDR
+	}
+
+	_, ipnet, err := net.ParseCIDR(serviceCIDR)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse service CIDR %q: %w", n.ServiceCIDR, err)
+		return "", fmt.Errorf("failed to parse service CIDR %q: %w", serviceCIDR, err)
 	}
 
 	addr := slices.Clone(ipnet.IP)

--- a/pkg/apis/k0s/v1beta1/network_test.go
+++ b/pkg/apis/k0s/v1beta1/network_test.go
@@ -19,38 +19,38 @@ type NetworkSuite struct {
 func (s *NetworkSuite) TestAddresses() {
 	s.Run("DNS_default_service_cidr", func() {
 		n := DefaultNetwork()
-		dns, err := n.DNSAddress()
+		dns, err := n.DNSAddress(PrimaryFamilyIPv4)
 		s.Require().NoError(err)
 		s.Equal("10.96.0.10", dns)
 	})
 	s.Run("DNS_uses_non_default_service_cidr", func() {
 		n := DefaultNetwork()
 		n.ServiceCIDR = "10.96.0.248/29"
-		dns, err := n.DNSAddress()
+		dns, err := n.DNSAddress(PrimaryFamilyIPv4)
 		s.Require().NoError(err)
 		s.Equal("10.96.0.250", dns)
 	})
 	s.Run("DNS_service_cidr_too_narrow", func() {
 		n := Network{ServiceCIDR: "192.168.178.0/31"}
-		dns, err := n.DNSAddress()
+		dns, err := n.DNSAddress(PrimaryFamilyIPv4)
 		s.Empty(dns)
 		s.ErrorContains(err, "failed to calculate DNS address: CIDR too narrow: 192.168.178.0/31")
 	})
 	s.Run("DNS_uses_v6_service_cidr", func() {
 		n := Network{ServiceCIDR: "fd00:abcd:1234::/64"}
-		dns, err := n.DNSAddress()
+		dns, err := n.DNSAddress(PrimaryFamilyIPv6)
 		s.NoError(err)
 		s.Equal("fd00:abcd:1234::a", dns)
 	})
 	s.Run("DNS_uses_v6_small_service_cidr", func() {
 		n := Network{ServiceCIDR: "fd00::/126"}
-		dns, err := n.DNSAddress()
+		dns, err := n.DNSAddress(PrimaryFamilyIPv6)
 		s.NoError(err)
 		s.Equal("fd00::2", dns)
 	})
 	s.Run("DNS_service_v6_cidr_too_narrow", func() {
 		n := Network{ServiceCIDR: "fd00::/127"}
-		dns, err := n.DNSAddress()
+		dns, err := n.DNSAddress(PrimaryFamilyIPv6)
 		s.Empty(dns)
 		s.ErrorContains(err, "failed to calculate DNS address: CIDR too narrow: fd00::/127")
 	})

--- a/pkg/component/controller/calico.go
+++ b/pkg/component/controller/calico.go
@@ -93,7 +93,7 @@ type calicoClusterConfig struct {
 
 // NewCalico creates new Calico reconciler component
 func NewCalico(nodeConfig *v1beta1.ClusterConfig, manifestsDir string, hasWindowsNodes func() (*bool, <-chan struct{})) (*Calico, error) {
-	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress()
+	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.PrimaryAddressFamily())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -293,7 +293,7 @@ type coreDNSConfig struct {
 
 // NewCoreDNS creates new instance of CoreDNS component
 func NewCoreDNS(k0sVars *config.CfgVars, clientFactory k8sutil.ClientFactoryInterface, nodeConfig *v1beta1.ClusterConfig) (*CoreDNS, error) {
-	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress()
+	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.PrimaryAddressFamily())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -83,10 +83,10 @@ var (
 )
 
 // NewReconciler creates a new reconciler for worker configurations.
-func NewReconciler(k0sVars *config.CfgVars, nodeSpec *v1beta1.ClusterSpec, clientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface, konnectivityEnabled, autopilotDisabled bool) (*Reconciler, error) {
+func NewReconciler(k0sVars *config.CfgVars, nodeConfig *v1beta1.ClusterConfig, clientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface, konnectivityEnabled, autopilotDisabled bool) (*Reconciler, error) {
 	log := logrus.WithFields(logrus.Fields{"component": "workerconfig.Reconciler"})
 
-	clusterDNSIPString, err := nodeSpec.Network.DNSAddress()
+	clusterDNSIPString, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.PrimaryAddressFamily())
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func NewReconciler(k0sVars *config.CfgVars, nodeSpec *v1beta1.ClusterSpec, clien
 	reconciler := &Reconciler{
 		log: log,
 
-		clusterDomain:       nodeSpec.Network.ClusterDomain,
+		clusterDomain:       nodeConfig.Spec.Network.ClusterDomain,
 		clusterDNSIP:        clusterDNSIP,
 		clientFactory:       clientFactory,
 		leaderElector:       leaderElector,

--- a/pkg/component/controller/workerconfig/reconciler_test.go
+++ b/pkg/component/controller/workerconfig/reconciler_test.go
@@ -49,11 +49,13 @@ func TestReconciler_Lifecycle(t *testing.T) {
 		require.NoError(t, err)
 		underTest, err := NewReconciler(
 			k0sVars,
-			&v1beta1.ClusterSpec{
-				API: &v1beta1.APISpec{},
-				Network: &v1beta1.Network{
-					ClusterDomain: "test.local",
-					ServiceCIDR:   "99.99.99.0/24",
+			&v1beta1.ClusterConfig{
+				Spec: &v1beta1.ClusterSpec{
+					API: &v1beta1.APISpec{},
+					Network: &v1beta1.Network{
+						ClusterDomain: "test.local",
+						ServiceCIDR:   "99.99.99.0/24",
+					},
 				},
 			},
 			clients,
@@ -305,11 +307,13 @@ func TestReconciler_ResourceGeneration(t *testing.T) {
 	require.NoError(t, err)
 	underTest, err := NewReconciler(
 		k0sVars,
-		&v1beta1.ClusterSpec{
-			API: &v1beta1.APISpec{},
-			Network: &v1beta1.Network{
-				ClusterDomain: "test.local",
-				ServiceCIDR:   "99.99.99.0/24",
+		&v1beta1.ClusterConfig{
+			Spec: &v1beta1.ClusterSpec{
+				API: &v1beta1.APISpec{},
+				Network: &v1beta1.Network{
+					ClusterDomain: "test.local",
+					ServiceCIDR:   "99.99.99.0/24",
+				},
 			},
 		},
 		clients,
@@ -489,11 +493,13 @@ func TestReconciler_ReconcilesOnChangesOnly(t *testing.T) {
 	require.NoError(t, err)
 	underTest, err := NewReconciler(
 		k0sVars,
-		&v1beta1.ClusterSpec{
-			API: &v1beta1.APISpec{},
-			Network: &v1beta1.Network{
-				ClusterDomain: "test.local",
-				ServiceCIDR:   "99.99.99.0/24",
+		&v1beta1.ClusterConfig{
+			Spec: &v1beta1.ClusterSpec{
+				API: &v1beta1.APISpec{},
+				Network: &v1beta1.Network{
+					ClusterDomain: "test.local",
+					ServiceCIDR:   "99.99.99.0/24",
+				},
 			},
 		},
 		clients,
@@ -640,11 +646,13 @@ func TestReconciler_LeaderElection(t *testing.T) {
 	require.NoError(t, err)
 	underTest, err := NewReconciler(
 		k0sVars,
-		&v1beta1.ClusterSpec{
-			API: &v1beta1.APISpec{},
-			Network: &v1beta1.Network{
-				ClusterDomain: "test.local",
-				ServiceCIDR:   "99.99.99.0/24",
+		&v1beta1.ClusterConfig{
+			Spec: &v1beta1.ClusterSpec{
+				API: &v1beta1.APISpec{},
+				Network: &v1beta1.Network{
+					ClusterDomain: "test.local",
+					ServiceCIDR:   "99.99.99.0/24",
+				},
 			},
 		},
 		clients,


### PR DESCRIPTION
## Description

Before this DNSAddress always was always set pbased on n.ServiceCIDR even if it was a dualstack cluster and the primaryAddressFamily was IPv6.

Fixes #7294

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
