### PR TITLE
[inttest] containerd v1 to v2 live migration

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -461,7 +461,6 @@ jobs:
       - name: "Docker prune"
         if: always()
         run: docker system prune --force --filter "until=$((24*7))h"
-  
   win-wsl-smoketest:
     name: "Windows WSL Smoketest"
     needs: [build-k0s]

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -31,6 +31,7 @@ smoketests := \
 	check-configchange \
 	check-containerd-deprecations \
 	check-containerdimports \
+	check-containerdupgrade \
 	check-cplb-ipvs \
 	check-cplb-ipvs-ipv6 \
 	check-cplb-userspace \

--- a/inttest/containerdupgrade/containerdupgrade_test.go
+++ b/inttest/containerdupgrade/containerdupgrade_test.go
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+package containerdupgrade
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/k0sproject/version"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+type ContainerdUpgradeSuite struct {
+	common.BootlooseSuite
+}
+
+func (s *ContainerdUpgradeSuite) TestContainerdUpgrade() {
+	ctx := s.Context()
+	var kc *kubernetes.Clientset
+	var oldPIDs map[string]int
+
+	s.Run("controller_and_workers_get_up", func() {
+		s.Require().NoError(s.InitController(0))
+		// get the latest 1.35 stable release so that we start the node with containerd 1.7.x
+		s.downloadRelease(ctx, s.WorkerNode(0), s.getLast35Release(ctx))
+		s.Require().NoError(s.RunWorkers())
+
+		var err error
+		kc, err = s.KubeClient(s.ControllerNode(0))
+		s.Require().NoError(err)
+
+		s.Require().NoError(s.WaitForNodeReady("worker0", kc))
+		s.ensureContainerdVersion(ctx, s.WorkerNode(0), "1.7")
+	})
+
+	s.Run("launch_test_pods", func() {
+		for _, podName := range []string{"nginx-kill", "nginx-graceful"} {
+			_, err := kc.CoreV1().Pods(metav1.NamespaceDefault).Create(ctx, &corev1.Pod{
+				TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: podName},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "nginx", Image: "docker.io/library/nginx:1.29.6-alpine"}},
+				},
+			}, metav1.CreateOptions{})
+			s.Require().NoError(err)
+		}
+	})
+
+	s.Run("gather_pids_before_upgrade", func() {
+		s.Require().NoError(common.WaitForCoreDNSReady(ctx, kc))
+		s.Require().NoError(common.WaitForDaemonSet(ctx, kc, "konnectivity-agent", metav1.NamespaceSystem))
+		s.Require().NoError(common.WaitForDaemonSet(ctx, kc, "kube-proxy", metav1.NamespaceSystem))
+		s.Require().NoError(common.WaitForDaemonSet(ctx, kc, "kube-router", metav1.NamespaceSystem))
+		s.Require().NoError(common.WaitForPod(ctx, kc, "nginx-kill", metav1.NamespaceDefault), "nginx pod did not start")
+		s.Require().NoError(common.WaitForPod(ctx, kc, "nginx-graceful", metav1.NamespaceDefault), "nginx pod did not start")
+		oldPIDs = s.gatherPIDs(ctx, s.WorkerNode(0))
+	})
+
+	s.Run("upgrade_k0s_to_testing_version", func() {
+		s.Require().NoError(s.StopWorker(s.WorkerNode(0)))
+		s.upgradeContainerdToTesting(ctx, s.WorkerNode(0))
+		s.Require().NoError(s.StartWorker(s.WorkerNode(0)))
+
+		// Grace period to ensure contianerd is up and running
+		time.Sleep(30 * time.Second)
+		s.Require().NoError(s.WaitForNodeReady(s.WorkerNode(0), kc))
+		s.ensureContainerdVersion(ctx, s.WorkerNode(0), "2.2")
+	})
+
+	s.Run("validate_no_restarts", func() {
+		newPIDs := s.gatherPIDs(ctx, s.WorkerNode(0))
+		s.Require().Equal(oldPIDs, newPIDs, "PIDs of running containers changed after containerd upgrade")
+	})
+
+	s.Run("gracefully_terminate_nginx_pod", func() {
+		s.Require().NoError(kc.CoreV1().Pods(metav1.NamespaceDefault).Delete(ctx, "nginx-graceful", metav1.DeleteOptions{}))
+		s.Require().NoError(wait.PollUntilContextCancel(ctx, 1*time.Second, false, func(ctx context.Context) (bool, error) {
+			_, err := kc.CoreV1().Pods(metav1.NamespaceDefault).Get(ctx, "nginx-graceful", metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}))
+	})
+
+	s.Run("force_kill_nginx_pod", func() {
+		s.forceKillNginx(ctx, s.WorkerNode(0))
+		s.Require().NoError(wait.PollUntilContextCancel(ctx, 1*time.Second, false, func(ctx context.Context) (bool, error) {
+			pod, err := kc.CoreV1().Pods(metav1.NamespaceDefault).Get(ctx, "nginx-kill", metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			if err != nil {
+				return false, err
+			}
+			return pod.Status.ContainerStatuses[0].RestartCount > 0, nil
+		}))
+	})
+}
+
+func (s *ContainerdUpgradeSuite) forceKillNginx(ctx context.Context, node string) {
+	ssh, err := s.SSH(ctx, node)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	_, err = ssh.ExecWithOutput(ctx, "pkill -9 'nginx: master process nginx'")
+	s.Require().NoError(err)
+}
+
+func (s *ContainerdUpgradeSuite) upgradeContainerdToTesting(ctx context.Context, node string) {
+	ssh, err := s.SSH(ctx, node)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	_, err = ssh.ExecWithOutput(ctx, "rm -f /usr/local/bin/k0s")
+	s.Require().NoError(err)
+	_, err = ssh.ExecWithOutput(ctx, "mv /usr/local/bin/k0s-to-test /usr/local/bin/k0s")
+	s.Require().NoError(err)
+}
+
+func (s *ContainerdUpgradeSuite) ensureContainerdVersion(ctx context.Context, node string, expectedVersion string) {
+	ssh, err := s.SSH(ctx, node)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	output, err := ssh.ExecWithOutput(ctx, "k0s ctr version")
+	s.Require().NoError(err)
+	for line := range strings.Lines(output) {
+		if strings.Contains(line, "Version:") {
+			s.Require().Contains(line, fmt.Sprintf(" %s.", expectedVersion))
+		}
+	}
+}
+
+func (s *ContainerdUpgradeSuite) downloadRelease(ctx context.Context, node string, release string) {
+	ssh, err := s.SSH(ctx, node)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	arch, err := ssh.ExecWithOutput(ctx, "uname -m")
+	s.Require().NoError(err)
+	switch arch {
+	case "x86_64":
+		arch = "amd64"
+	case "aarch64":
+		arch = "arm64"
+	case "armv7l":
+		arch = "arm"
+	default:
+		s.Failf("unsupported architecture: %s", arch)
+	}
+
+	_, err = ssh.ExecWithOutput(ctx, "mv /usr/local/bin/k0s /usr/local/bin/k0s-to-test")
+	s.Require().NoError(err)
+
+	url := fmt.Sprintf("https://github.com/k0sproject/k0s/releases/download/%s/k0s-%s-%s", release, release, arch)
+
+	s.T().Logf("Downloading k0s release %s for architecture %s from URL: %s", release, arch, url)
+	_, err = ssh.ExecWithOutput(ctx, "wget -qO /usr/local/bin/k0s "+url)
+	s.Require().NoError(err)
+
+	_, err = ssh.ExecWithOutput(ctx, "chmod +x /usr/local/bin/k0s")
+	s.Require().NoError(err)
+}
+
+func (s *ContainerdUpgradeSuite) getLast35Release(ctx context.Context) string {
+	type Release struct {
+		Name string `json:"name"`
+	}
+
+	url := "https://api.github.com/repos/k0sproject/k0s/releases?per_page=10"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	s.Require().NoError(err, "failed to create request")
+
+	resp, err := http.DefaultClient.Do(req)
+	s.Require().NoError(err, "failed to fetch releases")
+	defer resp.Body.Close()
+
+	s.Require().Equal(http.StatusOK, resp.StatusCode, "unexpected status code from GitHub API")
+
+	var releases []Release
+	err = json.NewDecoder(resp.Body).Decode(&releases)
+	s.Require().NoError(err, "failed to decode releases response")
+
+	constraint := version.MustConstraint(">=1.35.0, <1.36.0")
+
+	var latestVersion *version.Version
+	var latestTag string
+
+	for _, release := range releases {
+		ver := version.MustParse(release.Name)
+		if !constraint.Check(ver) {
+			continue
+		}
+
+		if latestVersion == nil || ver.GreaterThan(latestVersion) {
+			latestVersion = ver
+			latestTag = release.Name
+		}
+	}
+
+	s.Require().NotEmpty(latestTag, "no 1.35.x release found")
+	return latestTag
+}
+
+func (s *ContainerdUpgradeSuite) gatherPIDs(ctx context.Context, name string) map[string]int {
+	type namespace struct {
+		Type string `json:"type"`
+		Path string `json:"path,omitempty"`
+	}
+
+	type containerInfo struct {
+		Labels map[string]string `json:"Labels"`
+		Spec   struct {
+			Linux struct {
+				Namespaces []namespace `json:"namespaces"`
+			} `json:"linux"`
+		} `json:"Spec"`
+	}
+
+	ssh, err := s.SSH(ctx, name)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	output, err := ssh.ExecWithOutput(ctx, "k0s ctr container list --quiet")
+	s.Require().NoError(err)
+
+	pidMap := make(map[string]int)
+
+	for _, containerID := range strings.Fields(output) {
+		infoOutput, err := ssh.ExecWithOutput(ctx, "k0s ctr container info "+containerID)
+		s.Require().NoError(err)
+
+		var info containerInfo
+		s.Require().NoError(json.Unmarshal([]byte(infoOutput), &info))
+
+		// We cannot get the PID from sandbox containers
+		if info.Labels["io.cri-containerd.kind"] != "container" {
+			continue
+		}
+
+		podName := info.Labels["io.kubernetes.pod.name"]
+		for _, ns := range info.Spec.Linux.Namespaces {
+			if m := regexp.MustCompile(`^/proc/(\d+)/ns/`).FindStringSubmatch(ns.Path); m != nil {
+				pid, err := strconv.Atoi(m[1])
+				s.Require().NoError(err)
+				pidMap[podName] = pid
+				break
+			}
+		}
+	}
+	return pidMap
+}
+
+func TestContainerdUpgradeSuite(t *testing.T) {
+	s := ContainerdUpgradeSuite{
+		common.BootlooseSuite{
+			LaunchMode:      common.LaunchModeOpenRC,
+			ControllerCount: 1,
+			WorkerCount:     1,
+		},
+	}
+	suite.Run(t, &s)
+}


### PR DESCRIPTION
## Description

Implement a test that verifies that the transition between containerd v1 and v2 can be done without restarting pods.

Fixes #7348

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
