### PR TITLE
[Backport release-1.34] Fix kube-dns address on dualstack clusters

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -222,7 +222,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 	logrus.Infof("using listen port: %d", nodeConfig.Spec.API.Port)
 	logrus.Infof("using sans: %s", nodeConfig.Spec.API.SANs)
 
-	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress()
+	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.PrimaryAddressFamily())
 	if err != nil {
 		return err
 	}
@@ -528,7 +528,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 		workerConfigLeasePool := leaderelector.NewLeasePool(c.K0sVars.InvocationID, adminClientFactory, leaseName)
 		clusterComponents.Add(ctx, workerConfigLeasePool)
 
-		reconciler, err := workerconfig.NewReconciler(c.K0sVars, nodeConfig.Spec, adminClientFactory, workerConfigLeasePool, enableKonnectivity)
+		reconciler, err := workerconfig.NewReconciler(c.K0sVars, nodeConfig, adminClientFactory, workerConfigLeasePool, enableKonnectivity)
 		if err != nil {
 			return err
 		}

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -186,6 +186,21 @@ func (s *DualstackSuite) SetupSuite() {
 	})
 	s.Require().NoError(err)
 	s.client = client
+
+	s.T().Log("Validate the kube-dns service address")
+	s.validateKubeDNSIP(client)
+}
+
+func (s *DualstackSuite) validateKubeDNSIP(client *k8s.Clientset) {
+	svc, err := client.CoreV1().Services(metav1.NamespaceSystem).Get(s.Context(), "kube-dns", metav1.GetOptions{})
+	s.NoError(err, "failed to get service kube-dns")
+	svcIP := net.ParseIP(svc.Spec.ClusterIP)
+	if s.defaultIPv6 {
+		s.Require().Nil(svcIP.To4(), "kube-dns has an unexpected IPv4 address")
+		s.Require().NotNil(svcIP.To16(), "kube-dns has an invalid IP address")
+	} else {
+		s.Require().NotNil(svcIP.To4(), "kube-dns has an unexpected non IPv4 address")
+	}
 }
 
 func (s *DualstackSuite) getIPv6Address(nodeName string) string {

--- a/pkg/apis/k0s/v1beta1/network.go
+++ b/pkg/apis/k0s/v1beta1/network.go
@@ -164,10 +164,15 @@ func (n *Network) Validate() []error {
 }
 
 // DNSAddress calculates the 10th address of configured service CIDR block.
-func (n *Network) DNSAddress() (string, error) {
-	_, ipnet, err := net.ParseCIDR(n.ServiceCIDR)
+func (n *Network) DNSAddress(primaryAddressFamily PrimaryAddressFamilyType) (string, error) {
+	serviceCIDR := n.ServiceCIDR
+	if n.DualStack.Enabled && primaryAddressFamily == PrimaryFamilyIPv6 {
+		serviceCIDR = n.DualStack.IPv6ServiceCIDR
+	}
+
+	_, ipnet, err := net.ParseCIDR(serviceCIDR)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse service CIDR %q: %w", n.ServiceCIDR, err)
+		return "", fmt.Errorf("failed to parse service CIDR %q: %w", serviceCIDR, err)
 	}
 
 	addr := slices.Clone(ipnet.IP)

--- a/pkg/apis/k0s/v1beta1/network_test.go
+++ b/pkg/apis/k0s/v1beta1/network_test.go
@@ -19,38 +19,38 @@ type NetworkSuite struct {
 func (s *NetworkSuite) TestAddresses() {
 	s.Run("DNS_default_service_cidr", func() {
 		n := DefaultNetwork()
-		dns, err := n.DNSAddress()
+		dns, err := n.DNSAddress(PrimaryFamilyIPv4)
 		s.Require().NoError(err)
 		s.Equal("10.96.0.10", dns)
 	})
 	s.Run("DNS_uses_non_default_service_cidr", func() {
 		n := DefaultNetwork()
 		n.ServiceCIDR = "10.96.0.248/29"
-		dns, err := n.DNSAddress()
+		dns, err := n.DNSAddress(PrimaryFamilyIPv4)
 		s.Require().NoError(err)
 		s.Equal("10.96.0.250", dns)
 	})
 	s.Run("DNS_service_cidr_too_narrow", func() {
 		n := Network{ServiceCIDR: "192.168.178.0/31"}
-		dns, err := n.DNSAddress()
+		dns, err := n.DNSAddress(PrimaryFamilyIPv4)
 		s.Empty(dns)
 		s.ErrorContains(err, "failed to calculate DNS address: CIDR too narrow: 192.168.178.0/31")
 	})
 	s.Run("DNS_uses_v6_service_cidr", func() {
 		n := Network{ServiceCIDR: "fd00:abcd:1234::/64"}
-		dns, err := n.DNSAddress()
+		dns, err := n.DNSAddress(PrimaryFamilyIPv6)
 		s.NoError(err)
 		s.Equal("fd00:abcd:1234::a", dns)
 	})
 	s.Run("DNS_uses_v6_small_service_cidr", func() {
 		n := Network{ServiceCIDR: "fd00::/126"}
-		dns, err := n.DNSAddress()
+		dns, err := n.DNSAddress(PrimaryFamilyIPv6)
 		s.NoError(err)
 		s.Equal("fd00::2", dns)
 	})
 	s.Run("DNS_service_v6_cidr_too_narrow", func() {
 		n := Network{ServiceCIDR: "fd00::/127"}
-		dns, err := n.DNSAddress()
+		dns, err := n.DNSAddress(PrimaryFamilyIPv6)
 		s.Empty(dns)
 		s.ErrorContains(err, "failed to calculate DNS address: CIDR too narrow: fd00::/127")
 	})

--- a/pkg/component/controller/calico.go
+++ b/pkg/component/controller/calico.go
@@ -93,7 +93,7 @@ type calicoClusterConfig struct {
 
 // NewCalico creates new Calico reconciler component
 func NewCalico(nodeConfig *v1beta1.ClusterConfig, manifestsDir string, hasWindowsNodes func() (*bool, <-chan struct{})) (*Calico, error) {
-	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress()
+	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.PrimaryAddressFamily())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -293,7 +293,7 @@ type coreDNSConfig struct {
 
 // NewCoreDNS creates new instance of CoreDNS component
 func NewCoreDNS(k0sVars *config.CfgVars, clientFactory k8sutil.ClientFactoryInterface, nodeConfig *v1beta1.ClusterConfig) (*CoreDNS, error) {
-	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress()
+	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.PrimaryAddressFamily())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -44,6 +44,8 @@ import (
 
 type resources = []*unstructured.Unstructured
 
+type updateFunc = func(*snapshot) chan<- error
+
 // Reconciler maintains ConfigMaps that hold configuration to be
 // used on k0s worker nodes, depending on their selected worker profile.
 type Reconciler struct {
@@ -82,10 +84,10 @@ var (
 )
 
 // NewReconciler creates a new reconciler for worker configurations.
-func NewReconciler(k0sVars *config.CfgVars, nodeSpec *v1beta1.ClusterSpec, clientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface, konnectivityEnabled bool) (*Reconciler, error) {
+func NewReconciler(k0sVars *config.CfgVars, nodeConfig *v1beta1.ClusterConfig, clientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface, konnectivityEnabled bool) (*Reconciler, error) {
 	log := logrus.WithFields(logrus.Fields{"component": "workerconfig.Reconciler"})
 
-	clusterDNSIPString, err := nodeSpec.Network.DNSAddress()
+	clusterDNSIPString, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.PrimaryAddressFamily())
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +99,7 @@ func NewReconciler(k0sVars *config.CfgVars, nodeSpec *v1beta1.ClusterSpec, clien
 	reconciler := &Reconciler{
 		log: log,
 
-		clusterDomain:       nodeSpec.Network.ClusterDomain,
+		clusterDomain:       nodeConfig.Spec.Network.ClusterDomain,
 		clusterDNSIP:        clusterDNSIP,
 		clientFactory:       clientFactory,
 		leaderElector:       leaderElector,
@@ -132,8 +134,6 @@ func (r *Reconciler) Init(context.Context) error {
 
 	return nil
 }
-
-type updateFunc = func(*snapshot) chan<- error
 
 // Start implements [manager.Component].
 func (r *Reconciler) Start(context.Context) error {

--- a/pkg/component/controller/workerconfig/reconciler_test.go
+++ b/pkg/component/controller/workerconfig/reconciler_test.go
@@ -49,11 +49,13 @@ func TestReconciler_Lifecycle(t *testing.T) {
 		require.NoError(t, err)
 		underTest, err := NewReconciler(
 			k0sVars,
-			&v1beta1.ClusterSpec{
-				API: &v1beta1.APISpec{},
-				Network: &v1beta1.Network{
-					ClusterDomain: "test.local",
-					ServiceCIDR:   "99.99.99.0/24",
+			&v1beta1.ClusterConfig{
+				Spec: &v1beta1.ClusterSpec{
+					API: &v1beta1.APISpec{},
+					Network: &v1beta1.Network{
+						ClusterDomain: "test.local",
+						ServiceCIDR:   "99.99.99.0/24",
+					},
 				},
 			},
 			clients,
@@ -304,11 +306,13 @@ func TestReconciler_ResourceGeneration(t *testing.T) {
 	require.NoError(t, err)
 	underTest, err := NewReconciler(
 		k0sVars,
-		&v1beta1.ClusterSpec{
-			API: &v1beta1.APISpec{},
-			Network: &v1beta1.Network{
-				ClusterDomain: "test.local",
-				ServiceCIDR:   "99.99.99.0/24",
+		&v1beta1.ClusterConfig{
+			Spec: &v1beta1.ClusterSpec{
+				API: &v1beta1.APISpec{},
+				Network: &v1beta1.Network{
+					ClusterDomain: "test.local",
+					ServiceCIDR:   "99.99.99.0/24",
+				},
 			},
 		},
 		clients,
@@ -487,11 +491,13 @@ func TestReconciler_ReconcilesOnChangesOnly(t *testing.T) {
 	require.NoError(t, err)
 	underTest, err := NewReconciler(
 		k0sVars,
-		&v1beta1.ClusterSpec{
-			API: &v1beta1.APISpec{},
-			Network: &v1beta1.Network{
-				ClusterDomain: "test.local",
-				ServiceCIDR:   "99.99.99.0/24",
+		&v1beta1.ClusterConfig{
+			Spec: &v1beta1.ClusterSpec{
+				API: &v1beta1.APISpec{},
+				Network: &v1beta1.Network{
+					ClusterDomain: "test.local",
+					ServiceCIDR:   "99.99.99.0/24",
+				},
 			},
 		},
 		clients,
@@ -637,11 +643,13 @@ func TestReconciler_LeaderElection(t *testing.T) {
 	require.NoError(t, err)
 	underTest, err := NewReconciler(
 		k0sVars,
-		&v1beta1.ClusterSpec{
-			API: &v1beta1.APISpec{},
-			Network: &v1beta1.Network{
-				ClusterDomain: "test.local",
-				ServiceCIDR:   "99.99.99.0/24",
+		&v1beta1.ClusterConfig{
+			Spec: &v1beta1.ClusterSpec{
+				API: &v1beta1.APISpec{},
+				Network: &v1beta1.Network{
+					ClusterDomain: "test.local",
+					ServiceCIDR:   "99.99.99.0/24",
+				},
 			},
 		},
 		clients,


### PR DESCRIPTION
Manual backport to release-1.34 of https://github.com/k0sproject/k0s/pull/7342.

Files with conflicts resolved manually:
- `pkg/component/controller/workerconfig/reconciler_test.go`
- `inttest/dualstack/dualstack_test.go`