### PR TITLE
[renovate] Don't bump go in release-1.34

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -238,17 +238,6 @@
       "allowedVersions": "<=3.29"
     },
     {
-      "description": "Bump Go for release-1.34",
-      "enabled": true,
-      "matchBaseBranches": [
-        "release-1.34"
-      ],
-      "matchDepNames": [
-        "go"
-      ],
-      "allowedVersions": "<=1.24"
-    },
-    {
       "description": "Bump Envoy for release-1.34",
       "enabled": true,
       "matchBaseBranches": [


### PR DESCRIPTION
We have to bump go to v1.25 in release-1.33 due to etcd v3.5.28. Therefore we are also bumping it on release-1.34 and hence we don't need to track the go version because it's the same as in release-1.35.
