### PR TITLE
etcd member demoting before shutdown

### DIFF
--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -511,11 +511,11 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 	}
 	defer etcdClient.Close()
 
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
+	etcdCtx, etcdCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer etcdCancel()
 
 	// Verify that the member is actually still present in etcd
-	members, err := etcdClient.ListMembers(ctx)
+	members, err := etcdClient.ListMembers(etcdCtx)
 	if err != nil {
 		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
 		member.Status.Message = err.Error()
@@ -526,9 +526,71 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 		return false
 	}
 
-	// Member marked for leave but no member found in etcd, mark for leaved
-	_, ok := members[member.Name]
-	if !ok {
+	otherMembersURLs := make([]string, 0, len(members)-1)
+	for name, url := range members {
+		if name != member.Name {
+			otherMembersURLs = append(otherMembersURLs, url)
+		}
+	}
+
+	// Convert the memberID to uint64
+	memberID, err := strconv.ParseUint(member.Status.MemberID, 16, 64)
+	if err != nil {
+		log.WithError(err).Error("failed to parse memberID")
+		return false
+	}
+
+	_, inCluster := members[member.Name]
+	if inCluster {
+		// Demote the member to learner so the peer can't participate in leader election anymore, but
+		// can still see the cluster state and changes to react to them.
+		// This is needed to trigger the shutdown later.
+		log.Debug("Deleting member from cluster")
+		err = retry.Do(func() error {
+			return etcdClient.DemoteMember(etcdCtx, memberID, otherMembersURLs)
+		},
+			retry.Delay(5*time.Second),
+			retry.LastErrorOnly(true),
+			retry.Attempts(5),
+			retry.Context(etcdCtx),
+			retry.RetryIf(func(err error) bool {
+				msg := err.Error()
+				switch {
+				case strings.Contains(msg, "unhealthy cluster"):
+					return true
+				case strings.Contains(msg, "leader changed"):
+					return true
+				}
+				return false
+			}),
+		)
+
+		if err != nil {
+			log.WithError(err).Errorf("Failed to delete member from cluster")
+			member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
+			member.Status.Message = err.Error()
+			if _, err = client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
+				log.WithError(err).Error("failed to update EtcdMember status")
+			}
+			return false
+		}
+
+		// Peer removed successfully, update status
+		log.Info("Member has been deleted from cluster")
+		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusSuccess
+		member.Status.Message = "Member removed from cluster"
+		member.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionFalse, member.Status.Message, time.Now())
+		member, err = client.UpdateStatus(ctx, member, metav1.UpdateOptions{})
+		if err != nil {
+			log.WithError(err).Error("failed to update EtcdMember status")
+			return false
+		}
+	} else {
+		joinStatus := member.Status.GetCondition(etcdv1beta1.ConditionTypeJoined)
+		if joinStatus != nil && joinStatus.Status == etcdv1beta1.ConditionFalse {
+			log.Debug("member already left, no action needed")
+			return true
+		}
 		log.Debug("member marked for leave but not in actual member list, updating state to reflect that")
 		member.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionFalse, member.Status.Message, time.Now())
 		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusSuccess
@@ -539,19 +601,8 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 		}
 	}
 
-	joinStatus := member.Status.GetCondition(etcdv1beta1.ConditionTypeJoined)
-	if joinStatus != nil && joinStatus.Status == etcdv1beta1.ConditionFalse && !ok {
-		log.Debug("member already left, no action needed")
-		return true
-	}
-
-	// Convert the memberID to uint64
-	memberID, err := strconv.ParseUint(member.Status.MemberID, 16, 64)
-	if err != nil {
-		log.WithError(err).Error("failed to parse memberID")
-		return false
-	}
-
+	// Now that the member is out of the cluster, signal the node to shut down
+	// if its k0s process is still running.
 	if memberInvocationID, ok := member.Labels[shutdownOnLeaveLabelName]; ok && memberInvocationID != "" {
 		clients, err := e.clientFactory.GetClient()
 		if err != nil {
@@ -577,7 +628,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 			return false
 		} else if ident := memberLease.Spec.HolderIdentity; ident != nil && *ident == memberInvocationID && kubeutil.IsValidLease(*memberLease) {
 			if member.Labels[shutdownLabelName] != memberInvocationID {
-				log.Info("Requesting member shutdown before deletion")
+				log.Info("Requesting member shutdown after etcd cluster removal")
 				member.Labels[shutdownLabelName] = memberInvocationID
 				if _, err := client.Update(ctx, member, metav1.UpdateOptions{}); err != nil {
 					log.WithError(err).Error("Failed to update member")
@@ -586,7 +637,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 				return true
 			}
 
-			msg := "Member is still active; waiting for it to shutdown"
+			msg := "Member removed from cluster; waiting for it to shutdown"
 			log.Info(msg)
 			member.Status.Message = msg
 			member.Status.ReconcileStatus = ""
@@ -595,49 +646,6 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 			}
 			return false
 		}
-	}
-
-	log.Debug("Deleting member from cluster")
-	err = retry.Do(func() error {
-		return etcdClient.DeleteMember(ctx, memberID)
-	},
-		retry.Delay(5*time.Second),
-		retry.LastErrorOnly(true),
-		retry.Attempts(5),
-		retry.Context(ctx),
-		retry.RetryIf(func(err error) bool {
-			// In case etcd reports unhealthy cluster, retry
-			msg := err.Error()
-			switch {
-			case strings.Contains(msg, "unhealthy cluster"):
-				return true
-			case strings.Contains(msg, "leader changed"):
-				return true
-			}
-			return false
-		}),
-	)
-
-	if err != nil {
-		log.WithError(err).Errorf("Failed to delete member from cluster")
-		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
-		member.Status.Message = err.Error()
-		_, err = client.UpdateStatus(ctx, member, metav1.UpdateOptions{})
-		if err != nil {
-			log.WithError(err).Error("failed to update EtcdMember status")
-		}
-		return false
-	}
-
-	// Peer removed successfully, update status
-	log.Info("Member has been deleted from cluster")
-	member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusSuccess
-	member.Status.Message = "Member removed from cluster"
-	member.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionFalse, member.Status.Message, time.Now())
-	_, err = client.UpdateStatus(ctx, member, metav1.UpdateOptions{})
-	if err != nil {
-		log.WithError(err).Error("failed to update EtcdMember status")
-		return false
 	}
 
 	return true

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -588,7 +588,21 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 	} else {
 		joinStatus := member.Status.GetCondition(etcdv1beta1.ConditionTypeJoined)
 		if joinStatus != nil && joinStatus.Status == etcdv1beta1.ConditionFalse {
-			log.Debug("member already left, no action needed")
+			// Member was previously demoted to learner. Check whether the learner
+			// is still registered (e.g. node hasn't fully stopped yet) and remove it.
+			learnerID, found, err := etcdClient.GetLearnerIDByAddress(etcdCtx, member.Status.PeerAddress)
+			if err != nil {
+				log.WithError(err).Error("Failed to check for lingering learner")
+				return false
+			}
+			if found {
+				log.Debug("Removing lingering learner from cluster")
+				if err := etcdClient.DeleteMember(etcdCtx, learnerID); err != nil {
+					log.WithError(err).Error("Failed to remove learner from cluster")
+					return false
+				}
+				log.Info("Learner removed from cluster")
+			}
 			return true
 		}
 		log.Debug("member marked for leave but not in actual member list, updating state to reflect that")

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -131,6 +131,21 @@ func (c *Client) DemoteMember(ctx context.Context, peerID uint64, peerAddresses 
 	return err
 }
 
+// GetLearnerIDByAddress looks up a learner member's ID by its peer URL.
+// Returns (id, true, nil) if found, (0, false, nil) if not present, or (0, false, err) on failure.
+func (c *Client) GetLearnerIDByAddress(ctx context.Context, peerAddress string) (uint64, bool, error) {
+	resp, err := c.client.MemberList(ctx)
+	if err != nil {
+		return 0, false, fmt.Errorf("etcd member list failed: %w", err)
+	}
+	for _, m := range resp.Members {
+		if m.IsLearner && slices.Contains(m.PeerURLs, peerAddress) {
+			return m.ID, true, nil
+		}
+	}
+	return 0, false, nil
+}
+
 // Close closes the etcd client
 func (c *Client) Close() error {
 	return c.client.Close()

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -121,6 +121,16 @@ func (c *Client) DeleteMember(ctx context.Context, peerID uint64) error {
 	return err
 }
 
+// DemoteMember demotes member by peer name. It removes the member and adds it back as learner. This is needed to trigger leader transfer if the member is a leader.
+func (c *Client) DemoteMember(ctx context.Context, peerID uint64, peerAddresses []string) error {
+	err := c.DeleteMember(ctx, peerID)
+	if err != nil {
+		return fmt.Errorf("demote member failed on removal: %w", err)
+	}
+	_, err = c.client.MemberAddAsLearner(ctx, peerAddresses)
+	return err
+}
+
 // Close closes the etcd client
 func (c *Client) Close() error {
 	return c.client.Close()


### PR DESCRIPTION
## Description

Currently we turn off the k0s node first and then try to remove it from cluster on the leader node, which is incorrect order since etcd is turned off and we lost a quorum. On the other hand we can't do it vice verse since k0s connects only to local etcd node. 

So instead, let's demote the member to a learner (by removing and then adding it again) to let local etcd node see the shutdown signal.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
