### PR TITLE
Removing self etcd member from cluster before shutdown

### DIFF
--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -270,9 +270,10 @@ func (e *EtcdMemberReconciler) watchEtcdMembers(ctx context.Context, client etcd
 }
 
 // leaveIfMarked watches this node's own EtcdMember for Spec.Leave=true, then
-// removes itself from the etcd cluster and shuts down k0s. If self-removal
-// fails (with retries), it reports the failure in status and stays running so
-// the leader's dead-node fallback can remove the stale membership entry.
+// removes itself from the etcd cluster and shuts down k0s. Status updates are
+// intentionally left to the leader: after DeleteMember succeeds this node is
+// no longer part of etcd, so any k8s API write would fail. The leader will
+// detect the removal on its next reconcile and update the status accordingly.
 func (e *EtcdMemberReconciler) leaveIfMarked(ctx context.Context, log logrus.FieldLogger, client etcdclient.EtcdMemberInterface) {
 	name := e.etcdConfig.GetMemberName()
 	name, err := nodeutil.GetHostname(name)
@@ -342,12 +343,6 @@ func (e *EtcdMemberReconciler) leaveIfMarked(ctx context.Context, log logrus.Fie
 	}
 
 	log.Info("Successfully removed self from etcd cluster; shutting down")
-	member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusSuccess
-	member.Status.Message = "Member removed from cluster"
-	member.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionFalse, member.Status.Message, time.Now())
-	if _, statusErr := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); statusErr != nil {
-		log.WithError(statusErr).Warn("Failed to update EtcdMember status after self-removal")
-	}
 	e.shutdown(errors.New("etcd member leave requested"))
 }
 
@@ -479,6 +474,7 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context, client et
 	em.Labels = labels.Merge(em.Labels, labels.Set{
 		controllerLeaseLabelName: controllerLeaseName,
 	})
+	em.Spec.Leave = false
 
 	log.Debug("EtcdMember object already exists, updating it")
 	// Update the object if it already exists

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -34,8 +34,6 @@ import (
 
 const (
 	controllerLeaseLabelName = "k0s.k0sproject.io/controller-lease"
-	shutdownOnLeaveLabelName = "k0s.k0sproject.io/shutdown-on-leave"
-	shutdownLabelName        = "k0s.k0sproject.io/shutdown"
 )
 
 const EtcdMemberStackName = "etcd-member"
@@ -167,7 +165,7 @@ func (e *EtcdMemberReconciler) reconcile(ctx context.Context, log logrus.FieldLo
 			e.watchAndResync(statusCtx, client, log)
 
 		case leaderelection.StatusPending:
-			e.shutdownIfMarked(statusCtx, log, client)
+			e.leaveIfMarked(statusCtx, log, client)
 		}
 
 		// Bail out if the context has been canceled.
@@ -271,8 +269,11 @@ func (e *EtcdMemberReconciler) watchEtcdMembers(ctx context.Context, client etcd
 	}
 }
 
-// Waits for the shutdown label on this member and then requests a k0s shutdown.
-func (e *EtcdMemberReconciler) shutdownIfMarked(ctx context.Context, log logrus.FieldLogger, client etcdclient.EtcdMemberInterface) {
+// leaveIfMarked watches this node's own EtcdMember for Spec.Leave=true, then
+// removes itself from the etcd cluster and shuts down k0s. If self-removal
+// fails (with retries), it reports the failure in status and stays running so
+// the leader's dead-node fallback can remove the stale membership entry.
+func (e *EtcdMemberReconciler) leaveIfMarked(ctx context.Context, log logrus.FieldLogger, client etcdclient.EtcdMemberInterface) {
 	name := e.etcdConfig.GetMemberName()
 	name, err := nodeutil.GetHostname(name)
 	if err != nil {
@@ -280,18 +281,74 @@ func (e *EtcdMemberReconciler) shutdownIfMarked(ctx context.Context, log logrus.
 		return
 	}
 
-	log.Info("Starting to watch etcd member object ", name, " using invocation ID ", e.k0sVars.InvocationID)
+	log.Info("Starting to watch etcd member object ", name, " for leave signal")
+	var member *etcdv1beta1.EtcdMember
 	err = watch.EtcdMembers(client).
 		WithObjectName(name).
-		WithLabels(labels.Set{shutdownLabelName: e.k0sVars.InvocationID}).
-		Until(ctx, func(*etcdv1beta1.EtcdMember) (bool, error) { return true, nil })
+		Until(ctx, func(em *etcdv1beta1.EtcdMember) (bool, error) {
+			member = em
+			return em.Spec.Leave, nil
+		})
 
-	if err == nil {
-		log.Info("Etcd member marked for shutdown; stopping components and waiting for external termination")
-		e.shutdown(errors.New("etcd member marked for shutdown"))
-	} else if ctxErr := context.Cause(ctx); !errors.Is(err, ctxErr) {
-		log.WithError(err).Error("Error watching etcd member object")
+	if err != nil {
+		if ctxErr := context.Cause(ctx); !errors.Is(err, ctxErr) {
+			log.WithError(err).Error("Error watching etcd member object")
+		}
+		return
 	}
+
+	log.Info("Leave requested; removing self from etcd cluster before shutdown")
+
+	etcdClient, err := etcd.NewClient(e.k0sVars.CertRootDir, e.k0sVars.EtcdCertDir, e.etcdConfig)
+	if err != nil {
+		log.WithError(err).Error("Failed to create etcd client for self-removal")
+		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
+		member.Status.Message = "Failed to create etcd client: " + err.Error()
+		if _, statusErr := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); statusErr != nil {
+			log.WithError(statusErr).Warn("Failed to update EtcdMember status")
+		}
+		return
+	}
+	defer etcdClient.Close()
+
+	memberID, err := etcdClient.GetPeerIDByAddress(ctx, e.etcdConfig.GetPeerURL())
+	if err != nil {
+		log.WithError(err).Error("Failed to find own etcd member ID")
+		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
+		member.Status.Message = "Failed to find own etcd member ID: " + err.Error()
+		if _, statusErr := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); statusErr != nil {
+			log.WithError(statusErr).Warn("Failed to update EtcdMember status")
+		}
+		return
+	}
+
+	err = retry.Do(func() error {
+		return etcdClient.DeleteMember(ctx, memberID)
+	},
+		retry.Delay(5*time.Second),
+		retry.LastErrorOnly(true),
+		retry.Attempts(0), // retry until success or context canceled
+		retry.Context(ctx),
+	)
+
+	if err != nil {
+		log.WithError(err).Error("Failed to remove self from etcd cluster")
+		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
+		member.Status.Message = "Failed to remove self from etcd cluster: " + err.Error()
+		if _, statusErr := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); statusErr != nil {
+			log.WithError(statusErr).Warn("Failed to update EtcdMember status")
+		}
+		return
+	}
+
+	log.Info("Successfully removed self from etcd cluster; shutting down")
+	member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusSuccess
+	member.Status.Message = "Member removed from cluster"
+	member.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionFalse, member.Status.Message, time.Now())
+	if _, statusErr := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); statusErr != nil {
+		log.WithError(statusErr).Warn("Failed to update EtcdMember status after self-removal")
+	}
+	e.shutdown(errors.New("etcd member leave requested"))
 }
 
 // Cancels the reconcile loop and waits for it to exit.
@@ -393,7 +450,6 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context, client et
 					Name: name,
 					Labels: map[string]string{
 						controllerLeaseLabelName: controllerLeaseName,
-						shutdownOnLeaveLabelName: e.k0sVars.InvocationID,
 					},
 				},
 				Spec: etcdv1beta1.EtcdMemberSpec{
@@ -422,10 +478,7 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context, client et
 
 	em.Labels = labels.Merge(em.Labels, labels.Set{
 		controllerLeaseLabelName: controllerLeaseName,
-		shutdownOnLeaveLabelName: e.k0sVars.InvocationID,
 	})
-	delete(em.Labels, shutdownLabelName) // Clear any lingering shutdown request on re-join.
-	em.Spec.Leave = false
 
 	log.Debug("EtcdMember object already exists, updating it")
 	// Update the object if it already exists
@@ -552,49 +605,34 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 		return false
 	}
 
-	if memberInvocationID, ok := member.Labels[shutdownOnLeaveLabelName]; ok && memberInvocationID != "" {
-		clients, err := e.clientFactory.GetClient()
-		if err != nil {
-			log.WithError(err).Error("Failed to get Kubernetes client")
-			return false
+	// Wait for the member's controller to remove itself from etcd before
+	// doing any forced cleanup. This preserves quorum: the leaving node
+	// removes itself first (via leaveIfMarked), then shuts down. Only
+	// proceed with removal here when the controller is no longer running
+	// (dead/crashed node cleanup).
+	memberLeaseName := member.Labels[controllerLeaseLabelName]
+	if memberLeaseName == "" {
+		memberLeaseName = "k0s-ctrl-" + member.Name
+	}
+	k8sClients, err := e.clientFactory.GetClient()
+	if err != nil {
+		log.WithError(err).Error("Failed to get Kubernetes client")
+		return false
+	}
+	memberLease, err := k8sClients.CoordinationV1().Leases(corev1.NamespaceNodeLease).Get(ctx, memberLeaseName, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		log.WithError(err).Error("Failed to get controller lease")
+		return false
+	}
+	if err == nil && kubeutil.IsValidLease(*memberLease) {
+		msg := "Member is still active; waiting for it to remove itself from the etcd cluster"
+		log.Info(msg)
+		member.Status.Message = msg
+		member.Status.ReconcileStatus = ""
+		if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
+			log.WithError(err).Error("Failed to update member state")
 		}
-
-		memberLeaseName := member.Labels[controllerLeaseLabelName]
-		if memberLeaseName == "" {
-			memberLeaseName = "k0s-ctrl-" + member.Name
-		}
-		if memberLease, err := clients.CoordinationV1().Leases(corev1.NamespaceNodeLease).Get(ctx, memberLeaseName, metav1.GetOptions{}); err != nil {
-			log.WithError(err).Error("Failed to get etcd member lease")
-			msg := "Failed to get k0s controller lease: " + err.Error()
-			if apierrors.IsNotFound(err) {
-				msg = "No k0s controller lease found"
-			}
-			member.Status.Message = msg
-			member.Status.ReconcileStatus = ""
-			if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
-				log.WithError(err).Error("Failed to update member state")
-			}
-			return false
-		} else if ident := memberLease.Spec.HolderIdentity; ident != nil && *ident == memberInvocationID && kubeutil.IsValidLease(*memberLease) {
-			if member.Labels[shutdownLabelName] != memberInvocationID {
-				log.Info("Requesting member shutdown before deletion")
-				member.Labels[shutdownLabelName] = memberInvocationID
-				if _, err := client.Update(ctx, member, metav1.UpdateOptions{}); err != nil {
-					log.WithError(err).Error("Failed to update member")
-					return false
-				}
-				return true
-			}
-
-			msg := "Member is still active; waiting for it to shutdown"
-			log.Info(msg)
-			member.Status.Message = msg
-			member.Status.ReconcileStatus = ""
-			if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
-				log.WithError(err).Error("Failed to update member state")
-			}
-			return false
-		}
+		return false
 	}
 
 	log.Debug("Deleting member from cluster")


### PR DESCRIPTION
## Description

Currently we turn off the k0s node first and then try to remove it from cluster on the leader node, which is incorrect order since etcd is turned off and we lost a quorum. 

In this change node give up leadership, removes itself and then shutdowns k0s. 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
