### PR TITLE
Require v3 configuration on containerd imports

### DIFF
--- a/inttest/containerd-deprecations/containerd_deprecations_test.go
+++ b/inttest/containerd-deprecations/containerd_deprecations_test.go
@@ -97,16 +97,6 @@ func TestContainerdDeprecationsSuite(t *testing.T) {
 	suite.Run(t, &s)
 }
 
-// TODO before 1.36: This is broken at the moment, we have to figure out
-// how to merge the configuration and revist this test.
-const deprecatedConfig = `version = 2
-
-[plugins]
-  [plugins."io.containerd.grpc.v1.cri"]
-    [plugins."io.containerd.grpc.v1.cri".registry]
-      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-          endpoint = ["https://registry-1.docker.io"]
-    [plugins."io.containerd.grpc.v1.cri".cni]
-      bin_dir = "/opt/cni/bin"
-`
+// In containerd 2.2 is no configuration that can throw deprecation warnings in containerd, therefore we just
+// dump some legal file as a placeholder. In the future if deprecations are available we can update this to trigger them.
+const deprecatedConfig = "version = 3"

--- a/inttest/containerdupgrade/containerdupgrade_test.go
+++ b/inttest/containerdupgrade/containerdupgrade_test.go
@@ -69,12 +69,20 @@ func (s *ContainerdUpgradeSuite) TestContainerdUpgrade() {
 		oldPIDs = s.gatherPIDs(ctx, s.WorkerNode(0))
 	})
 
+	s.Run("add_containerd_v2_config", func() {
+		s.PutFile(s.WorkerNode(0), "/etc/k0s/containerd.d/v2.toml", "version = 2")
+	})
+
 	s.Run("upgrade_k0s_to_testing_version", func() {
 		s.Require().NoError(s.StopWorker(s.WorkerNode(0)))
 		s.upgradeContainerdToTesting(ctx, s.WorkerNode(0))
+		// k0s should exit after containerd upgrade because of the containerd v2 config
+		s.validateK0sExitAndCleanUpContainerdV2Conf(ctx, s.WorkerNode(0))
+
+		// After removing it, it should start up again
 		s.Require().NoError(s.StartWorker(s.WorkerNode(0)))
 
-		// Grace period to ensure contianerd is up and running
+		// Grace period to ensure containerd is up and running
 		time.Sleep(30 * time.Second)
 		s.Require().NoError(s.WaitForNodeReady(s.WorkerNode(0), kc))
 		s.ensureContainerdVersion(ctx, s.WorkerNode(0), "2.2")
@@ -109,6 +117,27 @@ func (s *ContainerdUpgradeSuite) TestContainerdUpgrade() {
 			return pod.Status.ContainerStatuses[0].RestartCount > 0, nil
 		}))
 	})
+}
+
+func (s *ContainerdUpgradeSuite) validateK0sExitAndCleanUpContainerdV2Conf(ctx context.Context, node string) {
+	ssh, err := s.SSH(ctx, node)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	s.T().Log("waiting for k0s process to stop")
+	err = wait.PollUntilContextCancel(ctx, 1*time.Second, false, func(ctx context.Context) (bool, error) {
+		_, err := ssh.ExecWithOutput(ctx, "pgrep /usr/local/bin/k0s")
+		if err != nil {
+			return true, nil
+		}
+		return false, nil
+	})
+	s.Require().NoError(err)
+
+	s.T().Logf("k0s process exited")
+
+	_, err = ssh.ExecWithOutput(ctx, "rm -f /etc/k0s/containerd.d/v2.toml")
+	s.Require().NoError(err)
 }
 
 func (s *ContainerdUpgradeSuite) forceKillNginx(ctx context.Context, node string) {
@@ -269,7 +298,6 @@ func (s *ContainerdUpgradeSuite) gatherPIDs(ctx context.Context, name string) ma
 func TestContainerdUpgradeSuite(t *testing.T) {
 	s := ContainerdUpgradeSuite{
 		common.BootlooseSuite{
-			LaunchMode:      common.LaunchModeOpenRC,
 			ControllerCount: 1,
 			WorkerCount:     1,
 		},

--- a/pkg/component/worker/containerd/component.go
+++ b/pkg/component/worker/containerd/component.go
@@ -5,13 +5,9 @@ package containerd
 
 import (
 	"bufio"
-	"bytes"
 	"context"
-	"crypto/md5"
-	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -307,24 +303,13 @@ func (c *Component) Stop() error {
 	return nil
 }
 
-// This is the md5sum of the default k0s containerd config file before 1.27
-const pre1_27ConfigSum = "59039b43303742a5496b13fd57f9beec"
-
 // isK0sManagedConfig checks if the config file is k0s managed:
 //   - If the config file doesn't exist, it's k0s managed.
-//   - If the config file's md5sum matches the pre 1.27 config, it's k0s managed.
 //   - If the config file starts with the magic marker line "# k0s_managed=true",
 //     it's k0s managed.
 func isK0sManagedConfig(path string) (_ bool, err error) {
 	// If the file does not exist, it's k0s managed (new install)
 	if !file.Exists(path) {
-		return true, nil
-	}
-	pre1_27Managed, err := isPre1_27ManagedConfig(path)
-	if err != nil {
-		return false, err
-	}
-	if pre1_27Managed {
 		return true, nil
 	}
 	// Check if the config file has the magic marker
@@ -334,41 +319,8 @@ func isK0sManagedConfig(path string) (_ bool, err error) {
 	}
 	defer func() { err = errors.Join(err, f.Close()) }()
 	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		switch scanner.Text() {
-		case "": // K0s versions before 1.30 had a leading empty line.
-			continue
-		case "# k0s_managed=true":
-			return true, nil
-		}
-	}
-	return false, scanner.Err()
-}
-
-func isPre1_27ManagedConfig(path string) (bool, error) {
-	// Check MD5 sum of the config file
-	// If it matches the pre 1.27 config, it's k0s managed
-	md5sum := md5.New()
-	f, err := os.Open(path)
-	if err != nil {
-		return false, err
-	}
-	defer f.Close()
-
-	if _, err := io.Copy(md5sum, f); err != nil {
-		return false, err
-	}
-
-	sum := md5sum.Sum(nil)
-
-	pre1_27ConfigSumBytes, err := hex.DecodeString(pre1_27ConfigSum)
-	if err != nil {
-		return false, err
-	}
-
-	if bytes.Equal(pre1_27ConfigSumBytes, sum) {
+	if scanner.Scan() && scanner.Text() == "# k0s_managed=true" {
 		return true, nil
 	}
-
-	return false, nil
+	return false, scanner.Err()
 }

--- a/pkg/component/worker/containerd/component_test.go
+++ b/pkg/component/worker/containerd/component_test.go
@@ -53,34 +53,17 @@ func Test_isK0sManagedConfig(t *testing.T) {
 		require.False(t, isManaged)
 	})
 
-	t.Run("should return true for pre-1.30 generated config", func(t *testing.T) {
+	t.Run("should return true if file has marker", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "containerd.toml")
-		cfg := `
-# k0s_managed=true
-# This is a placeholder configuration for k0s managed containerD. 
+		cfg := `# k0s_managed=true
+# This is a placeholder configuration for k0s managed containerD.
 # If you wish to override the config, remove the first line and replace this file with your custom configuration.
 # For reference see https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md
 version = 3
 imports = [
 	"/run/k0s/containerd-cri.toml",
 ]
-`
-		err := os.WriteFile(configPath, []byte(cfg), 0644)
-		require.NoError(t, err)
-		isManaged, err := isK0sManagedConfig(configPath)
-		require.NoError(t, err)
-		require.True(t, isManaged)
-	})
-
-	t.Run("should return true if md5 matches with pre 1.27 default config", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		configPath := filepath.Join(tmpDir, "containerd.toml")
-		cfg := `
-# This is a placeholder configuration for k0s managed containerD.
-# If you wish to customize the config replace this file with your custom configuration.
-# For reference see https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md
-version = 2
 `
 		err := os.WriteFile(configPath, []byte(cfg), 0644)
 		require.NoError(t, err)

--- a/pkg/component/worker/containerd/configurer.go
+++ b/pkg/component/worker/containerd/configurer.go
@@ -57,6 +57,7 @@ func (c *configurer) handleImports() (*resolvedConfig, error) {
 	// do, treat them as merge patches to the default config, if they don't,
 	// just add them as normal imports to be handled by containerd.
 	finalConfig := string(defaultConfig)
+	errs := []error{}
 	for _, filePath := range filePaths {
 		c.log.Debugf("Processing containerd configuration file %s", filePath)
 
@@ -65,21 +66,37 @@ func (c *configurer) handleImports() (*resolvedConfig, error) {
 			return nil, err
 		}
 
-		hasCRI, err := hasCRIPluginConfig(data)
+		tree, err := toml.LoadBytes(data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to check for CRI plugin configuration in %s: %w", filePath, err)
+			errs = append(errs, fmt.Errorf("failed to parse TOML in %q: %w", filePath, err))
+			continue
 		}
 
-		if hasCRI {
-			c.log.Infof("Found CRI plugin configuration in %s, treating as merge patch", filePath)
+		isV3Config := true
+		if err := assertV3Config(tree); err != nil {
+			errs = append(errs, fmt.Errorf("invalid containerd configuration in %q: %w", filePath, err))
+			isV3Config = false
+		}
+
+		if hasV2CRIConfig(tree) {
+			errs = append(errs, fmt.Errorf("containerd configuration file %q contains v2 CRI plugin configuration, which is not compatible with k0s. Please update the configuration to use the v3 plugin format", filePath))
+			isV3Config = false
+		}
+
+		if isV3Config && hasCRIPluginConfig(tree) {
+			c.log.Infof("Found CRI plugin configuration in %q, treating as merge patch", filePath)
 			finalConfig, err = patch.TOMLString(finalConfig, patch.FilePatches(filePath))
 			if err != nil {
-				return nil, fmt.Errorf("failed to merge data from %s into containerd configuration: %w", filePath, err)
+				errs = append(errs, fmt.Errorf("failed to merge data from %s into containerd configuration: %w", filePath, err))
 			}
 		} else {
 			c.log.Debugf("No CRI plugin configuration found in %s, adding as-is to imports", filePath)
 			importPaths = append(importPaths, filePath)
 		}
+	}
+
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("encountered errors while processing containerd configuration import files: %v", errs)
 	}
 
 	return &resolvedConfig{CRIConfig: finalConfig, ImportPaths: importPaths}, nil
@@ -91,7 +108,6 @@ func (c *configurer) handleImports() (*resolvedConfig, error) {
 // containerd's defaults for the CRI plugin.
 func generateDefaultCRIConfig(sandboxContainerImage string) ([]byte, error) {
 	// https://github.com/containerd/containerd/blob/main/docs/cri/config.md#full-configuration
-
 	imagesConf := map[string]any{
 		"pinned_images": map[string]any{
 			"sandbox": sandboxContainerImage,
@@ -116,11 +132,28 @@ func generateDefaultCRIConfig(sandboxContainerImage string) ([]byte, error) {
 	})
 }
 
-func hasCRIPluginConfig(data []byte) (bool, error) {
-	tree, err := toml.LoadBytes(data)
-	if err != nil {
-		return false, fmt.Errorf("failed to parse TOML: %w", err)
-	}
+func hasCRIPluginConfig(tree *toml.Tree) bool {
+	return tree.HasPath([]string{"plugins", "io.containerd.cri.v1.runtime"}) || tree.HasPath([]string{"plugins", "io.containerd.cri.v1.images"})
+}
 
-	return tree.HasPath([]string{"plugins", "io.containerd.cri.v1.runtime"}) || tree.HasPath([]string{"plugins", "io.containerd.cri.v1.images"}), nil
+// hasV2CRIConfig checks if the given containerd configuration tree contains any plugins."io.containerd.grpc.v1.cri"
+// configuration section. This is the main difference between containerd v2 and v3 configuration formats, so if this is present we
+// want the user to fix it manually instead of trying to merge it and potentially causing unexpected breakage.
+func hasV2CRIConfig(tree *toml.Tree) bool {
+	return tree.HasPath([]string{"plugins", "io.containerd.grpc.v1.cri"})
+}
+
+func assertV3Config(tree *toml.Tree) error {
+	version := tree.Get("version")
+	if version != nil {
+		v, ok := version.(int64)
+		if !ok {
+			return fmt.Errorf("unexpected type for version field: expected integer, got %T", version)
+		}
+
+		if v != 3 {
+			return fmt.Errorf("unsupported containerd configuration version: expected 3, got %d", v)
+		}
+	}
+	return nil
 }

--- a/pkg/component/worker/containerd/configurer_test.go
+++ b/pkg/component/worker/containerd/configurer_test.go
@@ -88,4 +88,43 @@ version = 3
 		assert.NoError(t, err)
 		assert.Equal(t, []string{nonCriConfigPath}, criConfig.ImportPaths)
 	})
+
+	t.Run("shouldn't return an error if version isn't explicitly defined", func(t *testing.T) {
+		importsPath := t.TempDir()
+		criRuntimeConfig := `
+[plugins]
+  [plugins."io.containerd.cri.v1.images"]
+	snapshotter = "zfs"
+`
+		err := os.WriteFile(filepath.Join(importsPath, "foo.toml"), []byte(criRuntimeConfig), 0644)
+		require.NoError(t, err)
+		c := configurer{
+			loadPath: filepath.Join(importsPath, "*.toml"),
+			log:      logrus.New().WithField("test", t.Name()),
+		}
+		criConfig, err := c.handleImports()
+		assert.NoError(t, err)
+		assert.NotNil(t, criConfig)
+	})
+
+	t.Run("should return an error if a configuration file contains v2 CRI plugin configuration", func(t *testing.T) {
+		importsPath := t.TempDir()
+		v2CRIConfig := `version = 2
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.foo]
+      runtime_type = "io.containerd.runc.v2"
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.foo.options]
+        BinaryName = "/var/lib/k0s/bin/runfoo"`
+		err := os.WriteFile(filepath.Join(importsPath, "foo.toml"), []byte(v2CRIConfig), 0644)
+		require.NoError(t, err)
+		c := configurer{
+			loadPath: filepath.Join(importsPath, "*.toml"),
+			log:      logrus.New().WithField("test", t.Name()),
+		}
+		criConfig, err := c.handleImports()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported containerd configuration version")
+		assert.Contains(t, err.Error(), "contains v2 CRI plugin configuration")
+		assert.Nil(t, criConfig)
+	})
+
 }


### PR DESCRIPTION
## Description

Enforces containerd v3 configuration expectations when processing imported containerd config fragments, and updates tests/integration coverage to validate failures on v2/invalid configs. Also simplifies detection of k0s managed containerd configuration because there is no need for us to track older versions than 1.35.

Fixes #7377

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
