### PR TITLE
Add healthzBindAddress parameter to kubeProxy conf

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,7 @@ spec:
     dualStack:
       enabled: false
     kubeProxy:
+      healthzBindAddress: 0.0.0.0:10256
       iptables:
         minSyncPeriod: 0s
         syncPeriod: 0s
@@ -250,16 +251,18 @@ CALICO_IPV6POOL_CIDR: "{{ spec.network.dualStack.IPv6podCIDR }}"
 
 #### `spec.network.kubeProxy`
 
-| Element             | Description                                                                                                                                                                                                                                                               |
-|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `disabled`          | Disable kube-proxy altogether (default: `false`).                                                                                                                                                                                                                         |
-| `mode`              | Kube proxy operating mode, supported modes `iptables`, `ipvs`, `nftables`¹, `userspace` (default: `iptables`)                                                                                                                                                             |
-| `iptables`          | Kube proxy iptables settings                                                                                                                                                                                                                                              |
-| `ipvs`              | Kube proxy IPVS settings                                                                                                                                                                                                                                                  |
-| `nftables`          | Kube proxy nftables settings                                                                                                                                                                                                                                              |
-| `nodePortAddresses` | Kube proxy [nodePortAddresses](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/)                                                                                                                                                             |
-| `extraArgs`         | Map of key-values (strings) for any extra arguments to pass down to kube-proxy process. `extraArgs` are recommended over `rawArgs` if the use case allows it. Any behavior triggered by these parameters is outside k0s support. (default: empty)                         |
-| `rawArgs`           | Slice of strings for any raw arguments to pass down to the kube-proxy process. These are appended after `extraArgs`. If possible, it's recommended to use `extraArgs` over `rawArgs`. Any behavior triggered by these parameters is outside k0s support. (default: empty) |
+| Element              | Description                                                                                                                                                                                                                                                               |
+|----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `disabled`           | Disable kube-proxy altogether (default: `false`).                                                                                                                                                                                                                         |
+| `mode`               | Kube proxy operating mode, supported modes `iptables`, `ipvs`, `nftables`¹, `userspace` (default: `iptables`)                                                                                                                                                             |
+| `iptables`           | Kube proxy iptables settings                                                                                                                                                                                                                                              |
+| `ipvs`               | Kube proxy IPVS settings                                                                                                                                                                                                                                                  |
+| `nftables`           | Kube proxy nftables settings                                                                                                                                                                                                                                              |
+| `nodePortAddresses`  | Kube proxy [nodePortAddresses](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/)                                                                                                                                                             |
+| `healthzBindAddress` | Kube proxy [healthzBindAddress](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/) (default: 0.0.0.0:10256)                                                                                                                                   |
+| `metricsBindAddress` | Kube proxy [metricsBindAddress](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/) (default: 0.0.0.0:10249)                                                                                                                                   |
+| `extraArgs`          | Map of key-values (strings) for any extra arguments to pass down to kube-proxy process. `extraArgs` are recommended over `rawArgs` if the use case allows it. Any behavior triggered by these parameters is outside k0s support. (default: empty)                         |
+| `rawArgs`            | Slice of strings for any raw arguments to pass down to the kube-proxy process. These are appended after `extraArgs`. If possible, it's recommended to use `extraArgs` over `rawArgs`. Any behavior triggered by these parameters is outside k0s support. (default: empty) |
 
 ¹ For nftables, the kubeproxy container's nftables version needs to be less than or equal to the host OS's in order to avoid segmentation faults.
 For example, a host OS with nftables v1.1.1 requires quay.io/k0sproject/kube-proxy:v1.33.2 or lower.

--- a/pkg/apis/k0s/v1beta1/kubeproxy.go
+++ b/pkg/apis/k0s/v1beta1/kubeproxy.go
@@ -5,8 +5,11 @@ package v1beta1
 
 import (
 	"fmt"
+	"strconv"
 
+	"github.com/k0sproject/k0s/internal/pkg/net"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/cluster/ports"
 )
 
 var _ Validateable = (*KubeProxy)(nil)
@@ -25,6 +28,7 @@ type KubeProxy struct {
 	// Defaults to "iptables"
 	Mode               string `json:"mode,omitempty"`
 	MetricsBindAddress string `json:"metricsBindAddress,omitempty"`
+	HealthzBindAddress string `json:"healthzBindAddress,omitempty"`
 	// +optional
 	IPTables KubeProxyIPTablesConfiguration `json:"iptables"`
 	// +optional
@@ -88,7 +92,8 @@ type KubeProxyNFTablesConfiguration struct {
 func DefaultKubeProxy() *KubeProxy {
 	return &KubeProxy{
 		Mode:               ModeIptables,
-		MetricsBindAddress: "0.0.0.0:10249",
+		MetricsBindAddress: "0.0.0.0:" + strconv.Itoa(ports.ProxyStatusPort),
+		HealthzBindAddress: "0.0.0.0:" + strconv.Itoa(ports.ProxyHealthzPort),
 	}
 }
 
@@ -100,6 +105,12 @@ func (k *KubeProxy) Validate() []error {
 	var errors []error
 	if k.Mode != ModeIptables && k.Mode != ModeIPVS && k.Mode != ModeUSerspace && k.Mode != ModeNFT {
 		errors = append(errors, fmt.Errorf("unsupported mode %s for kubeProxy config", k.Mode))
+	}
+	if _, err := net.ParseHostPort(k.HealthzBindAddress); err != nil {
+		errors = append(errors, fmt.Errorf("healthzBindAddress: %w", err))
+	}
+	if _, err := net.ParseHostPort(k.MetricsBindAddress); err != nil {
+		errors = append(errors, fmt.Errorf("metricsBindAddress: %w", err))
 	}
 	return errors
 }

--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -234,6 +234,7 @@ func (k *KubeProxy) getConfig(clusterConfig *v1beta1.ClusterConfig) (*proxyConfi
 		DualStack:            clusterConfig.Spec.Network.DualStack.Enabled,
 		Mode:                 clusterConfig.Spec.Network.KubeProxy.Mode,
 		MetricsBindAddress:   clusterConfig.Spec.Network.KubeProxy.MetricsBindAddress,
+		HealthzBindAddress:   clusterConfig.Spec.Network.KubeProxy.HealthzBindAddress,
 		FeatureGates:         clusterConfig.Spec.FeatureGates.AsMap("kube-proxy"),
 		Args:                 append(args.ToDashedArgs(), clusterConfig.Spec.Network.KubeProxy.RawArgs...),
 	}
@@ -275,6 +276,7 @@ type proxyConfig struct {
 	PullPolicy           string
 	Mode                 string
 	MetricsBindAddress   string
+	HealthzBindAddress   string
 	IPTables             string
 	IPVS                 string
 	NFTables             string
@@ -387,7 +389,7 @@ data:
       tcpEstablishedTimeout: null
     detectLocalMode: ""
     enableProfiling: false
-    healthzBindAddress: ""
+    healthzBindAddress: {{ .HealthzBindAddress }}
     hostnameOverride: ""
     iptables: {{ .IPTables }}
     ipvs: {{ .IPVS }}

--- a/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
+++ b/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
@@ -799,6 +799,8 @@ spec:
                           Map of key-values (strings) for any extra arguments to pass down to kube-proxy process
                           Any behavior triggered by these parameters is outside k0s support.
                         type: object
+                      healthzBindAddress:
+                        type: string
                       iptables:
                         description: |-
                           KubeProxyIPTablesConfiguration contains iptables-related kube-proxy configuration


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Prior to this the value was hardcoded to an empty string.

As kubeproxy ignores the related commandline argument when a config file is present, this option was not configurable otherwise.

Fixes: https://github.com/k0sproject/k0s/issues/7363

The changes are made to mirror changes of https://github.com/k0sproject/k0s/pull/2378.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

`make lint` failed, unable to find `golang.sh` to check whats wrong
   > 0.201 + git apply
0.202 error: patch failed: hack/lib/golang.sh:27
0.202 error: hack/lib/golang.sh: patch does not apply
0.202 error: patch failed: hack/lib/util.sh:185
0.202 error: hack/lib/util.sh: patch does not apply

unfortunately the same for `make build && git diff --exit-code` and the other commands mentioned in https://docs.k0sproject.io/stable/contributors/testing/


## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
