### PR TITLE
Use less RBAC-heavy connection probing in k0s status

### DIFF
--- a/pkg/component/status/status.go
+++ b/pkg/component/status/status.go
@@ -15,7 +15,6 @@ import (
 	"github.com/k0sproject/k0s/pkg/component/prober"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -120,17 +119,19 @@ func (sh *statusHandler) getCurrentStatus(ctx context.Context) K0sStatus {
 	if sh.client == nil {
 		kubeClient, err := sh.buildWorkerSideKubeAPIClient(ctx)
 		if err != nil {
-			status.WorkerToAPIConnectionStatus.Message = "failed to create kube-api client required for kube-api status reports, probably kubelet failed to init: " + err.Error()
+			status.WorkerToAPIConnectionStatus = ProbeStatus{
+				Message: "failed to create kube-api client required for kube-api status reports, probably kubelet failed to init: " + err.Error(),
+			}
 			return status
 		}
 		sh.client = kubeClient
 	}
-	_, err := sh.client.CoreV1().Nodes().List(context.Background(), v1.ListOptions{})
+	_, err := sh.client.Discovery().RESTClient().Get().AbsPath("/version").Do(ctx).Raw()
 	if err != nil {
-		status.WorkerToAPIConnectionStatus.Message = err.Error()
+		status.WorkerToAPIConnectionStatus = ProbeStatus{Message: err.Error()}
 		return status
 	}
-	status.WorkerToAPIConnectionStatus.Success = true
+	status.WorkerToAPIConnectionStatus = ProbeStatus{Success: true}
 	return status
 }
 


### PR DESCRIPTION
## Description

The `status` subcommand used to list all nodes in the cluster to probe the API server connectivity for workloads. This process is very resource-heavy and requires more RBAC rules than a normal kubelet should have. While this used to work since Autopilot required these RBAC rules for signaling, this issue has been addressed in v1.35 and the rules will be removed in subsequent k0s versions. If Autopilot is disabled, these RBAC rules are no longer applied, consequently breaking the `k0s status` workload API server connectivity check.

Replace the node listing with a simple API server version request. This is sufficient and does not require any special RBAC.

Fixes:

* #6726
* #7362

See:

* #6848

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
