### PR TITLE
ci: Add support for linux-riscv64

### DIFF
--- a/.github/workflows/build-image-bundle.yml
+++ b/.github/workflows/build-image-bundle.yml
@@ -14,6 +14,10 @@ on:
         type: string
         required: true
         description: The platform suffix of the image bundle to be built.
+      runs-on:
+        type: string
+        required: false
+        description: The platform to build the image bundle on.
     outputs:
       cache-key:
         description: The image bundle's cache key.
@@ -25,7 +29,7 @@ env:
 jobs:
   build:
     name: "${{ inputs.image-bundle-name }}-${{ inputs.image-bundle-platform }}"
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runs-on || 'ubuntu-24.04' }}
 
     env:
       IMAGE_BUNDLE_NAME: ${{ inputs.image-bundle-name }}
@@ -40,7 +44,7 @@ jobs:
       - name: "Download :: k0s"
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          name: k0s-linux-amd64
+          name: ${{ inputs.runs-on == 'ubuntu-24.04-riscv' && 'k0s-linux-riscv64' || 'k0s-linux-amd64' }}
 
       - name: "Download :: Image list"
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0

--- a/.github/workflows/build-k0s.yml
+++ b/.github/workflows/build-k0s.yml
@@ -13,7 +13,7 @@ on:
         description: The architecture to build k0s for.
 
 env:
-  MAKEFLAGS: -j
+  MAKEFLAGS: -j --output-sync=line
 
 jobs:
   build:
@@ -22,6 +22,7 @@ jobs:
       ${{
            inputs.target-arch == 'arm'   && fromJSON('["self-hosted", "linux", "arm"]')
         || inputs.target-arch == 'arm64' && 'ubuntu-24.04-arm'
+        || inputs.target-arch == 'riscv64' && 'ubuntu-24.04-riscv'
         || 'ubuntu-24.04'
       }}
 
@@ -103,9 +104,11 @@ jobs:
             k0s${{ steps.build-prepare.outputs.executable-suffix }}
 
       - name: "Build :: SBOM"
+        if: inputs.target-arch != 'riscv64' # FIXME: https://github.com/anchore/syft/pull/4757, it doesn't support linux-riscv64 yet
         run: make spdx.json
 
       - name: "Upload :: SBOM"
+        if: inputs.target-arch != 'riscv64' # FIXME: https://github.com/anchore/syft/pull/4757, it doesn't support linux-riscv64 yet
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: sbom-${{ inputs.target-os }}-${{ inputs.target-arch }}

--- a/.github/workflows/build-k0s.yml
+++ b/.github/workflows/build-k0s.yml
@@ -23,6 +23,7 @@ jobs:
         case(
           inputs.target-arch == 'arm', fromJSON('["self-hosted", "linux", "arm"]'),
           inputs.target-arch == 'arm64', 'ubuntu-24.04-arm',
+          inputs.target-arch == 'riscv64', 'ubuntu-24.04-riscv',
           'ubuntu-24.04'
         )
       }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -100,6 +100,8 @@ jobs:
             target-arch: amd64
           - target-os: linux
             target-arch: arm64
+          - target-os: linux
+            target-arch: riscv64
           - target-os: windows
             target-arch: amd64
 
@@ -113,7 +115,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target-arch: [amd64, arm64]
+        target-arch: [amd64, arm64, riscv64]
 
     name: "Build :: Airgap image bundle"
     needs: [build-k0s]
@@ -161,6 +163,8 @@ jobs:
         include:
           - name: linux-amd64
             runs-on: ubuntu-24.04
+          - name: linux-riscv64
+            runs-on: ubuntu-24.04-riscv
           - name: windows-amd64
             runs-on: windows-2022
             target-os: windows
@@ -267,6 +271,24 @@ jobs:
     uses: ./.github/workflows/smoketest.yaml
     with:
       arch: arm64
+      name: ${{ matrix.smoke-suite }}
+
+  smoketests-linux-riscv64:
+    strategy:
+      fail-fast: false
+      matrix:
+        smoke-suite:
+          - airgap
+          - basic
+          - network-conformance-calico
+          - network-conformance-kuberouter
+
+    name: "check-${{ matrix.smoke-suite }} :: riscv64"
+    needs: [build-k0s, build-airgap-image-bundle]
+
+    uses: ./.github/workflows/smoketest.yaml
+    with:
+      arch: riscv64
       name: ${{ matrix.smoke-suite }}
 
   autopilot-tests:

--- a/.github/workflows/riscv64.yml
+++ b/.github/workflows/riscv64.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 k0s authors
+
+name: "RISC-V build"
+
+on:
+  workflow_dispatch:
+    inputs:
+      smoketests:
+        description: Which smoketests to run.
+        type: string
+  schedule:
+    - cron: 45 2 * * *
+
+jobs:
+  build-k0s:
+    name: "Build :: k0s :: linux-riscv64"
+    uses: ./.github/workflows/build-k0s.yml
+    with:
+      target-os: linux
+      target-arch: riscv64
+
+  build-airgap-image-bundle:
+    name: "Build :: Airgap image bundle"
+    needs: [build-k0s]
+    uses: ./.github/workflows/build-image-bundle.yml
+    with:
+      image-bundle-name: airgap
+      image-bundle-platform: linux-riscv64
+      runs-on: ubuntu-24.04-riscv
+
+  unittests-k0s:
+    name: "check-unit :: k0s :: linux-riscv64"
+    uses: ./.github/workflows/unittests-k0s.yml
+    with:
+      runs-on: ubuntu-24.04-riscv
+
+  smoketests:
+    strategy:
+      fail-fast: false
+      matrix:
+        smoke-suite: >-
+          ${{ fromJSON(inputs.smoketests || '
+              [
+                "airgap",
+                "basic"
+              ]
+            ')
+          }}
+    name: "check-${{ matrix.smoke-suite }} :: riscv64"
+    needs: [build-k0s, build-airgap-image-bundle]
+
+    uses: ./.github/workflows/smoketest.yaml
+    with:
+      arch: riscv64
+      name: ${{ matrix.smoke-suite }}

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   smoketest:
     name: Test
-    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ (inputs.arch == 'arm64' && 'ubuntu-24.04-arm') || (inputs.arch == 'riscv64' && 'ubuntu-24.04-riscv') || 'ubuntu-24.04' }}
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -30,6 +30,7 @@ jobs:
       ${{
         case(
           inputs.arch == 'arm64', 'ubuntu-24.04-arm',
+          inputs.arch == 'riscv64', 'ubuntu-24.04-riscv',
           'ubuntu-24.04'
         )
       }}


### PR DESCRIPTION
## Description

_This is currently an experiment. Happy to get reviews as always._

Add GitHub Actions CI on `linux-riscv64` using [RISE RISC-V Runners](https://riseproject-dev.github.io/riscv-runner/).

Relates to https://github.com/k0sproject/k0s/issues/1919
Depends on https://github.com/k0sproject/image-builder/pull/253 https://github.com/k0sproject/k0s/pull/7459

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
