### PR TITLE
[Backport release-1.33] Bump go to v1.25.9

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM $BUILDIMAGE
 ARG TARGETARCH
 RUN set -ex; \
 # Need to use the gold linker on ARM, Go really wants to have it.
-# https://github.com/golang/go/blob/go1.25.8/src/cmd/link/internal/ld/lib.go#L1678-L1697
+# https://github.com/golang/go/blob/go1.25.9/src/cmd/link/internal/ld/lib.go#L1678-L1697
   case "$TARGETARCH" in \
   arm*) binutils=binutils-gold ;; \
     *)    binutils=binutils ;; \

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -3,7 +3,7 @@ alpine_patch_version = 3.21.6
 alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 
 # renovate: datasource=golang-version depName=go
-go_version = 1.25.8
+go_version = 1.25.9
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine3.23
 
 # renovate: datasource=github-releases depName=opencontainers/runc

--- a/internal/pkg/file/atomic_test.go
+++ b/internal/pkg/file/atomic_test.go
@@ -214,7 +214,7 @@ func TestWriteAtomically(t *testing.T) {
 			)
 			assert.Equal(t, file, linkErr.New)
 			if runtime.GOOS == "windows" {
-				// https://github.com/golang/go/blob/go1.25.8/src/syscall/types_windows.go#L13
+				// https://github.com/golang/go/blob/go1.25.9/src/syscall/types_windows.go#L13
 				//revive:disable-next-line:var-naming
 				const ERROR_ACCESS_DENIED syscall.Errno = 5
 				var errno syscall.Errno


### PR DESCRIPTION
Backport to `release-1.33`:

* #7401

See:

* #7399