### PR TITLE
Teach Renovate the k0s OCI image versioning scheme

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,13 @@
   ],
   "packageRules": [
     {
+      "description": "Special version scheme for k0sproject OCI images",
+      "matchPackageNames": [
+        "quay.io/k0sproject/*"
+      ],
+      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-(?:k0s\\.|iptables\\d+\\.\\d+\\.\\d+-)?(?<build>\\d+))?$"
+    },
+    {
       "description": "Ignore all Go dependencies by default",
       "enabled": false,
       "matchManagers": [


### PR DESCRIPTION
## Description

Renovate's Docker versioning scheme will treat the dashed suffixes as Docker compatibility suffixes, not as part of the version number. Add a special package rule that matches all k0sproject images and makes the number suffix a part of the version number.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
