### PR TITLE
[Backport release-1.34] Bump k3s-io/kine to v0.14.16

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -38,11 +38,11 @@ kubernetes_build_go_flags = "-v"
 kubernetes_build_go_ldflags_extra = -extldflags=-static
 
 # renovate: datasource=github-releases depName=k3s-io/kine
-kine_version = 0.14.15
+kine_version = 0.14.16
 kine_buildimage = $(golang_buildimage)
 kine_build_go_tags = nats
 #kine_build_go_cgo_enabled =
-# Flags taken from https://github.com/k3s-io/kine/blob/v0.14.15/scripts/build#L25
+# Flags taken from https://github.com/k3s-io/kine/blob/v0.14.16/scripts/build#L25
 kine_build_go_cgo_cflags = -DSQLITE_USE_ALLOCA=1
 
 #kine_build_go_flags =

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -113,7 +113,7 @@ func (k *Kine) Start(ctx context.Context) error {
 			"--endpoint=" + k.Config.DataSource,
 			// NB: kine doesn't parse URLs properly, so construct potentially
 			// invalid URLs that are understood by kine.
-			// https://github.com/k3s-io/kine/blob/v0.14.15/pkg/util/network.go#L5-L13
+			// https://github.com/k3s-io/kine/blob/v0.14.16/pkg/util/network.go#L5-L13
 			"--listen-address=unix://" + k.K0sVars.KineSocketPath,
 			// Enable metrics on port 2380. The default is 8080, which clashes with kube-router.
 			"--metrics-bind-address=:2380",


### PR DESCRIPTION
Backport to `release-1.34`:

* #7428

See:

* #7426