### PR TITLE
feat: delegate konnectivity server counting to lease controller

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -303,7 +303,6 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 			K0sVars:      c.K0sVars,
 			LogLevel:     c.LogLevels.Konnectivity,
 			EventEmitter: prober.NewEventEmitter(),
-			ServerCount:  numActiveControllers.Peek,
 		})
 	}
 
@@ -564,7 +563,6 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 			ManifestsDir:           c.K0sVars.ManifestsDir,
 			KonnectivityServerHost: cmp.Or(nodeConfig.Spec.API.ExternalHost(), nodeConfig.Spec.API.Address),
 			EventEmitter:           prober.NewEventEmitter(),
-			ServerCount:            numActiveControllers.Peek,
 		})
 	}
 

--- a/hack/ostests/.terraform.lock.hcl
+++ b/hack/ostests/.terraform.lock.hcl
@@ -2,6 +2,7 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/hashicorp/aws" {
+<<<<<<< HEAD
   version     = "6.44.0"
   constraints = "~> 6.0"
   hashes = [
@@ -35,6 +36,41 @@ provider "registry.opentofu.org/hashicorp/aws" {
     "zh:d3965e6b0202204ef4d80d58bb870abb1c944025cac3e6b423bc4492d6cd9365",
     "zh:e2a71e1d0ec03f920a5a962871d9270af3a066ff0c0c55ee48f97c544fbfe93a",
     "zh:f472d8603f14d6e34627d00d3368f1304821d4f2ce4334a155ff75877a1b5364",
+=======
+  version     = "6.43.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:+KqeS3Q6D1NhSzLZmRXoHL1Kzvf30oyALRMvUBMZ8Nc=",
+    "h1:3D9yhPDlUFWY4abKnRKJ0VdqpQA8IY5M1tsVtTI8+wc=",
+    "h1:4YZrG9IunRIrkcAgE6qV42qguuq3fCui84BNHouGMKs=",
+    "h1:4qsQKGEOXVaMUOyqCjUcC4+30KmJJtah9keqB+D+kp0=",
+    "h1:54qmZjnQTVQN06YH3yQNDSmh00+roFRfj8XSFep7UYI=",
+    "h1:HdCiG7D+bN5YNBcfKGo02fff5jKMfLywEs1+NmccNEs=",
+    "h1:J3yxQV4sjTHOIsCzoJwEOO6ZQI2nNyQ7K7R6C8FWBy0=",
+    "h1:P4mAJhld0+iKMhiLK54oK3tdRhhuVeWWBq5+zKwrz8E=",
+    "h1:PxlQKivBbRceV0svN2OL/p7sZQEacMjUOftw4bHK2ho=",
+    "h1:SNrr0bGqSp8layADAv0tdb73DB9b6gtDfnx2ktu9mm4=",
+    "h1:WRONI5OW8FuSWm2YXR8K4I6JtBvuJG9dGokcNAYRkUw=",
+    "h1:ejQVQfnYGbX7ozHalfy4l44VontY+aw8q63eUqj73EY=",
+    "h1:kCnEcXYwJCJd/PohXF9DK7BQYfFmMYJh+M6iMy4ScXQ=",
+    "h1:kOJ3LBH3GpjH/e3BH5l78ToXaeK6WuWQfTWLL971Rac=",
+    "h1:nRNOnEEuX92jMA+XeoQQ/6PoOjzajn0XJOA4kOdiMM4=",
+    "zh:108a58036307f9f0687d2583f86936eb75401e43d358ea62f9702acf5f9d70b2",
+    "zh:373cb307d87cab9806f8cd71388d7ba451d7bb310a9e2807c7afb80cee6841a2",
+    "zh:42a59943c3f46e3e17ab707df0fcf6313916389383866d3017a467ad37993924",
+    "zh:5c3b005efb2ec73833cbb80cd9d1bd2fae27586c510f4c58a7ed28d6c4f1df8f",
+    "zh:612ee0001c46dae19255252c3a9344bc0fcdda42568508dda558079ed8cf437f",
+    "zh:625d1b0c8e4dc0bb43583c4ad0e7a30c030e3e67d919b6c5e8247707b7ca1e6b",
+    "zh:92ecce00bdf17b63fcf31fb8eb7679cfbec0c741097554055f810ee879a96094",
+    "zh:b1fa126cb4f52c1fc00beda5c3fa34fac41a95f5a2ad3a14751e335bc93ee7ab",
+    "zh:b54a80475ac532f44f7c8cb900c48c01780b50f5dae0fe852175f3331ca9371b",
+    "zh:bb77f0c00778d5ac3257ded46c1034df656bdd67f3cf29e74e68da376fea1ec3",
+    "zh:bedcc72914998315e8faac3997b5eb6ac49269a14e557efd5916c1946e734179",
+    "zh:cbf429abd34c247a57ef1b703d059fea30ecf5463ee0d20a2850bd25adb22d5a",
+    "zh:cfbc5decdfce32cde83de9f7e10e30b30297246611c69a2243d88a6421d2dd7a",
+    "zh:d656ba4ddd17f108397d7dfd28670a7d70a9c4d46229621748e8755783e391fc",
+    "zh:f304352bb8936b9d7dc9f57273c50db72768004ed4789b5712e20b96c3342478",
+>>>>>>> a3d85fa9 (feat: delegate konnectivity server counting to lease controller)
   ]
 }
 

--- a/inttest/hacontrolplane/konnectivity_test.go
+++ b/inttest/hacontrolplane/konnectivity_test.go
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hacontrolplane
+
+import (
+	"testing"
+	"time"
+
+	"github.com/k0sproject/k0s/inttest/common"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// KonnectivityLeaseSuite verifies that konnectivity server count is delegated
+// to the lease controller (k0s issue #5736): the agent DaemonSet must no
+// longer be re-rendered when the controller count changes, and the server/agent
+// must run with the new lease-controller flags + RBAC.
+type KonnectivityLeaseSuite struct {
+	common.BootlooseSuite
+}
+
+func (s *KonnectivityLeaseSuite) TestLeaseCounting() {
+	ctx := s.Context()
+
+	// Bring up 3 controllers + 1 worker. Three so etcd retains quorum when
+	// we kill one controller later — a 2-node etcd loses quorum on any
+	// failure, which would freeze the apiserver and make every assertion
+	// below hang.
+	s.Require().NoError(s.InitController(0))
+	s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(0)))
+
+	token, err := s.GetJoinToken("controller")
+	s.Require().NoError(err)
+	for i := 1; i <= 2; i++ {
+		s.PutFile(s.ControllerNode(i), "/etc/k0s.token", token)
+		s.Require().NoError(s.InitController(i, "--token-file=/etc/k0s.token"))
+		s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(i)))
+	}
+
+	s.Require().NoError(s.RunWorkers())
+
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.Require().NoError(s.WaitForNodeReady(s.WorkerNode(0), kc))
+
+	// 1. RBAC for the konnectivity-agent (read leases) is in place.
+	_, err = kc.RbacV1().ClusterRoles().
+		Get(ctx, "system:konnectivity-agent", metav1.GetOptions{})
+	s.NoError(err, "ClusterRole system:konnectivity-agent must exist")
+	_, err = kc.RbacV1().ClusterRoleBindings().
+		Get(ctx, "system:konnectivity-agent", metav1.GetOptions{})
+	s.NoError(err, "ClusterRoleBinding system:konnectivity-agent must exist")
+
+	// 3. Konnectivity-server runs with --enable-lease-controller and no
+	//    longer takes a static --server-count.
+	srvArgs, err := s.execOnNode(s.ControllerNode(0),
+		"cat /proc/$(pidof konnectivity-server)/cmdline | tr '\\0' ' '")
+	s.Require().NoError(err)
+	s.Contains(srvArgs, "--enable-lease-controller")
+	s.NotContains(srvArgs, "--server-count=")
+
+	// 4. Konnectivity-agent DaemonSet runs with --count-server-leases=true and
+	//    no longer carries the K0S_CONTROLLER_COUNT trigger env var.
+	//    Worker-Ready doesn't guarantee the manifest applier has pushed the DS
+	//    yet, so wait for it to appear.
+	var ds *appsv1.DaemonSet
+	s.Require().Eventually(func() bool {
+		got, err := kc.AppsV1().DaemonSets(metav1.NamespaceSystem).
+			Get(ctx, "konnectivity-agent", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		ds = got
+		return true
+	}, 2*time.Minute, 2*time.Second, "konnectivity-agent DaemonSet never appeared")
+	s.Require().Len(ds.Spec.Template.Spec.Containers, 1)
+	c := ds.Spec.Template.Spec.Containers[0]
+	s.Contains(c.Args, "--count-server-leases=true")
+	for _, e := range c.Env {
+		s.NotEqual("K0S_CONTROLLER_COUNT", e.Name,
+			"K0S_CONTROLLER_COUNT env var must be gone — it only existed to force agent restarts")
+	}
+
+	// 5. All three konnectivity-server instances publish a lease under
+	//    k8s-app=konnectivity-server in kube-system. This proves the lease
+	//    controller is actually running — upstream names them
+	//    "konnectivity-proxy-server-<serverID>" with the default
+	//    --lease-label=k8s-app=konnectivity-server.
+	s.Require().Eventually(func() bool {
+		return s.countServerLeases(kc) == 3
+	}, 90*time.Second, 2*time.Second, "expected 3 konnectivity-server leases")
+
+	// Also wait until the agent DS is fully Ready so the generation below
+	// reflects the settled state, not a mid-rollout glimpse.
+	s.waitDSReady(kc, "konnectivity-agent")
+	genBefore := s.getAgentDS(kc).Generation
+	s.T().Logf("konnectivity-agent DaemonSet generation before controller leaves: %d", genBefore)
+
+	// 6. THE behavioral assertion. Stop one controller; the agent DaemonSet
+	//    must NOT be re-rendered. Pre-refactor, k0s rewrote the manifest with
+	//    a new K0S_CONTROLLER_COUNT value, bumping .metadata.generation and
+	//    rolling every agent pod. With lease-counting, the surviving server
+	//    just sees one fewer lease and the agent reacts on its own.
+	_, err = s.execOnNode(s.ControllerNode(1),
+		"kill $(pidof k0s) && while pidof k0s; do sleep 0.1s; done")
+	s.Require().NoError(err)
+
+	// The dead server's lease expires after LeaseDuration=30s and is GC'd on
+	// the next GCInterval=15s tick — so ~45s worst case. Assert positively
+	// that the count drops to 2, which proves the mechanism works end-to-end.
+	s.Require().Eventually(func() bool {
+		return s.countServerLeases(kc) == 2
+	}, 90*time.Second, 2*time.Second, "dead server's lease was never GC'd")
+
+	// And the regression guard: the surviving controller must NOT have
+	// re-rendered the agent DS in response to its peer going away.
+	dsAfter := s.getAgentDS(kc)
+	s.Equal(genBefore, dsAfter.Generation,
+		"konnectivity-agent DaemonSet generation must not change when controller count changes")
+}
+
+func (s *KonnectivityLeaseSuite) countServerLeases(kc *kubernetes.Clientset) int {
+	ll, err := kc.CoordinationV1().Leases(metav1.NamespaceSystem).
+		List(s.Context(), metav1.ListOptions{LabelSelector: "k8s-app=konnectivity-server"})
+	if err != nil {
+		s.T().Logf("list konnectivity-server leases: %v", err)
+		return -1
+	}
+	return len(ll.Items)
+}
+
+func (s *KonnectivityLeaseSuite) getAgentDS(kc *kubernetes.Clientset) *appsv1.DaemonSet {
+	ds, err := kc.AppsV1().DaemonSets(metav1.NamespaceSystem).
+		Get(s.Context(), "konnectivity-agent", metav1.GetOptions{})
+	s.Require().NoError(err)
+	return ds
+}
+
+func (s *KonnectivityLeaseSuite) waitDSReady(kc *kubernetes.Clientset, name string) {
+	s.Require().Eventually(func() bool {
+		ds, err := kc.AppsV1().DaemonSets(metav1.NamespaceSystem).
+			Get(s.Context(), name, metav1.GetOptions{})
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				s.T().Logf("get %s: %v", name, err)
+			}
+			return false
+		}
+		return ds.Status.DesiredNumberScheduled > 0 &&
+			ds.Status.NumberReady == ds.Status.DesiredNumberScheduled
+	}, 3*time.Minute, 5*time.Second, "DaemonSet %s never became fully Ready", name)
+
+	// Sanity: at least one agent pod exists and is Ready.
+	pods, err := kc.CoreV1().Pods(metav1.NamespaceSystem).
+		List(s.Context(), metav1.ListOptions{LabelSelector: "k8s-app=" + name})
+	s.Require().NoError(err)
+	s.Require().NotEmpty(pods.Items)
+	for _, p := range pods.Items {
+		ready := false
+		for _, c := range p.Status.Conditions {
+			if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+				ready = true
+				break
+			}
+		}
+		s.True(ready, "agent pod %s should be Ready", p.Name)
+	}
+}
+
+func (s *KonnectivityLeaseSuite) execOnNode(node, cmd string) (string, error) {
+	ssh, err := s.SSH(s.Context(), node)
+	if err != nil {
+		return "", err
+	}
+	defer ssh.Disconnect()
+	return ssh.ExecWithOutput(s.Context(), cmd)
+}
+
+func TestKonnectivityLeaseSuite(t *testing.T) {
+	s := KonnectivityLeaseSuite{
+		common.BootlooseSuite{
+			ControllerCount: 3,
+			WorkerCount:     1,
+		},
+	}
+	suite.Run(t, &s)
+}

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -31,10 +31,9 @@ import (
 
 // Konnectivity implements the component interface for konnectivity server
 type Konnectivity struct {
-	Spec        *v1beta1.KonnectivitySpec // FIXME: This should be reconciled via dynamic config
-	K0sVars     *config.CfgVars
-	LogLevel    string
-	ServerCount func() (uint, <-chan struct{})
+	Spec     *v1beta1.KonnectivitySpec // FIXME: This should be reconciled via dynamic config
+	K0sVars  *config.CfgVars
+	LogLevel string
 
 	supervisor     *supervisor.Supervisor
 	executablePath string
@@ -43,8 +42,6 @@ type Konnectivity struct {
 	log *logrus.Entry
 
 	*prober.EventEmitter
-
-	stop func()
 }
 
 var _ manager.Component = (*Konnectivity)(nil)
@@ -86,56 +83,15 @@ func (k *Konnectivity) Init(ctx context.Context) error {
 
 // Run ..
 func (k *Konnectivity) Start(ctx context.Context) error {
-	serverCount, serverCountChanged := k.ServerCount()
-
-	if err := k.runServer(ctx, serverCount); err != nil {
+	if err := k.runServer(ctx); err != nil {
 		k.EmitWithPayload("failed to start konnectivity server", err)
 		return fmt.Errorf("failed to start konnectivity server: %w", err)
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
-
-	go func() {
-		defer close(done)
-		var retry <-chan time.Time
-		for {
-			select {
-			case <-serverCountChanged:
-				prevServerCount := serverCount
-				serverCount, serverCountChanged = k.ServerCount()
-				// restart only if the server count actually changed
-				if serverCount == prevServerCount {
-					continue
-				}
-
-			case <-retry:
-				k.Emit("retrying to start konnectivity server")
-				k.log.Info("Retrying to start konnectivity server")
-
-			case <-ctx.Done():
-				k.Emit("stopped konnectivity server")
-				k.log.Info("stopping konnectivity server reconfig loop")
-				return
-			}
-
-			retry = nil
-
-			if err := k.runServer(ctx, serverCount); err != nil {
-				k.EmitWithPayload("failed to start konnectivity server", err)
-				k.log.WithError(err).Errorf("Failed to start konnectivity server")
-				retry = time.After(10 * time.Second)
-				continue
-			}
-		}
-	}()
-
-	k.stop = func() { cancel(); <-done }
-
 	return nil
 }
 
-func (k *Konnectivity) serverArgs(count uint) []string {
+// See the example in [apiserver-network-proxy](https://github.com/carreter/apiserver-network-proxy/blob/714d09261101800120373cb1a3bb10278f32220d/examples/kind-multinode/templates/k8s/konnectivity-server.yaml)
+func (k *Konnectivity) serverArgs() []string {
 	return stringmap.StringMap{
 		"--uds-name":                 filepath.Join(k.K0sVars.KonnectivitySocketDir, "konnectivity-server.sock"),
 		"--cluster-cert":             filepath.Join(k.K0sVars.CertRootDir, "server.crt"),
@@ -155,37 +111,28 @@ func (k *Konnectivity) serverArgs(count uint) []string {
 		"--v":                        k.LogLevel,
 		"--enable-profiling":         "false",
 		"--delete-existing-uds-file": "true",
-		"--server-count":             strconv.FormatUint(uint64(count), 10),
 		"--server-id":                k.K0sVars.InvocationID,
 		"--proxy-strategies":         "destHost,defaultRoute,default",
 		"--cipher-suites":            constant.AllowedTLS12CipherSuiteNames(),
+		"--enable-lease-controller":  "true",
 	}.ToArgs()
 }
 
-func (k *Konnectivity) runServer(ctx context.Context, count uint) error {
-	// Stop supervisor
-	if k.supervisor != nil {
-		k.EmitWithPayload("restarting konnectivity server due to server count change",
-			map[string]any{"serverCount": count})
-		if err := k.supervisor.Stop(); err != nil {
-			k.log.WithError(err).Error("Failed to stop executable")
-		}
-	}
-
+func (k *Konnectivity) runServer(ctx context.Context) error {
 	k.supervisor = &supervisor.Supervisor{
 		Name:    "konnectivity",
 		BinPath: k.executablePath,
 		DataDir: k.K0sVars.DataDir,
 		RunDir:  k.K0sVars.RunDir,
-		Args:    k.serverArgs(count),
+		Args:    k.serverArgs(),
 		UID:     k.uid,
 	}
 	err := k.supervisor.Supervise(ctx)
 	if err != nil {
-		k.supervisor = nil // not to make the next loop to try to stop it first
+		k.supervisor = nil
 		return err
 	}
-	k.EmitWithPayload("started konnectivity server", map[string]any{"serverCount": count})
+	k.Emit("started konnectivity server")
 
 	return nil
 }
@@ -208,10 +155,6 @@ func (k *Konnectivity) Healthy() error {
 
 // Stop stops
 func (k *Konnectivity) Stop() error {
-	if k.stop != nil {
-		logrus.Debug("stopping konnectivity component")
-		k.stop()
-	}
 	if k.supervisor == nil {
 		return nil
 	}

--- a/pkg/component/controller/konnectivityagent.go
+++ b/pkg/component/controller/konnectivityagent.go
@@ -23,7 +23,6 @@ import (
 type KonnectivityAgent struct {
 	ManifestsDir           string
 	KonnectivityServerHost string
-	ServerCount            func() (uint, <-chan struct{})
 
 	configChangeChan chan *v1beta1.ClusterConfig
 	log              *logrus.Entry
@@ -45,22 +44,12 @@ func (k *KonnectivityAgent) Init(_ context.Context) error {
 func (k *KonnectivityAgent) Start(ctx context.Context) error {
 
 	go func() {
-		serverCount, serverCountChanged := k.ServerCount()
-
 		var clusterConfig *v1beta1.ClusterConfig
 		var retry <-chan time.Time
 		for {
 			select {
 			case config := <-k.configChangeChan:
 				clusterConfig = config
-
-			case <-serverCountChanged:
-				prevServerCount := serverCount
-				serverCount, serverCountChanged = k.ServerCount()
-				// write only if the server count actually changed
-				if serverCount == prevServerCount {
-					continue
-				}
 
 			case <-retry:
 				k.log.Info("Retrying to write konnectivity agent manifest")
@@ -76,7 +65,7 @@ func (k *KonnectivityAgent) Start(ctx context.Context) error {
 				continue
 			}
 
-			if err := k.writeKonnectivityAgent(clusterConfig, serverCount); err != nil {
+			if err := k.writeKonnectivityAgent(clusterConfig); err != nil {
 				k.log.Errorf("failed to write konnectivity agent manifest: %v", err)
 				retry = time.After(10 * time.Second)
 				continue
@@ -98,7 +87,7 @@ func (k *KonnectivityAgent) Stop() error {
 	return nil
 }
 
-func (k *KonnectivityAgent) writeKonnectivityAgent(clusterConfig *v1beta1.ClusterConfig, serverCount uint) error {
+func (k *KonnectivityAgent) writeKonnectivityAgent(clusterConfig *v1beta1.ClusterConfig) error {
 	konnectivityDir := filepath.Join(k.ManifestsDir, "konnectivity")
 	err := dir.Init(konnectivityDir, constant.ManifestsDirMode)
 	if err != nil {
@@ -109,7 +98,6 @@ func (k *KonnectivityAgent) writeKonnectivityAgent(clusterConfig *v1beta1.Cluste
 		ProxyServerHost: k.KonnectivityServerHost,
 		ProxyServerPort: uint16(clusterConfig.Spec.Konnectivity.AgentPort),
 		Image:           clusterConfig.Spec.Images.Konnectivity.URI(),
-		ServerCount:     serverCount,
 		PullPolicy:      clusterConfig.Spec.Images.DefaultPullPolicy,
 	}
 
@@ -195,34 +183,39 @@ type konnectivityAgentConfig struct {
 	ProxyServerHost string
 	ProxyServerPort uint16
 	Image           string
-	ServerCount     uint
 	PullPolicy      string
 	HostNetwork     bool
 }
 
+// See the example in [apiserver-network-proxy](https://github.com/carreter/apiserver-network-proxy/blob/714d09261101800120373cb1a3bb10278f32220d/examples/kind-multinode/templates/k8s/konnectivity-agent-ds.yaml)
 const konnectivityAgentTemplate = `
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: system:konnectivity-server
-  labels:
-    kubernetes.io/cluster-service: "true"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:auth-delegator
-subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: User
-    name: system:konnectivity-server
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: konnectivity-agent
   namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:konnectivity-agent
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:konnectivity-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:konnectivity-agent
+subjects:
+  - kind: ServiceAccount
+    name: konnectivity-agent
+    namespace: kube-system
 ---
 apiVersion: apps/v1
 # Alternatively, you can deploy the agents as Deployments. It is not necessary
@@ -264,11 +257,6 @@ spec:
           imagePullPolicy: {{ .PullPolicy }}
           name: konnectivity-agent
           env:
-              # the variable is not in a use
-              # we need it to have agent restarted on server count change
-              - name: K0S_CONTROLLER_COUNT
-                value: "{{ .ServerCount }}"
-
               - name: NODE_IP
                 valueFrom:
                   fieldRef:
@@ -281,6 +269,7 @@ spec:
             - --service-account-token-path=/var/run/secrets/tokens/konnectivity-agent-token
             - --agent-identifiers=host=$(NODE_IP)
             - --agent-id=$(NODE_IP)
+            - --count-server-leases=true
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/pkg/component/controller/konnectivityagent_test.go
+++ b/pkg/component/controller/konnectivityagent_test.go
@@ -63,13 +63,13 @@ func TestKonnectivityAgent_ProxyServerHostPort(t *testing.T) {
 							AgentPort:       9876,
 						},
 					},
-				}, 1))
+				}))
 
 				daemonSet := loadDaemonSet(t, manifestsDir)
 				containers := daemonSet.Spec.Template.Spec.Containers
 				require.Len(t, containers, 1)
 				args := containers[0].Args
-				require.Len(t, args, 7)
+				require.Len(t, args, 8)
 				assert.Equal(t, "--proxy-server-host="+expectedHost, args[2])
 				assert.Equal(t, "--proxy-server-port="+expectedPort, args[3])
 			})
@@ -90,8 +90,8 @@ func loadDaemonSet(t *testing.T, manifestsDir string) *appsv1.DaemonSet {
 		Infos()
 	require.NoError(t, err)
 
-	require.Len(t, objects, 3)
-	daemonSet, ok := objects[2].Object.(*appsv1.DaemonSet)
-	require.Truef(t, ok, "unexpected type: %T", objects[2].Object)
+	require.Len(t, objects, 4)
+	daemonSet, ok := objects[3].Object.(*appsv1.DaemonSet)
+	require.Truef(t, ok, "unexpected type: %T", objects[3].Object)
 	return daemonSet
 }


### PR DESCRIPTION
## Description

Delegates konnectivity server counting to the built-in lease controller instead of k0s tracking it manually.
  - konnectivity-server: add `--enable-lease-controller=true`, drop `--server-count`
  - konnectivity-agent: add `--count-server-leases`, drop the `K0S_CONTROLLER_COUNT` env var

### Changes:                                                                                          
  - The server now publishes its own coordination Lease and the agent counts them directly, so k0s no longer 
  needs to watch the controller count, restart the server, or re-render the agent DaemonSet on every HA
  event. New RBAC is added so both sides can manage leases in kube-system.                                   
 - Adds an integration test asserting the new flags/RBAC and that the agent DaemonSet's generation is
  unchanged when a controller leaves.
 
### Notes:                                                                                             
We do not pass `--lease-label` to either konnectivity-server or konnectivity-agent. Both sides rely on the upstream default `k8s-app=konnectivity-server` — see [server default](https://github.com/kubernetes-sigs/apiservernetwork-proxy/blob/ea0a0d314b4d7ae02383adb6f8b74cee5ae330d4/cmd/server/app/options/options.go#L381) and [agent default](https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/ea0a0d314b4d7ae02383adb6f8b74cee5ae330d4/cmd/agent/app/options/options.go#L283) (added in[#670](https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/670)). The server publishes leases with that label, the agent selects them by the same label, so they match by design. If either default ever changes upstream, `--lease-label` will need to be set explicitly on both sides.

(Note: [#643](https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/643)'s description still refers to a `--server-lease-selector` flag, but that name only existed during PR development — the merged code uses `--count-server-leases` to enable the system and `--lease-label` to configure the selector.)

Co-authored with [Claude](https://claude.com/claude-code). 

Closes #5736 

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
