### PR TITLE
Deprecate disabling worker-config component

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -524,18 +524,19 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 
 	disableAutopilot := slices.Contains(flags.DisableComponents, constant.AutopilotComponentName)
 
-	if !slices.Contains(flags.DisableComponents, constant.WorkerConfigComponentName) {
-		// Create new dedicated leasepool for worker config reconciler
-		leaseName := fmt.Sprintf("k0s-%s-%s", constant.WorkerConfigComponentName, constant.KubernetesMajorMinorVersion)
-		workerConfigLeasePool := leaderelector.NewLeasePool(c.K0sVars.InvocationID, adminClientFactory, leaseName)
-		clusterComponents.Add(ctx, workerConfigLeasePool)
-
-		reconciler, err := workerconfig.NewReconciler(c.K0sVars, nodeConfig, adminClientFactory, workerConfigLeasePool, enableKonnectivity, disableAutopilot)
-		if err != nil {
-			return err
-		}
-		clusterComponents.Add(ctx, reconciler)
+	if slices.Contains(flags.DisableComponents, constant.WorkerConfigComponentName) {
+		logrus.Warnf("disabling worker-config component is deprecated. This flag is ignored")
 	}
+	// Create new dedicated leasepool for worker-config reconciler
+	leaseName := fmt.Sprintf("k0s-%s-%s", constant.WorkerConfigComponentName, constant.KubernetesMajorMinorVersion)
+	workerConfigLeasePool := leaderelector.NewLeasePool(c.K0sVars.InvocationID, adminClientFactory, leaseName)
+	clusterComponents.Add(ctx, workerConfigLeasePool)
+
+	reconciler, err := workerconfig.NewReconciler(c.K0sVars, nodeConfig, adminClientFactory, workerConfigLeasePool, enableKonnectivity, disableAutopilot)
+	if err != nil {
+		return err
+	}
+	clusterComponents.Add(ctx, reconciler)
 
 	if !slices.Contains(flags.DisableComponents, constant.SystemRBACComponentName) {
 		clusterComponents.Add(ctx, &controller.SystemRBAC{

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -55,7 +55,7 @@ Flags:
       --data-dir string                                Data Directory for k0s. DO NOT CHANGE for an existing setup, things will break! (default `+defaultDataDir+`)
   -d, --debug                                          Debug logging (implies verbose logging)
       --debugListenOn string                           Http listenOn for Debug pprof handler (default ":6060")
-      --disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,update-prober,windows-node,worker-config)
+      --disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,update-prober,windows-node)
       --enable-cloud-provider                          Whether or not to enable cloud provider support in kubelet
       --enable-dynamic-config                          enable cluster-wide dynamic config based on custom resource
       --enable-k0s-cloud-provider                      enables the k0s-cloud-provider (default false)

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -46,7 +46,7 @@ Flags:
   -c, --config string                                  config file, use '-' to read the config from stdin (default `+defaultConfigPath+`)
       --cri-socket string                              container runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]
       --data-dir string                                Data Directory for k0s. DO NOT CHANGE for an existing setup, things will break! (default `+defaultDataDir+`)
-      --disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,update-prober,windows-node,worker-config)
+      --disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,update-prober,windows-node)
       --enable-cloud-provider                          Whether or not to enable cloud provider support in kubelet
       --enable-dynamic-config                          enable cluster-wide dynamic config based on custom resource
       --enable-k0s-cloud-provider                      enables the k0s-cloud-provider (default false)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -597,7 +597,7 @@ they need to fulfill their need for the control plane. Disabling the system
 components happens through a command line flag for the controller process:
 
 ```text
---disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,update-prober,windows-node,worker-config)
+--disable-components strings                     disable components (valid items: applier-manager,autopilot,control-api,coredns,csr-approver,endpoint-reconciler,helm,konnectivity-server,kube-controller-manager,kube-proxy,kube-scheduler,metrics-server,network-provider,node-role,system-rbac,update-prober,windows-node)
 ```
 
 If you use k0sctl, just add the flag when installing the cluster for the first

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -99,7 +99,7 @@ func (o *ControllerOptions) Normalize() error {
 	// Normalize component names
 	var disabledComponents []string
 	for _, disabledComponent := range o.DisableComponents {
-		if !slices.Contains(availableComponents, disabledComponent) {
+		if !slices.Contains(availableComponents, disabledComponent) && !slices.Contains(deprecatedComponents, disabledComponent) {
 			return fmt.Errorf("unknown component %s", disabledComponent)
 		}
 
@@ -279,6 +279,11 @@ var availableComponents = []string{
 	constant.SystemRBACComponentName,
 	constant.UpdateProberComponentName,
 	constant.WindowsNodeComponentName,
+}
+
+// deprecatedComponents are components that are no longer configurable via
+// --disable-components but are still accepted for backward compatibility.
+var deprecatedComponents = []string{
 	constant.WorkerConfigComponentName,
 }
 

--- a/pkg/config/cli_test.go
+++ b/pkg/config/cli_test.go
@@ -11,14 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAvailableComponents_SortedAndUnique(t *testing.T) {
-	expected := slices.Clone(availableComponents)
-	slices.Sort(expected)
+func TestComponents_SortedAndUnique(t *testing.T) {
+	for key, components := range map[string][]string{"available": availableComponents, "deprecated": deprecatedComponents} {
+		expected := slices.Clone(components)
+		slices.Sort(expected)
 
-	assert.Equal(t, expected, availableComponents, "Available components aren't sorted")
+		assert.Equal(t, expected, components, key+" components aren't sorted")
 
-	expected = slices.Compact(expected)
-	assert.Equal(t, expected, availableComponents, "Available components contain duplicates")
+		expected = slices.Compact(expected)
+		assert.Equal(t, expected, components, key+" components contain duplicates")
+	}
 }
 
 func TestControllerOptions_Normalize(t *testing.T) {
@@ -29,6 +31,16 @@ func TestControllerOptions_Normalize(t *testing.T) {
 		err := underTest.Normalize()
 
 		assert.ErrorContains(t, err, "unknown component i-dont-exist")
+	})
+
+	t.Run("acceptsDeprecatedComponents", func(t *testing.T) {
+		disabled := []string{"worker-config"}
+
+		underTest := ControllerOptions{DisableComponents: disabled}
+		err := underTest.Normalize()
+
+		require.NoError(t, err)
+		assert.Equal(t, disabled, underTest.DisableComponents)
 	})
 
 	t.Run("removesDuplicateComponents", func(t *testing.T) {


### PR DESCRIPTION
## Description

As discussed on #7321 k0s workers simply cannot start without the worker-config component at all. There is no way this is being used by anybody so just making the flag not doing anything at all seems saner.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
