### PR TITLE
Make StringMap args output deterministic

### DIFF
--- a/internal/pkg/stringmap/stringmap.go
+++ b/internal/pkg/stringmap/stringmap.go
@@ -4,8 +4,8 @@
 package stringmap
 
 import (
-	"fmt"
 	"maps"
+	"slices"
 )
 
 // StringMap defines map like arguments that can be "evaluated" into args=value pairs
@@ -21,21 +21,17 @@ func Merge(inputMap StringMap, existingMap StringMap) StringMap {
 
 // ToArgs maps the data into cmd arguments like foo=bar baz=baf
 func (m StringMap) ToArgs() []string {
-	args := make([]string, len(m))
-	idx := 0
-	for k, v := range m {
-		args[idx] = fmt.Sprintf("%s=%s", k, v)
-		idx++
+	args := make([]string, 0, len(m))
+	for _, name := range slices.Sorted(maps.Keys(m)) {
+		args = append(args, name+"="+m[name])
 	}
 	return args
 }
 
 func (m StringMap) ToDashedArgs() []string {
-	args := make([]string, len(m))
-	idx := 0
-	for k, v := range m {
-		args[idx] = fmt.Sprintf("--%s=%s", k, v)
-		idx++
+	args := make([]string, 0, len(m))
+	for _, name := range slices.Sorted(maps.Keys(m)) {
+		args = append(args, "--"+name+"="+m[name])
 	}
 	return args
 }


### PR DESCRIPTION
## Description

Map iteration order in Go is intentionally randomized. `ToArgs` and `ToDashedArgs` were iterating directly over the map, producing non-deterministic output. Since k0s embeds the arguments in Kubernetes resources, it's preferable to ensure deterministic output.

Sort the map keys and iterate over the sorted keys instead.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
