### PR TITLE
Make airgap list-images platform-aware

### DIFF
--- a/cmd/airgap/listimages.go
+++ b/cmd/airgap/listimages.go
@@ -10,13 +10,17 @@ import (
 	"github.com/k0sproject/k0s/pkg/airgap"
 	"github.com/k0sproject/k0s/pkg/config"
 
+	"github.com/containerd/platforms"
 	"github.com/spf13/cobra"
 )
 
 func newAirgapListImagesCmd() *cobra.Command {
 	var (
 		debugFlags internal.DebugFlags
-		all        bool
+		targetEnv  = airgap.TargetEnv{
+			Platform: platforms.DefaultSpec(),
+		}
+		all bool
 	)
 
 	cmd := &cobra.Command{
@@ -31,13 +35,14 @@ func newAirgapListImagesCmd() *cobra.Command {
 				return err
 			}
 
-			clusterConfig, err := opts.K0sVars.NodeConfig()
-			if err != nil {
+			if clusterConfig, err := opts.K0sVars.NodeConfig(); err != nil {
 				return fmt.Errorf("failed to get config: %w", err)
+			} else {
+				targetEnv.Spec = clusterConfig.Spec
 			}
 
 			out := cmd.OutOrStdout()
-			for _, uri := range airgap.GetImageURIs(clusterConfig.Spec, all) {
+			for _, uri := range airgap.GetImageURIs(targetEnv, all) {
 				if _, err := fmt.Fprintln(out, uri); err != nil {
 					return err
 				}
@@ -51,6 +56,7 @@ func newAirgapListImagesCmd() *cobra.Command {
 	flags := cmd.Flags()
 	flags.AddFlagSet(config.GetPersistentFlagSet())
 	flags.AddFlagSet(config.FileInputFlag())
+	flags.Var((*platformFlag)(&targetEnv.Platform), "platform", "the platform to list images for")
 	flags.BoolVar(&all, "all", false, "include all images, even if they are not used in the current configuration")
 
 	return cmd

--- a/cmd/airgap/listimages_test.go
+++ b/cmd/airgap/listimages_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"testing/iotest"
@@ -30,11 +31,20 @@ func TestAirgapListImages(t *testing.T) {
 	// on a host executing this test, it will interfere with it.
 	require.NoFileExists(t, "/run/k0s/k0s.yaml", "Runtime config exists and will interfere with this test.")
 
-	defaultImage := v1beta1.DefaultEnvoyProxyImage().URI()
+	defaults := v1beta1.DefaultClusterImages()
+	defaultEnvoyImage := v1beta1.DefaultEnvoyProxyImage().URI()
 
 	t.Run("HonorsIOErrors", func(t *testing.T) {
+		var args []string
+		switch runtime.GOOS {
+		case "linux", "windows":
+		default:
+			// Hard-code the platform when testing on platforms that won't list any images
+			args = slices.Insert(args, 0, "--platform=linux/amd64")
+		}
+
 		var writes uint
-		underTest, _, stderr := newAirgapListImagesCmdWithConfig(t, "")
+		underTest, _, stderr := newAirgapListImagesCmdWithConfig(t, "", args...)
 		underTest.SilenceUsage = true // Cobra writes usage to stdout on errors 🤔
 		underTest.SetOut(internalio.WriterFunc(func(p []byte) (int, error) {
 			writes++
@@ -47,17 +57,123 @@ func TestAirgapListImages(t *testing.T) {
 	})
 
 	t.Run("All", func(t *testing.T) {
-		underTest, out, err := newAirgapListImagesCmdWithConfig(t, "{}", "--all")
-
-		require.NoError(t, underTest.Execute())
-		lines := strings.Split(out.String(), "\n")
-		if runtime.GOARCH == "arm" {
-			assert.NotContains(t, lines, defaultImage)
-		} else {
-			assert.Contains(t, lines, defaultImage)
+		tests := []struct {
+			name                    string
+			args                    []string
+			contained, notContained []string
+		}{
+			{
+				name: "linux-amd64",
+				args: []string{"--all", "--platform=linux/amd64"},
+				contained: []string{
+					defaults.KubeProxy.URI(),
+					defaults.Pause.URI(),
+					defaults.KubeRouter.CNI.URI(),
+					defaults.Calico.CNI.URI(),
+					defaults.PushGateway.URI(),
+					defaultEnvoyImage,
+				},
+				notContained: []string{
+					defaults.Windows.KubeProxy.URI(),
+				},
+			},
+			{
+				name: "linux-arm-v7",
+				args: []string{"--all", "--platform=linux/arm/v7"},
+				contained: []string{
+					defaults.KubeProxy.URI(),
+					defaults.PushGateway.URI(),
+				},
+				notContained: []string{
+					defaultEnvoyImage,
+				},
+			},
+			{
+				name: "windows-amd64",
+				args: []string{"--all", "--platform=windows/amd64"},
+				contained: []string{
+					defaults.Windows.KubeProxy.URI(),
+					defaults.Windows.Pause.URI(),
+					defaults.Calico.Windows.CNI.URI(),
+					defaults.Calico.Windows.Node.URI(),
+				},
+				notContained: []string{
+					defaults.KubeProxy.URI(),
+					defaults.Pause.URI(),
+					defaults.CoreDNS.URI(),
+					defaults.KubeRouter.CNI.URI(),
+					defaultEnvoyImage,
+				},
+			},
 		}
 
-		assert.Empty(t, err.String())
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				underTest, out, err := newAirgapListImagesCmdWithConfig(t, "{}", test.args...)
+
+				require.NoError(t, underTest.Execute())
+
+				lines := strings.Split(out.String(), "\n")
+				for _, contained := range test.contained {
+					assert.Contains(t, lines, contained)
+				}
+				for _, notContained := range test.notContained {
+					assert.NotContains(t, lines, notContained)
+				}
+				assert.Empty(t, err.String())
+			})
+		}
+	})
+
+	t.Run("Defaults", func(t *testing.T) {
+		tests := []struct {
+			name                    string
+			args                    []string
+			contained, notContained []string
+		}{
+			{
+				name: "linux-amd64",
+				args: []string{"--platform=linux/amd64"},
+				contained: []string{
+					defaults.KubeProxy.URI(),
+					defaults.KubeRouter.CNI.URI(),
+				},
+				notContained: []string{
+					defaults.Calico.CNI.URI(),
+					defaults.PushGateway.URI(),
+					defaultEnvoyImage,
+				},
+			},
+			{
+				name: "windows-amd64",
+				args: []string{"--platform=windows/amd64"},
+				contained: []string{
+					defaults.Windows.KubeProxy.URI(),
+					defaults.Windows.Pause.URI(),
+				},
+				notContained: []string{
+					defaults.Calico.Windows.CNI.URI(),
+					defaults.KubeProxy.URI(),
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				underTest, out, err := newAirgapListImagesCmdWithConfig(t, "{}", test.args...)
+
+				require.NoError(t, underTest.Execute())
+
+				lines := strings.Split(out.String(), "\n")
+				for _, contained := range test.contained {
+					assert.Contains(t, lines, contained)
+				}
+				for _, notContained := range test.notContained {
+					assert.NotContains(t, lines, notContained)
+				}
+				assert.Empty(t, err.String())
+			})
+		}
 	})
 
 	t.Run("NodeLocalLoadBalancing", func(t *testing.T) {
@@ -80,23 +196,22 @@ spec:
 		for _, test := range []struct {
 			name                    string
 			enabled                 bool
+			args                    []string
 			contained, notContained []string
 		}{
-			{"enabled", true, []string{customImage}, []string{defaultImage}},
-			{"disabled", false, nil, []string{customImage, defaultImage}},
+			{"enabled-linux-amd64", true, []string{"--platform=linux/amd64"}, []string{customImage}, []string{defaultEnvoyImage}},
+			{"enabled-linux-arm-v7", true, []string{"--platform=linux/arm/v7"}, nil, []string{customImage, defaultEnvoyImage}},
+			{"enabled-windows-amd64", true, []string{"--platform=windows/amd64"}, nil, []string{customImage, defaultEnvoyImage}},
+			{"disabled-linux-amd64", false, []string{"--platform=linux/amd64"}, nil, []string{customImage, defaultEnvoyImage}},
 		} {
 			t.Run(test.name, func(t *testing.T) {
-				underTest, out, err := newAirgapListImagesCmdWithConfig(t, fmt.Sprintf(yamlData, test.enabled))
+				underTest, out, err := newAirgapListImagesCmdWithConfig(t, fmt.Sprintf(yamlData, test.enabled), test.args...)
 
 				require.NoError(t, underTest.Execute())
 
 				lines := strings.Split(out.String(), "\n")
 				for _, contained := range test.contained {
-					if runtime.GOARCH == "arm" {
-						assert.NotContains(t, lines, contained)
-					} else {
-						assert.Contains(t, lines, contained)
-					}
+					assert.Contains(t, lines, contained)
 				}
 				for _, notContained := range test.notContained {
 					assert.NotContains(t, lines, notContained)

--- a/docs/nllb.md
+++ b/docs/nllb.md
@@ -28,8 +28,9 @@ into the cluster. This improves the reliability and fault tolerance of the
 cluster in case a controller node becomes unhealthy.
 
 [Envoy](https://www.envoyproxy.io/) is the only load balancer that is supported
-so far. Please note that Envoy is not available on ARMv7, so node-local load
-balancing is currently unavailable on that platform.
+so far. Please note that Envoy is currently unavailable for ARMv7, RISC-V, and
+Windows, so node-local load balancing is currently unavailable on those
+platforms.
 
 ## Enabling in a cluster
 

--- a/inttest/airgap/airgap_test.go
+++ b/inttest/airgap/airgap_test.go
@@ -15,6 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 
+	"github.com/containerd/platforms"
+
 	"github.com/stretchr/testify/suite"
 )
 
@@ -78,7 +80,10 @@ func (s *AirgapSuite) TestK0sGetsUp() {
 	ssh, err := s.SSH(ctx, s.WorkerNode(0))
 	s.Require().NoError(err)
 	defer ssh.Disconnect()
-	for _, i := range airgap.GetImageURIs(v1beta1.DefaultClusterSpec(), true) {
+	for _, i := range airgap.GetImageURIs(airgap.TargetEnv{
+		Spec:     v1beta1.DefaultClusterSpec(),
+		Platform: platforms.DefaultSpec(),
+	}, true) {
 		output, err := ssh.ExecWithOutput(ctx, fmt.Sprintf(`k0s ctr i ls "name==%s"`, i))
 		s.Require().NoError(err)
 		s.Require().Containsf(output, "io.cri-containerd.pinned=pinned", "expected %s image to have io.cri-containerd.pinned=pinned label", i)

--- a/inttest/ap-airgap/airgap_test.go
+++ b/inttest/ap-airgap/airgap_test.go
@@ -19,6 +19,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 
+	"github.com/containerd/platforms"
+
 	"github.com/k0sproject/k0s/inttest/common"
 	aptest "github.com/k0sproject/k0s/inttest/common/autopilot"
 
@@ -66,7 +68,10 @@ func (s *airgapSuite) SetupTest() {
 	ssh, err := s.SSH(ctx, s.WorkerNode(0))
 	s.Require().NoError(err)
 	defer ssh.Disconnect()
-	for _, i := range airgap.GetImageURIs(v1beta1.DefaultClusterSpec(), true) {
+	for _, i := range airgap.GetImageURIs(airgap.TargetEnv{
+		Spec:     v1beta1.DefaultClusterSpec(),
+		Platform: platforms.DefaultSpec(),
+	}, true) {
 		if strings.HasPrefix(i, constant.KubePauseContainerImage+":") {
 			continue // The pause image is pinned by containerd itself
 		}
@@ -184,7 +189,10 @@ spec:
 	ssh, err := s.SSH(ctx, s.WorkerNode(0))
 	s.Require().NoError(err)
 	defer ssh.Disconnect()
-	for _, i := range airgap.GetImageURIs(v1beta1.DefaultClusterSpec(), true) {
+	for _, i := range airgap.GetImageURIs(airgap.TargetEnv{
+		Spec:     v1beta1.DefaultClusterSpec(),
+		Platform: platforms.DefaultSpec(),
+	}, true) {
 		output, err := ssh.ExecWithOutput(ctx, fmt.Sprintf(`k0s ctr i ls "name==%s"`, i))
 		if s.NoErrorf(err, "Failed to check %s", i) {
 			s.Contains(output, "io.cri-containerd.pinned=pinned", "%s is not pinned", i)

--- a/pkg/airgap/images.go
+++ b/pkg/airgap/images.go
@@ -4,46 +4,111 @@
 package airgap
 
 import (
-	"runtime"
+	"cmp"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+
+	imagespecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// GetImageURIs returns all image tags
-func GetImageURIs(spec *v1beta1.ClusterSpec, all bool) []string {
+// Describes the environment to generate an image list for, i.e. the k0s node's
+// platform and configuration.
+type TargetEnv struct {
+	// The platform of the node to generate the image list for.
+	Platform imagespecv1.Platform
 
-	imageURIs := []string{
-		spec.Images.Calico.CNI.URI(),
-		spec.Images.Calico.KubeControllers.URI(),
-		spec.Images.Calico.Node.URI(),
-		spec.Images.CoreDNS.URI(),
-		spec.Images.Konnectivity.URI(),
-		spec.Images.KubeProxy.URI(),
-		spec.Images.KubeRouter.CNI.URI(),
-		spec.Images.KubeRouter.CNIInstaller.URI(),
-		spec.Images.MetricsServer.URI(),
-		spec.Images.Pause.URI(),
-	}
+	// The cluster configuration to select images from. Note that this must be
+	// properly defaulted.
+	Spec *v1beta1.ClusterSpec
+}
 
-	if all {
-		// Currently we can't determine if the user has enabled the PushGateway via
-		// config so include it only if all is requested
-		imageURIs = append(imageURIs,
-			spec.Images.PushGateway.URI(),
+// GetImageURIs returns the image URIs that match the given env. If all is
+// specified, all images will be included in the returned list, no matter if
+// they're used in the current environment's configuration or not.
+func GetImageURIs(env TargetEnv, all bool) (uris []string) {
+	// Add base images
+	switch env.Platform.OS {
+	case "linux":
+		// Enabled by default.
+		uris = append(uris,
+			env.Spec.Images.Pause.URI(),
+			env.Spec.Images.Konnectivity.URI(),
+			env.Spec.Images.KubeProxy.URI(),
+			env.Spec.Images.CoreDNS.URI(),
+			env.Spec.Images.MetricsServer.URI(),
+		)
+
+		// Include disabled-by default images, if the user wants all images.
+		if all {
+			uris = append(uris, env.Spec.Images.PushGateway.URI())
+		}
+
+	case "windows":
+		// Enabled by default.
+		uris = append(uris,
+			env.Spec.Images.Windows.Pause.URI(),
+			env.Spec.Images.Windows.KubeProxy.URI(),
 		)
 	}
 
-	if spec.Network != nil {
-		nllb := spec.Network.NodeLocalLoadBalancing
-		if nllb != nil && (all || nllb.IsEnabled()) {
-			switch nllb.Type {
-			case v1beta1.NllbTypeEnvoyProxy:
-				if runtime.GOARCH != "arm" && nllb.EnvoyProxy != nil && nllb.EnvoyProxy.Image != nil {
-					imageURIs = append(imageURIs, nllb.EnvoyProxy.Image.URI())
-				}
+	if all || env.wantsNetworkProvider("kuberouter") {
+		switch env.Platform.OS {
+		case "linux":
+			uris = append(uris,
+				env.Spec.Images.KubeRouter.CNIInstaller.URI(),
+				env.Spec.Images.KubeRouter.CNI.URI(),
+			)
+		}
+	}
+
+	if all || env.wantsNetworkProvider("calico") {
+		switch env.Platform.OS {
+		case "linux":
+			uris = append(uris,
+				env.Spec.Images.Calico.CNI.URI(),
+				env.Spec.Images.Calico.KubeControllers.URI(),
+				env.Spec.Images.Calico.Node.URI(),
+			)
+		case "windows":
+			uris = append(uris,
+				env.Spec.Images.Calico.Windows.CNI.URI(),
+				env.Spec.Images.Calico.Windows.Node.URI(),
+			)
+		}
+	}
+
+	if all || env.wantsNLLBBackend(v1beta1.NllbTypeEnvoyProxy) {
+		switch env.Platform.OS {
+		case "linux":
+			switch env.Platform.Architecture {
+			case "arm", "riscv64":
+			default:
+				uris = append(uris,
+					env.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy.Image.URI(),
+				)
 			}
 		}
 	}
 
-	return imageURIs
+	return
+}
+
+func (e *TargetEnv) wantsNetworkProvider(provider string) bool {
+	usedProvider := "kuberouter"
+	if e.Spec != nil && e.Spec.Network != nil {
+		usedProvider = cmp.Or(e.Spec.Network.Provider, usedProvider)
+	}
+
+	return provider == usedProvider
+}
+
+func (e *TargetEnv) wantsNLLBBackend(backend v1beta1.NllbType) bool {
+	var nllbType v1beta1.NllbType
+	if e.Spec != nil && e.Spec.Network != nil {
+		if nllb := e.Spec.Network.NodeLocalLoadBalancing; nllb.IsEnabled() {
+			nllbType = cmp.Or(nllb.Type, v1beta1.NllbTypeEnvoyProxy)
+		}
+	}
+
+	return nllbType == backend
 }


### PR DESCRIPTION
## Description

Select the images for the requested target platform instead of the host platform so that list-images can produce the right list for Linux and Windows nodes. This also removes the hardcoded Envoy architecture check and makes the tests explicit about the target platform they cover.

Fixes:

* #7268

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
