### PR TITLE
Don't let Renovate bump indirect containerd v1 versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -147,6 +147,19 @@
       "groupSlug": "containerd"
     },
     {
+      "description": "Ignore indirect containerd v1 gomod bumps",
+      "enabled": false,
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepTypes": [
+        "indirect"
+      ],
+      "matchPackageNames": [
+        "github.com/containerd/containerd"
+      ]
+    },
+    {
       "description": "Group all konnectivity bumps",
       "enabled": true,
       "matchDepNames": [


### PR DESCRIPTION
## Description

Enabling the containerd version bumps in go.mod also includes the indirect containerd v1 dependency, but we don't need this to be bumped.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
