### PR TITLE
Fix kubelet dual stack kubelet flags

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -220,7 +220,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 	logrus.Infof("using listen port: %d", nodeConfig.Spec.API.Port)
 	logrus.Infof("using sans: %s", nodeConfig.Spec.API.SANs)
 
-	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.PrimaryAddressFamily())
+	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.Spec.PrimaryAddressFamily())
 	if err != nil {
 		return err
 	}
@@ -464,7 +464,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 			leaderElector,
 			adminClientFactory,
 			net.DefaultResolver,
-			nodeConfig.PrimaryAddressFamily(),
+			nodeConfig.Spec.PrimaryAddressFamily(),
 		))
 	}
 
@@ -571,7 +571,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 			LogLevel:              c.LogLevels.KubeControllerManager,
 			K0sVars:               c.K0sVars,
 			DisableLeaderElection: singleController,
-			ServiceClusterIPRange: nodeConfig.Spec.Network.BuildServiceCIDR(nodeConfig.PrimaryAddressFamily()),
+			ServiceClusterIPRange: nodeConfig.Spec.Network.BuildServiceCIDR(nodeConfig.Spec.PrimaryAddressFamily()),
 			ExtraArgs:             flags.KubeControllerManagerExtraArgs,
 		})
 	}

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -274,18 +274,19 @@ func (c *Command) Start(ctx context.Context, nodeName apitypes.NodeName, kubelet
 	}
 	componentManager.Add(ctx,
 		&worker.Kubelet{
-			NodeName:            nodeName,
-			CRISocket:           c.CriSocket,
-			EnableCloudProvider: c.CloudProvider,
-			K0sVars:             c.K0sVars,
-			StaticPods:          staticPods,
-			Kubeconfig:          kubeletKubeconfigPath,
-			Configuration:       *workerConfig.KubeletConfiguration.DeepCopy(),
-			LogLevel:            c.LogLevels.Kubelet,
-			Labels:              c.Labels,
-			Taints:              c.Taints,
-			ExtraArgs:           kubeletExtraArgs,
-			DualStackEnabled:    workerConfig.DualStackEnabled,
+			NodeName:             nodeName,
+			CRISocket:            c.CriSocket,
+			EnableCloudProvider:  c.CloudProvider,
+			K0sVars:              c.K0sVars,
+			StaticPods:           staticPods,
+			Kubeconfig:           kubeletKubeconfigPath,
+			Configuration:        *workerConfig.KubeletConfiguration.DeepCopy(),
+			LogLevel:             c.LogLevels.Kubelet,
+			Labels:               c.Labels,
+			Taints:               c.Taints,
+			ExtraArgs:            kubeletExtraArgs,
+			DualStackEnabled:     workerConfig.DualStackEnabled,
+			PrimaryAddressFamily: workerConfig.PrimaryAddressFamily,
 		})
 
 	addPlatformSpecificComponents(ctx, componentManager, c.K0sVars, workerConfig, controller, certManager)

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -152,39 +152,24 @@ func (s *DualstackSuite) SetupSuite() {
 	s.Require().NoError(err)
 	s.NoError(common.WaitForPod(s.Context(), kc, "nginx-worker1", metav1.NamespaceDefault), "nginx-worker1 pod did not start")
 
-	// test ipv6 address
-	err = wait.PollImmediateWithContext(s.Context(), 100*time.Millisecond, time.Minute, func(ctx context.Context) (done bool, err error) {
-		s.Require().Len(targetPod.Status.PodIPs, 2)
-		podIP := targetPod.Status.PodIPs[1].IP
-		targetIP := net.ParseIP(podIP)
-		s.Require().NotNil(targetIP)
-		out, err := common.PodExecCmdOutput(kc, restConfig, sourcePod.Name, sourcePod.Namespace, fmt.Sprintf("/usr/bin/wget -qO- [%s]", targetIP))
-		s.T().Log(out, err)
-		if err != nil {
-			s.T().Log("error calling ipv6 address: ", err)
-			return false, nil
-		}
-		s.T().Log("server response", out)
-		return strings.Contains(out, "Welcome to nginx"), nil
-	})
-	s.Require().NoError(err)
+	// test both ipv4 and ipv6 addresses
+	podIPs := map[string]string{}
+	podIPs["ipv4"], podIPs["ipv6"] = s.getPodIPs(targetPod)
+	for ipVersion, podIP := range podIPs {
+		err := wait.PollUntilContextTimeout(s.Context(), 100*time.Millisecond, time.Minute, true, func(ctx context.Context) (done bool, err error) {
+			target := net.JoinHostPort(podIP, "80")
+			out, err := common.PodExecCmdOutput(kc, restConfig, sourcePod.Name, sourcePod.Namespace, "/usr/bin/wget -qO- http://"+target)
+			s.T().Logf("Trying to access %s address %s: %s", ipVersion, target, out)
+			if err != nil {
+				s.T().Logf("error calling %s address: %v", ipVersion, err)
+				return false, nil
+			}
+			s.T().Logf("server response from %s address: %s", ipVersion, out)
+			return strings.Contains(out, "Welcome to nginx"), nil
+		})
+		s.Require().NoErrorf(err, "failed to access nginx server via %s address", ipVersion)
+	}
 
-	// test ipv4 address
-	err = wait.PollImmediateWithContext(s.Context(), 100*time.Millisecond, time.Minute, func(ctx context.Context) (done bool, err error) {
-		s.Require().Len(targetPod.Status.PodIPs, 2)
-		podIP := targetPod.Status.PodIPs[0].IP
-		targetIP := net.ParseIP(podIP)
-		s.Require().NotNil(targetIP)
-		out, err := common.PodExecCmdOutput(kc, restConfig, sourcePod.Name, sourcePod.Namespace, fmt.Sprintf("/usr/bin/wget -qO- %s", targetIP))
-		s.T().Log(out, err)
-		if err != nil {
-			s.T().Log("error calling ipv4 address: ", err)
-			return false, nil
-		}
-		s.T().Log("server response", out)
-		return strings.Contains(out, "Welcome to nginx"), nil
-	})
-	s.Require().NoError(err)
 	s.client = client
 
 	s.T().Log("Validate the kube-dns service address")
@@ -198,6 +183,19 @@ func (s *DualstackSuite) SetupSuite() {
 	for _, err := range common.VerifyNoRestartedPods(s.Context(), client) {
 		s.NoError(err)
 	}
+}
+
+func (s *DualstackSuite) getPodIPs(pod *corev1.Pod) (string, string) {
+	s.Require().Len(pod.Status.PodIPs, 2)
+	ipv4, ipv6 := pod.Status.PodIPs[0].IP, pod.Status.PodIPs[1].IP
+	if s.defaultIPv6 {
+		ipv4, ipv6 = pod.Status.PodIPs[1].IP, pod.Status.PodIPs[0].IP
+	}
+	s.Require().NotNil(net.ParseIP(ipv4).To4(), "pod has an unexpected non IPv4 address %q", ipv4)
+	s.Require().Nil(net.ParseIP(ipv6).To4(), "pod has an unexpected IPv4 address %q", ipv6)
+	s.Require().NotNil(net.ParseIP(ipv6).To16(), "pod has an unexpected non IPv6 address %q", ipv6)
+
+	return ipv4, ipv6
 }
 
 func (s *DualstackSuite) validateKubeDNSIP(client *k8s.Clientset) {

--- a/pkg/apis/k0s/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types.go
@@ -482,7 +482,7 @@ func (c *ClusterConfig) Validate() (errs []error) {
 // - Network.PrimaryAddressFamily
 // - Install
 func (c *ClusterConfig) GetClusterWideConfig() *ClusterConfig {
-	primaryAF := c.PrimaryAddressFamily()
+	primaryAF := c.Spec.PrimaryAddressFamily()
 	c = c.DeepCopy()
 	if c != nil && c.Spec != nil {
 		c.Spec.API = nil
@@ -508,9 +508,9 @@ func (c *ClusterConfig) CRValidator() *ClusterConfig {
 	return copy
 }
 
-func (c *ClusterConfig) PrimaryAddressFamily() PrimaryAddressFamilyType {
-	if c != nil && c.Spec != nil && c.Spec.Network != nil && c.Spec.Network.PrimaryAddressFamily != PrimaryFamilyUnknown {
-		return c.Spec.Network.PrimaryAddressFamily
+func (s *ClusterSpec) PrimaryAddressFamily() PrimaryAddressFamilyType {
+	if s != nil && s.Network != nil && s.Network.PrimaryAddressFamily != PrimaryFamilyUnknown {
+		return s.Network.PrimaryAddressFamily
 	}
-	return c.Spec.API.DetectPrimaryAddressFamily()
+	return s.API.DetectPrimaryAddressFamily()
 }

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -104,7 +104,7 @@ func (a *APIServer) Start(ctx context.Context) error {
 		"requestheader-allowed-names":      "front-proxy-client",
 		"requestheader-client-ca-file":     filepath.Join(a.K0sVars.CertRootDir, "front-proxy-ca.crt"),
 		"service-account-key-file":         filepath.Join(a.K0sVars.CertRootDir, "sa.pub"),
-		"service-cluster-ip-range":         a.ClusterConfig.Spec.Network.BuildServiceCIDR(a.ClusterConfig.PrimaryAddressFamily()),
+		"service-cluster-ip-range":         a.ClusterConfig.Spec.Network.BuildServiceCIDR(a.ClusterConfig.Spec.PrimaryAddressFamily()),
 		"tls-min-version":                  "VersionTLS12",
 		"tls-cert-file":                    filepath.Join(a.K0sVars.CertRootDir, "server.crt"),
 		"tls-private-key-file":             filepath.Join(a.K0sVars.CertRootDir, "server.key"),

--- a/pkg/component/controller/calico.go
+++ b/pkg/component/controller/calico.go
@@ -93,7 +93,7 @@ type calicoClusterConfig struct {
 
 // NewCalico creates new Calico reconciler component
 func NewCalico(nodeConfig *v1beta1.ClusterConfig, manifestsDir string, hasWindowsNodes func() (*bool, <-chan struct{})) (*Calico, error) {
-	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.PrimaryAddressFamily())
+	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.Spec.PrimaryAddressFamily())
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func NewCalico(nodeConfig *v1beta1.ClusterConfig, manifestsDir string, hasWindow
 			ServiceCIDRIPv4: nodeConfig.Spec.Network.ServiceCIDR,
 			ClusterDNSIP:    dnsAddress,
 		},
-		primaryAddressFamily: nodeConfig.PrimaryAddressFamily(),
+		primaryAddressFamily: nodeConfig.Spec.PrimaryAddressFamily(),
 		manifestsDir:         manifestsDir,
 		hasWindowsNodes:      hasWindowsNodes,
 	}, nil

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -293,7 +293,7 @@ type coreDNSConfig struct {
 
 // NewCoreDNS creates new instance of CoreDNS component
 func NewCoreDNS(k0sVars *config.CfgVars, clientFactory k8sutil.ClientFactoryInterface, nodeConfig *v1beta1.ClusterConfig) (*CoreDNS, error) {
-	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.PrimaryAddressFamily())
+	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.Spec.PrimaryAddressFamily())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -119,7 +119,7 @@ func (k *KubeRouter) Reconcile(_ context.Context, clusterConfig *v1beta1.Cluster
 	}
 
 	// IPv6 requires a router ID, instead of generating one ourselves, rely on kube-router logic
-	if clusterConfig.PrimaryAddressFamily() == v1beta1.PrimaryFamilyIPv6 {
+	if clusterConfig.Spec.PrimaryAddressFamily() == v1beta1.PrimaryFamilyIPv6 {
 		args["router-id"] = "generate"
 	}
 

--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -86,7 +86,7 @@ var (
 func NewReconciler(k0sVars *config.CfgVars, nodeConfig *v1beta1.ClusterConfig, clientFactory kubeutil.ClientFactoryInterface, leaderElector leaderelector.Interface, konnectivityEnabled, autopilotDisabled bool) (*Reconciler, error) {
 	log := logrus.WithFields(logrus.Fields{"component": "workerconfig.Reconciler"})
 
-	clusterDNSIPString, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.PrimaryAddressFamily())
+	clusterDNSIPString, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.Spec.PrimaryAddressFamily())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -49,12 +49,13 @@ type resources = []*unstructured.Unstructured
 type Reconciler struct {
 	log logrus.FieldLogger
 
-	clusterDomain       string
-	clusterDNSIP        net.IP
-	clientFactory       kubeutil.ClientFactoryInterface
-	leaderElector       leaderelector.Interface
-	konnectivityEnabled bool
-	autopilotDisabled   bool
+	clusterDomain        string
+	clusterDNSIP         net.IP
+	clientFactory        kubeutil.ClientFactoryInterface
+	leaderElector        leaderelector.Interface
+	konnectivityEnabled  bool
+	autopilotDisabled    bool
+	primaryAddressFamily v1beta1.PrimaryAddressFamilyType
 
 	mu    sync.Mutex
 	state reconcilerState
@@ -98,12 +99,13 @@ func NewReconciler(k0sVars *config.CfgVars, nodeConfig *v1beta1.ClusterConfig, c
 	reconciler := &Reconciler{
 		log: log,
 
-		clusterDomain:       nodeConfig.Spec.Network.ClusterDomain,
-		clusterDNSIP:        clusterDNSIP,
-		clientFactory:       clientFactory,
-		leaderElector:       leaderElector,
-		konnectivityEnabled: konnectivityEnabled,
-		autopilotDisabled:   autopilotDisabled,
+		clusterDomain:        nodeConfig.Spec.Network.ClusterDomain,
+		clusterDNSIP:         clusterDNSIP,
+		clientFactory:        clientFactory,
+		leaderElector:        leaderElector,
+		konnectivityEnabled:  konnectivityEnabled,
+		autopilotDisabled:    autopilotDisabled,
+		primaryAddressFamily: nodeConfig.Spec.PrimaryAddressFamily(),
 
 		state: reconcilerCreated,
 	}
@@ -604,8 +606,9 @@ func (r *Reconciler) buildProfile(snapshot *snapshot) *workerconfig.Profile {
 			Enabled:   r.konnectivityEnabled,
 			AgentPort: snapshot.konnectivityAgentPort,
 		},
-		DualStackEnabled:  snapshot.dualStackEnabled,
-		AutopilotDisabled: r.autopilotDisabled,
+		DualStackEnabled:     snapshot.dualStackEnabled,
+		AutopilotDisabled:    r.autopilotDisabled,
+		PrimaryAddressFamily: snapshot.primaryAddressFamily,
 	}
 
 	if workerProfile.NodeLocalLoadBalancing != nil &&

--- a/pkg/component/controller/workerconfig/reconciler_test.go
+++ b/pkg/component/controller/workerconfig/reconciler_test.go
@@ -356,6 +356,7 @@ func TestReconciler_ResourceGeneration(t *testing.T) {
 						APIServerBindPort: 1337,
 					},
 				},
+				PrimaryAddressFamily: v1beta1.PrimaryFamilyIPv4,
 			},
 			Images: &v1beta1.ClusterImages{
 				DefaultPullPolicy: string(corev1.PullNever),

--- a/pkg/component/controller/workerconfig/snapshot.go
+++ b/pkg/component/controller/workerconfig/snapshot.go
@@ -38,6 +38,7 @@ type configSnapshot struct {
 	featureGates           v1beta1.FeatureGates
 	pauseImage             *v1beta1.ImageSpec
 	pauseWindowsImage      *v1beta1.ImageSpec
+	primaryAddressFamily   v1beta1.PrimaryAddressFamilyType
 }
 
 func (s *snapshot) DeepCopy() *snapshot {
@@ -71,6 +72,7 @@ func (s *configSnapshot) DeepCopyInto(out *configSnapshot) {
 	out.featureGates = s.featureGates.DeepCopy()
 	out.pauseImage = s.pauseImage.DeepCopy()
 	out.pauseWindowsImage = s.pauseWindowsImage.DeepCopy()
+	out.primaryAddressFamily = s.primaryAddressFamily
 }
 
 // takeConfigSnapshot converts ClusterSpec to a delta snapshot
@@ -91,5 +93,6 @@ func takeConfigSnapshot(spec *v1beta1.ClusterSpec) configSnapshot {
 		spec.FeatureGates.DeepCopy(),
 		spec.Images.Pause.DeepCopy(),
 		spec.Images.Windows.Pause.DeepCopy(),
+		spec.PrimaryAddressFamily(),
 	}
 }

--- a/pkg/component/worker/config/config.go
+++ b/pkg/component/worker/config/config.go
@@ -28,6 +28,7 @@ type Profile struct {
 	PauseImage             *v1beta1.ImageSpec
 	DualStackEnabled       bool
 	AutopilotDisabled      bool
+	PrimaryAddressFamily   v1beta1.PrimaryAddressFamilyType
 }
 
 func (p *Profile) DeepCopy() *Profile {
@@ -145,6 +146,7 @@ func forEachConfigMapEntry(profile *Profile, f func(fieldName string, ptr any)) 
 		"pauseImage":             &profile.PauseImage,
 		"dualStackEnabled":       &profile.DualStackEnabled,
 		"autopilotDisabled":      &profile.AutopilotDisabled,
+		"primaryAddressFamily":   &profile.PrimaryAddressFamily,
 	} {
 		f(fieldName, ptr)
 	}

--- a/pkg/component/worker/kubelet.go
+++ b/pkg/component/worker/kubelet.go
@@ -17,6 +17,7 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/internal/pkg/stringmap"
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/assets"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/config"
@@ -37,19 +38,20 @@ import (
 
 // Kubelet is the component implementation to manage kubelet
 type Kubelet struct {
-	NodeName            apitypes.NodeName
-	CRISocket           string
-	EnableCloudProvider bool
-	K0sVars             *config.CfgVars
-	Kubeconfig          string
-	Configuration       kubeletv1beta1.KubeletConfiguration
-	StaticPods          StaticPods
-	LogLevel            string
-	ClusterDNS          string
-	Labels              map[string]string
-	Taints              []string
-	ExtraArgs           stringmap.StringMap
-	DualStackEnabled    bool
+	NodeName             apitypes.NodeName
+	CRISocket            string
+	EnableCloudProvider  bool
+	K0sVars              *config.CfgVars
+	Kubeconfig           string
+	Configuration        kubeletv1beta1.KubeletConfiguration
+	StaticPods           StaticPods
+	LogLevel             string
+	ClusterDNS           string
+	Labels               map[string]string
+	Taints               []string
+	ExtraArgs            stringmap.StringMap
+	DualStackEnabled     bool
+	PrimaryAddressFamily v1beta1.PrimaryAddressFamilyType
 
 	configPath     string
 	supervisor     *supervisor.Supervisor
@@ -128,7 +130,11 @@ func (k *Kubelet) Start(ctx context.Context) error {
 		// The kubelet will perform some extra validations on the discovered IP
 		// addresses in the private function k8s.io/kubernetes/pkg/kubelet.validateNodeIP
 		// which won't be replicated here.
-		args["--node-ip"] = ipv4.String() + "," + ipv6.String()
+		if k.PrimaryAddressFamily == v1beta1.PrimaryFamilyIPv6 {
+			args["--node-ip"] = ipv6.String() + "," + ipv4.String()
+		} else {
+			args["--node-ip"] = ipv4.String() + "," + ipv6.String()
+		}
 	}
 
 	switch runtime.GOOS {


### PR DESCRIPTION
## Description

This commit does three different things:
1- Move the method `PrimaryAddressFamily` from `ClusterConfig` to `ClusterSpec`. This is a preparation for including the `primaryAddressFamily` in the `workerProfile`
2- Add a `PrimaryAddressFamily` to the `workerProfile`
3- Set kubelet's node-ip to a value according to the `primaryAddressFamily`.

Fixes #7464

#7464 mentions that they need to set several flags, but we only need to set the node-ip. The remaining flagsare not required as we're not filling them and kubelet is inferring them from the node-ip.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
