### PR TITLE
Add GitHub Actions problem matchers for golangci-lint

### DIFF
--- a/.github/golangci-lint-problem-matchers.json
+++ b/.github/golangci-lint-problem-matchers.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Adopted from https://github.com/golangci/golangci-lint-action/blob/789f114c52eaee9275c87b15fc90e449e56d1b0a/problem-matchers.json",
+  "problemMatcher": [
+    {
+      "owner": "golangci-lint",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^([^:]+):(\\d+):(?:(\\d+):)?\\s+(.+ \\(.+\\))$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -81,6 +81,9 @@ jobs:
             build/cache/go/build
             build/cache/golangci-lint
 
+      - name: Register golangci-lint problem matchers
+        run: echo "::add-matcher::.github/golangci-lint-problem-matchers.json"
+
       - name: Run linter
         env:
           CACHE_HIT_GOLANGCI: "${{ steps.cache-golangci.outputs.cache-hit }}"


### PR DESCRIPTION
## Description

Register some GitHub Actions problem matchers before running golangci-lint so that errors will be picked up and displayed in PR review UI.

The problem matchers have been copied over from golangci/golangci-lint-action, which should just work with golangci-lint's default text output format.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
