### PR TITLE
Add missing releaseName to Prometheus HelmChart example

### DIFF
--- a/docs/helm-charts.md
+++ b/docs/helm-charts.md
@@ -33,6 +33,7 @@ metadata:
   namespace: kube-system
 spec:
   chartName: prometheus-community/prometheus
+  releaseName: prometheus
   version: "14.6.1"
   namespace: default
   values: |


### PR DESCRIPTION
## Summary

Fixes #7291

The Prometheus HelmChart example in the docs was missing the releaseName field. Added it so the example actually works.

## Type of change

- [x] Documentation update

## Checklist

- [x] My code follows the code style of this project
- [x] My commits are signed off
- [x] I have self-reviewed my code
- [x] I have updated documentation
- [ ] I have added tests