### PR TITLE
Hard-code the containerd git revision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,11 +102,7 @@ LD_FLAGS += -X k8s.io/component-base/version.gitMinor=$(word 2,$(subst ., ,$(kub
 LD_FLAGS += -X k8s.io/component-base/version.buildDate=$(BUILD_DATE)
 LD_FLAGS += -X k8s.io/component-base/version.gitCommit=not_available
 LD_FLAGS += -X github.com/containerd/containerd/v2/version.Version=$(containerd_version)
-ifeq ($(EMBEDDED_BINS_BUILDMODE), docker)
-ifeq ($(TARGET_OS),linux)
-LD_FLAGS += -X github.com/containerd/containerd/v2/version.Revision=$(shell ./embedded-bins/staging/linux/bin/containerd --version | awk '{print $$4}')
-endif
-endif
+LD_FLAGS += -X github.com/containerd/containerd/v2/version.Revision=$(containerd_revision)
 LD_FLAGS += $(BUILD_GO_LDFLAGS_EXTRA)
 
 GOLANG_IMAGE ?= $(golang_buildimage)

--- a/embedded-bins/Makefile
+++ b/embedded-bins/Makefile
@@ -91,6 +91,7 @@ build_docker_image = \
 	  --build-arg CONTAINERD_BINS="$(containerd_bins)" \
 	  --build-arg KUBERNETES_BINS="$(kubernetes_bins)" \
 	  --build-arg VERSION=$($(patsubst %/Dockerfile,%,$<)_version) \
+	  --build-arg REVISION=$($(patsubst %/Dockerfile,%,$<)_revision) \
 	  --build-arg SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
 	  --build-arg BUILDIMAGE=$($(patsubst %/Dockerfile,%,$<)_buildimage) \
 	  --build-arg BUILD_GO_TAGS=$($(patsubst %/Dockerfile,%,$<)_build_go_tags) \

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -16,8 +16,11 @@ runc_build_go_tags = "seccomp"
 runc_build_go_ldflags = -w -s
 runc_build_go_ldflags_extra = -extldflags=-static
 
-# renovate: datasource=github-releases depName=containerd/containerd
-containerd_version = 2.2.2
+# renovate: datasource=github-tags depName=containerd/containerd
+containerd_version_and_rev = 2.2.2@301b2dac98f15c27117da5c8af12118a041a31d9
+containerd_revision = $(word 2,$(subst @, ,$(containerd_version_and_rev)))
+containerd_version = $(word 1,$(subst @, ,$(containerd_version_and_rev)))
+containerd_build_extra_args = --build-arg REVISION=$(containerd_revision)
 containerd_buildimage = $(golang_buildimage)
 containerd_build_go_tags = "apparmor,selinux"
 containerd_build_shim_go_cgo_enabled = 0

--- a/embedded-bins/containerd/Dockerfile
+++ b/embedded-bins/containerd/Dockerfile
@@ -19,10 +19,17 @@ RUN if [ ! -z "$(which apt)" ]; then \
     fi
 
 ARG VERSION
-RUN mkdir -p $GOPATH/src/github.com/containerd/containerd
-RUN \
-  git -c advice.detachedHead=false clone -b v$VERSION --depth=1 https://github.com/containerd/containerd.git $GOPATH/src/github.com/containerd/containerd
 WORKDIR /go/src/github.com/containerd/containerd
+RUN git -c advice.detachedHead=false clone --revision refs/tags/v$VERSION --depth=1 https://github.com/containerd/containerd.git .
+ARG REVISION
+RUN set -eu \
+  && if [ -n "$REVISION" ]; then \
+    actual=$(git rev-parse HEAD); \
+    [ "$actual" = "$REVISION" ] || { \
+      printf 'error: tag v%s resolves to %s, expected %s\n' "$VERSION" "$actual" "$REVISION" >&2; \
+      exit 1; \
+    }; \
+  fi
 
 ARG TARGET_OS \
   BUILD_GO_TAGS \

--- a/renovate.json
+++ b/renovate.json
@@ -393,7 +393,7 @@
         "**/*.yml"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+)( registryUrl=(?<registryUrl>.+))? depName=(?<depName>\\S+)( versioning=(?<versioning>.+))?\\n[^:=\\n]+[:=][ \\t]*[\"']?(?<currentValue>\\S+?)[\"']?[ \\t]*(:?#|\\n)",
+        "# renovate: datasource=(?<datasource>\\S+)( registryUrl=(?<registryUrl>.+))? depName=(?<depName>\\S+)( versioning=(?<versioning>.+))?\\n[^:=\\n]+[:=][ \\t]*[\"']?(?<currentValue>[^@\\s\"']+)(?:@(?<currentDigest>[0-9a-f]{40}))?[\"']?[ \\t]*(:?#|\\n)",
         "[=:][ \\t]*[\"']?(?<currentValue>\\S+?)[\"']?[ \\t]*# renovate: datasource=(?<datasource>\\S+)( registryUrl=(?<registryUrl>.+))? depName=(?<depName>\\S+)( versioning=(?<versioning>.+))?\\n"
       ],
       "datasourceTemplate": "{{{datasource}}}",


### PR DESCRIPTION
## Description

The k0s build used a $(shell ...) expansion in the Makefile to retrieve the containerd revision from the embedded executable. This was sort of a hack in the first place, as it wasn't guaranteed that the built executable would actually run on the host system, nor that it even existed. However, it used to work reliably on CI. Now that k0s uses an appended ZIP file to embed the executables, the executable is no longer guaranteed to be built before k0s. This makes it now fail on CI, depending on the build timing.

Instead, store the expected git revision alongside the containerd version as version@revision in the embedded binaries Makefile.variables, and derive both containerd_version and containerd_revision from it. The revision is passed as the REVISION build arg to the containerd Dockerfile and verified against the cloned tag after checkout.

Teach Renovate to update the revision alongside with the tag. Extend the regex to optionally include the revision after the @ character, and switch containerd's datasource to github-tags, as this is the source which is providing git revisions. The github-releases source provides artifact file hashes instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
