### PR TITLE
Default Chart release name to the object name when unset

### DIFF
--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -9,7 +9,9 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -463,7 +465,10 @@ func (as *AddonsSuite) deleteUninstalledChart(ctx context.Context) {
 		Version:     spec.Version,
 		AppVersion:  "1",
 		Revision:    1,
-		ValuesHash:  spec.HashValues(),
+		ValuesHash: func() string {
+			hash := sha256.Sum256([]byte(spec.ReleaseName))
+			return hex.EncodeToString(hash[:])
+		}(),
 	}
 	chart := &helmv1beta1.Chart{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/helm/v1beta1/chart_types.go
+++ b/pkg/apis/helm/v1beta1/chart_types.go
@@ -71,10 +71,10 @@ type ChartSpec struct {
 }
 
 // YamlValues returns values as map
-func (cs ChartSpec) YamlValues() map[string]any {
+func (s *ChartSpec) YamlValues() map[string]any {
 	res := map[string]any{}
-	if err := yaml.Unmarshal([]byte(cs.Values), &res); err != nil {
-		logrus.WithField("values", cs.Values).Warn("broken yaml values")
+	if err := yaml.Unmarshal([]byte(s.Values), &res); err != nil {
+		logrus.WithField("values", s.Values).Warn("broken yaml values")
 	}
 	// We need to clean the map to have nested maps as map[string]interface{} types
 	// otherwise Helm will fail to merge default values and create the release object
@@ -82,17 +82,17 @@ func (cs ChartSpec) YamlValues() map[string]any {
 }
 
 // HashValues returns hash of the values
-func (cs ChartSpec) HashValues() string {
+func (s *ChartSpec) HashValues() string {
 	h := sha256.New()
-	h.Write([]byte(cs.ReleaseName + cs.Values))
+	h.Write([]byte(s.ReleaseName + s.Values))
 	return hex.EncodeToString(h.Sum(nil))
 }
 
 // ShouldForceUpgrade returns true if the chart should be force upgraded
-func (cs ChartSpec) ShouldForceUpgrade() bool {
+func (s *ChartSpec) ShouldForceUpgrade() bool {
 	// This defaults to true when not explicitly set to false.
 	// Better have this the other way round in the next API version.
-	return cs.ForceUpgrade == nil || *cs.ForceUpgrade
+	return s.ForceUpgrade == nil || *s.ForceUpgrade
 }
 
 // ChartStatus defines the observed state of Chart

--- a/pkg/apis/helm/v1beta1/chart_types.go
+++ b/pkg/apis/helm/v1beta1/chart_types.go
@@ -4,9 +4,6 @@
 package v1beta1
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -79,13 +76,6 @@ func (s *ChartSpec) YamlValues() map[string]any {
 	// We need to clean the map to have nested maps as map[string]interface{} types
 	// otherwise Helm will fail to merge default values and create the release object
 	return CleanUpGenericMap(res)
-}
-
-// HashValues returns hash of the values
-func (s *ChartSpec) HashValues() string {
-	h := sha256.New()
-	h.Write([]byte(s.ReleaseName + s.Values))
-	return hex.EncodeToString(h.Sum(nil))
 }
 
 // ShouldForceUpgrade returns true if the chart should be force upgraded

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -4,7 +4,10 @@
 package controller
 
 import (
+	"cmp"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -464,16 +467,17 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart helmv
 	if chart.Status.ReleaseName == "" {
 		isInstalling = true
 		status := release.StatusUnknown
-		if chartRelease, err = helmCmd.GetRelease(ctx, chart.Spec.ReleaseName, chart.Spec.Namespace); err == nil && chartRelease.Info != nil {
+		releaseName := effectiveChartReleaseName(&chart)
+		if chartRelease, err = helmCmd.GetRelease(ctx, releaseName, chart.Spec.Namespace); err == nil && chartRelease.Info != nil {
 			status = chartRelease.Info.Status
 		}
 
 		switch {
 		case status == release.StatusPendingInstall, status == release.StatusFailed, status == release.StatusUninstalling:
-			if err := helmCmd.UninstallRelease(ctx, chart.Spec.ReleaseName, chart.Spec.Namespace); err != nil {
-				return fmt.Errorf("failed to uninstall %q in %q before reinstall: %w", chart.Spec.ReleaseName, chart.Spec.Namespace, err)
+			if err := helmCmd.UninstallRelease(ctx, releaseName, chart.Spec.Namespace); err != nil {
+				return fmt.Errorf("failed to uninstall %q in %q before reinstall: %w", releaseName, chart.Spec.Namespace, err)
 			}
-			cr.L.Info("Uninstalled release ", chart.Spec.ReleaseName, " before reinstall due to status ", status)
+			cr.L.Info("Uninstalled release ", releaseName, " before reinstall due to status ", status)
 			fallthrough // proceed with installation
 
 		case status == release.StatusUninstalled, err != nil:
@@ -486,7 +490,7 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart helmv
 			chartRelease, err = helmCmd.InstallChart(ctx,
 				chartName,
 				chart.Spec.Version,
-				chart.Spec.ReleaseName,
+				releaseName,
 				chart.Spec.Namespace,
 				chart.Spec.YamlValues(),
 				timeout,
@@ -498,7 +502,7 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart helmv
 					case <-ctx.Done():
 						err = fmt.Errorf("%w (%w)", err, context.Cause(ctx))
 					default:
-						if uninstallErr := helmCmd.UninstallRelease(ctx, chart.Spec.ReleaseName, chart.Spec.Namespace); uninstallErr != nil {
+						if uninstallErr := helmCmd.UninstallRelease(ctx, releaseName, chart.Spec.Namespace); uninstallErr != nil {
 							err = fmt.Errorf("an error occurred while uninstalling: %w; original install error: %w", uninstallErr, err)
 						}
 					}
@@ -627,10 +631,20 @@ func extractOCIRegistryURL(chartName string) string {
 
 func (cr *ChartReconciler) chartNeedsUpgrade(chart helmv1beta1.Chart) bool {
 	return chart.Status.Namespace != chart.Spec.Namespace ||
-		chart.Status.ReleaseName != chart.Spec.ReleaseName ||
+		chart.Status.ReleaseName != effectiveChartReleaseName(&chart) ||
 		chart.Status.Version != chart.Spec.Version ||
 		chart.Status.Error != "" ||
-		chart.Status.ValuesHash != chart.Spec.HashValues()
+		chart.Status.ValuesHash != hashChartValues(&chart)
+}
+
+func effectiveChartReleaseName(chart *helmv1beta1.Chart) string {
+	return cmp.Or(chart.Spec.ReleaseName, chart.Name)
+}
+
+func hashChartValues(chart *helmv1beta1.Chart) string {
+	h := sha256.New()
+	h.Write([]byte(effectiveChartReleaseName(chart) + chart.Spec.Values))
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // updateStatus updates the status of the chart with the given release information. This function
@@ -659,7 +673,7 @@ func (cr *ChartReconciler) updateStatus(ctx context.Context, chart helmv1beta1.C
 	if err != nil {
 		updchart.Status.Error = err.Error()
 	}
-	updchart.Status.ValuesHash = chart.Spec.HashValues()
+	updchart.Status.ValuesHash = hashChartValues(&chart)
 	if updErr := cr.Client.Status().Update(ctx, &updchart); updErr != nil {
 		cr.L.WithError(updErr).Error("Failed to update status for chart release", chart.Name)
 		return updErr

--- a/pkg/component/controller/extensions_controller_test.go
+++ b/pkg/component/controller/extensions_controller_test.go
@@ -119,6 +119,27 @@ func TestChartNeedsUpgrade(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"no_changes_with_implicit_release_name",
+			v1beta1.Chart{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-release",
+				},
+				Spec: v1beta1.ChartSpec{
+					ChartName: "test",
+					Values:    "",
+					Version:   "0.0.1",
+					Namespace: "ns",
+				},
+				Status: v1beta1.ChartStatus{
+					ReleaseName: "test-release",
+					Version:     "0.0.1",
+					Namespace:   "ns",
+					ValuesHash:  "41c7250e092d11639c77c823fb34afa232c5ceb316ad546b4df506606ef9b3e4",
+				},
+			},
+			false,
+		},
 	}
 
 	cr := new(ChartReconciler)


### PR DESCRIPTION
## Description

The Chart spec's `releaseName` field is documented as optional, with a fallback to the Chart object's name. However, this has never been implemented. In that case, an empty releaseName was passed to Helm as is, which in turn resulted in an error.

Implement the proper fallback. Add a helper function that returns either the release name or the Chart object's name. Move the value hashing from being a method on the ChartSpec struct to the reconciler, so that it can use the new helper, and the data model is not exposing reconciler implementation details.

See:

* #7291

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
