### PR TITLE
Let Renovate bump the OpenTofu modules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,12 +23,23 @@
   },
   "enabledManagers": [
     "gomod",
+    "terraform",
     "custom.regex"
   ],
   "postUpdateOptions": [
     "gomodTidy"
   ],
   "packageRules": [
+    {
+      "description": "Use OpenTofu registry for Terraform providers and modules",
+      "matchDatasources": [
+        "terraform-provider",
+        "terraform-module"
+      ],
+      "registryUrls": [
+        "https://registry.opentofu.org"
+      ]
+    },
     {
       "description": "Special version scheme for k0sproject OCI images",
       "matchPackageNames": [


### PR DESCRIPTION
## Description

See https://docs.renovatebot.com/modules/manager/terraform/#terraform-vs-opentofu.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
