### PR TITLE
Remove Dependabot rule for hack/tool/

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,9 +72,3 @@ updates:
       mkdocs:
         patterns:
           - "mkdocs*"
-
-  - package-ecosystem: gomod
-    directory: /hack/tool
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 5


### PR DESCRIPTION
## Description

That folder has been deleted quite some time ago.

See:

* #6424

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
