### PR TITLE
dynamic-config: immutable primaryAddressFamily

### DIFF
--- a/inttest/configchange/config_test.go
+++ b/inttest/configchange/config_test.go
@@ -182,6 +182,17 @@ func (s *ConfigSuite) TestK0sGetsUp() {
 		}
 
 	})
+
+	s.Run("changing primary address family should fail", func() {
+		originalConfig, err := cfgClient.Get(s.Context(), "k0s", metav1.GetOptions{})
+		s.Require().NoError(err)
+		s.Require().Equal(v1beta1.PrimaryFamilyIPv4, originalConfig.Spec.Network.PrimaryAddressFamily)
+		newConfig := originalConfig.DeepCopy()
+		newConfig.Spec.Network = v1beta1.DefaultNetwork()
+		newConfig.Spec.Network.PrimaryAddressFamily = v1beta1.PrimaryFamilyIPv6
+		_, err = cfgClient.Update(s.Context(), newConfig, metav1.UpdateOptions{})
+		s.Require().Error(err)
+	})
 }
 
 func (s *ConfigSuite) waitForReconcileEvent(eventWatch watch.Interface) (*corev1.Event, error) {

--- a/pkg/apis/k0s/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types.go
@@ -482,6 +482,7 @@ func (c *ClusterConfig) Validate() (errs []error) {
 // - Network.PrimaryAddressFamily
 // - Install
 func (c *ClusterConfig) GetClusterWideConfig() *ClusterConfig {
+	primaryAF := c.PrimaryAddressFamily()
 	c = c.DeepCopy()
 	if c != nil && c.Spec != nil {
 		c.Spec.API = nil
@@ -490,7 +491,7 @@ func (c *ClusterConfig) GetClusterWideConfig() *ClusterConfig {
 			c.Spec.Network.ServiceCIDR = ""
 			c.Spec.Network.ClusterDomain = ""
 			c.Spec.Network.ControlPlaneLoadBalancing = nil
-			c.Spec.Network.PrimaryAddressFamily = ""
+			c.Spec.Network.PrimaryAddressFamily = primaryAF
 		}
 		c.Spec.Install = nil
 	}

--- a/pkg/apis/k0s/v1beta1/network.go
+++ b/pkg/apis/k0s/v1beta1/network.go
@@ -54,7 +54,7 @@ type Network struct {
 	// If empty, k0s determines it based on `.spec.API.ExternalAddress`,
 	// if this isn't present it will use `.spec.API.Address.`.
 	// If both addresses are empty or the chosen address is a hostname, defaults to `IPv4`.
-	// +Kubebuilder:validation:Enum=IPv4;IPv6
+	// +kubebuilder:validation:XValidation:rule="oldSelf == '' || self == oldSelf",message="cannot change primary address family"
 	PrimaryAddressFamily PrimaryAddressFamilyType `json:"primaryAddressFamily,omitempty"`
 }
 

--- a/pkg/component/controller/clusterconfig/apiconfigsource.go
+++ b/pkg/component/controller/clusterconfig/apiconfigsource.go
@@ -13,6 +13,8 @@ import (
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -42,6 +44,7 @@ func (*apiConfigSource) Init(context.Context) error { return nil }
 // Start implements [manager.Component].
 func (a *apiConfigSource) Start(context.Context) error {
 	var lastObservedVersion string
+	var lastKnownPAF v1beta1.PrimaryAddressFamilyType
 
 	log := logrus.WithField("component", "clusterconfig.apiConfigSource")
 	watch := watch.ClusterConfigs(a.configClient).
@@ -75,6 +78,22 @@ func (a *apiConfigSource) Start(context.Context) error {
 		defer close(done)
 		defer close(a.resultChan)
 		_ = watch.Until(ctx, func(cfg *v1beta1.ClusterConfig) (bool, error) {
+			// Restore PrimaryAddressFamily if a client dropped it.
+			if cfg.Spec != nil && cfg.Spec.Network != nil {
+				if cfg.Spec.Network.PrimaryAddressFamily == "" && lastKnownPAF != "" {
+					restored := cfg.DeepCopy()
+					restored.Spec.Network.PrimaryAddressFamily = lastKnownPAF
+					if _, err := a.configClient.Update(ctx, restored, metav1.UpdateOptions{}); err != nil {
+						log.WithError(err).Warnf("Failed to restore primary address family to %q", lastKnownPAF)
+					} else {
+						log.Infof("Restored primary address family to %q", lastKnownPAF)
+						return false, nil
+					}
+				} else if cfg.Spec.Network.PrimaryAddressFamily != "" {
+					lastKnownPAF = cfg.Spec.Network.PrimaryAddressFamily
+				}
+			}
+
 			// Push changes only when the config actually changes
 			if lastObservedVersion != cfg.ResourceVersion {
 				log.Debugf("Cluster configuration update to resource version %q", cfg.ResourceVersion)

--- a/pkg/component/controller/clusterconfig_test.go
+++ b/pkg/component/controller/clusterconfig_test.go
@@ -55,7 +55,9 @@ func TestClusterConfigInitializer_Create(t *testing.T) {
 			ClusterConfigs(constant.ClusterConfigNamespace).
 			Get(t.Context(), "k0s", metav1.GetOptions{})
 		if assert.NoError(t, err) {
-			assert.Equal(t, initialConfig, actualConfig)
+			expectedConfig := initialConfig.DeepCopy()
+			expectedConfig.Spec.Network.PrimaryAddressFamily = k0sv1beta1.PrimaryFamilyIPv4
+			assert.Equal(t, expectedConfig, actualConfig)
 		}
 	})
 }

--- a/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
+++ b/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
@@ -1024,6 +1024,9 @@ spec:
                       if this isn't present it will use `.spec.API.Address.`.
                       If both addresses are empty or the chosen address is a hostname, defaults to `IPv4`.
                     type: string
+                    x-kubernetes-validations:
+                    - message: cannot change primary address family
+                      rule: oldSelf == '' || self == oldSelf
                   provider:
                     default: kuberouter
                     description: 'Network provider (valid values: calico, kuberouter,


### PR DESCRIPTION
## Description

Gives `spec.network.primaryAddressFamily` a default value and also makes it immutable.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
