### PR TITLE
Fix the security context of konnectivity-agent

### DIFF
--- a/pkg/component/controller/konnectivityagent.go
+++ b/pkg/component/controller/konnectivityagent.go
@@ -235,11 +235,6 @@ spec:
         prometheus.io/port: '8093'
     spec:
       securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-          - all
-        readOnlyRootFilesystem: true
         runAsNonRoot: true
         supplementalGroups: [0]` /* in order to read the projected service account token */ + `
       nodeSelector:
@@ -273,6 +268,12 @@ spec:
             - --service-account-token-path=/var/run/secrets/tokens/konnectivity-agent-token
             - --agent-identifiers=host=$(NODE_IP)
             - --agent-id=$(NODE_IP)
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - all
+            readOnlyRootFilesystem: true
           volumeMounts:
             - mountPath: /var/run/secrets/tokens
               name: konnectivity-agent-token


### PR DESCRIPTION
## Description

The `allowPrivilegeEscalation`, `capabilities` and `readOnlyRootFilesystem` fields do not belong to the pod security context, but to the container's security context instead.

Fixes:

* #6231

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [X] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
