### PR TITLE
[Backport release-1.34] Default Chart release name to the object name when unset

### DIFF
--- a/inttest/addons/addons_test.go
+++ b/inttest/addons/addons_test.go
@@ -7,7 +7,9 @@ import (
 	"bytes"
 	"context"
 	"crypto"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -311,7 +313,10 @@ func (as *AddonsSuite) deleteUninstalledChart(ctx context.Context) {
 		Version:     spec.Version,
 		AppVersion:  "1",
 		Revision:    1,
-		ValuesHash:  spec.HashValues(),
+		ValuesHash: func() string {
+			hash := sha256.Sum256([]byte(spec.ReleaseName))
+			return hex.EncodeToString(hash[:])
+		}(),
 	}
 	chart := &helmv1beta1.Chart{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/helm/v1beta1/chart_types.go
+++ b/pkg/apis/helm/v1beta1/chart_types.go
@@ -26,10 +26,10 @@ type ChartSpec struct {
 }
 
 // YamlValues returns values as map
-func (cs ChartSpec) YamlValues() map[string]any {
+func (s *ChartSpec) YamlValues() map[string]any {
 	res := map[string]any{}
-	if err := yaml.Unmarshal([]byte(cs.Values), &res); err != nil {
-		logrus.WithField("values", cs.Values).Warn("broken yaml values")
+	if err := yaml.Unmarshal([]byte(s.Values), &res); err != nil {
+		logrus.WithField("values", s.Values).Warn("broken yaml values")
 	}
 	// We need to clean the map to have nested maps as map[string]interface{} types
 	// otherwise Helm will fail to merge default values and create the release object
@@ -37,17 +37,17 @@ func (cs ChartSpec) YamlValues() map[string]any {
 }
 
 // HashValues returns hash of the values
-func (cs ChartSpec) HashValues() string {
+func (s *ChartSpec) HashValues() string {
 	h := sha256.New()
-	h.Write([]byte(cs.ReleaseName + cs.Values))
+	h.Write([]byte(s.ReleaseName + s.Values))
 	return hex.EncodeToString(h.Sum(nil))
 }
 
 // ShouldForceUpgrade returns true if the chart should be force upgraded
-func (cs ChartSpec) ShouldForceUpgrade() bool {
+func (s *ChartSpec) ShouldForceUpgrade() bool {
 	// This defaults to true when not explicitly set to false.
 	// Better have this the other way round in the next API version.
-	return cs.ForceUpgrade == nil || *cs.ForceUpgrade
+	return s.ForceUpgrade == nil || *s.ForceUpgrade
 }
 
 // ChartStatus defines the observed state of Chart

--- a/pkg/apis/helm/v1beta1/chart_types.go
+++ b/pkg/apis/helm/v1beta1/chart_types.go
@@ -4,9 +4,6 @@
 package v1beta1
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -34,13 +31,6 @@ func (s *ChartSpec) YamlValues() map[string]any {
 	// We need to clean the map to have nested maps as map[string]interface{} types
 	// otherwise Helm will fail to merge default values and create the release object
 	return CleanUpGenericMap(res)
-}
-
-// HashValues returns hash of the values
-func (s *ChartSpec) HashValues() string {
-	h := sha256.New()
-	h.Write([]byte(s.ReleaseName + s.Values))
-	return hex.EncodeToString(h.Sum(nil))
 }
 
 // ShouldForceUpgrade returns true if the chart should be force upgraded

--- a/pkg/component/controller/extensions_controller.go
+++ b/pkg/component/controller/extensions_controller.go
@@ -4,7 +4,10 @@
 package controller
 
 import (
+	"cmp"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -268,12 +271,13 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart helmv
 		}
 	}()
 	if chart.Status.ReleaseName == "" {
+		releaseName := effectiveChartReleaseName(&chart)
 		// new chartRelease
 		cr.L.Tracef("Start update or install %s", chart.Spec.ChartName)
 		chartRelease, err = cr.helm.InstallChart(ctx,
 			chart.Spec.ChartName,
 			chart.Spec.Version,
-			chart.Spec.ReleaseName,
+			releaseName,
 			chart.Spec.Namespace,
 			chart.Spec.YamlValues(),
 			timeout,
@@ -309,9 +313,19 @@ func (cr *ChartReconciler) updateOrInstallChart(ctx context.Context, chart helmv
 
 func (cr *ChartReconciler) chartNeedsUpgrade(chart helmv1beta1.Chart) bool {
 	return chart.Status.Namespace != chart.Spec.Namespace ||
-		chart.Status.ReleaseName != chart.Spec.ReleaseName ||
+		chart.Status.ReleaseName != effectiveChartReleaseName(&chart) ||
 		chart.Status.Version != chart.Spec.Version ||
-		chart.Status.ValuesHash != chart.Spec.HashValues()
+		chart.Status.ValuesHash != hashChartValues(&chart)
+}
+
+func effectiveChartReleaseName(chart *helmv1beta1.Chart) string {
+	return cmp.Or(chart.Spec.ReleaseName, chart.Name)
+}
+
+func hashChartValues(chart *helmv1beta1.Chart) string {
+	h := sha256.New()
+	h.Write([]byte(effectiveChartReleaseName(chart) + chart.Spec.Values))
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // updateStatus updates the status of the chart with the given release information. This function
@@ -338,7 +352,7 @@ func (cr *ChartReconciler) updateStatus(ctx context.Context, chart helmv1beta1.C
 	if err != nil {
 		updchart.Status.Error = err.Error()
 	}
-	updchart.Status.ValuesHash = chart.Spec.HashValues()
+	updchart.Status.ValuesHash = hashChartValues(&chart)
 	if updErr := cr.Client.Status().Update(ctx, &updchart); updErr != nil {
 		cr.L.WithError(updErr).Error("Failed to update status for chart release", chart.Name)
 		return updErr

--- a/pkg/component/controller/extensions_controller_test.go
+++ b/pkg/component/controller/extensions_controller_test.go
@@ -118,6 +118,27 @@ func TestChartNeedsUpgrade(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"no_changes_with_implicit_release_name",
+			v1beta1.Chart{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-release",
+				},
+				Spec: v1beta1.ChartSpec{
+					ChartName: "test",
+					Values:    "",
+					Version:   "0.0.1",
+					Namespace: "ns",
+				},
+				Status: v1beta1.ChartStatus{
+					ReleaseName: "test-release",
+					Version:     "0.0.1",
+					Namespace:   "ns",
+					ValuesHash:  "41c7250e092d11639c77c823fb34afa232c5ceb316ad546b4df506606ef9b3e4",
+				},
+			},
+			false,
+		},
 	}
 
 	cr := new(ChartReconciler)


### PR DESCRIPTION
Backport to `release-1.34`:

* #7498

See:

* #7480
* #7291