### PR TITLE
Make konnectivity-agent work on Windows

### DIFF
--- a/.github/workflows/win-wsl.yaml
+++ b/.github/workflows/win-wsl.yaml
@@ -163,7 +163,7 @@ jobs:
 
           install -m755 -D -- '$dir/k0s' /usr/local/bin/k0s
 
-          k0s install controller --debug --enable-worker --no-taints --disable-components metrics-server,konnectivity-server
+          k0s install controller --debug --enable-worker --no-taints --disable-components metrics-server
           # Do not use "k0s start" here, as its error reporting is poor.
           systemctl start k0scontroller.service
           # some trailing carriage return

--- a/internal/testutil/portforward.go
+++ b/internal/testutil/portforward.go
@@ -1,0 +1,377 @@
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/validation"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// PodDialer dials ports on Kubernetes pods via the API server's port-forwarding
+// endpoint. It offers a dialer implementation via [PodDialer.DialContext] that
+// is compatible to [net.Dialer.DialContext] with addresses of the form
+// "<podname>.<namespace>:<portnum>".
+//
+// This allows you to "pivot" your Go network stack into a Kubernetes cluster.
+// Anything that accepts a dialer can connect to arbitrary pods as if it were
+// running as a sidecar (given the provided kubeconfig has enough privileges).
+//
+// HTTP requests are as easy as
+//
+//	podDialer, err := NewPodDialer(config)
+//	if err != nil {
+//	    return nil, err
+//	}
+//
+//	c := http.Client{Transport: &http.Transport{DialContext: podDialer.DialContext}}
+//	resp, err := c.Get("http://my-pod.my-namespace:8080/healthz")
+//	// ...
+//
+// Prior art: https://microcumul.us/blog/k8s-port-forwarding/
+type PodDialer struct {
+	rest     rest.Interface
+	client   http.Client
+	upgrader spdy.Upgrader
+}
+
+// NewPodDialer creates a PodDialer backed by the given REST config.
+func NewPodDialer(config *rest.Config) (*PodDialer, error) {
+	client, err := corev1client.NewForConfigAndClient(config, nil)
+	if err != nil {
+		return nil, err
+	}
+	transport, upgrader, err := spdy.RoundTripperFor(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transport: %w", err)
+	}
+
+	return &PodDialer{client.RESTClient(), http.Client{Transport: transport}, upgrader}, nil
+}
+
+// DialContext connects to a port on a pod. The addr must be of the form
+// "<podname>.<namespace>:<portnum>". It looks up the pod, establishes the
+// port-forward streams via the portforward.k8s.io protocol, connects to the
+// specified port, and wraps everything up into a single [net.Conn]. The
+// connection metadata is backed by [PodPortConnInfo].
+func (d *PodDialer) DialContext(ctx context.Context, network, addr string) (_ net.Conn, err error) {
+	pod, port, err := parsePodAddr(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	podConn, err := d.dialPod(ctx, pod)
+	if err != nil {
+		return nil, fmt.Errorf("while dialing pod %s: %w", pod, err)
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, podConn.Close())
+		}
+	}()
+
+	portConn, requestID, err := podConn.DialPort(port)
+	if err != nil {
+		return nil, fmt.Errorf("while connecting port %d on %s: %w", port, pod, err)
+	}
+
+	// Close the pod connection as soon as the port connection is done.
+	var podConnCloseErr error
+	podConnDone := make(chan struct{})
+	go func() {
+		defer close(podConnDone)
+		<-portConn.done
+		podConnCloseErr = podConn.Close()
+	}()
+
+	return (&PodPortConnInfo{pod, port, requestID}).Wrap(portConn, func() error {
+		portConnCloseErr := portConn.Close()
+		<-podConnDone
+		return errors.Join(portConnCloseErr, podConnCloseErr)
+	}), nil
+}
+
+func parsePodAddr(addr string) (types.NamespacedName, uint16, error) {
+	if host, port, ok := strings.Cut(addr, ":"); ok {
+		var pod types.NamespacedName
+		if pod.Name, pod.Namespace, ok = strings.Cut(host, "."); ok {
+			if err := validatePod(&pod); err != nil {
+				return types.NamespacedName{}, 0, err
+			}
+
+			port, err := strconv.ParseUint(port, 10, 16)
+			if err != nil {
+				return types.NamespacedName{}, 0, fmt.Errorf("port number is invalid: %w", err)
+			}
+
+			return pod, uint16(port), nil
+		}
+	}
+
+	return types.NamespacedName{}, 0, errors.New("address needs to be <podname>.<namespace>:<portnum>")
+}
+
+func validatePod(pod *types.NamespacedName) error {
+	if errs := validation.IsDNS1123Subdomain(pod.Namespace); len(errs) > 0 {
+		return fmt.Errorf("namespace %q is invalid: %s", pod.Namespace, strings.Join(errs, ", "))
+	}
+	if errs := validation.IsDNS1123Subdomain(pod.Name); len(errs) > 0 {
+		return fmt.Errorf("pod name %q is invalid: %s", pod.Name, strings.Join(errs, ", "))
+	}
+
+	return nil
+}
+
+// DialPod opens a multiplexed connection to the given pod's port-forwarding
+// endpoint. Individual ports can then be dialed via [PodConnection.DialPort].
+// Use [PodDialer.DialContext] instead if you only need a single [net.Conn].
+// Setting deadlines on the returned connection is not supported.
+func (d *PodDialer) DialPod(ctx context.Context, pod types.NamespacedName) (*PodConnection, error) {
+	if err := validatePod(&pod); err != nil {
+		return nil, err
+	}
+
+	return d.dialPod(ctx, pod)
+}
+
+func (d *PodDialer) dialPod(ctx context.Context, pod types.NamespacedName) (*PodConnection, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		d.rest.Post().Resource("pods").
+			Name(pod.Name).Namespace(pod.Namespace).
+			SubResource("portforward").URL().String(),
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	conn, _, err := spdy.Negotiate(d.upgrader, &d.client, req, portforward.PortForwardProtocolV1Name)
+	if err != nil {
+		var statusErr *apierrors.StatusError
+		if !errors.As(err, &statusErr) {
+			return nil, fmt.Errorf("failed to negotiate: %w", err)
+		}
+		if d := statusErr.ErrStatus.Details; d != nil && d.Kind == "pods" && statusErr.ErrStatus.Reason == metav1.StatusReasonNotFound {
+			return nil, (*PodNotFoundError)(statusErr)
+		}
+		return nil, statusErr
+	}
+
+	return &PodConnection{conn: conn}, nil
+}
+
+// PodConnection is a multiplexed connection to a pod's port-forwarding
+// endpoint. Multiple logical port-forwarded connections to different ports on
+// the pod can be dialed concurrently on a single connection.
+type PodConnection struct {
+	conn             httpstream.Connection
+	requestSequencer atomic.Uint64
+	connTracker      sync.WaitGroup
+}
+
+// Terminates the connection. When it returns nil, all background goroutines
+// have exited. Otherwise, no such guarantee is made.
+func (c *PodConnection) Close() error {
+	if err := c.conn.Close(); err != nil {
+		return err
+	}
+	c.connTracker.Wait()
+	return nil
+}
+
+// The connection will be automatically closed after the given period of inactivity.
+func (c *PodConnection) SetIdleTimeout(timeout time.Duration) {
+	c.conn.SetIdleTimeout(timeout)
+}
+
+// Opens a new port-forwarded connection to the given port on the pod.
+func (c *PodConnection) DialPort(port uint16) (_ *PodPortConnection, requestID uint64, err error) {
+	requestID = c.requestSequencer.Add(1)
+	headers := http.Header{}
+	headers.Set(corev1.StreamType, corev1.StreamTypeError)
+	headers.Set(corev1.PortHeader, strconv.FormatUint(uint64(port), 10))
+	headers.Set(corev1.PortForwardRequestIDHeader, strconv.FormatUint(requestID, 10))
+
+	errorStream, err := c.conn.CreateStream(headers)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to create err stream: %w", err)
+	}
+	// The error stream is read-only. Closing it will shut-down the sending side only.
+	if err := errorStream.Close(); err != nil {
+		return nil, 0, err
+	}
+	defer func() {
+		if err != nil {
+			c.conn.RemoveStreams(errorStream)
+		}
+	}()
+
+	headers.Set(corev1.StreamType, corev1.StreamTypeData)
+	dataStream, err := c.conn.CreateStream(headers)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to create data stream: %w", err)
+	}
+
+	portConn := PodPortConnection{
+		conn:       c.conn,
+		dataStream: dataStream,
+		errStream:  errorStream,
+		done:       make(chan struct{}),
+	}
+	c.connTracker.Go(portConn.watchErr)
+	c.connTracker.Go(portConn.watchClose)
+
+	return &portConn, requestID, nil
+}
+
+// Indicates that a to-be-dialed pod does not exist.
+type PodNotFoundError apierrors.StatusError
+
+func (*PodNotFoundError) Error() string   { return "pod not found" }
+func (e *PodNotFoundError) Unwrap() error { return (*apierrors.StatusError)(e) }
+
+var errPodConnectionClosed = errors.New("pod connection closed")
+
+// A port-forwarded connection to a specific port on a pod.
+type PodPortConnection struct {
+	conn                  httpstream.Connection
+	dataStream, errStream httpstream.Stream
+	done                  chan struct{}
+	doneErr               atomic.Pointer[error]
+}
+
+func (c *PodPortConnection) watchErr() {
+	msg, err := io.ReadAll(c.errStream)
+	if err != nil {
+		err := fmt.Errorf("failed to read port-forwarding error: %w", err)
+		if c.doneErr.CompareAndSwap(nil, &err) {
+			c.close()
+		}
+	} else if len(msg) > 0 {
+		err := fmt.Errorf("port-forwarding error: %s", msg)
+		if c.doneErr.CompareAndSwap(nil, &err) {
+			c.close()
+		}
+	}
+}
+
+func (c *PodPortConnection) watchClose() {
+	<-c.conn.CloseChan()
+	if c.doneErr.CompareAndSwap(nil, &errPodConnectionClosed) {
+		c.close()
+	}
+}
+
+func (c *PodPortConnection) Read(b []byte) (int, error) {
+	if err := c.doneErr.Load(); err != nil {
+		return 0, *err
+	}
+
+	n, err := c.dataStream.Read(b)
+	if err != nil && n == 0 && errors.Is(err, io.EOF) {
+		// The data stream may return EOF before the error stream has been fully
+		// read. Give watchErr a chance to capture the actual error instead of
+		// returning directly.
+		select {
+		case <-c.done:
+			return 0, *c.doneErr.Load()
+		case <-time.After(1 * time.Second):
+		}
+	}
+
+	return n, err
+}
+
+func (c *PodPortConnection) Write(b []byte) (int, error) {
+	if err := c.doneErr.Load(); err != nil {
+		return 0, *err
+	}
+	return c.dataStream.Write(b)
+}
+
+// Closes the connection. Safe to call concurrently and more than once.
+// Subsequent calls wait for the first to finish and return nil.
+func (c *PodPortConnection) Close() error {
+	if c.doneErr.Swap(&net.ErrClosed) == nil {
+		return errors.Join(c.close()...)
+	}
+
+	<-c.done
+	return nil
+}
+
+func (c *PodPortConnection) close() (errs []error) {
+	defer close(c.done)
+	if err := c.dataStream.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("while closing data stream: %w", err))
+	}
+	if err := c.dataStream.Reset(); err != nil {
+		errs = append(errs, fmt.Errorf("while resetting data stream: %w", err))
+	}
+	if err := c.errStream.Reset(); err != nil {
+		errs = append(errs, fmt.Errorf("while resetting error stream: %w", err))
+	}
+	c.conn.RemoveStreams(c.dataStream, c.errStream)
+	return errs
+}
+
+// PodPortConnInfo carries the identifying metadata of a port-forward
+// connection. It implements [net.Addr] and can be used as local/remote address
+// in a [net.Conn]. The network reported will be kubernetes/portforward.
+type PodPortConnInfo struct {
+	Pod       types.NamespacedName
+	Port      uint16
+	RequestID uint64
+}
+
+func (i *PodPortConnInfo) String() string       { return fmt.Sprintf("%s:%d:%d", i.Pod, i.Port, i.RequestID) }
+func (i *PodPortConnInfo) LocalAddr() net.Addr  { return podPortConnNetAddr("local:" + i.String()) }
+func (i *PodPortConnInfo) RemoteAddr() net.Addr { return podPortConnNetAddr("remote:" + i.String()) }
+
+// Wraps c as a [net.Conn] using i as local and remote addresses. If close is
+// nil, c.Close is used.
+func (i *PodPortConnInfo) Wrap(c *PodPortConnection, close func() error) net.Conn {
+	if close == nil {
+		close = c.Close
+	}
+
+	return &netPodPortConn{c, *i, close}
+}
+
+type netPodPortConn struct {
+	*PodPortConnection
+	PodPortConnInfo
+	close func() error
+}
+
+func (c *netPodPortConn) Close() error                   { return c.close() }
+func (*netPodPortConn) SetDeadline(time.Time) error      { return errors.ErrUnsupported }
+func (*netPodPortConn) SetReadDeadline(time.Time) error  { return errors.ErrUnsupported }
+func (*netPodPortConn) SetWriteDeadline(time.Time) error { return errors.ErrUnsupported }
+
+type podPortConnNetAddr string
+
+var _ net.Addr = (*podPortConnNetAddr)(nil)
+
+func (a podPortConnNetAddr) Network() string { return "kubernetes/portforward" }
+func (a podPortConnNetAddr) String() string  { return (string)(a) }

--- a/inttest/windows/windows_test.go
+++ b/inttest/windows/windows_test.go
@@ -4,17 +4,30 @@
 package windows
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"math/bits"
+	"net/http"
 	"os"
+	"strconv"
 	"testing"
+	"time"
 
-	"github.com/k0sproject/k0s/inttest/common"
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/k0sproject/k0s/internal/testutil"
+	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/stretchr/testify/require"
 )
 
 const testNamespace = "windows-test"
@@ -97,7 +110,13 @@ func TestWindows(t *testing.T) {
 		require.NoError(common.WaitForDaemonSet(t.Context(), kc, "calico-node", metav1.NamespaceSystem))
 		t.Log("Waiting for calico-node-windows DaemonSet to be ready")
 		require.NoError(common.WaitForDaemonSet(t.Context(), kc, "calico-node-windows", metav1.NamespaceSystem))
+		t.Log("Waiting for konnectivity-agent DaemonSet to be ready")
+		require.NoError(common.WaitForDaemonSet(t.Context(), kc, "konnectivity-agent", metav1.NamespaceSystem))
 		t.Log("All system DaemonSets are ready")
+	})
+
+	t.Run("Verify konnectivity is operational", func(t *testing.T) {
+		require.NoError(verifyKonnectivityPods(t.Context(), restConfig, kc, t))
 	})
 
 	t.Run("Verify pods can be scheduled on Windows node", func(t *testing.T) {
@@ -114,6 +133,117 @@ func TestWindows(t *testing.T) {
 
 	})
 
+}
+
+func verifyKonnectivityPods(ctx context.Context, config *rest.Config, kc kubernetes.Interface, t *testing.T) error {
+	podDialer, err := testutil.NewPodDialer(config)
+	if err != nil {
+		return err
+	}
+
+	client := http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			DialContext: podDialer.DialContext,
+		},
+	}
+	t.Cleanup(client.CloseIdleConnections)
+
+	return wait.PollUntilContextCancel(ctx, 3*time.Second, true, func(ctx context.Context) (bool, error) {
+		pods, err := kc.CoreV1().Pods(metav1.NamespaceSystem).List(ctx, metav1.ListOptions{
+			LabelSelector: fields.OneTermEqualSelector("k8s-app", "konnectivity-agent").String(),
+		})
+		if err != nil {
+			t.Logf("Failed to get konnectivity pods: %v", err)
+			return false, nil
+		}
+
+		if len := len(pods.Items); len > 2 {
+			return false, fmt.Errorf("unexpected number of konnectivity pods: %d", len)
+		}
+
+		var goodPods uint
+		for _, pod := range pods.Items {
+			openServerConnections, err := fetchOpenServerConnections(ctx, &client, &pod)
+			if err != nil {
+				t.Logf("Failed to fetch konnectivity metrics from pod %s on node %s: %v", pod.Name, pod.Spec.NodeName, err)
+				return false, nil
+			}
+
+			switch openServerConnections {
+			case 0:
+				t.Logf("Pod %s on node %s has no open konnectivity server connections", pod.Name, pod.Spec.NodeName)
+			case 1:
+				t.Logf("Pod %s on node %s has one open konnectivity server connection", pod.Name, pod.Spec.NodeName)
+				goodPods++
+			default:
+				return false, fmt.Errorf("unexpected number of open server connections for pod %s on node %s: %d", pod.Name, pod.Spec.NodeName, openServerConnections)
+			}
+		}
+
+		t.Logf("Pods with one open konnectivity server connection: %d/%d", goodPods, len(pods.Items))
+		return goodPods == 2, nil
+	})
+}
+
+func fetchOpenServerConnections(ctx context.Context, client *http.Client, pod *corev1.Pod) (_ uint, err error) {
+	var port uint16
+	for k, v := range pod.Annotations {
+		if k == "prometheus.io/port" {
+			parsed, err := strconv.ParseUint(v, 10, 16)
+			if err != nil {
+				return 0, fmt.Errorf("invalid port: %w", err)
+			}
+			if parsed == 0 {
+				return 0, errors.New("zero port")
+			}
+			port = uint16(parsed)
+		}
+	}
+
+	if port == 0 {
+		return 0, errors.New("no port")
+	}
+
+	url := fmt.Sprintf("http://%s.%s:%d/metrics", pod.Name, pod.Namespace, port)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("failed to send HTTP request: %w", err)
+	}
+
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to close HTTP response body: %w", closeErr))
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("non-OK HTTP response status: %s", resp.Status)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		key, val, found := bytes.Cut(scanner.Bytes(), []byte{' '})
+		if !found || !bytes.Equal(key, []byte("konnectivity_network_proxy_agent_open_server_connections")) {
+			continue
+		}
+
+		val, _, _ = bytes.Cut(val, []byte{' '})
+		count, err := strconv.ParseUint(string(val), 10, bits.UintSize)
+		if err != nil {
+			return 0, fmt.Errorf("invalid metric: %s %s: %w", key, val, err)
+		}
+		return uint(count), nil
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("failed to read HTTP response body: %w", err)
+	}
+
+	return 0, errors.New("metric konnectivity_network_proxy_agent_open_server_connections not found")
 }
 
 func runLinuxDeployment(ctx context.Context, kc *kubernetes.Clientset) error {

--- a/pkg/component/controller/konnectivityagent.go
+++ b/pkg/component/controller/konnectivityagent.go
@@ -242,8 +242,11 @@ spec:
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         supplementalGroups: [0]` /* in order to read the projected service account token */ + `
-      nodeSelector:
-        kubernetes.io/os: linux
+        {{- if .HostNetwork }}
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: NT AUTHORITY\Local service
+        {{- end }}
       priorityClassName: system-cluster-critical
       tolerations:
         - operator: Exists
@@ -254,7 +257,6 @@ spec:
         - image: {{ .Image }}
           imagePullPolicy: {{ .PullPolicy }}
           name: konnectivity-agent
-          command: ["/proxy-agent"]
           env:
               # the variable is not in a use
               # we need it to have agent restarted on server count change


### PR DESCRIPTION
## Description

Use a multi-platform container image. Remove the nodeSelector from, and add the necessary Windows related options to the konnectivity-agent DaemonSet. This is surprisingly working with a single DaemonSet, so no need to add an extra one, as we need to do it for Calico.

No longer disable konnectivity when running the Windows WSL CI to prove that it works. Add some validation to the Windows integration test, which does basically the same as the testKonnectivityPods function in the OS tests.

In order to test konnectivity functionality, add `PodDialer` to the test utilities, which allows for dialing Kubernetes pods like a sidecar via port-forwarding. It implements `net.DialContext` over the Kubernetes port-forwarding endpoint, allowing to use standard Go network clients (e.g. http.Client) to connect to pods by namespace, name and port number.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
