### PR TITLE
Lint doc copyright in docs CI workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2022 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 ## Description
 
 <!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0 # for copyright linting
+          persist-credentials: false
+
       - uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v23.0.0
         with:
           config: .markdownlint.jsonc
           globs: '**/*.md'
+
+      - name: Check copyright headers
+        run: WHAT=docs make lint-copyright

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -128,7 +128,7 @@ jobs:
         run: make codegen && git diff --exit-code
 
       - name: Check copyright headers
-        run: make lint-copyright
+        run: WHAT=code make lint-copyright
 
   validate-os-tests:
     name: Validate OS tests

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2024 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Adopters of k0s
 
 This page lists, in alphabetical order, individuals and organizations that are

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # K0s Community Code of Conduct
 
-K0s follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+K0s follows the [CNCF Code of Conduct].
+
+[CNCF Code of Conduct]: https://github.com/cncf/foundation/blob/main/code-of-conduct.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # K0s Contributor Guide
 
 Please refer to our [Contributor Guide](docs/contributors/).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2024 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # k0s maintainers
 
 We're currently working on providing more detailed project governance documentation for k0s. This file documents the current maintainers and their affiliation.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # k0s - The Zero Friction Kubernetes
 
 <!-- When changing this file, consider to change docs/README.md, too! -->

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Releasing k0s
 
 We try to follow the practice of releasing often. That allows us to have smaller releases and thus, hopefully, we'll also break less things while doing so.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2025 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # k0s roadmap
 
 k0s maintainers work in a KanBan-ish style, with a [public board] available defining the roadmap items. As always, a roadmap is a living entity and subject to change based on user feedback, maintainer interests, and other factors.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2025 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Security policy
 
 This policy is adapted from the policies of various other mature CNCF projects:

--- a/docs/directories.md
+++ b/docs/directories.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # k0s directories
 
 This page describes the directories k0s reads and writes on the host, what

--- a/docs/version-skew-policy.md
+++ b/docs/version-skew-policy.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Version skew policy
 
 k0s ships a curated set of Kubernetes components (kube-apiserver,

--- a/hack/copyright.sh
+++ b/hack/copyright.sh
@@ -7,6 +7,7 @@ set -eu
 
 RESULT=0
 FIX=${FIX:=n}
+WHAT=${WHAT:=all}
 
 get_year(){
     # The -1 has to be added because if a file has been added, removed and added
@@ -31,10 +32,19 @@ has_date_copyright(){
 }
 
 find_files_to_check() {
+    case "$WHAT" in
     # All the Go files
-    find cmd hack internal inttest pkg static -type f -name '*.go' -not -name 'zz_generated*'
+    all | code)
+        find cmd hack internal inttest pkg static -type f -name '*.go' -not -name 'zz_generated*'
+        ;;
+    esac
+
+    case "$WHAT" in
     # All the markdown documentation, excluding the auto-generated CLI docs
-    find docs -type f -name '*.md' -not -path 'docs/cli/*'
+    all | docs)
+        git ls-files '*.md'
+        ;;
+    esac
 }
 
 for i in $(find_files_to_check); do

--- a/hack/ostests/README.md
+++ b/hack/ostests/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # OpenTofu modules for k0s OS testing
 
 Provisioning of k0s test clusters using different operating system stacks and

--- a/inttest/README.md
+++ b/inttest/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2020 k0s authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Integration tests a.k.a e2e testing
 
 This folder is the root of k0s integration tests. These tests are such that run the actual k0s clusters, currently using [bootloose](https://github.com/k0sproject/bootloose) as the target environment.


### PR DESCRIPTION
## Description

Previously, the docs were only linted in the standard CI workflow. However, that one is not triggered for docs-only PRs. This means that CI on a PR could pass, but subsequent CI runs on the main branch would fail.

As the docs workflow is triggered whenever a Markdown file is touched, split up the copyright notice check into checks for code-related files and docs-related files. Add missing SPDX headers to the Markdown files that didn't have them already.

Fixes:

* #6047
* #7540
* #7539

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
