### PR TITLE
Use consistent names for node and cluster config

### DIFF
--- a/cmd/airgap/listimages.go
+++ b/cmd/airgap/listimages.go
@@ -35,10 +35,10 @@ func newAirgapListImagesCmd() *cobra.Command {
 				return err
 			}
 
-			if clusterConfig, err := opts.K0sVars.NodeConfig(); err != nil {
-				return fmt.Errorf("failed to get config: %w", err)
+			if nodeConfig, err := opts.K0sVars.NodeConfig(); err != nil {
+				return fmt.Errorf("failed to get node config: %w", err)
 			} else {
-				targetEnv.Spec = clusterConfig.Spec
+				targetEnv.Spec = nodeConfig.Spec
 			}
 
 			out := cmd.OutOrStdout()

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -121,17 +121,17 @@ func NewControllerCmd() *cobra.Command {
 				return err
 			}
 
-			rtc, err := config.NewRuntimeConfig(c.K0sVars, nodeConfig)
+			runtimeConfig, err := config.NewRuntimeConfig(c.K0sVars, nodeConfig)
 			if err != nil {
 				return fmt.Errorf("failed to initialize runtime config: %w", err)
 			}
 			defer func() {
-				if err := rtc.Spec.Cleanup(); err != nil {
+				if err := runtimeConfig.Spec.Cleanup(); err != nil {
 					logrus.WithError(err).Warn("Failed to cleanup runtime config")
 				}
 			}()
 
-			if err := c.start(ctx, rtc, nodeConfig, &controllerFlags, debugFlags.IsDebug()); err != nil {
+			if err := c.start(ctx, runtimeConfig, nodeConfig, &controllerFlags, debugFlags.IsDebug()); err != nil {
 				if controllerFlags.InitOnly && errors.Is(err, errInitOnly) {
 					return nil
 				}
@@ -197,7 +197,7 @@ func (c *command) initDirs() error {
 	return nil
 }
 
-func (c *command) start(ctx context.Context, rtc *config.RuntimeConfig, nodeConfig *v1beta1.ClusterConfig, flags *config.ControllerOptions, debug bool) error {
+func (c *command) start(ctx context.Context, runtimeConfig *config.RuntimeConfig, nodeConfig *v1beta1.ClusterConfig, flags *config.ControllerOptions, debug bool) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
 
@@ -331,7 +331,7 @@ func (c *command) start(ctx context.Context, rtc *config.RuntimeConfig, nodeConf
 	}
 
 	nodeComponents.Add(ctx, &controller.APIServer{
-		ClusterConfig:      nodeConfig,
+		NodeConfig:         nodeConfig,
 		K0sVars:            c.K0sVars,
 		LogLevel:           c.LogLevels.KubeAPIServer,
 		EnableKonnectivity: enableKonnectivity,
@@ -350,7 +350,6 @@ func (c *command) start(ctx context.Context, rtc *config.RuntimeConfig, nodeConf
 		nodeComponents.Add(ctx, &controller.K0sControllersLeaseCounter{
 			NodeName:              nodeName,
 			InvocationID:          c.K0sVars.InvocationID,
-			ClusterConfig:         nodeConfig,
 			KubeClientFactory:     adminClientFactory,
 			UpdateControllerCount: numActiveControllers.Set,
 		})
@@ -388,13 +387,11 @@ func (c *command) start(ctx context.Context, rtc *config.RuntimeConfig, nodeConf
 	}
 
 	if !slices.Contains(flags.DisableComponents, constant.ControlAPIComponentName) && nodeConfig.Spec.Storage.IsJoinable() {
-		nodeComponents.Add(ctx, &controller.K0SControlAPI{RuntimeConfig: rtc})
+		nodeComponents.Add(ctx, &controller.K0SControlAPI{RuntimeConfig: runtimeConfig})
 	}
 
 	if !slices.Contains(flags.DisableComponents, constant.CsrApproverComponentName) {
-		nodeComponents.Add(ctx, controller.NewCSRApprover(nodeConfig,
-			leaderElector,
-			adminClientFactory))
+		nodeComponents.Add(ctx, controller.NewCSRApprover(leaderElector, adminClientFactory))
 	}
 
 	if flags.EnableK0sCloudProvider {

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -33,7 +33,7 @@ import (
 
 // APIServer implement the component interface to run kube api
 type APIServer struct {
-	ClusterConfig             *v1beta1.ClusterConfig
+	NodeConfig                *v1beta1.ClusterConfig
 	K0sVars                   *config.CfgVars
 	LogLevel                  string
 	EnableKonnectivity        bool
@@ -92,8 +92,8 @@ func (a *APIServer) Init(_ context.Context) error {
 func (a *APIServer) Start(ctx context.Context) error {
 	logrus.Info("Starting kube-apiserver")
 	args := stringmap.StringMap{
-		"advertise-address":                a.ClusterConfig.Spec.API.Address,
-		"secure-port":                      strconv.Itoa(a.ClusterConfig.Spec.API.Port),
+		"advertise-address":                a.NodeConfig.Spec.API.Address,
+		"secure-port":                      strconv.Itoa(a.NodeConfig.Spec.API.Port),
 		"authorization-mode":               "Node,RBAC",
 		"client-ca-file":                   filepath.Join(a.K0sVars.CertRootDir, "ca.crt"),
 		"enable-bootstrap-token-auth":      "true",
@@ -105,7 +105,7 @@ func (a *APIServer) Start(ctx context.Context) error {
 		"requestheader-allowed-names":      "front-proxy-client",
 		"requestheader-client-ca-file":     filepath.Join(a.K0sVars.CertRootDir, "front-proxy-ca.crt"),
 		"service-account-key-file":         filepath.Join(a.K0sVars.CertRootDir, "sa.pub"),
-		"service-cluster-ip-range":         a.ClusterConfig.Spec.Network.BuildServiceCIDR(a.ClusterConfig.Spec.PrimaryAddressFamily()),
+		"service-cluster-ip-range":         a.NodeConfig.Spec.Network.BuildServiceCIDR(a.NodeConfig.Spec.PrimaryAddressFamily()),
 		"tls-min-version":                  "VersionTLS12",
 		"tls-cert-file":                    filepath.Join(a.K0sVars.CertRootDir, "server.crt"),
 		"tls-private-key-file":             filepath.Join(a.K0sVars.CertRootDir, "server.key"),
@@ -118,8 +118,8 @@ func (a *APIServer) Start(ctx context.Context) error {
 		"enable-admission-plugins":         "NodeRestriction",
 	}
 
-	if a.ClusterConfig.Spec.API.OnlyBindToAddress {
-		args["bind-address"] = a.ClusterConfig.Spec.API.Address
+	if a.NodeConfig.Spec.API.OnlyBindToAddress {
+		args["bind-address"] = a.NodeConfig.Spec.API.Address
 	}
 
 	apiAudiences := []string{"https://kubernetes.default.svc"}
@@ -135,13 +135,13 @@ func (a *APIServer) Start(ctx context.Context) error {
 
 	args["api-audiences"] = strings.Join(apiAudiences, ",")
 
-	for name, value := range a.ClusterConfig.Spec.API.ExtraArgs {
+	for name, value := range a.NodeConfig.Spec.API.ExtraArgs {
 		if _, ok := args[name]; ok {
 			logrus.Warnf("overriding apiserver flag with user provided value: %s", name)
 		}
 		args[name] = value
 	}
-	args = a.ClusterConfig.Spec.FeatureGates.BuildArgs(args, kubeAPIComponentName)
+	args = a.NodeConfig.Spec.FeatureGates.BuildArgs(args, kubeAPIComponentName)
 	for name, value := range apiDefaultArgs {
 		if args[name] == "" {
 			args[name] = value
@@ -198,7 +198,7 @@ func (a *APIServer) Start(ctx context.Context) error {
 	for name, value := range args {
 		apiServerArgs = append(apiServerArgs, fmt.Sprintf("--%s=%s", name, value))
 	}
-	apiServerArgs = append(apiServerArgs, a.ClusterConfig.Spec.API.RawArgs...)
+	apiServerArgs = append(apiServerArgs, a.NodeConfig.Spec.API.RawArgs...)
 
 	a.supervisor = &supervisor.Supervisor{
 		Name:        kubeAPIComponentName,
@@ -210,7 +210,7 @@ func (a *APIServer) Start(ctx context.Context) error {
 		TimeoutStop: stopTimeout,
 	}
 
-	etcdArgs, err := getEtcdArgs(a.ClusterConfig.Spec.Storage, a.K0sVars)
+	etcdArgs, err := getEtcdArgs(a.NodeConfig.Spec.Storage, a.K0sVars)
 	if err != nil {
 		return err
 	}
@@ -269,7 +269,7 @@ func (a *APIServer) Ready() error {
 		TLSClientConfig: tlsConfig,
 	}
 	client := &http.Client{Transport: tr}
-	apiAddress := net.JoinHostPort(a.ClusterConfig.Spec.API.Address, strconv.Itoa(a.ClusterConfig.Spec.API.Port))
+	apiAddress := net.JoinHostPort(a.NodeConfig.Spec.API.Address, strconv.Itoa(a.NodeConfig.Spec.API.Port))
 	resp, err := client.Get(fmt.Sprintf("https://%s/readyz?verbose", apiAddress))
 	if err != nil {
 		return err

--- a/pkg/component/controller/clusterconfig.go
+++ b/pkg/component/controller/clusterconfig.go
@@ -60,19 +60,19 @@ func (r *ClusterConfigReconciler) Start(ctx context.Context) error {
 		r.log.Debug("start listening changes from config source")
 		for {
 			select {
-			case cfg, ok := <-r.configSource.ResultChan():
+			case clusterConfig, ok := <-r.configSource.ResultChan():
 				if !ok {
 					// Recv channel close, we can stop now
 					r.log.Debug("config source closed channel")
 					return
 				}
-				err := errors.Join(cfg.Validate()...)
+				err := errors.Join(clusterConfig.Validate()...)
 				if err != nil {
 					err = fmt.Errorf("failed to validate cluster configuration: %w", err)
 				} else {
-					err = r.reconciler.Reconcile(ctx, cfg)
+					err = r.reconciler.Reconcile(ctx, clusterConfig)
 				}
-				r.reportStatus(statusCtx, cfg, err)
+				r.reportStatus(statusCtx, clusterConfig, err)
 				if err != nil {
 					r.log.WithError(err).Error("Failed to reconcile cluster configuration")
 				} else {
@@ -94,7 +94,7 @@ func (r *ClusterConfigReconciler) Stop() error {
 	return nil
 }
 
-func (r *ClusterConfigReconciler) reportStatus(ctx context.Context, config *k0sv1beta1.ClusterConfig, reconcileError error) {
+func (r *ClusterConfigReconciler) reportStatus(ctx context.Context, clusterConfig *k0sv1beta1.ClusterConfig, reconcileError error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		r.log.Error("failed to get hostname:", err)
@@ -114,11 +114,11 @@ func (r *ClusterConfigReconciler) reportStatus(ctx context.Context, config *k0sv
 		LastTimestamp:  metav1.Now(),
 		InvolvedObject: corev1.ObjectReference{
 			Kind:            k0sv1beta1.ClusterConfigKind,
-			Namespace:       config.Namespace,
-			Name:            config.Name,
-			UID:             config.UID,
+			Namespace:       clusterConfig.Namespace,
+			Name:            clusterConfig.Name,
+			UID:             clusterConfig.UID,
 			APIVersion:      k0sv1beta1.ClusterConfigAPIVersion,
-			ResourceVersion: config.ResourceVersion,
+			ResourceVersion: clusterConfig.ResourceVersion,
 		},
 		Action:              "ConfigReconciling",
 		ReportingController: "k0s-controller",

--- a/pkg/component/controller/clusterconfig/apiconfigsource.go
+++ b/pkg/component/controller/clusterconfig/apiconfigsource.go
@@ -74,13 +74,13 @@ func (a *apiConfigSource) Start(context.Context) error {
 	go func() {
 		defer close(done)
 		defer close(a.resultChan)
-		_ = watch.Until(ctx, func(cfg *v1beta1.ClusterConfig) (bool, error) {
+		_ = watch.Until(ctx, func(clusterConfig *v1beta1.ClusterConfig) (bool, error) {
 			// Push changes only when the config actually changes
-			if lastObservedVersion != cfg.ResourceVersion {
-				log.Debugf("Cluster configuration update to resource version %q", cfg.ResourceVersion)
-				lastObservedVersion = cfg.ResourceVersion
+			if lastObservedVersion != clusterConfig.ResourceVersion {
+				log.Debugf("Cluster configuration update to resource version %q", clusterConfig.ResourceVersion)
+				lastObservedVersion = clusterConfig.ResourceVersion
 				select {
-				case a.resultChan <- cfg:
+				case a.resultChan <- clusterConfig:
 				case <-ctx.Done():
 					return true, nil
 				}

--- a/pkg/component/controller/controllersleasecounter.go
+++ b/pkg/component/controller/controllersleasecounter.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/pkg/leaderelection"
@@ -27,7 +26,6 @@ import (
 type K0sControllersLeaseCounter struct {
 	NodeName              apitypes.NodeName
 	InvocationID          string
-	ClusterConfig         *v1beta1.ClusterConfig
 	KubeClientFactory     kubeutil.ClientFactoryInterface
 	UpdateControllerCount func(uint)
 

--- a/pkg/component/controller/csrapprover.go
+++ b/pkg/component/controller/csrapprover.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 
-	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
@@ -30,7 +29,6 @@ type CSRApprover struct {
 	log  *logrus.Entry
 	stop context.CancelFunc
 
-	ClusterConfig     *v1beta1.ClusterConfig
 	KubeClientFactory kubeutil.ClientFactoryInterface
 	leaderElector     leaderelector.Interface
 	clientset         clientset.Interface
@@ -39,9 +37,8 @@ type CSRApprover struct {
 var _ manager.Component = (*CSRApprover)(nil)
 
 // NewCSRApprover creates the CSRApprover component
-func NewCSRApprover(c *v1beta1.ClusterConfig, leaderElector leaderelector.Interface, kubeClientFactory kubeutil.ClientFactoryInterface) *CSRApprover {
+func NewCSRApprover(leaderElector leaderelector.Interface, kubeClientFactory kubeutil.ClientFactoryInterface) *CSRApprover {
 	return &CSRApprover{
-		ClusterConfig:     c,
 		leaderElector:     leaderElector,
 		KubeClientFactory: kubeClientFactory,
 		log:               logrus.WithFields(logrus.Fields{"component": "csrapprover"}),

--- a/pkg/component/controller/csrapprover_test.go
+++ b/pkg/component/controller/csrapprover_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/internal/testutil"
-	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/stretchr/testify/assert"
 	certv1 "k8s.io/api/certificates/v1"
@@ -49,15 +48,7 @@ func TestBasicCRSApprover(t *testing.T) {
 	newCsr, err := client.CertificatesV1().CertificateSigningRequests().Create(ctx, csrReq, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	config := &v1beta1.ClusterConfig{
-		Spec: &v1beta1.ClusterSpec{
-			API: &v1beta1.APISpec{
-				Address:         "1.2.3.4",
-				ExternalAddress: "get.k0s.sh",
-			},
-		},
-	}
-	c := NewCSRApprover(config, leaderelector.Off(), fakeFactory)
+	c := NewCSRApprover(leaderelector.Off(), fakeFactory)
 
 	assert.NoError(t, c.Init(ctx))
 	assert.NoError(t, c.approveCSR(ctx))

--- a/pkg/component/controller/konnectivityagent.go
+++ b/pkg/component/controller/konnectivityagent.go
@@ -51,8 +51,8 @@ func (k *KonnectivityAgent) Start(ctx context.Context) error {
 		var retry <-chan time.Time
 		for {
 			select {
-			case config := <-k.configChangeChan:
-				clusterConfig = config
+			case updatedClusterConfig := <-k.configChangeChan:
+				clusterConfig = updatedClusterConfig
 
 			case <-serverCountChanged:
 				prevServerCount := serverCount

--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -44,7 +44,7 @@ import (
 type KubeProxy struct {
 	log logrus.FieldLogger
 
-	nodeConf        *v1beta1.ClusterConfig
+	nodeConfig      *v1beta1.ClusterConfig
 	K0sVars         *config.CfgVars
 	manifestDir     string
 	hasWindowsNodes func() (*bool, <-chan struct{})
@@ -61,7 +61,7 @@ func NewKubeProxy(k0sVars *config.CfgVars, nodeConfig *v1beta1.ClusterConfig, ha
 	return &KubeProxy{
 		log: logrus.WithFields(logrus.Fields{"component": "kubeproxy"}),
 
-		nodeConf:        nodeConfig,
+		nodeConfig:      nodeConfig,
 		K0sVars:         k0sVars,
 		manifestDir:     filepath.Join(k0sVars.ManifestsDir, "kubeproxy"),
 		hasWindowsNodes: hasWindowsNodes,
@@ -216,7 +216,7 @@ func (k *KubeProxy) getConfig(clusterConfig *v1beta1.ClusterConfig) *proxyConfig
 		return &proxyConfig{}
 	}
 
-	controlPlaneEndpoint := k.nodeConf.Spec.API.APIAddressURL()
+	controlPlaneEndpoint := k.nodeConfig.Spec.API.APIAddressURL()
 	nllb := clusterConfig.Spec.Network.NodeLocalLoadBalancing
 	if nllb.IsEnabled() {
 		// FIXME: Transitions from non-node-local load balanced to node-local

--- a/pkg/component/controller/updateprober.go
+++ b/pkg/component/controller/updateprober.go
@@ -11,7 +11,6 @@ import (
 
 	// "github.com/k0sproject/k0s/pkg/component/manager"
 
-	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/autopilot/channels"
 	"github.com/k0sproject/k0s/pkg/autopilot/controller/updates"
 	"github.com/k0sproject/k0s/pkg/build"
@@ -28,7 +27,6 @@ var _ manager.Component = (*UpdateProber)(nil)
 
 type UpdateProber struct {
 	APClientFactory kubeutil.ClientFactoryInterface
-	ClusterConfig   *v1beta1.ClusterConfig
 	log             logrus.FieldLogger
 	leaderElector   leaderelector.Interface
 	collector       *updates.ClusterInfoCollector

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -110,7 +110,7 @@ func NewRuntimeConfig(k0sVars *CfgVars, nodeConfig *v1beta1.ClusterConfig) (*Run
 		return nil, err
 	}
 
-	cfg := &RuntimeConfig{
+	runtimeConfig := &RuntimeConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			CreationTimestamp: metav1.Now(),
 		},
@@ -125,7 +125,7 @@ func NewRuntimeConfig(k0sVars *CfgVars, nodeConfig *v1beta1.ClusterConfig) (*Run
 		},
 	}
 
-	content, err := yaml.Marshal(cfg)
+	content, err := yaml.Marshal(runtimeConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func NewRuntimeConfig(k0sVars *CfgVars, nodeConfig *v1beta1.ClusterConfig) (*Run
 		return nil, fmt.Errorf("failed to write runtime config: %w", err)
 	}
 
-	return cfg, nil
+	return runtimeConfig, nil
 }
 
 func (r *RuntimeConfigSpec) Cleanup() error {


### PR DESCRIPTION
## Description

For historical reasons, k0s has multiple configuration flavors, all of which are backed by the same ClusterConfig struct. Node-local configuration is usually called "node config", whereas the cluster-wide, reconcilable configuration is called "cluster config". The ClusterConfig struct represents a superset of all the fields, though not all of them are part of one or the other.

Different parts of the code didn't use the correct wording for the actual values being operated on. This made it difficult to determine which configuration a variable or field referred to, potentially leading to false assumptions, even.

Make the naming consistent with the actual values and remove a few ClusterConfig fields that are no longer used.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
