### PR TITLE
Make controller --init-only work again

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -111,6 +111,9 @@ func NewControllerCmd() *cobra.Command {
 
 			ctx := cmd.Context()
 			if err := c.start(ctx, &controllerFlags, debugFlags.IsDebug()); err != nil {
+				if controllerFlags.InitOnly && errors.Is(err, errInitOnly) {
+					return nil
+				}
 				return err
 			}
 
@@ -140,6 +143,8 @@ func NewControllerCmd() *cobra.Command {
 
 	return cmd
 }
+
+var errInitOnly = errors.New("init-only")
 
 func (c *command) start(ctx context.Context, flags *config.ControllerOptions, debug bool) error {
 	ctx, cancel := context.WithCancelCause(ctx)
@@ -408,7 +413,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 	perfTimer.Checkpoint("starting-node-components")
 
 	if flags.InitOnly {
-		return nil
+		return errInitOnly
 	}
 
 	// Start components


### PR DESCRIPTION
## Description

After implementing the self-shutdown for leaving etcd, the controller command was waiting for a context cancellation before exiting. However, when the `--init-only` flag is used, there's no such cancellation.

Introduce a special error indicating that the controller startup was interrupted after initialization. Then, detect it in the controller command and exit cleanly without waiting for a signal.

Fixes:

* #6901

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
