### PR TITLE
Don't use etcd component at all when external etcd is used

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -236,18 +236,23 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 			K0sVars: c.K0sVars,
 		}
 	case v1beta1.EtcdStorageType:
-		storageBackend = &controller.Etcd{
-			CertManager: certificateManager,
-			Config:      nodeConfig.Spec.Storage.Etcd,
-			JoinClient:  joinClient,
-			K0sVars:     c.K0sVars,
-			LogLevel:    c.LogLevels.Etcd,
+		config := nodeConfig.Spec.Storage.Etcd
+		if !config.IsExternalClusterUsed() {
+			storageBackend = &controller.Etcd{
+				CertManager: certificateManager,
+				Config:      config,
+				JoinClient:  joinClient,
+				K0sVars:     c.K0sVars,
+				LogLevel:    c.LogLevels.Etcd,
+			}
 		}
 	default:
 		return fmt.Errorf("invalid storage type: %s", nodeConfig.Spec.Storage.Type)
 	}
-	logrus.Infof("using storage backend %s", nodeConfig.Spec.Storage.Type)
-	nodeComponents.Add(ctx, storageBackend)
+	if storageBackend != nil {
+		logrus.Infof("using storage backend %s", nodeConfig.Spec.Storage.Type)
+		nodeComponents.Add(ctx, storageBackend)
+	}
 
 	controllerMode := flags.Mode()
 	// Will the cluster support multiple controllers, or just a single one?
@@ -300,7 +305,6 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 		ClusterConfig:      nodeConfig,
 		K0sVars:            c.K0sVars,
 		LogLevel:           c.LogLevels.KubeAPIServer,
-		Storage:            storageBackend,
 		EnableKonnectivity: enableKonnectivity,
 
 		// If k0s reconciles the kubernetes endpoint, the API server shouldn't do it.

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -35,7 +35,6 @@ type APIServer struct {
 	ClusterConfig             *v1beta1.ClusterConfig
 	K0sVars                   *config.CfgVars
 	LogLevel                  string
-	Storage                   manager.Component
 	EnableKonnectivity        bool
 	DisableEndpointReconciler bool
 

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -140,10 +140,6 @@ func (e *Etcd) syncEtcdConfig(ctx context.Context, etcdRequest v1beta1.EtcdReque
 
 // Run runs etcd if external cluster is not configured
 func (e *Etcd) Start(ctx context.Context) error {
-	if e.Config.IsExternalClusterUsed() {
-		return nil
-	}
-
 	etcdCaCert := filepath.Join(e.K0sVars.EtcdCertDir, "ca.crt")
 	etcdCaCertKey := filepath.Join(e.K0sVars.EtcdCertDir, "ca.key")
 	etcdServerCert := filepath.Join(e.K0sVars.EtcdCertDir, "server.crt")


### PR DESCRIPTION
## Description

The Start method was already a no-op in this case, but the Init method is also unnecessary.

Also, remove the unused Storage field from the APIServer component. It modeled the logical dependency but is otherwise useless.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
