### PR TITLE
Build admin kubeconfig directly from PKI files

### DIFF
--- a/cmd/controller/certificates.go
+++ b/cmd/controller/certificates.go
@@ -53,7 +53,6 @@ func (c *Certificates) Init(ctx context.Context) error {
 		return fmt.Errorf("failed to read ca cert: %w", err)
 	}
 	c.CACert = string(cert)
-	// Changing the URL here also requires changes in the "k0s kubeconfig admin" subcommand.
 	kubeConfigAPIUrl := c.ClusterSpec.API.LocalURL()
 
 	apiServerUID, err := users.LookupUID(constant.ApiserverUser)
@@ -312,7 +311,6 @@ func kubeConfig(dest string, url *url.URL, caCert, clientCert, clientKey string,
 
 	kubeconfig, err := clientcmd.Write(clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{clusterName: {
-			// The server URL is replaced in the "k0s kubeconfig admin" subcommand.
 			Server:                   url.String(),
 			CertificateAuthorityData: []byte(caCert),
 		}},

--- a/cmd/kubeconfig/admin.go
+++ b/cmd/kubeconfig/admin.go
@@ -7,11 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"path/filepath"
 
 	"github.com/k0sproject/k0s/pkg/config"
-	"github.com/k0sproject/k0s/pkg/kubernetes"
 
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/spf13/cobra"
 )
@@ -31,36 +32,43 @@ func kubeConfigAdminCmd() *cobra.Command {
 				return err
 			}
 
-			// The admin kubeconfig in k0s' data dir uses the internal cluster
-			// address. This command is intended to provide a kubeconfig that
-			// uses the external address. Load the existing admin kubeconfig and
-			// rewrite it.
-			adminConfig, err := kubernetes.KubeconfigFromFile(opts.K0sVars.AdminKubeConfigPath)()
-			if pathErr := (*fs.PathError)(nil); errors.As(err, &pathErr) &&
-				pathErr.Path == opts.K0sVars.AdminKubeConfigPath &&
-				errors.Is(pathErr.Err, fs.ErrNotExist) {
-				return fmt.Errorf("admin config %q not found, check if the control plane is initialized on this node", pathErr.Path)
-			}
-			if err != nil {
-				return fmt.Errorf("failed to load admin config: %w", err)
-			}
-
-			// Now replace the internal address with the external one. See
-			// cmd/controller/certificates.go to see how the original kubeconfig
-			// is generated.
 			nodeConfig, err := opts.K0sVars.NodeConfig()
 			if err != nil {
 				return err
 			}
-			internalURL := nodeConfig.Spec.API.LocalURL().String()
-			externalURL := nodeConfig.Spec.API.APIAddressURL()
-			for _, c := range adminConfig.Clusters {
-				if c.Server == internalURL {
-					c.Server = externalURL
-				}
+
+			const (
+				clusterName = "k0s"
+				contextName = "k0s-admin"
+				userName    = "admin"
+			)
+
+			adminConfig := clientcmdapi.Config{
+				Clusters: map[string]*clientcmdapi.Cluster{clusterName: {
+					Server:               nodeConfig.Spec.API.APIAddressURL(),
+					CertificateAuthority: filepath.Join(opts.K0sVars.CertRootDir, "ca.crt"),
+				}},
+				Contexts: map[string]*clientcmdapi.Context{contextName: {
+					Cluster:  clusterName,
+					AuthInfo: userName,
+				}},
+				CurrentContext: contextName,
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{userName: {
+					ClientCertificate: filepath.Join(opts.K0sVars.CertRootDir, "admin.crt"),
+					ClientKey:         filepath.Join(opts.K0sVars.CertRootDir, "admin.key"),
+				}},
 			}
 
-			data, err := clientcmd.Write(*adminConfig)
+			if err := clientcmdapi.FlattenConfig(&adminConfig); err != nil {
+				if pathErr := (*fs.PathError)(nil); errors.As(err, &pathErr) &&
+					filepath.Dir(pathErr.Path) == opts.K0sVars.CertRootDir &&
+					errors.Is(pathErr.Err, fs.ErrNotExist) {
+					return fmt.Errorf("admin PKI file %q not found, check if the control plane is initialized on this node", pathErr.Path)
+				}
+				return fmt.Errorf("failed to create admin kubeconfig: %w", err)
+			}
+
+			data, err := clientcmd.Write(adminConfig)
 			if err != nil {
 				return fmt.Errorf("failed to serialize admin kubeconfig: %w", err)
 			}

--- a/cmd/kubeconfig/admin_test.go
+++ b/cmd/kubeconfig/admin_test.go
@@ -4,7 +4,6 @@
 package kubeconfig_test
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,8 +15,6 @@ import (
 	"github.com/k0sproject/k0s/pkg/config"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/yaml"
 
 	"github.com/stretchr/testify/assert"
@@ -35,59 +32,65 @@ func TestAdmin(t *testing.T) {
 		}},
 	})
 
-	adminConfPath := filepath.Join(dataDir, "admin.conf")
-	require.NoError(t, clientcmd.WriteToFile(api.Config{
-		Clusters: map[string]*api.Cluster{
-			t.Name(): {Server: "https://localhost:65432"},
-		},
-	}, adminConfPath))
+	certRootDir := filepath.Join(dataDir, "pki")
+	require.NoError(t, os.Mkdir(certRootDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(certRootDir, "ca.crt"), []byte("contents of ca.crt"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(certRootDir, "admin.crt"), []byte("contents of admin.crt"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(certRootDir, "admin.key"), []byte("contents of admin.key"), 0600))
 
 	k0sVars := &config.CfgVars{
-		AdminKubeConfigPath: adminConfPath,
-		DataDir:             dataDir,
-		RuntimeConfigPath:   filepath.Join(dataDir, "run", "k0s.yaml"),
-		StartupConfigPath:   configPath,
+		StartupConfigPath: configPath,
+		RuntimeConfigPath: filepath.Join(dataDir, "run", "k0s.yaml"),
+		DataDir:           dataDir,
+		CertRootDir:       certRootDir,
 	}
 	require.NoError(t, os.Mkdir(filepath.Dir(k0sVars.RuntimeConfigPath), 0700))
 	cfg, err := config.NewRuntimeConfig(k0sVars, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, cfg.Spec.Cleanup()) })
 
-	var stdout bytes.Buffer
-	var stderr strings.Builder
+	var stdout, stderr strings.Builder
 	underTest := cmd.NewRootCmd()
 	underTest.SetArgs([]string{"kubeconfig", "--data-dir", dataDir, "admin"})
 	underTest.SetOut(&stdout)
 	underTest.SetErr(&stderr)
 
 	assert.NoError(t, underTest.Execute())
-
 	assert.Empty(t, stderr.String())
-
-	adminConf, err := clientcmd.Load(stdout.Bytes())
-	require.NoError(t, err)
-
-	if theCluster, ok := adminConf.Clusters[t.Name()]; assert.True(t, ok) {
-		assert.Equal(t, "https://not-here.example.com:65432", theCluster.Server)
-	}
+	assert.Equal(t, `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: Y29udGVudHMgb2YgY2EuY3J0` /* contents of ca.crt */ +`
+    server: https://not-here.example.com:65432
+  name: k0s
+contexts:
+- context:
+    cluster: k0s
+    user: admin
+  name: k0s-admin
+current-context: k0s-admin
+kind: Config
+users:
+- name: admin
+  user:
+    client-certificate-data: Y29udGVudHMgb2YgYWRtaW4uY3J0` /* contents of admin.crt */ +`
+    client-key-data: Y29udGVudHMgb2YgYWRtaW4ua2V5` /* contents of admin.key */ +`
+`,
+		stdout.String(),
+	)
 }
 
 func TestAdmin_NoAdminConfig(t *testing.T) {
 	dataDir := t.TempDir()
 
 	configPath := filepath.Join(dataDir, "k0s.yaml")
-	writeYAML(t, configPath, &v1beta1.ClusterConfig{
-		TypeMeta: metav1.TypeMeta{APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: v1beta1.ClusterConfigKind},
-		Spec: &v1beta1.ClusterSpec{API: &v1beta1.APISpec{
-			Port: 65432, ExternalAddress: "not-here.example.com",
-		}},
-	})
+	require.NoError(t, os.WriteFile(configPath, nil, 0644))
 
 	k0sVars := &config.CfgVars{
-		AdminKubeConfigPath: filepath.Join(dataDir, "admin.conf"),
-		DataDir:             dataDir,
-		RuntimeConfigPath:   filepath.Join(dataDir, "run", "k0s.yaml"),
-		StartupConfigPath:   filepath.Join(dataDir, "k0s.yaml"),
+		StartupConfigPath: configPath,
+		RuntimeConfigPath: filepath.Join(dataDir, "run", "k0s.yaml"),
+		DataDir:           dataDir,
+		CertRootDir:       filepath.Join(dataDir, "pki"),
 	}
 	require.NoError(t, os.Mkdir(filepath.Dir(k0sVars.RuntimeConfigPath), 0700))
 
@@ -104,7 +107,7 @@ func TestAdmin_NoAdminConfig(t *testing.T) {
 	assert.Error(t, underTest.Execute())
 
 	assert.Empty(t, stdout.String())
-	msg := fmt.Sprintf("admin config %q not found, check if the control plane is initialized on this node", k0sVars.AdminKubeConfigPath)
+	msg := fmt.Sprintf("admin PKI file %q not found, check if the control plane is initialized on this node", filepath.Join(dataDir, "pki", "admin.crt"))
 	assert.Equal(t, "Error: "+msg+"\n", stderr.String())
 }
 


### PR DESCRIPTION
## Description

Previously, `kubeconfig admin` loaded the admin kubeconfig and then attempted to replace the API server URL with the external address. This was rather fragile because it required knowledge of the internal URL just to replace it later.

Instead, rebuild a fresh admin kubeconfig with the desired server URL on the fly, using the PKI files directly. This removes the coupling and makes things more self-contained.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
