### PR TITLE
[CI] Split out the unittests job to a separate workflow_call file

### DIFF
--- a/.github/workflows/build-k0s.yml
+++ b/.github/workflows/build-k0s.yml
@@ -20,9 +20,11 @@ jobs:
     name: ${{ inputs.target-os }}-${{ inputs.target-arch }}
     runs-on: >-
       ${{
-           inputs.target-arch == 'arm'   && fromJSON('["self-hosted", "linux", "arm"]')
-        || inputs.target-arch == 'arm64' && 'ubuntu-24.04-arm'
-        || 'ubuntu-24.04'
+        case(
+          inputs.target-arch == 'arm', fromJSON('["self-hosted", "linux", "arm"]'),
+          inputs.target-arch == 'arm64', 'ubuntu-24.04-arm',
+          'ubuntu-24.04'
+        )
       }}
 
     env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -157,80 +157,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: linux-amd64
-            runs-on: ubuntu-24.04
-          - name: windows-amd64
-            runs-on: windows-2022
-            target-os: windows
-          - name: macos-arm64
-            runs-on: macos-15
-            target-os: darwin
+          - runs-on: ubuntu-24.04
+          - runs-on: windows-2022
+          - runs-on: macos-15
 
-    name: "check-unit :: ${{ matrix.name }}"
-    runs-on: "${{ matrix.runs-on }}"
+    name: "check-unit :: k0s :: ${{ matrix.runs-on }}"
+    uses: ./.github/workflows/unittests-k0s.yml
+    with:
+      runs-on: ${{ matrix.runs-on }}
 
-    defaults:
-      run:
-        shell: bash
-
-    env:
-      EMBEDDED_BINS_BUILDMODE: none
-      # Set SOURCE_DATE_EPOCH to optimize cache usage
-      MAKEFLAGS: -j SOURCE_DATE_EPOCH=315532800
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          persist-credentials: false
-
-      - name: Prepare unit tests
-        if: matrix.target-os != ''
-        run: |
-          cat <<EOF >>"$GITHUB_ENV"
-          TARGET_OS=${{ matrix.target-os }}
-          DOCKER=
-          UNITTEST_EXTRA_ARGS=BUILD_GO_LDFLAGS_EXTRA=
-          EOF
-
-          echo ::group::Build Environment
-          cat -- "$GITHUB_ENV"
-          echo ::endgroup::
-
-      - name: Prepare build environment
-        run: .github/workflows/prepare-build-env.sh
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        if: matrix.target-os != ''
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: false
-
-      - name: Cache Go cache
-        id: cache-gocache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          key: "unittests-k0s-${{ matrix.name }}-gocache-go${{ env.GO_VERSION }}-${{ github.sha }}"
-          restore-keys: "unittests-k0s-${{ matrix.name }}-gocache-go${{ env.GO_VERSION }}-"
-          path: build/cache/go/build
-
-      - name: Run unit tests
-        env:
-          CACHE_HIT_GOCACHE: "${{ steps.cache-gocache.outputs.cache-hit }}"
-        run: |
-          if [ -n "$CACHE_HIT_GOCACHE" ]; then
-            echo Preparing Go cache
-            touch -t "$(TZ=UTC+24 date +%Y%m%d%H%M.%S)" build/cache/_cache_sentinel
-            find build/cache/go/build -type f \( -name '*-a' -o -name '*-d' \) -exec touch -r build/cache/_cache_sentinel {} +
-          fi
-
-          make check-unit $UNITTEST_EXTRA_ARGS
-
-          if [ -n "$CACHE_HIT_GOCACHE" ]; then
-            echo Trimming Go cache
-            find build/cache/go/build -type f \( -name '*-a' -o -name '*-d' \) -not -newer build/cache/_cache_sentinel -delete
-          fi
   smoketests:
     strategy:
       fail-fast: false

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -26,7 +26,13 @@ permissions:
 jobs:
   smoketest:
     name: Test
-    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{
+        case(
+          inputs.arch == 'arm64', 'ubuntu-24.04-arm',
+          'ubuntu-24.04'
+        )
+      }}
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/unittests-k0s.yml
+++ b/.github/workflows/unittests-k0s.yml
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 k0s authors
+
+name: Unit tests
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        type: string
+        required: true
+        description: The platform to test k0s on.
+
+
+jobs:
+  unittests:
+    name: "check-unit :: ${{ inputs.runs-on }}"
+    runs-on: ${{ inputs.runs-on }}
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      EMBEDDED_BINS_BUILDMODE: none
+      # Set SOURCE_DATE_EPOCH to optimize cache usage
+      MAKEFLAGS: -j SOURCE_DATE_EPOCH=315532800
+      TARGET_OS: >-
+        ${{
+          case(
+            startsWith(inputs.runs-on, 'windows-'), 'windows',
+            startsWith(inputs.runs-on, 'macos-'), 'darwin',
+            'linux'
+          )
+        }}
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Prepare unit tests
+        if: env.TARGET_OS != 'linux'
+        run: |
+          cat <<EOF >>"$GITHUB_ENV"
+          DOCKER=
+          UNITTEST_EXTRA_ARGS=BUILD_GO_LDFLAGS_EXTRA=
+          EOF
+
+          echo ::group::Build Environment
+          cat -- "$GITHUB_ENV"
+          echo ::endgroup::
+
+      - name: Prepare build environment
+        run: .github/workflows/prepare-build-env.sh
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        if: env.TARGET_OS != 'linux'
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+
+      - name: Cache Go cache
+        id: cache-gocache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          key: "unittests-k0s-${{ inputs.runs-on }}-gocache-go${{ env.GO_VERSION }}-${{ github.sha }}"
+          restore-keys: "unittests-k0s-${{ inputs.runs-on }}-gocache-go${{ env.GO_VERSION }}-"
+          path: build/cache/go/build
+
+      - name: Run unit tests
+        env:
+          CACHE_HIT_GOCACHE: "${{ steps.cache-gocache.outputs.cache-hit }}"
+        run: |
+          if [ -n "$CACHE_HIT_GOCACHE" ]; then
+            echo Preparing Go cache
+            touch -t "$(TZ=UTC+24 date +%Y%m%d%H%M.%S)" build/cache/_cache_sentinel
+            find build/cache/go/build -type f \( -name '*-a' -o -name '*-d' \) -exec touch -r build/cache/_cache_sentinel {} +
+          fi
+
+          make check-unit $UNITTEST_EXTRA_ARGS
+
+          if [ -n "$CACHE_HIT_GOCACHE" ]; then
+            echo Trimming Go cache
+            find build/cache/go/build -type f \( -name '*-a' -o -name '*-d' \) -not -newer build/cache/_cache_sentinel -delete
+          fi


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

Split out unittest jobs into dedicated workflow_call file. Allows reuse across multiple workflows.

Needed for https://github.com/k0sproject/k0s/pull/7414

cc @twz123 