### PR TITLE
[renovate] Fix kuberouter image regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,7 +45,7 @@
       "matchPackageNames": [
         "quay.io/k0sproject/*"
       ],
-      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-(?:k0s\\.|iptables\\d+\\.\\d+\\.\\d+-)?(?<build>\\d+))?$"
+      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-(?:iptables\\d+\\.\\d+\\.\\d+-)?(?:k0s\\.)?(?<build>\\d+))?$"
     },
     {
       "description": "Ignore all Go dependencies by default",


### PR DESCRIPTION
Starting kuberouter 2.9.0 we changed the tag format from v<x.y.z>-iptables<x.y.z>.<x> to v<x.y.z>-iptables<x.y.z>-k0x.<x>.

Fixes #7430