### PR TITLE
Remove bogus log line

### DIFF
--- a/pkg/backup/config_unix.go
+++ b/pkg/backup/config_unix.go
@@ -45,8 +45,6 @@ func (c configurationStep) Restore(restoreFrom, restoreTo string) error {
 		return nil
 	}
 
-	logrus.Infof("Previously used k0s.yaml saved under the data directory `%s`", restoreTo)
-
 	if c.restoredConfigPath == "-" {
 		f, err := os.Open(objectPathInArchive)
 		if err != nil {


### PR DESCRIPTION
## Description

Since 03c3c8bee, the k0s configuration file is no longer restored into the restore destination, even though the log line stating this has never been removed.

Fixes:

* #973

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
