### PR TITLE
Fix autopilot periodic update window evaluation

### DIFF
--- a/pkg/apis/autopilot/v1beta2/updateconfig.go
+++ b/pkg/apis/autopilot/v1beta2/updateconfig.go
@@ -118,7 +118,7 @@ func (p *PeriodicUpgradeStrategy) IsWithinPeriod(t time.Time) bool {
 		return false
 	}
 
-	startTime := startTimeForCurrentDay(st)
+	startTime := startTimeForDay(st, t)
 
 	windowDuration, err := time.ParseDuration(p.Length)
 	if err != nil {
@@ -137,10 +137,10 @@ func (p *PeriodicUpgradeStrategy) IsWithinPeriod(t time.Time) bool {
 
 }
 
-// Returns the "adjusted" time for the current day. I.e. if the starTime is 15:00, this function will return the current day at 15:00
-func startTimeForCurrentDay(startTime time.Time) time.Time {
-	now := time.Now()
-	return time.Date(now.Year(), now.Month(), now.Day(), startTime.Hour(), startTime.Minute(), 0, 0, time.Local)
+// Returns the "adjusted" time for the evaluated day. I.e. if the startTime is 15:00,
+// this function will return the evaluated day at 15:00.
+func startTimeForDay(startTime, evaluatedTime time.Time) time.Time {
+	return time.Date(evaluatedTime.Year(), evaluatedTime.Month(), evaluatedTime.Day(), startTime.Hour(), startTime.Minute(), 0, 0, evaluatedTime.Location())
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/autopilot/v1beta2/updateconfig_test.go
+++ b/pkg/apis/autopilot/v1beta2/updateconfig_test.go
@@ -73,6 +73,16 @@ func TestPeriodicUpgradeStrategy_IsWithinPeriod(t *testing.T) {
 			time: time.Now().Add(time.Hour * -24),
 			want: false,
 		},
+		{
+			name: "Fixed future time within window",
+			fields: fields{
+				Days:      []string{"Monday"},
+				StartTime: "10:00",
+				Length:    "1h",
+			},
+			time: time.Date(2099, time.January, 5, 10, 30, 0, 0, time.UTC),
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

`IsWithinPeriod(t)` looked like it checked the given time, but the window start was built from `time.Now()`. That made fixed/non-current evals miss the window; lowkey nasty for tests and edge timing.

No related issue found.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

Repro, on the old code with the new test:

```sh
go test ./pkg/apis/autopilot/v1beta2 -run 'TestPeriodicUpgradeStrategy_IsWithinPeriod/Fixed_future_time_within_window' -count=1
```

It fails with `got false, want true`. After this fix, it passes.

Also ran:

```sh
go test ./pkg/apis/autopilot/v1beta2 ./pkg/autopilot/controller/updates -count=1
git diff --check -- pkg/apis/autopilot/v1beta2/updateconfig.go pkg/apis/autopilot/v1beta2/updateconfig_test.go
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commit messages are signed-off
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings