### PR TITLE
Skip ipv6 network conformance hostPort test.

### DIFF
--- a/inttest/network-conformance/network_test.go
+++ b/inttest/network-conformance/network_test.go
@@ -98,20 +98,29 @@ func (s *networkSuite) TestK0sGetsUp() {
 	s.Require().NoError(err)
 
 	deadline, _ := s.Context().Deadline()
+	//
+	// Skipping flaky tests:
+	// - [It] [sig-network] Services should be able to switch session affinity for service with type clusterIP [LinuxOnly] [Conformance]
+	// - [It] [sig-network] Services should have session affinity work for service with type clusterIP [LinuxOnly] [Conformance]
+	// - [It] [sig-network] Services should have session affinity timeout work for service with type clusterIP [LinuxOnly] [Conformance]
+	//
+	e2eSkip := "\\[Serial\\]|(Services\\ should.*session\\ affinity\\ .*for\\ service\\ with\\ type\\ clusterIP)"
+	if s.isIPv6Only {
+		// [sig-network] HostPort uses hostIP=::1. The portmap CNI plugin has no
+		// IPv6 equivalent of the route_localnet kernel hack, so curl from a
+		// hostNetwork pod with --interface <nodeIP> to [::1]:<port> never
+		// reaches the DNAT rule and times out. Affects bridge+portmap (kuberouter)
+		// and any CNI chaining portmap for hostPort on IPv6.
+		e2eSkip += "|(HostPort.*hostPort.*hostIP.*protocol)"
+	}
 	err = client.Run(&sc.RunConfig{
 		GenConfig: sc.GenConfig{
 			EnableRBAC:     true,
 			DynamicPlugins: []string{"e2e"},
 			PluginEnvOverrides: map[string]map[string]string{
 				"e2e": {
-					"E2E_FOCUS": "\\[sig-network\\].*\\[Conformance\\]",
-					//
-					// Skipping flaky tests:
-					// - [It] [sig-network] Services should be able to switch session affinity for service with type clusterIP [LinuxOnly] [Conformance]
-					// - [It] [sig-network] Services should have session affinity work for service with type clusterIP [LinuxOnly] [Conformance]
-					// - [It] [sig-network] Services should have session affinity timeout work for service with type clusterIP [LinuxOnly] [Conformance]
-					//
-					"E2E_SKIP":          "\\[Serial\\]|(Services\\ should.*session\\ affinity\\ .*for\\ service\\ with\\ type\\ clusterIP)",
+					"E2E_FOCUS":         "\\[sig-network\\].*\\[Conformance\\]",
+					"E2E_SKIP":          e2eSkip,
 					"E2E_PARALLEL":      "y",
 					"E2E_USE_GO_RUNNER": "true",
 				},


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

Fixes CI test flakiness. 

The portmap CNI plugin has no IPv6 equivalent of the route_localnet kernel hack, so curl from a hostNetwork pod with --interface <nodeIP> to [::1]:<port> never reaches the DNAT rule and times out

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
