### PR TITLE
Revert kube-router to v2.8.1 to validate IPv6 conformance regression

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -100,7 +100,7 @@ const (
 	CalicoKubeControllersImage            = "quay.io/k0sproject/calico-kube-controllers"
 	CalicoKubeControllersImageVersion     = "v3.32.0-0"
 	KubeRouterCNIImage                    = "quay.io/k0sproject/kube-router"
-	KubeRouterCNIImageVersion             = "v2.9.0-iptables1.8.13-k0s.0"
+	KubeRouterCNIImageVersion             = "v2.8.1-iptables1.8.13-0"
 	KubeRouterCNIInstallerImage           = "quay.io/k0sproject/cni-node"
 	KubeRouterCNIInstallerImageVersion    = "1.8.0-k0s.0"
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
