### PR TITLE
[renovate] Fix kubernetes version bumps for 1.35

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -246,6 +246,32 @@
       "allowedVersions": "<=1.7"
     },
     {
+      "description": "Bump Kubernetes for release-1.35",
+      "enabled": true,
+      "matchBaseBranches": [
+        "release-1.35"
+      ],
+      "matchPackageNames": [
+        "k8s.io/**",
+        "**/kubernetes",
+        "**/kube-proxy"
+      ],
+      "allowedVersions": "/^v?[01]\\.35\\./"
+    },
+    {
+      "description": "Disallow Kubernetes digest bumps for release-1.35",
+      "enabled": false,
+      "matchBaseBranches": [
+        "release-1.35"
+      ],
+      "matchPackageNames": [
+        "k8s.io/**"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ]
+    },
+    {
       "description": "Bump Alpine for release-1.34",
       "enabled": true,
       "matchBaseBranches": [


### PR DESCRIPTION
After bumping kubernetes 1.36 we never automated kubernetes 1.35 version bumps
