### PR TITLE
Skip kuberouter IPv6 network conformance tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,9 +66,10 @@ jobs:
 
       - name: "Generate :: Smoke test matrix"
         id: generate-smoketest-matrix
+        #Discard ipv6 kuberouter tests for now, as they are very flaky.
         run: |
           ./vars.sh FROM=inttest smoketests | jq --raw-input --raw-output \
-              'split(" ") | [ .[] | select(startswith("check-")) | .[6:] ] | "smoketests=" + tojson' >>$GITHUB_OUTPUT
+              'split(" ") | [ .[] | select(startswith("check-")) | .[6:] | select(. != "network-conformance-kuberouter-ipv6" and . != "network-conformance-kuberouter-ipv6-nft") ] | "smoketests=" + tojson' >>$GITHUB_OUTPUT
 
       - name: "Generate :: Autopilot test matrix"
         id: generate-autopilot-matrix


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

Kuberouter network conformance IPv6 tests are far too flaky, so let's remove them from the CI

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
