### PR TITLE
fix(etcd): join new members as learners and self-promote

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -189,7 +189,7 @@ func etcdHandler(log logrus.FieldLogger, certRootDir, etcdCertDir string) http.H
 			sendError(err, resp)
 			return
 		}
-		log.Infof("etcd API, adding new member: %s", etcdReq.PeerAddress)
+		log.Infof("etcd API, adding new learner member: %s", etcdReq.PeerAddress)
 		err = etcdReq.Validate()
 		if err != nil {
 			sendError(err, resp)
@@ -203,7 +203,7 @@ func etcdHandler(log logrus.FieldLogger, certRootDir, etcdCertDir string) http.H
 		}
 		defer etcdClient.Close()
 
-		memberList, err := etcdClient.AddMember(ctx, etcdReq.Node, etcdReq.PeerAddress)
+		memberList, err := etcdClient.AddMemberAsLearner(ctx, etcdReq.Node, etcdReq.PeerAddress)
 		if err != nil {
 			sendError(err, resp)
 			return

--- a/cmd/etcd/list.go
+++ b/cmd/etcd/list.go
@@ -37,7 +37,11 @@ func etcdListCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("can't list etcd cluster members: %w", err)
 			}
-			return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"members": members})
+			memberMap := make(map[string]string, len(members))
+			for _, m := range members {
+				memberMap[m.Name] = m.PeerURL
+			}
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"members": memberMap})
 		},
 	}
 

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -49,6 +49,7 @@ smoketests := \
 	check-dualstack-kuberouter \
 	check-dualstack-kuberouter-dynamicconfig \
 	check-embedded-binaries \
+	check-etcdlearner \
 	check-etcdmember \
 	check-externaletcd \
 	check-extraargs \

--- a/inttest/etcdlearner/etcdlearner_test.go
+++ b/inttest/etcdlearner/etcdlearner_test.go
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package etcdlearner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	"github.com/k0sproject/k0s/pkg/token"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// EtcdLearnerSuite covers the join-as-learner safety property: a peer
+// added through the k0s join API with an unreachable peer URL must not
+// break quorum on the existing cluster, and the reconciler must not
+// promote it (since it can never catch up). This stands in for the
+// wrong-interface scenario the learner-join change exists to fix.
+type EtcdLearnerSuite struct {
+	common.BootlooseSuite
+}
+
+const phantomPeerURL = "https://192.0.2.42:2380" // RFC 5737 TEST-NET-1, unrouteable
+
+func (s *EtcdLearnerSuite) TestUnreachableLearnerPreservesQuorum() {
+	ctx := s.Context()
+
+	// Boot controller0 as a single-node cluster.
+	s.Require().NoError(s.WaitForSSH(s.ControllerNode(0), 2*time.Minute, 1*time.Second))
+	s.Require().NoError(s.InitController(0, ""))
+	s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(0)))
+	s.Require().NoError(s.WaitForKubeAPI(s.ControllerNode(0)))
+
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+
+	// Baseline write on the single-node cluster.
+	_, err = kc.CoreV1().ConfigMaps("default").Create(ctx,
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "pre-phantom"}},
+		metav1.CreateOptions{})
+	s.Require().NoError(err, "single-node cluster must accept writes before any peer is added")
+
+	// Register a phantom peer through the k0s join API. The phantom's
+	// advertised peer URL is TEST-NET-1 (RFC 5737), guaranteed
+	// unrouteable. With the join-as-learner change, the existing cluster
+	// adds it as a non-voting learner; quorum stays at 1.
+	s.callJoinEtcd(ctx, s.ControllerNode(0), v1beta1.EtcdRequest{
+		Node:        "phantom",
+		PeerAddress: phantomPeerURL,
+	})
+
+	// Wait until the phantom shows up in the member list as a learner.
+	s.Require().Eventually(func() bool {
+		for _, m := range s.listMembers(ctx, s.ControllerNode(0)) {
+			if matchesPhantom(m) {
+				return m.IsLearner
+			}
+		}
+		return false
+	}, time.Minute, 2*time.Second, "phantom never appeared in etcd member list as learner")
+
+	// The critical assertion: quorum stays at 1 and writes succeed.
+	// Pre-fix, the join API added members as voters; an unreachable
+	// voter would have made this write block until the request timeout.
+	ctxWrite, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	_, err = kc.CoreV1().ConfigMaps("default").Create(ctxWrite,
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "post-phantom"}},
+		metav1.CreateOptions{})
+	s.Require().NoErrorf(err,
+		"etcd quorum was lost after adding an unreachable peer; "+
+			"the new member must enter as a non-voting learner")
+
+	// Hold for a window and confirm the leader's reconciler does not
+	// wrongly promote a peer that cannot have caught up. The reconciler
+	// re-ticks every 30s on stuck learners; observing it stay False over
+	// ~30s rules out a one-shot race.
+	s.T().Log("verifying phantom stays a learner over a 30s observation window")
+	hold, cancelHold := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelHold()
+	for {
+		select {
+		case <-hold.Done():
+			return
+		case <-time.After(5 * time.Second):
+		}
+		var found bool
+		for _, m := range s.listMembers(ctx, s.ControllerNode(0)) {
+			if !matchesPhantom(m) {
+				continue
+			}
+			found = true
+			s.Require().Truef(m.IsLearner,
+				"phantom was promoted to voter despite being unreachable; "+
+					"reconciler must keep unreachable learners as learners")
+		}
+		s.Require().True(found, "phantom disappeared from etcd member list mid-test")
+	}
+}
+
+// etcdMember is a minimal subset of etcdctl's member-list -w json output.
+type etcdMember struct {
+	ID        uint64   `json:"ID"`
+	Name      string   `json:"name"`
+	PeerURLs  []string `json:"peerURLs"`
+	IsLearner bool     `json:"isLearner"`
+}
+
+// matchesPhantom returns true if m is the unreachable learner we added.
+// etcd only records a member's self-reported Name after it publishes via
+// raft, so an unreachable peer keeps an empty Name forever — match by
+// peer URL instead.
+func matchesPhantom(m etcdMember) bool {
+	for _, u := range m.PeerURLs {
+		if u == phantomPeerURL {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *EtcdLearnerSuite) listMembers(ctx context.Context, node string) []etcdMember {
+	ssh, err := s.SSH(ctx, node)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	out, err := ssh.ExecWithOutput(ctx,
+		"/opt/etcdctl member list -w json "+
+			"--endpoints=https://127.0.0.1:2379 "+
+			"--cacert=/var/lib/k0s/pki/etcd/ca.crt "+
+			"--cert=/var/lib/k0s/pki/apiserver-etcd-client.crt "+
+			"--key=/var/lib/k0s/pki/apiserver-etcd-client.key")
+	s.Require().NoErrorf(err, "etcdctl member list failed: %s", out)
+
+	var resp struct {
+		Members []etcdMember `json:"members"`
+	}
+	s.Require().NoError(json.Unmarshal([]byte(out), &resp), "etcdctl member list JSON: %s", out)
+	return resp.Members
+}
+
+// callJoinEtcd uses the real k0s JoinClient to POST an EtcdRequest to the
+// join API on the given node. The kubeconfig embedded in the join token
+// points to the controller's container-internal IP, which is not
+// reachable from the test host. We rewrite the server URL to the
+// host-mapped port (localhost is in the k0s-api cert's SAN list, so TLS
+// still validates) and hand the re-encoded token to JoinClientFromToken,
+// so the rest of the code path — including the EtcdRequest encoding
+// inside JoinClient.JoinEtcd — runs exactly as it does in production.
+func (s *EtcdLearnerSuite) callJoinEtcd(ctx context.Context, node string, req v1beta1.EtcdRequest) {
+	encToken, err := s.GetJoinToken("controller")
+	s.Require().NoError(err)
+
+	rawKubeconfig, err := token.DecodeJoinToken(encToken)
+	s.Require().NoError(err)
+	cfg, err := clientcmd.Load(rawKubeconfig)
+	s.Require().NoError(err)
+
+	m, err := s.MachineForName(node)
+	s.Require().NoError(err)
+	hostPort, err := m.HostPort(s.K0sAPIExternalPort)
+	s.Require().NoError(err)
+	hostURL := fmt.Sprintf("https://localhost:%d", hostPort)
+
+	for _, cluster := range cfg.Clusters {
+		cluster.Server = hostURL
+	}
+
+	rewritten, err := clientcmd.Write(*cfg)
+	s.Require().NoError(err)
+	reencoded, err := token.JoinEncode(bytes.NewReader(rewritten))
+	s.Require().NoError(err)
+
+	client, err := token.JoinClientFromToken(reencoded)
+	s.Require().NoError(err)
+
+	resp, err := client.JoinEtcd(ctx, req)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(resp.InitialCluster, "join API returned no initial-cluster")
+}
+
+func TestEtcdLearnerSuite(t *testing.T) {
+	s := EtcdLearnerSuite{
+		common.BootlooseSuite{
+			ControllerCount: 1,
+			LaunchMode:      common.LaunchModeOpenRC,
+		},
+	}
+	suite.Run(t, &s)
+}

--- a/inttest/etcdmember/etcdmember_test.go
+++ b/inttest/etcdmember/etcdmember_test.go
@@ -88,15 +88,15 @@ func (s *EtcdMemberSuite) TestDeregistration() {
 				WithObjectName(obj).
 				WithErrorCallback(common.RetryWatchErrors(s.T().Logf)).
 				Until(ctx, func(item *etcdv1beta1.EtcdMember) (done bool, err error) {
-					c := item.Status.GetCondition(etcdv1beta1.ConditionTypeJoined)
-					if c != nil {
-						// We have the condition so we can bail out
+					joined := item.Status.GetCondition(etcdv1beta1.ConditionTypeJoined)
+					if joined != nil && joined.Status == etcdv1beta1.ConditionTrue {
 						em = item
+						return true, nil
 					}
-					return c != nil, nil
+					return false, nil
 				})
 
-			// We've got the condition, verify status details
+			// We've got the conditions, verify status details
 			if err != nil {
 				return err
 			}
@@ -153,7 +153,7 @@ func (s *EtcdMemberSuite) TestDeregistration() {
 		if cond := em.Status.GetCondition(etcdv1beta1.ConditionTypeJoined); assert.NotNilf(tt, cond, "condition not found: %s", etcdv1beta1.ConditionTypeJoined) {
 			assert.Equal(tt, etcdv1beta1.ConditionTrue, cond.Status, "node not joined yet")
 		}
-	}, 30*time.Second, 1*time.Second)
+	}, 2*time.Minute, 1*time.Second)
 
 	// Check that after restarting the controller, the member is still present
 	s.Require().NoError(s.RestartController(s.ControllerNode(2)))

--- a/pkg/apis/etcd/v1beta1/types.go
+++ b/pkg/apis/etcd/v1beta1/types.go
@@ -86,7 +86,6 @@ const (
 )
 
 type JoinCondition struct {
-	// +kubebuilder:validation:Enum=Joined
 	Type   ConditionType   `json:"type"`
 	Status ConditionStatus `json:"status"`
 	// Last time the condition transitioned from one status to another.

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/avast/retry-go"
 	"github.com/sirupsen/logrus"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
 	"golang.org/x/sync/errgroup"
 
@@ -237,7 +239,18 @@ func (e *Etcd) Start(ctx context.Context) error {
 		KeepEnvPrefix: true,
 	}
 
-	return e.supervisor.Supervise(ctx)
+	if err := e.supervisor.Supervise(ctx); err != nil {
+		return err
+	}
+
+	// If this etcd was added as a learner (typical on join), promote it
+	// once raft has caught it up. For the initial member or any already-
+	// voting member, the loop short-circuits on the first lookup without
+	// calling MemberPromote. Blocking here keeps the apiserver from
+	// starting against a learner — learners reject linearizable reads, so
+	// nothing past this point would work anyway — and ensures a node that
+	// can never catch up doesn't masquerade as a working controller.
+	return e.selfPromote(ctx)
 }
 
 // Stop stops etcd
@@ -246,6 +259,61 @@ func (e *Etcd) Stop() error {
 		return e.supervisor.Stop()
 	}
 	return nil
+}
+
+// selfPromote drives this node's transition from learner to voting member.
+// It polls the local etcd until it can find itself in the member list, then
+// loops MemberPromote until raft accepts it. The call routes through the
+// local learner to the leader, so all this node needs is its own etcd
+// reachable on 127.0.0.1.
+func (e *Etcd) selfPromote(ctx context.Context) error {
+	log := logrus.WithField("component", "etcd-self-promote")
+	peerURL := e.Config.GetPeerURL()
+
+	return retry.Do(
+		func() error { return e.tryPromote(ctx, peerURL, log) },
+		retry.Attempts(10),
+		retry.Delay(5*time.Second),
+		retry.MaxDelay(30*time.Second),
+		retry.Context(ctx),
+		retry.LastErrorOnly(true),
+	)
+}
+
+func (e *Etcd) tryPromote(ctx context.Context, peerURL string, log logrus.FieldLogger) error {
+	cli, err := etcd.NewClient(e.K0sVars.CertRootDir, e.K0sVars.EtcdCertDir, e.Config)
+	if err != nil {
+		log.WithError(err).Debug("etcd client unavailable, retrying")
+		return err
+	}
+	defer cli.Close()
+
+	callCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	memberID, isLearner, err := cli.GetMemberByPeerAddress(callCtx, peerURL)
+	if err != nil {
+		log.WithError(err).Debug("local member lookup failed, retrying")
+		return err
+	}
+	if !isLearner {
+		return nil
+	}
+
+	switch err := cli.PromoteMember(callCtx, memberID); {
+	case err == nil:
+		log.Info("Promoted self to voting member")
+		return nil
+	case errors.Is(err, rpctypes.ErrMemberNotLearner):
+		// Someone else (older leader, manual etcdctl) already promoted us.
+		return nil
+	case errors.Is(err, rpctypes.ErrMemberLearnerNotReady):
+		log.Debug("Not caught up yet, retrying self-promotion")
+		return err
+	default:
+		log.WithError(err).Warn("Self-promotion failed, retrying")
+		return err
+	}
 }
 
 func (e *Etcd) setupCerts(ctx context.Context) error {

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -365,9 +366,17 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context, client et
 	}
 	defer etcdClient.Close()
 
-	memberID, err := etcdClient.GetPeerIDByAddress(ctx, e.etcdConfig.GetPeerURL())
+	memberID, isLearner, err := etcdClient.GetMemberByPeerAddress(ctx, e.etcdConfig.GetPeerURL())
 	if err != nil {
 		return err
+	}
+
+	// Defensive: by the time this runs, etcd.Etcd.Start has already
+	// self-promoted any learner to voting member. If we somehow still see
+	// learner here, refuse to claim "Joined" so consumers of the condition
+	// don't treat an unpromoted member as a full cluster participant.
+	if isLearner {
+		return fmt.Errorf("etcd member %x is still a learner; refusing to mark as joined", memberID)
 	}
 
 	// Convert the memberID to hex string
@@ -526,9 +535,11 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 		return false
 	}
 
+	exists := slices.ContainsFunc(members, func(m etcd.Member) bool {
+		return m.Name == member.Name
+	})
 	// Member marked for leave but no member found in etcd, mark for leaved
-	_, ok := members[member.Name]
-	if !ok {
+	if !exists {
 		log.Debug("member marked for leave but not in actual member list, updating state to reflect that")
 		member.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionFalse, member.Status.Message, time.Now())
 		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusSuccess
@@ -540,7 +551,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 	}
 
 	joinStatus := member.Status.GetCondition(etcdv1beta1.ConditionTypeJoined)
-	if joinStatus != nil && joinStatus.Status == etcdv1beta1.ConditionFalse && !ok {
+	if joinStatus != nil && joinStatus.Status == etcdv1beta1.ConditionFalse && !exists {
 		log.Debug("member already left, no action needed")
 		return true
 	}

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -24,6 +24,14 @@ type Client struct {
 	tlsInfo transport.TLSInfo
 }
 
+// Member describes an etcd cluster member.
+type Member struct {
+	ID        uint64
+	Name      string
+	PeerURL   string
+	IsLearner bool
+}
+
 // NewClient creates new Client
 func NewClient(certDir, etcdCertDir string, etcdConf *v1beta1.EtcdConfig) (*Client, error) {
 	client := &Client{}
@@ -62,18 +70,26 @@ func NewClientWithConfig(cfg clientv3.Config) (*Client, error) {
 	return client, nil
 }
 
-// ListMembers gets a list of current etcd members
-func (c *Client) ListMembers(ctx context.Context) (map[string]string, error) {
-	memberList := make(map[string]string)
-	members, err := c.client.MemberList(ctx)
+// ListMembers gets a list of current etcd members.
+func (c *Client) ListMembers(ctx context.Context) ([]Member, error) {
+	resp, err := c.client.MemberList(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("etcd member list failed: %w", err)
 	}
-	for _, m := range members.Members {
-		memberList[m.Name] = m.PeerURLs[0]
+	members := make([]Member, 0, len(resp.Members))
+	for _, m := range resp.Members {
+		var peerURL string
+		if len(m.PeerURLs) > 0 {
+			peerURL = m.PeerURLs[0]
+		}
+		members = append(members, Member{
+			ID:        m.ID,
+			Name:      m.Name,
+			PeerURL:   peerURL,
+			IsLearner: m.IsLearner,
+		})
 	}
-
-	return memberList, nil
+	return members, nil
 }
 
 // AddMember add new member to etcd cluster
@@ -101,6 +117,31 @@ func (c *Client) AddMember(ctx context.Context, name, peerAddress string) ([]str
 	return memberList, nil
 }
 
+// AddMemberAsLearner adds a new learner member to the etcd cluster.
+// Returns an initial-cluster list (name=peerURL pairs) suitable for the
+// joining etcd's --initial-cluster flag.
+func (c *Client) AddMemberAsLearner(ctx context.Context, name, peerAddress string) ([]string, error) {
+	addResp, err := c.client.MemberAddAsLearner(ctx, []string{peerAddress})
+	if err != nil {
+		return nil, fmt.Errorf("etcd member add as learner failed: %w", err)
+	}
+
+	newID := addResp.Member.ID
+
+	var memberList []string
+	// Each member is guaranteed by etcd to have at least one peer URL at this point,
+	// so indexing m.PeerURLs[0] is safe.
+	for _, m := range addResp.Members {
+		memberName := m.Name
+		if m.ID == newID {
+			memberName = name
+		}
+		memberList = append(memberList, fmt.Sprintf("%s=%s", memberName, m.PeerURLs[0]))
+	}
+
+	return memberList, nil
+}
+
 // GetPeerIDByAddress looks up peer id by peer url
 func (c *Client) GetPeerIDByAddress(ctx context.Context, peerAddress string) (uint64, error) {
 	resp, err := c.client.MemberList(ctx)
@@ -115,9 +156,32 @@ func (c *Client) GetPeerIDByAddress(ctx context.Context, peerAddress string) (ui
 	return 0, fmt.Errorf("peer not found: %s", peerAddress)
 }
 
+// GetMemberByPeerAddress looks up a member by peer URL and returns its
+// ID along with the IsLearner flag. Returns (0, false, error) if not found.
+func (c *Client) GetMemberByPeerAddress(ctx context.Context, peerAddress string) (uint64, bool, error) {
+	resp, err := c.client.MemberList(ctx)
+	if err != nil {
+		return 0, false, fmt.Errorf("etcd member list failed: %w", err)
+	}
+	for _, m := range resp.Members {
+		if slices.Contains(m.PeerURLs, peerAddress) {
+			return m.ID, m.IsLearner, nil
+		}
+	}
+	return 0, false, fmt.Errorf("peer not found: %s", peerAddress)
+}
+
 // DeleteMember deletes member by peer name
 func (c *Client) DeleteMember(ctx context.Context, peerID uint64) error {
 	_, err := c.client.MemberRemove(ctx, peerID)
+	return err
+}
+
+// PromoteMember promotes a learner to a voting member. Returns the etcd
+// error unwrapped. Callers must handle rpctypes.ErrLearnerNotReady and
+// rpctypes.ErrMemberNotLearner explicitly.
+func (c *Client) PromoteMember(ctx context.Context, memberID uint64) error {
+	_, err := c.client.MemberPromote(ctx, memberID)
 	return err
 }
 

--- a/static/_crds/etcd/etcd.k0sproject.io_etcdmembers.yaml
+++ b/static/_crds/etcd/etcd.k0sproject.io_etcdmembers.yaml
@@ -78,8 +78,6 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      enum:
-                      - Joined
                       type: string
                   required:
                   - status


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds new etcd members through the k0s join API as raft learners instead of voting members. The leader-elected EtcdMemberReconciler promotes them once etcd reports them caught up. This prevents an unreachable joiner (e.g. one advertising a wrong-interface peer URL) from breaking quorum on the existing cluster — notably the 1-node case where the surviving controller went from quorum=1 to quorum=2 and stalled waiting for an unreachable peer.

Fixes #7628

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
