### PR TITLE
Detect and reconcile stale EtcdMember objects

### DIFF
--- a/cmd/etcd/list.go
+++ b/cmd/etcd/list.go
@@ -4,14 +4,21 @@
 package etcd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/etcd"
+	"github.com/k0sproject/k0s/pkg/k0scontext"
 
 	"github.com/spf13/cobra"
 )
+
+type etcdMemberListClient interface {
+	ListMembers(context.Context) ([]etcd.Member, error)
+	Close() error
+}
 
 func etcdListCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -19,6 +26,8 @@ func etcdListCmd() *cobra.Command {
 		Short: "List etcd cluster members (JSON encoded)",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true
+
 			opts, err := config.GetCmdOpts(cmd)
 			if err != nil {
 				return err
@@ -28,20 +37,28 @@ func etcdListCmd() *cobra.Command {
 				return err
 			}
 			ctx := cmd.Context()
-			etcdClient, err := etcd.NewClient(opts.K0sVars.CertRootDir, opts.K0sVars.EtcdCertDir, nodeConfig.Spec.Storage.Etcd)
-			if err != nil {
-				return fmt.Errorf("can't list etcd cluster members: %w", err)
+			etcdClient := k0scontext.Value[etcdMemberListClient](ctx)
+			if etcdClient == nil {
+				etcdClient, err = etcd.NewClient(opts.K0sVars.CertRootDir, opts.K0sVars.EtcdCertDir, nodeConfig.Spec.Storage.Etcd)
+				if err != nil {
+					return fmt.Errorf("can't list etcd cluster members: %w", err)
+				}
 			}
 			defer etcdClient.Close()
+
 			members, err := etcdClient.ListMembers(ctx)
 			if err != nil {
 				return fmt.Errorf("can't list etcd cluster members: %w", err)
 			}
-			memberMap := make(map[string]string, len(members))
-			for _, m := range members {
-				memberMap[m.Name] = m.PeerURL
+			response := struct {
+				Members map[string]string `json:"members"`
+			}{
+				make(map[string]string, len(members)),
 			}
-			return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"members": memberMap})
+			for _, member := range members {
+				response.Members[member.Name] = member.PeerURL
+			}
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(response)
 		},
 	}
 

--- a/cmd/etcd/list_test.go
+++ b/cmd/etcd/list_test.go
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package etcd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/k0sproject/k0s/pkg/etcd"
+	"github.com/k0sproject/k0s/pkg/k0scontext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEtcdListCmd(t *testing.T) {
+	t.Run("lists_members_as_json", func(t *testing.T) {
+		client := fakeEtcdMemberListClient{
+			members: []etcd.Member{
+				{ID: 1, Name: "node-1", PeerURL: "https://10.0.0.1:2380"},
+				{ID: 2, Name: "node-2", PeerURL: "https://10.0.0.2:2380"},
+			},
+		}
+
+		ctx := t.Context()
+		ctx = k0scontext.WithValue[etcdMemberListClient](ctx, &client)
+
+		var (
+			stdout bytes.Buffer
+			stderr strings.Builder
+		)
+		underTest := etcdListCmd()
+		underTest.SetOut(&stdout)
+		underTest.SetErr(&stderr)
+		err := underTest.ExecuteContext(ctx)
+		require.NoError(t, err)
+		assert.True(t, client.closed, "expected the etcd client to be closed")
+		assert.Empty(t, stderr.String())
+
+		var got struct {
+			Members map[string]string `json:"members"`
+		}
+		require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+		assert.Equal(t, map[string]string{
+			"node-1": "https://10.0.0.1:2380",
+			"node-2": "https://10.0.0.2:2380",
+		}, got.Members)
+	})
+
+	t.Run("wraps_member_list_errors", func(t *testing.T) {
+		client := fakeEtcdMemberListClient{
+			listErr: errors.New("member list failed"),
+		}
+
+		ctx := t.Context()
+		ctx = k0scontext.WithValue[etcdMemberListClient](ctx, &client)
+
+		var (
+			stdout strings.Builder
+			stderr strings.Builder
+		)
+		underTest := etcdListCmd()
+		underTest.SetOut(&stdout)
+		underTest.SetErr(&stderr)
+		err := underTest.ExecuteContext(ctx)
+		assert.ErrorContains(t, err, "can't list etcd cluster members: member list failed")
+		assert.True(t, client.closed, "Expected the etcd client to be closed")
+		assert.Empty(t, stdout.String())
+		assert.Equal(t, "Error: can't list etcd cluster members: member list failed\n", stderr.String())
+	})
+}
+
+type fakeEtcdMemberListClient struct {
+	mu      sync.Mutex
+	members []etcd.Member
+	listErr error
+	closed  bool
+}
+
+func (s *fakeEtcdMemberListClient) ListMembers(context.Context) ([]etcd.Member, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return nil, errors.New("already closed")
+	}
+
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return slices.Clone(s.members), nil
+}
+
+func (s *fakeEtcdMemberListClient) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return errors.New("already closed")
+	}
+
+	s.closed = true
+	return nil
+}

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -77,9 +77,6 @@ check-ap-updater: .update-server.stamp
 check-ap-updater-periodic: .update-server.stamp
 check-ap-updater-periodic: TIMEOUT=10m
 
-# Backup check runs multiple scenarios
-check-backup: TIMEOUT=12m
-
 # Config change smoke runs actually many cases hence a bit longer timeout
 check-configchange: TIMEOUT=8m
 

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -19,6 +19,8 @@ smoketests := \
 	check-ap-updater \
 	check-ap-updater-periodic \
 	check-backup \
+	check-backup-stream \
+	check-backup-kine \
 	check-basic \
 	check-bind-address \
 	check-byocri \

--- a/inttest/backup/backup_test.go
+++ b/inttest/backup/backup_test.go
@@ -4,6 +4,8 @@
 package basic
 
 import (
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -263,30 +265,19 @@ func TestBackupSuite(t *testing.T) {
 	}
 	s.backupFunc = s.takeBackup
 	s.restoreFunc = s.restoreBackup
-	suite.Run(t, &s)
-}
 
-func TestBackupSuiteStream(t *testing.T) {
-	s := BackupSuite{
-		BootlooseSuite: common.BootlooseSuite{
-			ControllerCount: 1,
-			WorkerCount:     1,
-		},
+	if target := os.Getenv("K0S_INTTEST_TARGET"); strings.Contains(target, "stream") {
+		t.Log("Using stdout/stderr")
+		s.ControllerCount = 1
+		s.WorkerCount = 1
+		s.backupFunc = s.takeBackupStdout
+		s.restoreFunc = s.restoreBackupStdin
+	} else if strings.Contains(target, "kine") {
+		t.Log("Using kine")
+		s.ControllerCount = 1
+		s.WorkerCount = 2
+		s.useKine = true
 	}
-	s.backupFunc = s.takeBackupStdout
-	s.restoreFunc = s.restoreBackupStdin
-	suite.Run(t, &s)
-}
 
-func TestBackupSuiteKine(t *testing.T) {
-	s := BackupSuite{
-		BootlooseSuite: common.BootlooseSuite{
-			ControllerCount: 1,
-			WorkerCount:     2,
-		},
-		useKine: true,
-	}
-	s.backupFunc = s.takeBackup
-	s.restoreFunc = s.restoreBackup
 	suite.Run(t, &s)
 }

--- a/inttest/backup/backup_test.go
+++ b/inttest/backup/backup_test.go
@@ -4,13 +4,20 @@
 package basic
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/k0sproject/k0s/inttest/common"
-	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	etcdv1beta1 "github.com/k0sproject/k0s/pkg/apis/etcd/v1beta1"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,10 +36,10 @@ type BackupSuite struct {
 }
 
 func (s *BackupSuite) getControllerConfig() string {
-	config := v1beta1.ClusterConfig{
-		Spec: &v1beta1.ClusterSpec{
-			Network: &v1beta1.Network{
-				NodeLocalLoadBalancing: &v1beta1.NodeLocalLoadBalancing{
+	config := k0sv1beta1.ClusterConfig{
+		Spec: &k0sv1beta1.ClusterSpec{
+			Network: &k0sv1beta1.Network{
+				NodeLocalLoadBalancing: &k0sv1beta1.NodeLocalLoadBalancing{
 					Enabled: s.ControllerCount > 1,
 				},
 			},
@@ -40,8 +47,8 @@ func (s *BackupSuite) getControllerConfig() string {
 	}
 
 	if s.useKine {
-		config.Spec.Storage = &v1beta1.StorageSpec{
-			Type: v1beta1.KineStorageType,
+		config.Spec.Storage = &k0sv1beta1.StorageSpec{
+			Type: k0sv1beta1.KineStorageType,
 		}
 	}
 
@@ -51,6 +58,8 @@ func (s *BackupSuite) getControllerConfig() string {
 }
 
 func (s *BackupSuite) TestK0sGetsUp() {
+	ctx := s.TContext()
+
 	config := s.getControllerConfig()
 	s.T().Log("Config:", config)
 	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", config)
@@ -95,6 +104,12 @@ func (s *BackupSuite) TestK0sGetsUp() {
 
 	s.Require().NoError(s.restoreFunc())
 	s.Require().NoError(s.InitController(0, "--enable-worker"))
+	s.Require().NoError(s.WaitForNodeReady(s.ControllerNode(0), kc))
+
+	// Check if the first controller detects the other controllers as stale
+	if !s.useKine {
+		awaitEtcdMemberReconciliation(ctx, s)
+	}
 
 	// Join the other controllers in the usual way
 	if s.ControllerCount > 1 {
@@ -106,7 +121,6 @@ func (s *BackupSuite) TestK0sGetsUp() {
 		}
 	}
 
-	s.Require().NoError(s.WaitForNodeReady(s.ControllerNode(0), kc))
 	for i := range s.WorkerCount {
 		s.Require().NoError(s.WaitForNodeReady(s.WorkerNode(i), kc))
 	}
@@ -116,6 +130,11 @@ func (s *BackupSuite) TestK0sGetsUp() {
 	s.Require().Equal(snapshot, snapshotAfterBackup)
 
 	s.Require().NoError(s.VerifyFileSystemRestore())
+
+	// Check that all controllers are listed as joined etcd members
+	if !s.useKine {
+		awaitEtcdMemberReconciliation(ctx, s)
+	}
 }
 
 func (s *BackupSuite) reset(name string) {
@@ -254,6 +273,74 @@ func (s *BackupSuite) restoreBackupStdin() error {
 	s.T().Logf("restored successfully with output:\n%s", out)
 
 	return nil
+}
+
+func awaitEtcdMemberReconciliation(ctx context.Context, s *BackupSuite) {
+	ssh, err := s.SSH(ctx, s.ControllerNode(0))
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	emc, err := s.EtcdMemberClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+
+	for {
+		select {
+		case <-time.After(7 * time.Second):
+		case <-ctx.Done():
+			s.FailNow("Interrupted")
+		}
+
+		reconciled, err := emc.EtcdMembers().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			s.T().Log("Failed to list etcd members:", err)
+			continue
+		}
+
+		actual, err := listEtcdMembers(ctx, ssh)
+		if err != nil {
+			s.T().Logf("k0s etcd member-list failed: %v", err)
+			continue
+		}
+
+		var errs []string
+		for _, member := range reconciled.Items {
+			joined := slices.ContainsFunc(member.Status.Conditions, func(c etcdv1beta1.JoinCondition) bool {
+				return c.Status == etcdv1beta1.ConditionTrue && c.Type == etcdv1beta1.ConditionTypeJoined
+			})
+			if peerURL, ok := actual[member.Name]; ok {
+				delete(actual, member.Name)
+				if !joined {
+					errs = append(errs, "etcd member "+member.Name+" not marked as joined")
+				}
+				if peerURL, err := url.Parse(peerURL); err != nil {
+					errs = append(errs, "failed to parse peer URL of etcd member "+member.Name+" ("+err.Error()+")")
+				} else if peerURL.Hostname() != member.Status.PeerAddress {
+					errs = append(errs, fmt.Sprintf("etcd member %s peer address mismatch: %q != %q", member.Name, peerURL, member.Status.PeerAddress))
+				}
+			} else if joined {
+				errs = append(errs, "stale etcd member "+member.Name)
+			}
+		}
+		if len(errs) > 0 {
+			s.T().Log("Etcd members not fully reconciled:", strings.Join(errs, "; "))
+		} else {
+			s.T().Logf("Etcd members fully reconciled")
+			break
+		}
+	}
+}
+
+func listEtcdMembers(ctx context.Context, ssh *common.SSHConnection) (map[string]string, error) {
+	var out bytes.Buffer
+	if err := ssh.Exec(ctx, "k0s etcd member-list", common.SSHStreams{Out: &out}); err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Members map[string]string `json:"members"`
+	}
+	err := json.Unmarshal(out.Bytes(), &result)
+	return result.Members, err
 }
 
 func TestBackupSuite(t *testing.T) {

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -523,6 +523,47 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, etcdClient *
 
 	log.Debugf("reconciling EtcdMember: %s", member.Name)
 
+	// Convert the memberID to uint64
+	memberID, err := strconv.ParseUint(member.Status.MemberID, 16, 64)
+	if err != nil {
+		log.WithError(err).Error("Failed to parse memberID")
+		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
+		member.Status.Message = "Failed to parse memberID: " + err.Error()
+		if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
+			log.WithError(err).Error("Failed to update EtcdMember status")
+		}
+
+		return false
+	}
+
+	exists := slices.ContainsFunc(clusterMembers, func(m etcd.Member) bool {
+		return m.ID == memberID
+	})
+
+	// Member not listed as etcd member.
+	if !exists {
+		for i := range member.Status.Conditions {
+			c := &member.Status.Conditions[i]
+			if c.Type == etcdv1beta1.ConditionTypeJoined {
+				if c.Status == etcdv1beta1.ConditionFalse {
+					return true
+				}
+				break
+			}
+		}
+
+		msg := "No such member ID"
+		log.Debug(msg)
+		member.Status.Message = msg
+		member.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionFalse, member.Status.Message, time.Now())
+		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusSuccess
+		if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
+			log.WithError(err).Error("Failed to update EtcdMember status")
+			return false
+		}
+		return true
+	}
+
 	if !member.Spec.Leave {
 		log.Debug("member not marked for leave, no action needed")
 		return true
@@ -561,34 +602,6 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, etcdClient *
 		}
 
 		return false
-	}
-	// Convert the memberID to uint64
-	memberID, err := strconv.ParseUint(member.Status.MemberID, 16, 64)
-	if err != nil {
-		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
-		member.Status.Message = "Failed to parse memberID: " + err.Error()
-		if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
-			log.WithError(err).Error("Failed to update EtcdMember status")
-		}
-
-		log.WithError(err).Error("failed to parse memberID")
-		return false
-	}
-
-	exists := slices.ContainsFunc(clusterMembers, func(m etcd.Member) bool {
-		return m.ID == memberID
-	})
-	// Member marked for leave but no member found in etcd, mark for leaved
-	if !exists {
-		log.Debug("member marked for leave but not in actual member list, updating state to reflect that")
-		member.Status.Message = "No such member"
-		member.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionFalse, member.Status.Message, time.Now())
-		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusSuccess
-		if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
-			log.WithError(err).Error("Failed to update EtcdMember status")
-			return false
-		}
-		return true
 	}
 
 	joinStatus := member.Status.GetCondition(etcdv1beta1.ConditionTypeJoined)

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -428,9 +428,8 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context, client et
 				MemberID:    memberIDStr,
 			}
 			em.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionTrue, "Member joined", time.Now())
-			_, err = client.UpdateStatus(ctx, em, metav1.UpdateOptions{})
-			if err != nil {
-				log.WithError(err).Error("failed to update member status")
+			if _, err := client.UpdateStatus(ctx, em, metav1.UpdateOptions{}); err != nil {
+				log.WithError(err).Error("Failed to update EtcdMember status")
 			}
 			return nil
 		} else {
@@ -455,7 +454,7 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context, client et
 	em.Status.MemberID = memberIDStr
 	em.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionTrue, "Member joined", time.Now())
 	if _, err := client.UpdateStatus(ctx, em, metav1.UpdateOptions{}); err != nil {
-		return err
+		return fmt.Errorf("failed to update EtcdMember status: %w", err)
 	}
 
 	return nil
@@ -488,7 +487,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 			member.Status.Message = msg
 			member.Status.ReconcileStatus = ""
 			if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
-				log.WithError(err).Error("Failed to update member state")
+				log.WithError(err).Error("Failed to update EtcdMember status")
 			}
 			return false
 		}
@@ -499,7 +498,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 			member.Status.Message = msg
 			member.Status.ReconcileStatus = ""
 			if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
-				log.WithError(err).Error("Failed to update member state")
+				log.WithError(err).Error("Failed to update EtcdMember status")
 			}
 			le.YieldLease()
 		} else {
@@ -508,7 +507,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 			member.Status.Message = msg
 			member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
 			if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
-				log.WithError(err).Error("Failed to update member state")
+				log.WithError(err).Error("Failed to update EtcdMember status")
 			}
 		}
 
@@ -517,11 +516,11 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 
 	etcdClient, err := etcd.NewClient(e.k0sVars.CertRootDir, e.k0sVars.EtcdCertDir, e.etcdConfig)
 	if err != nil {
-		log.WithError(err).Warn("failed to create etcd client")
+		log.WithError(err).Warn("Failed to create etcd client")
 		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
-		member.Status.Message = err.Error()
-		if _, err = client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
-			log.WithError(err).Error("failed to update member state")
+		member.Status.Message = "Failed to create etcd client: " + err.Error()
+		if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
+			log.WithError(err).Error("Failed to update EtcdMember status")
 		}
 
 		return false
@@ -534,10 +533,11 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 	// Verify that the member is actually still present in etcd
 	members, err := etcdClient.ListMembers(ctx)
 	if err != nil {
+		log.WithError(err).Warn("Failed to list etcd members")
 		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
-		member.Status.Message = err.Error()
-		if _, err = client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
-			log.WithError(err).Error("failed to update member state")
+		member.Status.Message = "Failed to list etcd members: " + err.Error()
+		if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
+			log.WithError(err).Error("Failed to update EtcdMember status")
 		}
 
 		return false
@@ -553,7 +553,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 		member.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionFalse, member.Status.Message, time.Now())
 		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusSuccess
 		if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
-			log.WithError(err).Error("failed to update EtcdMember status")
+			log.WithError(err).Error("Failed to update EtcdMember status")
 			return false
 		}
 		return true
@@ -584,7 +584,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 			memberLeaseName = "k0s-ctrl-" + member.Name
 		}
 		if memberLease, err := clients.CoordinationV1().Leases(corev1.NamespaceNodeLease).Get(ctx, memberLeaseName, metav1.GetOptions{}); err != nil {
-			log.WithError(err).Error("Failed to get etcd member lease")
+			log.WithError(err).Error("Failed to get k0s controller lease")
 			msg := "Failed to get k0s controller lease: " + err.Error()
 			if apierrors.IsNotFound(err) {
 				msg = "No k0s controller lease found"
@@ -592,7 +592,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 			member.Status.Message = msg
 			member.Status.ReconcileStatus = ""
 			if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
-				log.WithError(err).Error("Failed to update member state")
+				log.WithError(err).Error("Failed to update EtcdMember status")
 			}
 			return false
 		} else if kubeutil.IsValidLease(*memberLease) {
@@ -602,7 +602,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 					log.Info("Requesting member shutdown before deletion")
 					member.Labels[shutdownLabelName] = memberInvocationID
 					if _, err := client.Update(ctx, member, metav1.UpdateOptions{}); err != nil {
-						log.WithError(err).Error("Failed to update member")
+						log.WithError(err).Error("Failed to update EtcdMember")
 						return false
 					}
 					return true
@@ -626,7 +626,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 			member.Status.Message = msg
 			member.Status.ReconcileStatus = ""
 			if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
-				log.WithError(err).Error("Failed to update member state")
+				log.WithError(err).Error("Failed to update EtcdMember status")
 			}
 			return false
 		}
@@ -654,12 +654,11 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 	)
 
 	if err != nil {
-		log.WithError(err).Errorf("Failed to delete member from cluster")
+		log.WithError(err).Error("Failed to delete member from cluster")
 		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
-		member.Status.Message = err.Error()
-		_, err = client.UpdateStatus(ctx, member, metav1.UpdateOptions{})
-		if err != nil {
-			log.WithError(err).Error("failed to update EtcdMember status")
+		member.Status.Message = "Failed to delete member from cluster: " + err.Error()
+		if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
+			log.WithError(err).Error("Failed to update EtcdMember status")
 		}
 		return false
 	}
@@ -669,9 +668,8 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 	member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusSuccess
 	member.Status.Message = "Member removed from cluster"
 	member.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionFalse, member.Status.Message, time.Now())
-	_, err = client.UpdateStatus(ctx, member, metav1.UpdateOptions{})
-	if err != nil {
-		log.WithError(err).Error("failed to update EtcdMember status")
+	if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
+		log.WithError(err).Error("Failed to update EtcdMember status")
 		return false
 	}
 

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -543,8 +543,21 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 		return false
 	}
 
+	// Convert the memberID to uint64
+	memberID, err := strconv.ParseUint(member.Status.MemberID, 16, 64)
+	if err != nil {
+		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
+		member.Status.Message = "Failed to parse memberID: " + err.Error()
+		if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
+			log.WithError(err).Error("Failed to update EtcdMember status")
+		}
+
+		log.WithError(err).Error("failed to parse memberID")
+		return false
+	}
+
 	exists := slices.ContainsFunc(members, func(m etcd.Member) bool {
-		return m.Name == member.Name
+		return m.ID == memberID
 	})
 	// Member marked for leave but no member found in etcd, mark for leaved
 	if !exists {
@@ -563,19 +576,6 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 	if joinStatus != nil && joinStatus.Status == etcdv1beta1.ConditionFalse && !exists {
 		log.Debug("member already left, no action needed")
 		return true
-	}
-
-	// Convert the memberID to uint64
-	memberID, err := strconv.ParseUint(member.Status.MemberID, 16, 64)
-	if err != nil {
-		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
-		member.Status.Message = "Failed to parse memberID: " + err.Error()
-		if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
-			log.WithError(err).Error("Failed to update EtcdMember status")
-		}
-
-		log.WithError(err).Error("failed to parse memberID")
-		return false
 	}
 
 	if memberInvocationID, ok := member.Labels[shutdownOnLeaveLabelName]; ok && memberInvocationID != "" {

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -568,6 +568,12 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 	// Convert the memberID to uint64
 	memberID, err := strconv.ParseUint(member.Status.MemberID, 16, 64)
 	if err != nil {
+		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
+		member.Status.Message = "Failed to parse memberID: " + err.Error()
+		if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
+			log.WithError(err).Error("Failed to update EtcdMember status")
+		}
+
 		log.WithError(err).Error("failed to parse memberID")
 		return false
 	}

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -81,19 +82,48 @@ func (e *EtcdMemberReconciler) Init(_ context.Context) error {
 // avoids stale state after leader changes, especially when the leader removes
 // itself and can no longer update its own EtcdMember status.
 func (e *EtcdMemberReconciler) resync(ctx context.Context, client etcdclient.EtcdMemberInterface, log logrus.FieldLogger) bool {
-	// Loop through all the members and run reconcile on them
-	// Use high timeout as etcd/api could be a bit slow when the leader changes
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
-	defer cancel()
-	members, err := client.List(ctx, metav1.ListOptions{})
+	members, err := func() (*etcdv1beta1.EtcdMemberList, error) {
+		// Use high timeout as etcd/api could be a bit slow when the leader changes
+		ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+		defer cancel()
+		return client.List(ctx, metav1.ListOptions{})
+	}()
 	if err != nil {
 		log.WithError(err).Error("Failed to list etcd members")
 		return false
 	}
 
+	etcdClient, clusterMembers, err := e.listEtcdClusterMembers(ctx)
+	if err != nil {
+		log.WithError(err).Error("Failed to list etcd cluster members")
+		msg := "Failed to list etcd cluster members: " + err.Error()
+
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		var wg sync.WaitGroup
+		for _, member := range members.Items {
+			wg.Go(func() {
+				member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
+				member.Status.Message = msg
+				if _, err := client.UpdateStatus(ctx, &member, metav1.UpdateOptions{}); err != nil {
+					log.WithFields(logrus.Fields{
+						"name":        member.Name,
+						"memberID":    member.Status.MemberID,
+						"peerAddress": member.Status.PeerAddress,
+					}).WithError(err).Error("Failed to update EtcdMember status")
+				}
+			})
+		}
+
+		wg.Wait()
+		return false
+	}
+	defer etcdClient.Close()
+
+	// Loop through all the members and reconcile them
 	var failed bool
 	for _, member := range members.Items {
-		if !e.reconcileMember(ctx, client, &member) {
+		if !e.reconcileMember(ctx, etcdClient, client, clusterMembers, &member) {
 			failed = true
 		}
 	}
@@ -103,6 +133,25 @@ func (e *EtcdMemberReconciler) resync(ctx context.Context, client etcdclient.Etc
 	}
 
 	return !failed
+}
+
+func (e *EtcdMemberReconciler) listEtcdClusterMembers(ctx context.Context) (_ *etcd.Client, _ []etcd.Member, err error) {
+	client, err := etcd.NewClient(e.k0sVars.CertRootDir, e.k0sVars.EtcdCertDir, e.etcdConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create etcd client: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, client.Close())
+		}
+	}()
+
+	// Use high timeout as etcd could be a bit slow when the leader changes
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	members, err := client.ListMembers(ctx)
+	return client, members, err
 }
 
 // Waits for CRDs, creates this node's EtcdMember, and launches the reconcile loop.
@@ -463,7 +512,7 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context, client et
 // Applies the leave/shutdown protocol for a single EtcdMember. It prevents the
 // last controller from leaving, waits for active controllers to stop, then
 // removes the etcd member and updates status accordingly.
-func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdclient.EtcdMemberInterface, member *etcdv1beta1.EtcdMember) bool {
+func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, etcdClient *etcd.Client, client etcdclient.EtcdMemberInterface, clusterMembers []etcd.Member, member *etcdv1beta1.EtcdMember) bool {
 	log := logrus.WithFields(logrus.Fields{
 		"component":   "etcdMemberReconciler",
 		"phase":       "reconcile",
@@ -513,36 +562,6 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 
 		return false
 	}
-
-	etcdClient, err := etcd.NewClient(e.k0sVars.CertRootDir, e.k0sVars.EtcdCertDir, e.etcdConfig)
-	if err != nil {
-		log.WithError(err).Warn("Failed to create etcd client")
-		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
-		member.Status.Message = "Failed to create etcd client: " + err.Error()
-		if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
-			log.WithError(err).Error("Failed to update EtcdMember status")
-		}
-
-		return false
-	}
-	defer etcdClient.Close()
-
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	// Verify that the member is actually still present in etcd
-	members, err := etcdClient.ListMembers(ctx)
-	if err != nil {
-		log.WithError(err).Warn("Failed to list etcd members")
-		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusFailed
-		member.Status.Message = "Failed to list etcd members: " + err.Error()
-		if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
-			log.WithError(err).Error("Failed to update EtcdMember status")
-		}
-
-		return false
-	}
-
 	// Convert the memberID to uint64
 	memberID, err := strconv.ParseUint(member.Status.MemberID, 16, 64)
 	if err != nil {
@@ -556,7 +575,7 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 		return false
 	}
 
-	exists := slices.ContainsFunc(members, func(m etcd.Member) bool {
+	exists := slices.ContainsFunc(clusterMembers, func(m etcd.Member) bool {
 		return m.ID == memberID
 	})
 	// Member marked for leave but no member found in etcd, mark for leaved


### PR DESCRIPTION
## Description

If a controller is permanently removed without going through the normal leave procedure (e.g. after a backup restore), its `EtcdMember` object remains marked as joined even though the controller is no longer present in the etcd cluster. This is confusing and may cause operators to draw false conclusions.

Make the etcd member reconciler detect such stale members and mark them as `Joined=false` (if not already marked as such), without requiring `Spec.Leave` to be set. Members are now matched against the etcd cluster by member ID rather than by name, which is more reliable after renames or re-adds. To keep the reconcile loop consistent, a single etcd client and member list is created once per resync cycle and shared across all member evaluations.

Extend the backup integration test to verify that stale members are detected after restore and that all members are correctly marked as joined once the cluster has been fully restored. Fan out the three backup test variants into separate CI runs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
