### PR TITLE
Self-remove from etcd cluster before stopping

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sync/atomic"
 	"time"
 
 	"github.com/k0sproject/k0s/cmd/internal"
@@ -249,6 +250,7 @@ func (c *command) start(ctx context.Context, rtc *config.RuntimeConfig, nodeConf
 	logrus.Infof("DNS address: %s", dnsAddress)
 
 	var storageBackend manager.Component
+	var leaveEtcdClusterOnStop *atomic.Bool
 	storageType := nodeConfig.Spec.Storage.Type
 
 	switch storageType {
@@ -260,12 +262,14 @@ func (c *command) start(ctx context.Context, rtc *config.RuntimeConfig, nodeConf
 	case v1beta1.EtcdStorageType:
 		config := nodeConfig.Spec.Storage.Etcd
 		if !config.IsExternalClusterUsed() {
+			leaveEtcdClusterOnStop = new(atomic.Bool)
 			storageBackend = &controller.Etcd{
 				CertManager: certificateManager,
 				Config:      config,
 				JoinClient:  joinClient,
 				K0sVars:     c.K0sVars,
 				LogLevel:    c.LogLevels.Etcd,
+				LeaveOnStop: leaveEtcdClusterOnStop.Load,
 			}
 		}
 	default:
@@ -606,7 +610,7 @@ func (c *command) start(ctx context.Context, rtc *config.RuntimeConfig, nodeConf
 		})
 	}
 
-	if nodeConfig.Spec.Storage.Type == v1beta1.EtcdStorageType && !nodeConfig.Spec.Storage.Etcd.IsExternalClusterUsed() {
+	if leaveEtcdClusterOnStop != nil {
 		etcdReconciler, err := controller.NewEtcdMemberReconciler(
 			adminClientFactory,
 			nodeName,
@@ -617,6 +621,7 @@ func (c *command) start(ctx context.Context, rtc *config.RuntimeConfig, nodeConf
 				num, _ := numActiveControllers.Peek()
 				return num
 			},
+			leaveEtcdClusterOnStop.Store,
 			cancel,
 		)
 		if err != nil {

--- a/inttest/common/bootloosesuite.go
+++ b/inttest/common/bootloosesuite.go
@@ -788,7 +788,7 @@ func (s *BootlooseSuite) StopController(name string) error {
 	ssh, err := s.SSH(s.Context(), name)
 	s.Require().NoError(err)
 	defer ssh.Disconnect()
-	s.T().Log("killing k0s")
+	s.T().Log("Stopping k0s controller on", name)
 
 	return s.launchDelegate.StopController(s.Context(), ssh)
 }
@@ -797,7 +797,7 @@ func (s *BootlooseSuite) RestartController(name string) error {
 	ssh, err := s.SSH(s.Context(), name)
 	s.Require().NoError(err)
 	defer ssh.Disconnect()
-	s.T().Log("killing k0s")
+	s.T().Log("Restarting k0s controller on", name)
 	err = s.launchDelegate.StopController(s.Context(), ssh)
 	if err != nil {
 		return err

--- a/inttest/etcdlearner/etcdlearner_test.go
+++ b/inttest/etcdlearner/etcdlearner_test.go
@@ -6,7 +6,6 @@ package etcdlearner
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"slices"
 	"testing"
@@ -18,7 +17,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/stretchr/testify/suite"
@@ -61,12 +59,16 @@ func (s *EtcdLearnerSuite) TestUnreachableLearnerPreservesQuorum() {
 		PeerAddress: phantomPeerURL,
 	})
 
+	ssh, err := s.SSH(ctx, s.ControllerNode(0))
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
 	// Wait until the phantom shows up in etcd's member list as a learner.
 	// Using etcdctl rather than `k0s etcd member-list`: the phantom has
 	// not (and cannot) self-report its name, and `k0s etcd member-list`
 	// surfaces only the name→peerURL map, which drops unnamed members.
 	s.Require().NoError(common.Poll(ctx, func(ctx context.Context) (bool, error) {
-		for _, m := range s.listMembers(ctx, s.ControllerNode(0)) {
+		for _, m := range s.listMembers(ctx, ssh) {
 			if slices.Contains(m.PeerURLs, phantomPeerURL) {
 				return m.IsLearner, nil
 			}
@@ -84,30 +86,25 @@ func (s *EtcdLearnerSuite) TestUnreachableLearnerPreservesQuorum() {
 		"etcd quorum was lost after adding an unreachable peer; "+
 			"the new member must enter as a non-voting learner")
 
-	// Confirm the leader's reconciler does not wrongly promote a peer
-	// that cannot have caught up. The reconciler re-ticks every 10s on
-	// stuck learners; observing it stay False over ~30s rules out a
-	// one-shot race.
-	s.T().Log("verifying phantom stays a learner over a 30s observation window")
-	holdCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	err = wait.PollUntilContextCancel(holdCtx, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-		var found bool
-		for _, m := range s.listMembers(ctx, s.ControllerNode(0)) {
-			if !slices.Contains(m.PeerURLs, phantomPeerURL) {
-				continue
-			}
-			found = true
-			if !m.IsLearner {
-				return false, errors.New("phantom was promoted to voter despite being unreachable")
-			}
+	// Confirm that the leader's reconciler does not incorrectly promote a peer
+	// that hasn't caught up yet. Check the etcd member list three times with a
+	// ten-second delay between each check to ensure that the phantom remains a
+	// learner for at least thirty seconds.
+	s.T().Log("Verifying phantom stays a learner for at least 30 seconds")
+	for range 3 {
+		select {
+		case <-time.After(10 * time.Second):
+		case <-ctx.Done():
+			s.FailNow("Interrupted while observing etcd members")
 		}
-		if !found {
-			return false, errors.New("phantom disappeared from etcd member list mid-test")
-		}
-		return false, nil // keep polling until the deadline elapses
-	})
-	s.Require().ErrorIs(err, context.DeadlineExceeded, "observation window must complete without seeing phantom promoted")
+
+		members := s.listMembers(ctx, ssh)
+		phantomIndex := slices.IndexFunc(members, func(m etcdMember) bool {
+			return slices.Contains(m.PeerURLs, phantomPeerURL)
+		})
+		s.Require().GreaterOrEqual(phantomIndex, 0, "Phantom disappeared from etcd member list mid-test")
+		s.Require().True(members[phantomIndex].IsLearner, "Phantom was promoted to voter despite being unreachable")
+	}
 }
 
 // etcdMember is a minimal subset of etcdctl's member-list -w json output.
@@ -121,11 +118,7 @@ type etcdMember struct {
 // listMembers returns the raw etcd member list via etcdctl. We can't use
 // `k0s etcd member-list` here because it drops unnamed members (the
 // phantom learner has no name).
-func (s *EtcdLearnerSuite) listMembers(ctx context.Context, node string) []etcdMember {
-	ssh, err := s.SSH(ctx, node)
-	s.Require().NoError(err)
-	defer ssh.Disconnect()
-
+func (s *EtcdLearnerSuite) listMembers(ctx context.Context, ssh *common.SSHConnection) []etcdMember {
 	out, err := ssh.ExecWithOutput(ctx,
 		"/opt/etcdctl member list -w json "+
 			"--endpoints=https://127.0.0.1:2379 "+

--- a/inttest/etcdmember/etcdmember_test.go
+++ b/inttest/etcdmember/etcdmember_test.go
@@ -57,7 +57,6 @@ func (s *EtcdMemberSuite) TestDeregistration() {
 		// Note that the token is intentionally empty for the first controller
 		s.Require().NoError(s.InitController(idx, joinToken))
 		s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(idx)))
-		s.Require().NoError(s.WaitForKubeAPI(s.ControllerNode(idx)))
 		// With the primary controller running, create the join token for subsequent controllers.
 		if idx == 0 {
 			token, err := s.GetJoinToken("controller")
@@ -112,48 +111,60 @@ func (s *EtcdMemberSuite) TestDeregistration() {
 	s.T().Log("waiting to see correct statuses on EtcdMembers")
 	s.NoError(eg.Wait())
 	s.T().Log("All statuses found")
-	// Make one of the nodes leave
-	s.leaveNode(ctx, "controller2")
 
-	// Check that the node is gone from the etcd cluster according to etcd itself
-	members := s.getMembers(ctx, 0)
-	s.Require().Len(members, s.ControllerCount-1)
-	s.Require().NotContains(members, "controller2")
+	for i := s.ControllerCount - 1; i > 0; i-- {
+		nodeName := s.ControllerNode(i)
 
-	// Make sure the EtcdMember CR status is successfully updated
-	em := s.getMember(ctx, "controller2")
-	s.Require().Equal(etcdv1beta1.ReconcileStatusSuccess, em.Status.ReconcileStatus)
-	s.Require().Equal(etcdv1beta1.ConditionFalse, em.Status.GetCondition(etcdv1beta1.ConditionTypeJoined).Status)
+		// Make one of the nodes leave
+		s.leaveNode(ctx, nodeName)
 
-	// Stop k0s and reset the node
-	s.Require().NoError(s.StopController(s.ControllerNode(2)))
-	s.Require().NoError(common.ResetNode(s.ControllerNode(2), &s.BootlooseSuite))
+		// Check that the node is gone from the etcd cluster according to etcd itself
+		members := s.getMembers(ctx, 0)
+		s.Require().Len(members, i)
+		s.Require().NotContains(members, nodeName)
 
-	// Make the node rejoin
-	s.Require().NoError(s.InitController(2, joinToken))
-	s.Require().NoError(s.WaitForKubeAPI(s.ControllerNode(2)))
+		// Make sure the EtcdMember CR status is successfully updated
+		em := s.getMember(ctx, nodeName)
+		s.Require().Equal(etcdv1beta1.ReconcileStatusSuccess, em.Status.ReconcileStatus)
+		s.Require().Equal(etcdv1beta1.ConditionFalse, em.Status.GetCondition(etcdv1beta1.ConditionTypeJoined).Status)
 
-	// Final sanity -- ensure all nodes see each other according to etcd
-	members = s.getMembers(ctx, 0)
-	s.Require().Len(members, s.ControllerCount)
-	s.Require().Contains(members, s.ControllerNode(2))
-	s.Require().EventuallyWithT(func(tt *assert.CollectT) {
-		s.Require().NoError(context.Cause(ctx), "Context done")
-		// Check the CR is present again
-		em = s.getMember(ctx, s.ControllerNode(2))
-		assert.Equal(tt, em.Status.PeerAddress, s.GetControllerIPAddress(2))
-		assert.False(tt, em.Spec.Leave, "Node is still flagged to be leaving")
-		if cond := em.Status.GetCondition(etcdv1beta1.ConditionTypeJoined); assert.NotNilf(tt, cond, "condition not found: %s", etcdv1beta1.ConditionTypeJoined) {
-			assert.Equal(tt, etcdv1beta1.ConditionTrue, cond.Status, "node not joined yet")
-		}
-	}, 30*time.Second, 1*time.Second)
+		// Stop k0s and reset the node
+		s.Require().NoError(s.StopController(nodeName))
+		s.Require().NoError(common.ResetNode(nodeName, &s.BootlooseSuite))
+	}
 
-	// Check that after restarting the controller, the member is still present
-	s.Require().NoError(s.RestartController(s.ControllerNode(2)))
-	em = &etcdv1beta1.EtcdMember{}
-	err = kc.RESTClient().Get().AbsPath(fmt.Sprintf(basePath, "controller2")).Do(ctx).Into(em)
-	s.Require().NoError(err)
-	s.Require().Equal(em.Status.PeerAddress, s.GetControllerIPAddress(2))
+	for i := 1; i < s.ControllerCount; i++ {
+		nodeName := s.ControllerNode(i)
+
+		// Make the node rejoin
+		s.Require().NoError(s.InitController(i, joinToken))
+
+		// Final sanity -- ensure all nodes see each other according to etcd
+		members := s.getMembers(ctx, 0)
+		s.Require().Len(members, i+1)
+		s.Require().Contains(members, nodeName)
+		s.Require().EventuallyWithT(func(tt *assert.CollectT) {
+			s.Require().NoError(context.Cause(ctx), "Context done")
+			// Check the CR is present again
+			em := s.getMember(ctx, nodeName)
+			assert.Equal(tt, em.Status.PeerAddress, s.GetControllerIPAddress(i))
+			assert.False(tt, em.Spec.Leave, "Node is still flagged to be leaving")
+			if cond := em.Status.GetCondition(etcdv1beta1.ConditionTypeJoined); assert.NotNilf(tt, cond, "condition not found: %s", etcdv1beta1.ConditionTypeJoined) {
+				assert.Equal(tt, etcdv1beta1.ConditionTrue, cond.Status, "node not joined yet")
+			}
+		}, 30*time.Second, 1*time.Second)
+
+		// Check that after restarting the controller, the member is still present
+		s.Require().NoError(s.RestartController(nodeName))
+		s.Require().NoError(s.WaitForKubeAPI(nodeName))
+		var em etcdv1beta1.EtcdMember
+		err = kc.RESTClient().Get().AbsPath(fmt.Sprintf(basePath, nodeName)).Do(ctx).Into(&em)
+		s.Require().NoError(err)
+		s.Require().Equal(em.Status.PeerAddress, s.GetControllerIPAddress(i))
+		joined := em.Status.GetCondition(etcdv1beta1.ConditionTypeJoined)
+		s.Require().NotNil(joined)
+		s.Require().Equal(etcdv1beta1.ConditionTrue, joined.Status)
+	}
 
 	// Figure out what node is the leader and mark it as leaving
 	leader := s.getLeader(ctx)

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -4,18 +4,16 @@
 package controller
 
 import (
+	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
-
-	"github.com/avast/retry-go"
-	"github.com/sirupsen/logrus"
-	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/file"
@@ -30,6 +28,13 @@ import (
 	"github.com/k0sproject/k0s/pkg/etcd"
 	"github.com/k0sproject/k0s/pkg/supervisor"
 	"github.com/k0sproject/k0s/pkg/token"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/avast/retry-go"
+	"github.com/sirupsen/logrus"
+	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
+	"golang.org/x/sync/errgroup"
 )
 
 const etcdGID = 0
@@ -41,6 +46,7 @@ type Etcd struct {
 	JoinClient  *token.JoinClient
 	K0sVars     *config.CfgVars
 	LogLevel    string
+	LeaveOnStop func() bool
 
 	supervisor     *supervisor.Supervisor
 	executablePath string
@@ -242,9 +248,113 @@ func (e *Etcd) Start(ctx context.Context) error {
 
 // Stop stops etcd
 func (e *Etcd) Stop() error {
-	if e.supervisor != nil {
-		return e.supervisor.Stop()
+	s := e.supervisor
+	if s == nil {
+		return nil
 	}
+
+	if !e.LeaveOnStop() {
+		return s.Stop()
+	}
+
+	var leaveErr, stopErr error
+	deferTermination := make(chan struct{})
+	ctx, cancel := context.WithCancelCause(context.TODO())
+
+	go func() {
+		defer cancel(errors.New("etcd process terminated"))
+		stopErr = s.StopWith(supervisor.StopOpts{
+			DeferGracefulTerminationUntil: deferTermination,
+		})
+	}()
+
+	go func() {
+		defer close(deferTermination)
+		leaveErr = e.leave(ctx)
+		if leaveErr == nil {
+			// If the leave request was successful, we expect that etcd will
+			// terminate itself. Wait 30 seconds before lifting the termination
+			// request inhibition.
+			select {
+			case <-time.After(30 * time.Second):
+			case <-ctx.Done():
+			}
+		}
+	}()
+
+	<-ctx.Done()
+	<-deferTermination
+
+	return errors.Join(leaveErr, stopErr)
+}
+
+func (e *Etcd) leave(ctx context.Context) error {
+	log := logrus.WithField("component", "etcd")
+	log.Info("Attempting to leave the cluster")
+
+	if err := func() error {
+		c, err := etcd.NewClient(e.K0sVars.CertRootDir, e.K0sVars.EtcdCertDir, e.Config)
+		if err != nil {
+			return fmt.Errorf("failed to initialize etcd client: %w", err)
+		}
+		defer c.Close()
+
+		var memberID uint64
+		return wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
+			Steps: 10, Duration: 3 * time.Second, Jitter: 1,
+		}, func(context.Context) (bool, error) {
+			// Decouple the request context from the outer context. The outer
+			// context will only interrupt retries, not the inner call itself.
+			// This is to ensure that the call is not terminated in-flight and
+			// returns an otherwise inappropriate error.
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			if memberID == 0 {
+				status, err := c.Status(ctx)
+				if err != nil {
+					log.WithError(err).Error("Failed to get etcd endpoint status")
+					return false, nil
+				}
+
+				memberID = status.ID
+				log = log.WithField("memberID", strconv.FormatUint(memberID, 16))
+			}
+
+			log.Info("Removing member")
+			if err := c.DeleteMember(ctx, memberID); err != nil {
+				if errors.Is(err, etcd.ErrMemberNotFound) {
+					log.Info("Member ID changed")
+					memberID = 0
+					return false, nil
+				}
+
+				// After removing itself from the cluster, etcd starts shutting
+				// itself down: Removal is committed through Raft, etcd applies
+				// it. During apply, etcd notices "Oh, it's me!" and begins
+				// shutting down. Meanwhile, the request handler is still
+				// finishing the RPC. If the shutdown signal reaches the request
+				// path first, it may return ErrServerStopped.
+				//
+				// Although we cannot completely rule out the possibility that
+				// external factors caused etcd to shut down, we still consider
+				// the self-removal to have succeeded.
+				if errors.Is(err, etcd.ErrServerStopped) {
+					log.Info("Server is stopping, assuming removal to have succeeded")
+					return true, nil
+				}
+
+				log.WithError(err).Error("Failed to remove member")
+				return false, nil
+			}
+
+			log.Info("Left the cluster")
+			return true, nil
+		})
+	}(); err != nil {
+		return fmt.Errorf("failed to leave the cluster: %w", cmp.Or(context.Cause(ctx), err))
+	}
+
 	return nil
 }
 

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -46,7 +46,7 @@ const EtcdMemberStackName = "etcd-member"
 
 var _ manager.Component = (*EtcdMemberReconciler)(nil)
 
-func NewEtcdMemberReconciler(kubeClientFactory kubeutil.ClientFactoryInterface, nodeName apitypes.NodeName, k0sVars *config.CfgVars, etcdConfig *v1beta1.EtcdConfig, leaderElector leaderelector.Interface, controllerCount func() uint, shutdown context.CancelCauseFunc) (*EtcdMemberReconciler, error) {
+func NewEtcdMemberReconciler(kubeClientFactory kubeutil.ClientFactoryInterface, nodeName apitypes.NodeName, k0sVars *config.CfgVars, etcdConfig *v1beta1.EtcdConfig, leaderElector leaderelector.Interface, controllerCount func() uint, leaveOnStop func(bool), shutdown context.CancelCauseFunc) (*EtcdMemberReconciler, error) {
 
 	return &EtcdMemberReconciler{
 		clientFactory:   kubeClientFactory,
@@ -55,6 +55,7 @@ func NewEtcdMemberReconciler(kubeClientFactory kubeutil.ClientFactoryInterface, 
 		etcdConfig:      etcdConfig,
 		leaderElector:   leaderElector,
 		controllerCount: controllerCount,
+		leaveOnStop:     leaveOnStop,
 		shutdown:        shutdown,
 	}, nil
 }
@@ -66,6 +67,7 @@ type EtcdMemberReconciler struct {
 	leaderElector   leaderelector.Interface
 	controllerCount func() uint
 	nodeName        apitypes.NodeName
+	leaveOnStop     func(bool)
 	shutdown        context.CancelCauseFunc
 	stop            func()
 }
@@ -284,14 +286,24 @@ func (e *EtcdMemberReconciler) shutdownIfMarked(ctx context.Context, log logrus.
 	}
 
 	log.Info("Starting to watch etcd member object ", name, " using invocation ID ", e.k0sVars.InvocationID)
+	var leave bool
 	err = watch.EtcdMembers(client).
 		WithObjectName(name).
 		WithLabels(labels.Set{shutdownLabelName: e.k0sVars.InvocationID}).
-		Until(ctx, func(*etcdv1beta1.EtcdMember) (bool, error) { return true, nil })
+		Until(ctx, func(m *etcdv1beta1.EtcdMember) (bool, error) {
+			leave = m.Spec.Leave
+			return true, nil
+		})
 
 	if err == nil {
 		log.Info("Etcd member marked for shutdown; stopping components and waiting for external termination")
-		e.shutdown(errors.New("etcd member marked for shutdown"))
+		if leave {
+			e.leaveOnStop(true)
+			log.Info("Will leave etcd cluster before shutting down")
+			e.shutdown(errors.New("etcd member marked for leave and shutdown"))
+		} else {
+			e.shutdown(errors.New("etcd member marked for shutdown"))
+		}
 	} else if ctxErr := context.Cause(ctx); !errors.Is(err, ctxErr) {
 		log.WithError(err).Error("Error watching etcd member object")
 	}
@@ -582,18 +594,33 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 				log.WithError(err).Error("Failed to update member state")
 			}
 			return false
-		} else if ident := memberLease.Spec.HolderIdentity; ident != nil && *ident == memberInvocationID && kubeutil.IsValidLease(*memberLease) {
-			if member.Labels[shutdownLabelName] != memberInvocationID {
-				log.Info("Requesting member shutdown before deletion")
-				member.Labels[shutdownLabelName] = memberInvocationID
-				if _, err := client.Update(ctx, member, metav1.UpdateOptions{}); err != nil {
-					log.WithError(err).Error("Failed to update member")
-					return false
+		} else if kubeutil.IsValidLease(*memberLease) {
+			msg := "Member is still active; waiting for it to shutdown"
+			if ident := memberLease.Spec.HolderIdentity; ident != nil && *ident == memberInvocationID {
+				if member.Labels[shutdownLabelName] != memberInvocationID {
+					log.Info("Requesting member shutdown before deletion")
+					member.Labels[shutdownLabelName] = memberInvocationID
+					if _, err := client.Update(ctx, member, metav1.UpdateOptions{}); err != nil {
+						log.WithError(err).Error("Failed to update member")
+						return false
+					}
+					return true
 				}
-				return true
+			} else {
+				msg = "Unexpected lease holder"
 			}
 
-			msg := "Member is still active; waiting for it to shutdown"
+			log.Info(msg)
+			member.Status.Message = msg
+			member.Status.ReconcileStatus = ""
+			if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
+				log.WithError(err).Error("Failed to update member state")
+			}
+			return false
+		} else if memberLease.Spec.RenewTime != nil && time.Since(memberLease.Spec.RenewTime.Time) < 5*time.Minute {
+			// The lease has only just been released.
+			// Give some time for the self-leave to take place.
+			msg := "Member is offline; waiting for it to leave"
 			log.Info(msg)
 			member.Status.Message = msg
 			member.Status.ReconcileStatus = ""

--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -371,13 +371,13 @@ func (e *EtcdMemberReconciler) createMemberObject(ctx context.Context, client et
 	// The local etcd has already passed its health check by the time this
 	// runs (a learner can't serve linearizable reads), so the member is
 	// guaranteed to be voting here. Stamp Joined=True unconditionally.
-	memberID, err := etcdClient.GetPeerIDByAddress(ctx, e.etcdConfig.GetPeerURL())
+	memberStatus, err := etcdClient.Status(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Convert the memberID to hex string
-	memberIDStr := strconv.FormatUint(memberID, 16)
+	memberIDStr := strconv.FormatUint(memberStatus.ID, 16)
 	memberName := e.etcdConfig.GetMemberName()
 	name, err := nodeutil.GetHostname(memberName)
 	if err != nil {

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -69,6 +69,39 @@ func NewClientWithConfig(cfg clientv3.Config) (*Client, error) {
 	return client, nil
 }
 
+// Describes the role of a cluster member.
+type MemberRole uint8
+
+const (
+	MemberRoleUnknown  MemberRole = iota
+	MemberRoleLearner             // Non-voting member still catching up.
+	MemberRoleFollower            // Voting member, not the current leader.
+	MemberRoleLeader              // Voting member and leader.
+)
+
+// The status of the local etcd endpoint.
+type EndpointStatus struct {
+	ID   uint64     // Member ID in the etcd cluster.
+	Role MemberRole // Role of this member at the time of the query.
+}
+
+// Queries the local etcd endpoint's status.
+func (c *Client) Status(ctx context.Context) (*EndpointStatus, error) {
+	resp, err := c.client.Status(ctx, c.Config.Endpoints[0])
+	if err != nil {
+		return nil, err
+	}
+
+	role := MemberRoleFollower
+	if resp.Header.MemberId == resp.Leader {
+		role = MemberRoleLeader
+	} else if resp.IsLearner {
+		role = MemberRoleLearner
+	}
+
+	return &EndpointStatus{resp.Header.MemberId, role}, nil
+}
+
 // ListMembers gets a list of current etcd members.
 func (c *Client) ListMembers(ctx context.Context) ([]Member, error) {
 	resp, err := c.client.MemberList(ctx)

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -85,6 +85,11 @@ type EndpointStatus struct {
 	Role MemberRole // Role of this member at the time of the query.
 }
 
+var (
+	ErrServerStopped  = rpctypes.ErrStopped
+	ErrMemberNotFound = rpctypes.ErrMemberNotFound
+)
+
 // Queries the local etcd endpoint's status.
 func (c *Client) Status(ctx context.Context) (*EndpointStatus, error) {
 	resp, err := c.client.Status(ctx, c.Config.Endpoints[0])

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -47,7 +47,7 @@ type Supervisor struct {
 	log            logrus.FieldLogger
 	mutex          sync.Mutex
 	startStopMutex sync.Mutex
-	stop           func()
+	stop           func(opts StopOpts)
 }
 
 const k0sManaged = "_K0S_MANAGED=yes"
@@ -64,8 +64,13 @@ func (s *Supervisor) processWaitQuit(ctx context.Context, cmd *exec.Cmd) bool {
 
 	select {
 	case <-ctx.Done():
-		s.log.Debugf("Attempting to terminate supervised process (%v)", context.Cause(ctx))
-		if err := s.terminateSupervisedProcess(cmd, waitresult); err != nil {
+		cause := context.Cause(ctx)
+		s.log.Debugf("Attempting to terminate supervised process (%v)", cause)
+		var stopOpts StopOpts
+		if stoppingErr := (*stoppingErr)(nil); errors.As(cause, &stoppingErr) {
+			stopOpts = stoppingErr.opts
+		}
+		if err := s.terminateSupervisedProcess(cmd, waitresult, stopOpts); err != nil {
 			s.log.WithError(err).Error("Error while terminating process")
 		} else {
 			s.log.Info("Process terminated successfully")
@@ -88,7 +93,27 @@ func (s *Supervisor) processWaitQuit(ctx context.Context, cmd *exec.Cmd) bool {
 	}
 }
 
-func (s *Supervisor) terminateSupervisedProcess(cmd *exec.Cmd, waitresult <-chan error) error {
+func (s *Supervisor) terminateSupervisedProcess(cmd *exec.Cmd, waitresult <-chan error, stopOpts StopOpts) error {
+	if timeout := stopOpts.DeferGracefulTerminationUntil; timeout != nil {
+		// Termination request deferred, wait for process to finish on its own.
+		s.log.Debug("Awaiting process termination")
+
+		select {
+		case err := <-waitresult:
+			var exitErr *exec.ExitError
+			switch {
+			case err == nil:
+				return nil
+			case errors.As(err, &exitErr):
+				return exitErr
+			default:
+				return fmt.Errorf("failed to wait for process: %w", err)
+			}
+		case <-timeout:
+			s.log.Debug("Timed out while waiting for process to terminate, requesting graceful termination")
+		}
+	}
+
 	err := requestGracefulTermination(cmd.Process)
 	switch {
 	case err == nil:
@@ -142,6 +167,22 @@ func (s *Supervisor) terminateSupervisedProcess(cmd *exec.Cmd, waitresult <-chan
 		return fmt.Errorf("failed to request graceful termination: %w", err)
 	}
 }
+
+// Controls how supervised processes are stopped.
+type StopOpts struct {
+	// Delays sending a graceful termination request to the supervised process
+	// until the channel is closed.
+	//
+	// This is useful when the process is expected to terminate on its own and
+	// an immediate termination request would be premature. Once the channel is
+	// closed, the supervisor reverts to the standard graceful termination
+	// process.
+	DeferGracefulTerminationUntil <-chan struct{}
+}
+
+type stoppingErr struct{ opts StopOpts }
+
+func (*stoppingErr) Error() string { return "supervisor is stopping" }
 
 // Supervise Starts supervising the given process
 func (s *Supervisor) Supervise(ctx context.Context) error {
@@ -247,22 +288,27 @@ func (s *Supervisor) Supervise(ctx context.Context) error {
 		return err
 	}
 
-	s.stop = func() {
-		cancel(errors.New("supervisor is stopping"))
+	s.stop = func(opts StopOpts) {
+		cancel(&stoppingErr{opts})
 		<-done
 	}
 	return nil
 }
 
-// Stop stops the supervised
+// Stops the supervised process using the default stop behavior.
 func (s *Supervisor) Stop() error {
+	return s.StopWith(StopOpts{})
+}
+
+// Stops the supervised process using the provided options.
+func (s *Supervisor) StopWith(opts StopOpts) error {
 	s.startStopMutex.Lock()
 	defer s.startStopMutex.Unlock()
 	if s.stop == nil {
 		return errors.New("not started")
 	}
 
-	s.stop()
+	s.stop(opts)
 	s.stop = nil
 	return nil
 }


### PR DESCRIPTION
## Description

The EtcdMember reconciler removed a leaving node from the etcd cluster only after that node had already stopped (i.e. its controller lease was no longer held). This could break the cluster if stopping of the leaving node dropped the cluster below quorum, effectively preventing downscaling below quorum, e.g. from two nodes to one.

Fix this by having the leaving node remove itself from etcd before stopping its process, while it can still contribute to quorum. When the k0s leader requests a node shutdown and the node's EtcdMember resource is flagged for leaving, the etcd component now removes itself from the cluster before handing off to the supervisor.

Extended the etcd member integration test to cover a full scale-down/scale-up cycle rather than a single leave-and-rejoin.

Fixes:

* #6901

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
