### PR TITLE
Set an appropriate status when a leaving member isn't found

### DIFF
--- a/pkg/component/controller/etcd_member_reconciler.go
+++ b/pkg/component/controller/etcd_member_reconciler.go
@@ -530,13 +530,14 @@ func (e *EtcdMemberReconciler) reconcileMember(ctx context.Context, client etcdc
 	_, ok := members[member.Name]
 	if !ok {
 		log.Debug("member marked for leave but not in actual member list, updating state to reflect that")
+		member.Status.Message = "No such member"
 		member.Status.SetCondition(etcdv1beta1.ConditionTypeJoined, etcdv1beta1.ConditionFalse, member.Status.Message, time.Now())
 		member.Status.ReconcileStatus = etcdv1beta1.ReconcileStatusSuccess
-		member, err = client.UpdateStatus(ctx, member, metav1.UpdateOptions{})
-		if err != nil {
+		if _, err := client.UpdateStatus(ctx, member, metav1.UpdateOptions{}); err != nil {
 			log.WithError(err).Error("failed to update EtcdMember status")
 			return false
 		}
+		return true
 	}
 
 	joinStatus := member.Status.GetCondition(etcdv1beta1.ConditionTypeJoined)


### PR DESCRIPTION
## Description

When a member is marked for leave and is absent from the etcd member list, set an explicit "No such member" status message and return early. Previously the reconciler continued executing steps intended for active members and left the reason as whatever stale value was already in the status.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
