### PR TITLE
Some log tweaks

### DIFF
--- a/pkg/component/controller/controllersleasecounter.go
+++ b/pkg/component/controller/controllersleasecounter.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -63,13 +64,13 @@ func (l *K0sControllersLeaseCounter) Start(context.Context) error {
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancelCause(context.Background())
 	var wg sync.WaitGroup
 
 	wg.Add(2)
 	go func() { defer wg.Done(); l.runLeaderElection(ctx, client) }()
 	go func() { defer wg.Done(); l.runLeaseCounter(ctx, kubeClient) }()
-	l.stop = func() { cancel(); wg.Wait() }
+	l.stop = func() { cancel(errors.New("component is stopping")); wg.Wait() }
 
 	return nil
 }
@@ -88,7 +89,11 @@ func (l *K0sControllersLeaseCounter) runLeaderElection(ctx context.Context, clie
 		if status == leaderelection.StatusLeading {
 			l.log.Info("Holding the controller lease")
 		} else {
-			l.log.Error("Lost the controller lease")
+			if err := context.Cause(ctx); err != nil {
+				l.log.Info("Lost the controller lease: ", err)
+			} else {
+				l.log.Error("Lost the controller lease")
+			}
 		}
 	})
 }

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -66,7 +66,11 @@ func (s *Supervisor) processWaitQuit(ctx context.Context, cmd *exec.Cmd) bool {
 	case <-ctx.Done():
 		s.log.Debugf("Attempting to terminate supervised process (%v)", context.Cause(ctx))
 		if err := s.terminateSupervisedProcess(cmd, waitresult); err != nil {
-			s.log.WithError(err).Error("Error while terminating process")
+			if errors.Is(err, errTerminated) {
+				s.log.Warn("Process ", errTerminated)
+			} else {
+				s.log.WithError(err).Error("Error while terminating process")
+			}
 		} else {
 			s.log.Info("Process terminated successfully")
 		}
@@ -88,6 +92,12 @@ func (s *Supervisor) processWaitQuit(ctx context.Context, cmd *exec.Cmd) bool {
 	}
 }
 
+// Indicates that a process terminated with SIGTERM. Some processes prefer to
+// re-raise SIGTERM instead of exiting with a zero exit code. In that case, k0s
+// cannot determine whether the process had a clean shutdown or if it even had a
+// proper signal handler to begin with.
+var errTerminated = errors.New("terminated with SIGTERM instead of exiting cleanly")
+
 func (s *Supervisor) terminateSupervisedProcess(cmd *exec.Cmd, waitresult <-chan error) error {
 	err := requestGracefulTermination(cmd.Process)
 	switch {
@@ -103,7 +113,7 @@ func (s *Supervisor) terminateSupervisedProcess(cmd *exec.Cmd, waitresult <-chan
 				return nil
 			case errors.As(err, &exitErr):
 				if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signal() == syscall.SIGTERM {
-					return errors.New("process terminated without handling SIGTERM")
+					return errTerminated
 				}
 				return exitErr
 			default:


### PR DESCRIPTION
## Description

* Some processes prefer to re-raise SIGTERM instead of exiting with a zero exit code. In that case, k0s cannot determine whether the process had a clean shutdown or if it even had a proper signal handler to begin with. Downgrade this case from an error to a warning in supervisor and make the log message reflect that the process terminated with SIGTERM instead of exiting cleanly.

* When the controller lease counter was stopped during component shutdown, an error was logged about losing the controller lease. This is actually the expected behavior. Downgrade that log to info.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
