### PR TITLE
Add OpenRC retry settings comparable to systemd's defaults

### DIFF
--- a/pkg/install/openrc_linux.go
+++ b/pkg/install/openrc_linux.go
@@ -14,6 +14,7 @@ command_args="{{range .Arguments}}'{{.}}' {{end}}"
 {{- end }}
 name=$(basename $(readlink -f $command))
 supervise_daemon_args="--stdout /var/log/${name}.log --stderr /var/log/${name}.err"
+retry="SIGTERM/90/SIGKILL/5"
 
 : "${rc_ulimit=-n 1048576 -u unlimited}"
 


### PR DESCRIPTION
## Description

By default, OpenRC uses SIGTERM/5, which may leave behind orphaned k0s processes. Switch to SIGTERM/90/SIGKILL/5 instead, as these are more in line with systemd's defaults.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
