### PR TITLE
Only generate konnectivity kubeconfig if it's enabled

### DIFF
--- a/cmd/controller/certificates.go
+++ b/cmd/controller/certificates.go
@@ -29,10 +29,11 @@ import (
 
 // Certificates is the Component implementation to manage all k0s certs
 type Certificates struct {
-	CACert      string
-	CertManager certificate.Manager
-	ClusterSpec *v1beta1.ClusterSpec
-	K0sVars     *config.CfgVars
+	CACert              string
+	CertManager         certificate.Manager
+	ClusterSpec         *v1beta1.ClusterSpec
+	K0sVars             *config.CfgVars
+	KonnectivityEnabled bool
 }
 
 // Init initializes the certificate component
@@ -102,30 +103,42 @@ func (c *Certificates) Init(ctx context.Context) error {
 		return c.CertManager.CreateKeyPair("sa", c.K0sVars, apiServerUID)
 	})
 
-	eg.Go(func() error {
-		// konnectivity kubeconfig
-		konnectivityReq := certificate.Request{
-			Name:   "konnectivity",
-			CN:     "kubernetes-konnectivity",
-			O:      "system:masters", // TODO: We need to figure out if konnectivity really needs superpowers
-			CACert: caCertPath,
-			CAKey:  caCertKey,
-		}
+	if c.KonnectivityEnabled {
+		eg.Go(func() error {
+			// konnectivity kubeconfig
+			konnectivityReq := certificate.Request{
+				Name:   "konnectivity",
+				CN:     "kubernetes-konnectivity",
+				O:      "system:masters", // TODO: We need to figure out if konnectivity really needs superpowers
+				CACert: caCertPath,
+				CAKey:  caCertKey,
+			}
 
-		uid, err := users.LookupUID(constant.KonnectivityServerUser)
-		if err != nil {
-			err = fmt.Errorf("failed to lookup UID for %q: %w", constant.KonnectivityServerUser, err)
-			uid = users.RootUID
-			logrus.WithError(err).Warn("Files with key material for konnectivity-server user will be owned by root")
-		}
+			uid, err := users.LookupUID(constant.KonnectivityServerUser)
+			if err != nil {
+				err = fmt.Errorf("failed to lookup UID for %q: %w", constant.KonnectivityServerUser, err)
+				uid = users.RootUID
+				logrus.WithError(err).Warn("Files with key material for konnectivity-server user will be owned by root")
+			}
 
-		konnectivityCert, err := c.CertManager.EnsureCertificate(konnectivityReq, uid, c.ClusterSpec.API.CA.CertificatesExpireAfter.Duration)
-		if err != nil {
-			return err
-		}
+			konnectivityCert, err := c.CertManager.EnsureCertificate(konnectivityReq, uid, c.ClusterSpec.API.CA.CertificatesExpireAfter.Duration)
+			if err != nil {
+				return err
+			}
 
-		return kubeConfig(c.K0sVars.KonnectivityKubeConfigPath, kubeConfigAPIUrl, c.CACert, konnectivityCert.Cert, konnectivityCert.Key, uid, constant.CertSecureMode)
-	})
+			return kubeConfig(c.K0sVars.KonnectivityKubeConfigPath, kubeConfigAPIUrl, c.CACert, konnectivityCert.Cert, konnectivityCert.Key, uid, constant.CertSecureMode)
+		})
+	} else {
+		eg.Go(func() error {
+			for _, ext := range []string{"conf", "crt", "key"} {
+				err := os.Remove(filepath.Join(c.K0sVars.CertRootDir, "konnectivity."+ext))
+				if err != nil && !errors.Is(err, os.ErrNotExist) {
+					logrus.WithError(err).Warn("Failed to remove an unused PKI file for konnectivity")
+				}
+			}
+			return nil
+		})
+	}
 
 	eg.Go(func() error {
 		ccmReq := certificate.Request{

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -405,9 +405,10 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 
 	perfTimer.Checkpoint("starting-certificates-init")
 	certs := &Certificates{
-		ClusterSpec: nodeConfig.Spec,
-		CertManager: certificateManager,
-		K0sVars:     c.K0sVars,
+		ClusterSpec:         nodeConfig.Spec,
+		CertManager:         certificateManager,
+		K0sVars:             c.K0sVars,
+		KonnectivityEnabled: enableKonnectivity,
 	}
 	if err := certs.Init(ctx); err != nil {
 		return err


### PR DESCRIPTION
## Description

Previously, the key material and kubeconfig were generated unconditionally. Pass in a boolean flag to the certificates component to indicate whether konnectivity is enabled or not. If it's not, don't generate anything, but try to delete any existing files from the file system.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
