### PR TITLE
More consistently build pod and service CIDRs

### DIFF
--- a/pkg/apis/k0s/v1beta1/network.go
+++ b/pkg/apis/k0s/v1beta1/network.go
@@ -282,16 +282,27 @@ func (n *Network) BuildServiceCIDR(primaryAddressFamily PrimaryAddressFamilyType
 	case PrimaryFamilyIPv6:
 		return n.DualStack.IPv6ServiceCIDR + "," + n.ServiceCIDR
 	default:
-		panic(fmt.Sprintf("BuildServiceCIDR called invalid PrimaryAddressFamily %q family. This is theoretically impossible", primaryAddressFamily))
+		panic(fmt.Sprintf("BuildServiceCIDR called with invalid PrimaryAddressFamily %q family. This is theoretically impossible", primaryAddressFamily))
 	}
 }
 
 // BuildPodCIDR returns actual argument value for pod cidr
-func (n *Network) BuildPodCIDR() string {
-	if n.DualStack.Enabled {
-		return n.DualStack.IPv6PodCIDR + "," + n.PodCIDR
+func (n *Network) BuildPodCIDR(primaryAddressFamily PrimaryAddressFamilyType) string {
+	if !n.DualStack.Enabled {
+		return n.PodCIDR
 	}
-	return n.PodCIDR
+
+	// Because Kubernetes relies on the order of the given CIDRs in dual-stack
+	// mode, the CIDR whose version matches the version of the IP address the
+	// API server is listening on must be specified first.
+	switch primaryAddressFamily {
+	case PrimaryFamilyIPv4:
+		return n.PodCIDR + "," + n.DualStack.IPv6PodCIDR
+	case PrimaryFamilyIPv6:
+		return n.DualStack.IPv6PodCIDR + "," + n.PodCIDR
+	default:
+		panic(fmt.Sprintf("BuildPodCIDR called with invalid PrimaryAddressFamily %q family. This is theoretically impossible", primaryAddressFamily))
+	}
 }
 
 // IsSingleStackIPv6 returns true if the ServiceCIDR is IPv6.

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -89,7 +89,7 @@ func (a *Manager) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterC
 		"requestheader-client-ca-file":     filepath.Join(a.K0sVars.CertRootDir, "front-proxy-ca.crt"),
 		"root-ca-file":                     filepath.Join(a.K0sVars.CertRootDir, "ca.crt"),
 		"service-account-private-key-file": filepath.Join(a.K0sVars.CertRootDir, "sa.key"),
-		"cluster-cidr":                     clusterConfig.Spec.Network.BuildPodCIDR(),
+		"cluster-cidr":                     clusterConfig.Spec.Network.BuildPodCIDR(clusterConfig.Spec.PrimaryAddressFamily()),
 		"service-cluster-ip-range":         a.ServiceClusterIPRange,
 		"profiling":                        "false",
 		"terminated-pod-gc-threshold":      "12500",

--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -280,7 +280,7 @@ func (k *KubeProxy) getConfig(clusterConfig *v1beta1.ClusterConfig) *proxyConfig
 				ClientConnection: configv1alpha1.ClientConnectionConfiguration{
 					Kubeconfig: "/var/lib/kube-proxy/kubeconfig.conf",
 				},
-				ClusterCIDR:        clusterConfig.Spec.Network.BuildPodCIDR(),
+				ClusterCIDR:        clusterConfig.Spec.Network.BuildPodCIDR(clusterConfig.Spec.PrimaryAddressFamily()),
 				FeatureGates:       clusterConfig.Spec.FeatureGates.AsMap("kube-proxy"),
 				Mode:               kubeproxyv1alpha1.ProxyMode(kubeProxy.Mode),
 				MetricsBindAddress: kubeProxy.MetricsBindAddress,

--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -115,7 +115,7 @@ func (k *KubeRouter) Reconcile(_ context.Context, clusterConfig *v1beta1.Cluster
 		"auto-mtu":                 strconv.FormatBool(clusterConfig.Spec.Network.KubeRouter.IsAutoMTU()),
 		"metrics-port":             strconv.Itoa(clusterConfig.Spec.Network.KubeRouter.MetricsPort),
 		"hairpin-mode":             strconv.FormatBool(globalHairpin),
-		"service-cluster-ip-range": clusterConfig.Spec.Network.ServiceCIDR,
+		"service-cluster-ip-range": clusterConfig.Spec.Network.BuildServiceCIDR(clusterConfig.Spec.PrimaryAddressFamily()),
 	}
 
 	// IPv6 requires a router ID, instead of generating one ourselves, rely on kube-router logic


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

This PR makes BuildPodCIDR consistent with BuildServiceCIDR in that it now also puts the primary address first. I don't think the order of the pod cidrs actually matters. More importantly this PR also make use of BuildServiceCIDR for building the `--service-cluster-ip-range` argument for kuberouter, which so far only had the primary address.

Doesn't fix, but is related to: #7186

## Type of change

<!-- check the related options -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [X] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [X] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [X] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
