### PR TITLE
Allow workers to use cached config

### DIFF
--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -50,6 +50,7 @@ Examples:
 	Note: Token can be passed either as a CLI argument, a flag, or an environment variable
 
 Flags:
+      --allow-cached-config                            allow worker startup with cached configuration when the Kubernetes API is unavailable
       --api-server-stop-timeout duration               time to wait for the API server to stop
   -c, --config string                                  config file, use '-' to read the config from stdin (default `+defaultConfigPath+`)
       --cri-socket string                              container runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -43,6 +43,7 @@ With the controller subcommand you can setup a single node cluster by running:
 	
 
 Flags:
+      --allow-cached-config                            allow worker startup with cached configuration when the Kubernetes API is unavailable
       --api-server-stop-timeout duration               time to wait for the API server to stop
   -c, --config string                                  config file, use '-' to read the config from stdin (default `+defaultConfigPath+`)
       --cri-socket string                              container runtime socket to use, default to internal containerd. Format: [remote|docker]:[path-to-socket]

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -218,11 +218,12 @@ func (c *Command) Start(ctx context.Context, nodeName apitypes.NodeName, kubelet
 	}
 
 	kubeletKubeconfigPath := c.K0sVars.KubeletAuthConfigPath
-	workerConfig, err := workerconfig.LoadProfile(
+	workerConfig, err := workerconfig.LoadProfileWithCachedFallback(
 		ctx,
 		kubernetes.KubeconfigFromFile(kubeletKubeconfigPath),
 		c.K0sVars.DataDir,
 		c.WorkerProfile,
+		c.AllowCachedConfig,
 	)
 	if err != nil {
 		return err

--- a/pkg/component/worker/config/loader.go
+++ b/pkg/component/worker/config/loader.go
@@ -32,6 +32,13 @@ import (
 // LoadProfile loads the worker profile with the given profile name from
 // Kubernetes, using cacheDir as cache folder.
 func LoadProfile(ctx context.Context, kubeconfig clientcmd.KubeconfigGetter, cacheDir, profileName string) (*Profile, error) {
+	return LoadProfileWithCachedFallback(ctx, kubeconfig, cacheDir, profileName, false)
+}
+
+// LoadProfileWithCachedFallback loads the worker profile from Kubernetes. If
+// allowCachedFallback is true and the Kubernetes API is unavailable, it returns
+// a cached profile from cacheDir when the cached profile name matches.
+func LoadProfileWithCachedFallback(ctx context.Context, kubeconfig clientcmd.KubeconfigGetter, cacheDir, profileName string, allowCachedFallback bool) (*Profile, error) {
 	clientConfig, err := kubeutil.ClientConfig(kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Kubernetes client config: %w", err)
@@ -45,10 +52,10 @@ func LoadProfile(ctx context.Context, kubeconfig clientcmd.KubeconfigGetter, cac
 		return kubernetes.NewForConfig(&clientConfig)
 	}
 
-	return loadProfile(ctx, logrus.StandardLogger(), clientFactory, cacheDir, profileName)
+	return loadProfile(ctx, logrus.StandardLogger(), clientFactory, cacheDir, profileName, allowCachedFallback)
 }
 
-func loadProfile(ctx context.Context, log logrus.FieldLogger, clientFactory func(host string) (kubernetes.Interface, error), cacheDir, profileName string) (*Profile, error) {
+func loadProfile(ctx context.Context, log logrus.FieldLogger, clientFactory func(host string) (kubernetes.Interface, error), cacheDir, profileName string, allowCachedFallback bool) (*Profile, error) {
 	cachedAPIServerAddresses := loadAPIServerAddressesFromCache(log, cacheDir)
 	if len(cachedAPIServerAddresses) < 1 {
 		log.Info("No cached API server addresses found")
@@ -88,6 +95,17 @@ func loadProfile(ctx context.Context, log logrus.FieldLogger, clientFactory func
 	); err != nil {
 		if apierrors.IsUnauthorized(err) {
 			err = fmt.Errorf("the k0s worker node credentials are invalid, the node needs to be rejoined into the cluster with a fresh bootstrap token: %w", err)
+			return nil, err
+		}
+
+		if allowCachedFallback && isAPIServerUnavailable(err) {
+			profile, cacheErr := loadCachedProfile(log, cacheDir, profileName)
+			if cacheErr != nil {
+				return nil, fmt.Errorf("failed to load worker profile %q from Kubernetes API and no valid cached profile is available: %w", profileName, cacheErr)
+			}
+
+			log.WithError(err).Warnf("Using cached worker profile %q because the Kubernetes API is unavailable", profileName)
+			return profile, nil
 		}
 
 		return nil, err
@@ -105,6 +123,67 @@ func loadProfile(ctx context.Context, log logrus.FieldLogger, clientFactory func
 	return profile, nil
 }
 
+func loadCachedProfile(log logrus.FieldLogger, cacheDir, profileName string) (*Profile, error) {
+	lastProfile, err := loadFromCacheDir(cacheDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if lastProfile.Name != profileName {
+		return nil, fmt.Errorf("cached worker profile %q does not match requested profile %q", lastProfile.Name, profileName)
+	}
+
+	profile, err := FromConfigMapData(lastProfile.Data)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to parse cached worker profile %q", lastProfile.Name)
+		return nil, err
+	}
+
+	return profile, nil
+}
+
+func isAPIServerUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		errs := joined.Unwrap()
+		if len(errs) == 0 {
+			return false
+		}
+		for _, err := range errs {
+			if !isAPIServerUnavailable(err) {
+				return false
+			}
+		}
+		return true
+	}
+
+	if apierrors.IsServiceUnavailable(err) || apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) {
+		return true
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+	for _, text := range []string{
+		"connection refused",
+		"connection reset by peer",
+		"i/o timeout",
+		"network is unreachable",
+		"no route to host",
+		"host is down",
+	} {
+		if strings.Contains(msg, text) {
+			return true
+		}
+	}
+
+	return false
+}
 func loadAPIServerAddressesFromCache(log logrus.FieldLogger, cacheDir string) (addresses []string) {
 	lastProfile, err := loadFromCacheDir(cacheDir)
 	if err != nil {

--- a/pkg/component/worker/config/loader_test.go
+++ b/pkg/component/worker/config/loader_test.go
@@ -18,8 +18,10 @@ import (
 	"github.com/k0sproject/k0s/pkg/constant"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -97,6 +99,7 @@ data:
 			clientFactory,
 			cacheDir,
 			"fake",
+			false,
 		)
 
 		if t.Failed() {
@@ -120,6 +123,90 @@ data:
 		theTriedHosts,
 		"Not all API server addresses were tried",
 	)
+}
+
+func TestLoadProfileWithCachedFallback(t *testing.T) {
+	const cachedProfile = `
+name: fake
+data:
+  apiServerAddresses: |
+    [127.10.10.1:9998]
+  nodeLocalLoadBalancing: |
+    {enabled: true}
+  konnectivity: |
+    {agentPort: 1337}
+`
+
+	cacheDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "worker-profile.yaml"), []byte(cachedProfile), 0644))
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Nanosecond)
+	defer cancel()
+
+	log := logrus.New()
+	profile, err := loadProfile(
+		ctx,
+		log.WithField("test", t.Name()),
+		func(string) (kubernetes.Interface, error) { return fake.NewSimpleClientset(), nil },
+		cacheDir,
+		"fake",
+		true,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, profile)
+	assert.True(t, profile.NodeLocalLoadBalancing.IsEnabled())
+}
+
+func TestLoadProfileWithCachedFallback_ProfileMismatch(t *testing.T) {
+	const cachedProfile = `
+name: other
+data:
+  nodeLocalLoadBalancing: |
+    {enabled: false}
+  konnectivity: |
+    {agentPort: 1337}
+`
+
+	cacheDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "worker-profile.yaml"), []byte(cachedProfile), 0644))
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Nanosecond)
+	defer cancel()
+
+	log := logrus.New()
+	_, err := loadProfile(
+		ctx,
+		log.WithField("test", t.Name()),
+		func(string) (kubernetes.Interface, error) { return fake.NewSimpleClientset(), nil },
+		cacheDir,
+		"fake",
+		true,
+	)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, `cached worker profile "other" does not match requested profile "fake"`)
+}
+
+func TestIsAPIServerUnavailable(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"service_unavailable", apierrors.NewServiceUnavailable("api unavailable"), true},
+		{"too_many_requests", apierrors.NewTooManyRequests("busy", 1), false},
+		{"deadline", context.DeadlineExceeded, true},
+		{"connection_refused", errors.New("Get \"https://127.0.0.1:6443\": dial tcp 127.0.0.1:6443: connect: connection refused"), true},
+		{"joined_unavailable", errors.Join(apierrors.NewServiceUnavailable("api unavailable"), context.DeadlineExceeded), true},
+		{"joined_mixed", errors.Join(apierrors.NewServiceUnavailable("api unavailable"), apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "worker-config-default")), false},
+		{"not_found", apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "worker-config-default"), false},
+		{"unauthorized", apierrors.NewUnauthorized("invalid credentials"), false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, isAPIServerUnavailable(test.err))
+		})
+	}
 }
 
 func TestWatchProfile(t *testing.T) {

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -65,16 +65,17 @@ type ControllerOptions struct {
 
 // Shared worker cli flags
 type WorkerOptions struct {
-	CloudProvider    bool
-	LogLevels        LogLevels
-	CriSocket        string
-	KubeletExtraArgs string
-	Labels           map[string]string
-	Taints           []string
-	TokenFile        string
-	TokenArg         string
-	WorkerProfile    string
-	IPTablesMode     string
+	CloudProvider     bool
+	LogLevels         LogLevels
+	CriSocket         string
+	KubeletExtraArgs  string
+	Labels            map[string]string
+	Taints            []string
+	TokenFile         string
+	TokenArg          string
+	WorkerProfile     string
+	AllowCachedConfig bool
+	IPTablesMode      string
 }
 
 func (m ControllerMode) WorkloadsEnabled() bool {
@@ -251,6 +252,7 @@ func GetWorkerFlags() *pflag.FlagSet {
 
 	flagset.String("kubelet-root-dir", "", "Kubelet root directory for k0s")
 	flagset.StringVar(&workerOpts.WorkerProfile, "profile", defaultWorkerProfile, "worker profile to use on the node")
+	flagset.BoolVar(&workerOpts.AllowCachedConfig, "allow-cached-config", false, "allow worker startup with cached configuration when the Kubernetes API is unavailable")
 	flagset.BoolVar(&workerOpts.CloudProvider, "enable-cloud-provider", false, "Whether or not to enable cloud provider support in kubelet")
 	flagset.StringVar(&workerOpts.TokenFile, "token-file", "", "Path to the file containing join-token.")
 	flagset.VarP((*logLevelsFlag)(&workerOpts.LogLevels), "logging", "l", "Logging Levels for the different components")


### PR DESCRIPTION
Fixes #7379

Adds `--allow-cached-config` for workers. When enabled, k0s still tries to load the worker profile from the Kubernetes API first. If the API server is unavailable, it falls back to the cached worker profile when the cached profile exists and matches the requested profile.

Default behavior is unchanged.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Unit tests:

```sh
go test ./pkg/component/worker/config ./pkg/config ./cmd/worker ./cmd/controller ./cmd/install
go test ./cmd/... ./pkg/component/worker/... ./pkg/config
```

Manual bootloose verification:

1. Started a `check-basic` bootloose cluster.
2. Confirmed `/var/lib/k0s/worker-profile.yaml` exists on `worker0`.
3. Stopped the controller.
4. Restarted `worker0` with `--allow-cached-config`.
5. Confirmed the worker used the cached profile:

```text
Using cached worker profile "default" because the Kubernetes API is unavailable
```

6. Confirmed `k0s`, `containerd`, and `kubelet` were running on the worker.
7. Started the controller again.
8. Confirmed both workers returned to `Ready` and all kube-system pods were `Running`.

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings