### PR TITLE
Keep the old names when generating admin kubeconfigs

### DIFF
--- a/cmd/kubeconfig/admin.go
+++ b/cmd/kubeconfig/admin.go
@@ -38,9 +38,9 @@ func kubeConfigAdminCmd() *cobra.Command {
 			}
 
 			const (
-				clusterName = "k0s"
-				contextName = "k0s-admin"
-				userName    = "admin"
+				clusterName = "local"
+				contextName = "Default"
+				userName    = "user"
 			)
 
 			adminConfig := clientcmdapi.Config{

--- a/cmd/kubeconfig/admin_test.go
+++ b/cmd/kubeconfig/admin_test.go
@@ -62,16 +62,16 @@ clusters:
 - cluster:
     certificate-authority-data: Y29udGVudHMgb2YgY2EuY3J0` /* contents of ca.crt */ +`
     server: https://not-here.example.com:65432
-  name: k0s
+  name: local
 contexts:
 - context:
-    cluster: k0s
-    user: admin
-  name: k0s-admin
-current-context: k0s-admin
+    cluster: local
+    user: user
+  name: Default
+current-context: Default
 kind: Config
 users:
-- name: admin
+- name: user
   user:
     client-certificate-data: Y29udGVudHMgb2YgYWRtaW4uY3J0` /* contents of admin.crt */ +`
     client-key-data: Y29udGVudHMgb2YgYWRtaW4ua2V5` /* contents of admin.key */ +`


### PR DESCRIPTION
## Description

Of course, the initial assumption that nothing should rely on the actual names of the cluster, auth info and context in the admin kubeconfig was wrong: k0sctl relies on them and will panic if the admin kubeconfig has a different structure.

Use the old names again for them. Those aren't that important anyways, and it doesn't make sense to introduce a breaking change for this.

See:

* k0sproject/k0sctl#1087

Fixes:

* #7600

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
