### PR TITLE
Add containerd config drop-in validation to sysprobes

### DIFF
--- a/internal/pkg/sysinfo/probes/containerd.go
+++ b/internal/pkg/sysinfo/probes/containerd.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package probes
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/k0sproject/k0s/pkg/component/worker/containerd"
+)
+
+// RequireContainerdV2ConfigSnippets registers a probe that checks every *.toml
+// file found in importsDir for containerd configuration formatting issues such as wrong version or deprecated keys.
+// Each incompatible file is reported individually as a rejection with
+// remediation instructions.  If importsDir does not exist or contains no TOML
+// files the top level probe passes.
+func RequireContainerdV2ConfigSnippets(parent ParentProbe, importsDir string) {
+	parent.Set("containerd:configSnippets", func(path ProbePath, _ Probe) Probe {
+		return ProbeFn(func(r Reporter) error {
+			groupDesc := NewProbeDesc("Containerd config snippets in "+importsDir, path)
+
+			files, err := filepath.Glob(filepath.Join(importsDir, "*.toml"))
+			if err != nil {
+				return r.Error(
+					groupDesc,
+					fmt.Errorf("failed to scan containerd import directory %q: %w", importsDir, err),
+				)
+			}
+
+			if len(files) == 0 {
+				return r.Pass(groupDesc, StringProp("no config snippets found"))
+			}
+
+			// Emit the depth-1 header row; individual file results appear nested under it.
+			if err := r.Pass(groupDesc, StringProp(importsDir)); err != nil {
+				return err
+			}
+
+			for _, filePath := range files {
+				// Need to clone the original path slice so we don't accindentally modify it for the next iteration of the loop.
+				fileProbePath := append(slices.Clone(path), "file:"+filepath.Base(filePath))
+				desc := NewProbeDesc(
+					"Containerd config snippet: "+filepath.Base(filePath),
+					fileProbePath,
+				)
+
+				data, err := os.ReadFile(filePath)
+				if err != nil {
+					if err := r.Error(desc, fmt.Errorf("failed to read containerd config snippet: %w", err)); err != nil {
+						return err
+					}
+					continue
+				}
+
+				if err := containerd.ValidateConfigFile(data); err != nil {
+					if err := r.Reject(desc, StringProp(filePath), err.Error()); err != nil {
+						return err
+					}
+					continue
+				}
+
+				if err := r.Pass(desc, StringProp(filePath)); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	})
+}

--- a/internal/pkg/sysinfo/probes/containerd_test.go
+++ b/internal/pkg/sysinfo/probes/containerd_test.go
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package probes_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingReporter collects outcomes from probes for assertions in tests.
+type recordingReporter struct {
+	passes     []string
+	warnings   []string
+	rejections []string
+	errors     []error
+}
+
+func (r *recordingReporter) Pass(d probes.ProbeDesc, prop probes.ProbedProp) error {
+	r.passes = append(r.passes, d.DisplayName())
+	return nil
+}
+
+func (r *recordingReporter) Warn(d probes.ProbeDesc, _ probes.ProbedProp, msg string) error {
+	r.warnings = append(r.warnings, msg)
+	return nil
+}
+
+func (r *recordingReporter) Reject(d probes.ProbeDesc, _ probes.ProbedProp, msg string) error {
+	r.rejections = append(r.rejections, msg)
+	return nil
+}
+
+func (r *recordingReporter) Error(d probes.ProbeDesc, err error) error {
+	r.errors = append(r.errors, err)
+	return nil
+}
+
+func TestRequireContainerdV2ConfigSnippets(t *testing.T) {
+	t.Run("missing directory passes silently", func(t *testing.T) {
+		dir := t.TempDir()
+		p := probes.NewRootProbes()
+		probes.RequireContainerdV2ConfigSnippets(p, filepath.Join(dir, "nonexistent"))
+
+		rep := &recordingReporter{}
+		require.NoError(t, p.Probe(rep))
+		assert.Empty(t, rep.rejections)
+		assert.Empty(t, rep.errors)
+	})
+
+	t.Run("empty directory passes silently", func(t *testing.T) {
+		dir := t.TempDir()
+
+		p := probes.NewRootProbes()
+		probes.RequireContainerdV2ConfigSnippets(p, dir)
+
+		rep := &recordingReporter{}
+		require.NoError(t, p.Probe(rep))
+		assert.Empty(t, rep.rejections)
+		assert.Empty(t, rep.errors)
+	})
+
+	t.Run("valid version 3 file passes", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "valid.toml", `
+version = 3
+
+[plugins."io.containerd.cri.v1.runtime"]
+  sandbox_image = "registry.k8s.io/pause:3.9"
+`)
+
+		p := probes.NewRootProbes()
+		probes.RequireContainerdV2ConfigSnippets(p, dir)
+
+		rep := &recordingReporter{}
+		require.NoError(t, p.Probe(rep))
+		assert.Empty(t, rep.rejections)
+		assert.Empty(t, rep.errors)
+		assert.Len(t, rep.passes, 2) // one for the directory, one for the file
+	})
+
+	t.Run("file without version field passes", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "noversion.toml", `
+[plugins."io.containerd.cri.v1.runtime"]
+  sandbox_image = "registry.k8s.io/pause:3.9"
+`)
+
+		p := probes.NewRootProbes()
+		probes.RequireContainerdV2ConfigSnippets(p, dir)
+
+		rep := &recordingReporter{}
+		require.NoError(t, p.Probe(rep))
+		assert.Empty(t, rep.rejections)
+		assert.Empty(t, rep.errors)
+	})
+
+	t.Run("file with version 2 is rejected with remediation", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "nvidia.toml", "version = 2\n")
+
+		p := probes.NewRootProbes()
+		probes.RequireContainerdV2ConfigSnippets(p, dir)
+
+		rep := &recordingReporter{}
+		require.NoError(t, p.Probe(rep))
+		require.Len(t, rep.rejections, 1)
+
+		msg := rep.rejections[0]
+		assert.Contains(t, msg, "expected 3, got 2")
+	})
+
+	t.Run("file with v1 CRI plugin key is rejected with remediation", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "cni.toml", `
+version = 3
+
+[plugins."io.containerd.grpc.v1.cri"]
+  sandbox_image = "registry.k8s.io/pause:3.9"
+`)
+
+		p := probes.NewRootProbes()
+		probes.RequireContainerdV2ConfigSnippets(p, dir)
+
+		rep := &recordingReporter{}
+		require.NoError(t, p.Probe(rep))
+		require.Len(t, rep.rejections, 1)
+
+		msg := rep.rejections[0]
+		assert.Contains(t, msg, "io.containerd.grpc.v1.cri")
+	})
+
+	t.Run("multiple files: only bad ones are rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "good.toml", "version = 3\n")
+		writeFile(t, dir, "bad.toml", "version = 2\n")
+
+		p := probes.NewRootProbes()
+		probes.RequireContainerdV2ConfigSnippets(p, dir)
+
+		rep := &recordingReporter{}
+		require.NoError(t, p.Probe(rep))
+		assert.Len(t, rep.rejections, 1)
+		assert.Contains(t, rep.rejections[0], "expected 3, got 2")
+		assert.Len(t, rep.passes, 2) // one for the directory, one for the good file
+	})
+
+	t.Run("invalid TOML results in rejection not error", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "corrupt.toml", "this is not [ valid toml !!!")
+
+		p := probes.NewRootProbes()
+		probes.RequireContainerdV2ConfigSnippets(p, dir)
+
+		rep := &recordingReporter{}
+		require.NoError(t, p.Probe(rep))
+		assert.Len(t, rep.rejections, 1)
+		assert.Contains(t, rep.rejections[0], "failed to parse TOML")
+		assert.Empty(t, rep.errors)
+	})
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644))
+}

--- a/internal/pkg/sysinfo/sysinfo.go
+++ b/internal/pkg/sysinfo/sysinfo.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/k0sproject/k0s/internal/pkg/sysinfo/probes"
+	"github.com/k0sproject/k0s/pkg/component/worker/containerd"
 
 	"github.com/sirupsen/logrus"
 )
@@ -64,6 +65,10 @@ func (s *K0sSysinfoSpec) NewSysinfoProbes() probes.Probes {
 		probes.AssertRelativeFreeDiskSpace(p, s.DataDir, 15)
 	}
 	probes.RequireNameResolution(p, net.LookupIP, "localhost")
+
+	if s.WorkerRoleEnabled {
+		probes.RequireContainerdV2ConfigSnippets(p, containerd.DefaultImportsPath)
+	}
 
 	s.addHostSpecificProbes(p)
 

--- a/pkg/component/worker/containerd/component.go
+++ b/pkg/component/worker/containerd/component.go
@@ -58,7 +58,7 @@ func NewComponent(logLevel string, vars *config.CfgVars, profile *workerconfig.P
 		K0sVars:     vars,
 		Profile:     profile,
 		confPath:    defaultConfPath,
-		importsPath: defaultImportsPath,
+		importsPath: DefaultImportsPath,
 	}
 	return c
 }

--- a/pkg/component/worker/containerd/component_other.go
+++ b/pkg/component/worker/containerd/component_other.go
@@ -10,8 +10,10 @@ import (
 )
 
 const (
-	defaultConfPath    = "/etc/k0s/containerd.toml"
-	defaultImportsPath = "/etc/k0s/containerd.d/"
+	defaultConfPath = "/etc/k0s/containerd.toml"
+
+	// DefaultImportsPath is the default directory for containerd config drop-in files.
+	DefaultImportsPath = "/etc/k0s/containerd.d/"
 )
 
 // containerRuntimeExecLabel is the SELinux label for container runtime executables.

--- a/pkg/component/worker/containerd/component_windows.go
+++ b/pkg/component/worker/containerd/component_windows.go
@@ -13,8 +13,10 @@ import (
 )
 
 const (
-	defaultConfPath    = `C:\Program Files\containerd\config.toml`
-	defaultImportsPath = `C:\etc\k0s\containerd.d\`
+	defaultConfPath = `C:\Program Files\containerd\config.toml`
+
+	// DefaultImportsPath is the default directory for containerd config drop-in files.
+	DefaultImportsPath = `C:\etc\k0s\containerd.d\`
 )
 
 var additionalExecutableNames = [...]string{

--- a/pkg/component/worker/containerd/configurer.go
+++ b/pkg/component/worker/containerd/configurer.go
@@ -4,6 +4,7 @@
 package containerd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -73,13 +74,8 @@ func (c *configurer) handleImports() (*resolvedConfig, error) {
 		}
 
 		isV3Config := true
-		if err := assertV3Config(tree); err != nil {
-			errs = append(errs, fmt.Errorf("invalid containerd configuration in %q: %w", filePath, err))
-			isV3Config = false
-		}
-
-		if hasV2CRIConfig(tree) {
-			errs = append(errs, fmt.Errorf("containerd configuration file %q contains v2 CRI plugin configuration, which is not compatible with k0s. Please update the configuration to use the v3 plugin format", filePath))
+		if err := validateConfigTree(tree); err != nil {
+			errs = append(errs, err)
 			isV3Config = false
 		}
 
@@ -136,6 +132,32 @@ func hasCRIPluginConfig(tree *toml.Tree) bool {
 	return tree.HasPath([]string{"plugins", "io.containerd.cri.v1.runtime"}) || tree.HasPath([]string{"plugins", "io.containerd.cri.v1.images"})
 }
 
+// Checks if the given config data is valid and compatible with the k0s-managed
+// version of containerd. Returns a descriptive error if not.
+func ValidateConfigFile(data []byte) error {
+	tree, err := toml.LoadBytes(data)
+	if err != nil {
+		return fmt.Errorf("failed to parse TOML: %w", err)
+	}
+	return validateConfigTree(tree)
+}
+
+// validateConfigTree performs compatibility checks on a parsed containerd
+// configuration tree and returns a combined error if any incompatibilities are found.
+func validateConfigTree(tree *toml.Tree) error {
+	var errs []error
+
+	if err := assertV3Config(tree); err != nil {
+		errs = append(errs, err)
+	}
+
+	if hasV2CRIConfig(tree) {
+		errs = append(errs, errors.New("configuration contains a [plugins.\"io.containerd.grpc.v1.cri\"] section which is the containerd v1 CRI plugin format"))
+	}
+
+	return errors.Join(errs...)
+}
+
 // hasV2CRIConfig checks if the given containerd configuration tree contains any plugins."io.containerd.grpc.v1.cri"
 // configuration section. This is the main difference between containerd v2 and v3 configuration formats, so if this is present we
 // want the user to fix it manually instead of trying to merge it and potentially causing unexpected breakage.
@@ -148,11 +170,11 @@ func assertV3Config(tree *toml.Tree) error {
 	if version != nil {
 		v, ok := version.(int64)
 		if !ok {
-			return fmt.Errorf("unexpected type for version field: expected integer, got %T", version)
+			return fmt.Errorf("unexpected type for version field: expected int64, got %T", version)
 		}
 
 		if v != 3 {
-			return fmt.Errorf("unsupported containerd configuration version: expected 3, got %d", v)
+			return fmt.Errorf("unsupported configuration version: expected 3, got %d", v)
 		}
 	}
 	return nil

--- a/pkg/component/worker/containerd/configurer_test.go
+++ b/pkg/component/worker/containerd/configurer_test.go
@@ -122,8 +122,7 @@ version = 3
 		}
 		criConfig, err := c.handleImports()
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "unsupported containerd configuration version")
-		assert.Contains(t, err.Error(), "contains v2 CRI plugin configuration")
+		assert.Contains(t, err.Error(), "v1 CRI plugin format")
 		assert.Nil(t, criConfig)
 	})
 


### PR DESCRIPTION
## Description

This way we can report possible problems earlier as users might need to fix e.g. v2 -> v3 config snippets in the case of upgrade.


With this, and some deliberately broken configs, the sysprobes fail with:
```
Containerd config snippets in /etc/k0s/containerd.d/: /etc/k0s/containerd.d/ (pass)
  Containerd config snippet: good.toml: /etc/k0s/containerd.d/good.toml (pass)
  Containerd config snippet: old-cri.toml.toml: /etc/k0s/containerd.d/old-cri.toml.toml (rejected: containerd configuration contains a [plugins."io.containerd.grpc.v1.cri"] section which is the containerd v2 CRI plugin format)
  Containerd config snippet: v2.toml: /etc/k0s/containerd.d/v2.toml (rejected: unsupported containerd configuration version: expected 3, got 2)
```

Fixes #7689

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
