### PR TITLE
Keep primary IP address family out of cluster-wide config

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -534,7 +534,7 @@ func (c *command) start(ctx context.Context, rtc *config.RuntimeConfig, nodeConf
 			return fmt.Errorf("failed to create Calico component: %w", err)
 		}
 		clusterComponents.Add(ctx, calico)
-		clusterComponents.Add(ctx, controller.NewKubeRouter(c.K0sVars))
+		clusterComponents.Add(ctx, controller.NewKubeRouter(c.K0sVars, nodeConfig.Spec.PrimaryAddressFamily()))
 	}
 
 	if !slices.Contains(flags.DisableComponents, constant.MetricsServerComponentName) {

--- a/inttest/configchange/config_test.go
+++ b/inttest/configchange/config_test.go
@@ -182,17 +182,6 @@ func (s *ConfigSuite) TestK0sGetsUp() {
 		}
 
 	})
-
-	s.Run("changing primary address family should fail", func() {
-		originalConfig, err := cfgClient.Get(s.Context(), "k0s", metav1.GetOptions{})
-		s.Require().NoError(err)
-		s.Require().Equal(v1beta1.PrimaryFamilyIPv4, originalConfig.Spec.Network.PrimaryAddressFamily)
-		newConfig := originalConfig.DeepCopy()
-		newConfig.Spec.Network = v1beta1.DefaultNetwork()
-		newConfig.Spec.Network.PrimaryAddressFamily = v1beta1.PrimaryFamilyIPv6
-		_, err = cfgClient.Update(s.Context(), newConfig, metav1.UpdateOptions{})
-		s.Require().Error(err)
-	})
 }
 
 func (s *ConfigSuite) waitForReconcileEvent(eventWatch watch.Interface) (*corev1.Event, error) {

--- a/pkg/apis/k0s/v1beta1/api.go
+++ b/pkg/apis/k0s/v1beta1/api.go
@@ -4,7 +4,6 @@
 package v1beta1
 
 import (
-	"cmp"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -117,18 +116,6 @@ func (a *APISpec) ExternalPort() int {
 // APIAddressURL returns kube-apiserver external URI
 func (a *APISpec) APIAddressURL() string {
 	return a.getExternalURIForPort(a.Port)
-}
-
-// DetectPrimaryAddressFamily tries to detect the primary address of the cluster
-// based on the address family of ExternalAddress. If this isn't set it will try
-// to detect it based on the address family of Address.
-// If the address used to detect it, isn't an IP address but a hostname or if
-// both are unset, it will default to IPv4
-func (a *APISpec) DetectPrimaryAddressFamily() PrimaryAddressFamilyType {
-	if ip := net.ParseIP(cmp.Or(a.ExternalHost(), a.Address)); ip != nil && ip.To4() == nil {
-		return PrimaryFamilyIPv6
-	}
-	return PrimaryFamilyIPv4
 }
 
 // K0sControlPlaneAPIAddress returns the controller join APIs address

--- a/pkg/apis/k0s/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types.go
@@ -503,7 +503,6 @@ func (c *ClusterConfig) Validate() (errs []error) {
 // - Network.PrimaryAddressFamily
 // - Install
 func (c *ClusterConfig) GetClusterWideConfig() *ClusterConfig {
-	primaryAF := c.Spec.PrimaryAddressFamily()
 	c = c.DeepCopy()
 	if c != nil && c.Spec != nil {
 		c.Spec.API = nil
@@ -512,7 +511,7 @@ func (c *ClusterConfig) GetClusterWideConfig() *ClusterConfig {
 			c.Spec.Network.ServiceCIDR = ""
 			c.Spec.Network.ClusterDomain = ""
 			c.Spec.Network.ControlPlaneLoadBalancing = nil
-			c.Spec.Network.PrimaryAddressFamily = primaryAF
+			c.Spec.Network.PrimaryAddressFamily = ""
 		}
 		c.Spec.Install = nil
 	}

--- a/pkg/apis/k0s/v1beta1/clusterconfig_types.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types.go
@@ -5,8 +5,10 @@ package v1beta1
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/json"
 	"fmt"
+	"net/netip"
 	"reflect"
 	"slices"
 	"strings"
@@ -528,8 +530,21 @@ func (c *ClusterConfig) CRValidator() *ClusterConfig {
 }
 
 func (s *ClusterSpec) PrimaryAddressFamily() PrimaryAddressFamilyType {
-	if s != nil && s.Network != nil && s.Network.PrimaryAddressFamily != PrimaryFamilyUnknown {
-		return s.Network.PrimaryAddressFamily
+	if s != nil {
+		if s.Network != nil && s.Network.PrimaryAddressFamily != PrimaryFamilyUnknown {
+			return s.Network.PrimaryAddressFamily
+		}
+
+		// Try to determin the primary address based on the address family of
+		// the cluster's external address, or, of this isn't set, based on the
+		// address family of the API server's address.
+		if s.API != nil {
+			addr, _ := netip.ParseAddr(cmp.Or(s.API.ExternalHost(), s.API.Address))
+			if addr.Is6() {
+				return PrimaryFamilyIPv6
+			}
+		}
 	}
-	return s.API.DetectPrimaryAddressFamily()
+
+	return PrimaryFamilyIPv4
 }

--- a/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
+++ b/pkg/apis/k0s/v1beta1/clusterconfig_types_test.go
@@ -336,6 +336,51 @@ func TestClusterConfig_StripDefaults_DefaultConfig(t *testing.T) {
 	a.Nil(stripped.Spec.Konnectivity)
 }
 
+func TestClusterConfig_GetClusterWideConfig(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		input    *ClusterConfig
+		expected *ClusterConfig
+	}{
+		{"nil", nil, nil},
+		{"zero", &ClusterConfig{}, &ClusterConfig{}},
+		{"zero spec", &ClusterConfig{Spec: &ClusterSpec{}}, &ClusterConfig{Spec: &ClusterSpec{}}},
+		{"zero network", &ClusterConfig{Spec: &ClusterSpec{
+			Network: &Network{},
+		}}, &ClusterConfig{Spec: &ClusterSpec{
+			Network: &Network{},
+		}}},
+		{"RemovesNodeConfig", &ClusterConfig{Spec: &ClusterSpec{
+			API: &APISpec{Address: "127.0.0.1"},
+			Storage: &StorageSpec{
+				Type: KineStorageType,
+			},
+			Install: &InstallSpec{
+				SystemUsers: &SystemUser{
+					KubeAPIServer: t.Name(),
+				},
+			},
+			Network: &Network{
+				Provider:      "calico",
+				ServiceCIDR:   "ServiceCIDR",
+				ClusterDomain: "ClusterDomain",
+				ControlPlaneLoadBalancing: &ControlPlaneLoadBalancingSpec{
+					Enabled: true,
+				},
+				PrimaryAddressFamily: PrimaryFamilyIPv6,
+			}},
+		}, &ClusterConfig{Spec: &ClusterSpec{
+			Network: &Network{
+				Provider: "calico",
+			},
+		}}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.input.GetClusterWideConfig())
+		})
+	}
+}
+
 func TestClusterConfig_StripDefaults_Images(t *testing.T) {
 	//nolint:dupword // it's YAML data
 	yaml := `
@@ -434,12 +479,13 @@ spec:
 }
 
 func TestStrippedClusterWideDefaultConfig(t *testing.T) {
-	underTest := DefaultClusterConfig().GetClusterWideConfig().StripDefaults()
-	if assert.NotNil(t, underTest.Spec) {
+	defaultConfig := DefaultClusterConfig()
+	stripped := defaultConfig.GetClusterWideConfig().StripDefaults()
+	if assert.NotNil(t, stripped.Spec) {
 		// The network and extensions fields aren't properly handled at the moment.
-		underTest.Spec.Network = nil
-		underTest.Spec.Extensions = nil
-		assert.Zero(t, *underTest.Spec, "%+v", underTest.Spec)
+		stripped.Spec.Network = nil
+		stripped.Spec.Extensions = nil
+		assert.Zero(t, *stripped.Spec, "%+v", stripped.Spec)
 	}
 }
 

--- a/pkg/apis/k0s/v1beta1/network.go
+++ b/pkg/apis/k0s/v1beta1/network.go
@@ -53,10 +53,10 @@ type Network struct {
 	// If empty, k0s determines it based on `.spec.API.ExternalAddress`,
 	// if this isn't present it will use `.spec.API.Address.`.
 	// If both addresses are empty or the chosen address is a hostname, defaults to `IPv4`.
-	// +kubebuilder:validation:XValidation:rule="oldSelf == '' || self == oldSelf",message="cannot change primary address family"
 	PrimaryAddressFamily PrimaryAddressFamilyType `json:"primaryAddressFamily,omitempty"`
 }
 
+// +kubebuilder:validation:Enum=IPv4;IPv6
 type PrimaryAddressFamilyType string
 
 const (

--- a/pkg/component/controller/clusterconfig/apiconfigsource.go
+++ b/pkg/component/controller/clusterconfig/apiconfigsource.go
@@ -13,8 +13,6 @@ import (
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -44,7 +42,6 @@ func (*apiConfigSource) Init(context.Context) error { return nil }
 // Start implements [manager.Component].
 func (a *apiConfigSource) Start(context.Context) error {
 	var lastObservedVersion string
-	var lastKnownPAF v1beta1.PrimaryAddressFamilyType
 
 	log := logrus.WithField("component", "clusterconfig.apiConfigSource")
 	watch := watch.ClusterConfigs(a.configClient).
@@ -78,22 +75,6 @@ func (a *apiConfigSource) Start(context.Context) error {
 		defer close(done)
 		defer close(a.resultChan)
 		_ = watch.Until(ctx, func(cfg *v1beta1.ClusterConfig) (bool, error) {
-			// Restore PrimaryAddressFamily if a client dropped it.
-			if cfg.Spec != nil && cfg.Spec.Network != nil {
-				if cfg.Spec.Network.PrimaryAddressFamily == "" && lastKnownPAF != "" {
-					restored := cfg.DeepCopy()
-					restored.Spec.Network.PrimaryAddressFamily = lastKnownPAF
-					if _, err := a.configClient.Update(ctx, restored, metav1.UpdateOptions{}); err != nil {
-						log.WithError(err).Warnf("Failed to restore primary address family to %q", lastKnownPAF)
-					} else {
-						log.Infof("Restored primary address family to %q", lastKnownPAF)
-						return false, nil
-					}
-				} else if cfg.Spec.Network.PrimaryAddressFamily != "" {
-					lastKnownPAF = cfg.Spec.Network.PrimaryAddressFamily
-				}
-			}
-
 			// Push changes only when the config actually changes
 			if lastObservedVersion != cfg.ResourceVersion {
 				log.Debugf("Cluster configuration update to resource version %q", cfg.ResourceVersion)

--- a/pkg/component/controller/clusterconfig_test.go
+++ b/pkg/component/controller/clusterconfig_test.go
@@ -55,9 +55,7 @@ func TestClusterConfigInitializer_Create(t *testing.T) {
 			ClusterConfigs(constant.ClusterConfigNamespace).
 			Get(t.Context(), "k0s", metav1.GetOptions{})
 		if assert.NoError(t, err) {
-			expectedConfig := initialConfig.DeepCopy()
-			expectedConfig.Spec.Network.PrimaryAddressFamily = k0sv1beta1.PrimaryFamilyIPv4
-			assert.Equal(t, expectedConfig, actualConfig)
+			assert.Equal(t, initialConfig, actualConfig)
 		}
 	})
 }

--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -27,7 +27,8 @@ import (
 type KubeRouter struct {
 	log logrus.FieldLogger
 
-	k0sVars *config.CfgVars
+	k0sVars              *config.CfgVars
+	primaryAddressFamily v1beta1.PrimaryAddressFamilyType
 
 	previousConfig kubeRouterConfig
 }
@@ -50,11 +51,12 @@ type kubeRouterConfig struct {
 }
 
 // NewKubeRouter creates new KubeRouter reconciler component
-func NewKubeRouter(k0sVars *config.CfgVars) *KubeRouter {
+func NewKubeRouter(k0sVars *config.CfgVars, primaryAddressFamily v1beta1.PrimaryAddressFamilyType) *KubeRouter {
 	return &KubeRouter{
 		log: logrus.WithFields(logrus.Fields{"component": "kube-router"}),
 
-		k0sVars: k0sVars,
+		k0sVars:              k0sVars,
+		primaryAddressFamily: primaryAddressFamily,
 	}
 }
 
@@ -119,7 +121,7 @@ func (k *KubeRouter) Reconcile(_ context.Context, clusterConfig *v1beta1.Cluster
 	}
 
 	// IPv6 requires a router ID, instead of generating one ourselves, rely on kube-router logic
-	if clusterConfig.Spec.PrimaryAddressFamily() == v1beta1.PrimaryFamilyIPv6 {
+	if k.primaryAddressFamily == v1beta1.PrimaryFamilyIPv6 {
 		args["router-id"] = "generate"
 	}
 

--- a/pkg/component/controller/kuberouter_test.go
+++ b/pkg/component/controller/kuberouter_test.go
@@ -38,7 +38,7 @@ func TestKubeRouterConfig(t *testing.T) {
 	cfg.Spec.Network.KubeRouter.IPMasq = true
 
 	ctx := t.Context()
-	kr := NewKubeRouter(k0sVars)
+	kr := NewKubeRouter(k0sVars, v1beta1.PrimaryFamilyIPv4)
 	require.NoError(t, kr.Init(ctx))
 	require.NoError(t, kr.Start(ctx))
 	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
@@ -123,7 +123,7 @@ func TestKubeRouterDefaultManifests(t *testing.T) {
 	cfg.Spec.Network.Provider = "kuberouter"
 	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
 	ctx := t.Context()
-	kr := NewKubeRouter(k0sVars)
+	kr := NewKubeRouter(k0sVars, v1beta1.PrimaryFamilyIPv4)
 	require.NoError(t, kr.Init(ctx))
 	require.NoError(t, kr.Start(ctx))
 	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
@@ -161,7 +161,7 @@ func TestKubeRouterManualMTUManifests(t *testing.T) {
 	cfg.Spec.Network.KubeRouter.AutoMTU = ptr.To(false)
 	cfg.Spec.Network.KubeRouter.MTU = 1234
 	ctx := t.Context()
-	kr := NewKubeRouter(k0sVars)
+	kr := NewKubeRouter(k0sVars, v1beta1.PrimaryFamilyIPv4)
 	require.NoError(t, kr.Init(ctx))
 	require.NoError(t, kr.Start(ctx))
 	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
@@ -202,7 +202,7 @@ func TestExtraArgs(t *testing.T) {
 	}
 
 	ctx := t.Context()
-	kr := NewKubeRouter(k0sVars)
+	kr := NewKubeRouter(k0sVars, v1beta1.PrimaryFamilyIPv6)
 	require.NoError(t, kr.Init(ctx))
 	require.NoError(t, kr.Start(ctx))
 	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
@@ -217,6 +217,7 @@ func TestExtraArgs(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ds)
 
+	assert.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--router-id=generate", "IPv6 related flags not found")
 	assert.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--run-firewall=false")
 	assert.Contains(t, ds.Spec.Template.Spec.Containers[0].Args, "--foo=bar")
 }
@@ -237,7 +238,7 @@ func TestRawArgs(t *testing.T) {
 	}
 
 	ctx := t.Context()
-	kr := NewKubeRouter(k0sVars)
+	kr := NewKubeRouter(k0sVars, v1beta1.PrimaryFamilyIPv4)
 	require.NoError(t, kr.Init(ctx))
 	require.NoError(t, kr.Start(ctx))
 	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })

--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -608,7 +608,7 @@ func (r *Reconciler) buildProfile(snapshot *snapshot) *workerconfig.Profile {
 		},
 		DualStackEnabled:     snapshot.dualStackEnabled,
 		AutopilotDisabled:    r.autopilotDisabled,
-		PrimaryAddressFamily: snapshot.primaryAddressFamily,
+		PrimaryAddressFamily: r.primaryAddressFamily,
 	}
 
 	if workerProfile.NodeLocalLoadBalancing != nil {

--- a/pkg/component/controller/workerconfig/snapshot.go
+++ b/pkg/component/controller/workerconfig/snapshot.go
@@ -38,7 +38,6 @@ type configSnapshot struct {
 	featureGates           v1beta1.FeatureGates
 	pauseImage             *v1beta1.ImageSpec
 	pauseWindowsImage      *v1beta1.ImageSpec
-	primaryAddressFamily   v1beta1.PrimaryAddressFamilyType
 }
 
 func (s *snapshot) DeepCopy() *snapshot {
@@ -72,7 +71,6 @@ func (s *configSnapshot) DeepCopyInto(out *configSnapshot) {
 	out.featureGates = s.featureGates.DeepCopy()
 	out.pauseImage = s.pauseImage.DeepCopy()
 	out.pauseWindowsImage = s.pauseWindowsImage.DeepCopy()
-	out.primaryAddressFamily = s.primaryAddressFamily
 }
 
 // takeConfigSnapshot converts ClusterSpec to a delta snapshot
@@ -93,6 +91,5 @@ func takeConfigSnapshot(spec *v1beta1.ClusterSpec) configSnapshot {
 		spec.FeatureGates.DeepCopy(),
 		spec.Images.Pause.DeepCopy(),
 		spec.Images.Windows.Pause.DeepCopy(),
-		spec.PrimaryAddressFamily(),
 	}
 }

--- a/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
+++ b/static/_crds/k0s/k0s.k0sproject.io_clusterconfigs.yaml
@@ -1078,10 +1078,10 @@ spec:
                       If empty, k0s determines it based on `.spec.API.ExternalAddress`,
                       if this isn't present it will use `.spec.API.Address.`.
                       If both addresses are empty or the chosen address is a hostname, defaults to `IPv4`.
+                    enum:
+                    - IPv4
+                    - IPv6
                     type: string
-                    x-kubernetes-validations:
-                    - message: cannot change primary address family
-                      rule: oldSelf == '' || self == oldSelf
                   provider:
                     default: kuberouter
                     description: 'Network provider (valid values: calico, kuberouter,


### PR DESCRIPTION
## Description

The primary address family is one of the settings that cannot be dynamically reconciled. Traditionally, k0s didn't store these fields in the ClusterConfig resource at all. However, this was changed in #7494 for the primary address family because it was required in the kube-router's reconcile method. While it would generally be desirable to store all "init-only" settings, such as the service CIDR and cluster domain, inside the ClusterConfig resource, doing so correctly requires quite some effort and lots of thought around edge cases. For example, k0s would potentially need to fetch the current ClusterConfig from the cluster before starting up and compare that to the local node's config to ensure compatibility.

Revert #7494 for the most part, and some parts of #7468 concerning the workerconfig. Pass the resolved primary address family directly to the kube-router component so that the kube-router executable still gets the right router ID flag for IPv6 clusters without depending on the ClusterConfig resource to carry that field, and actually use the captured local primary address family in the workerconfig component, instead of getting it from the cluster config. This is how it's done for the other init-only settings in other components, as well.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
