### PR TITLE
Makefile: prune build/cache and inttest from GO_SRCS find

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,12 @@ DOCKER ?= docker
 
 K0S_GO_BUILD_CACHE ?= build/cache
 
-GO_SRCS := $(shell $(FIND) . -type f -name "*.go" -not -path "./$(K0S_GO_BUILD_CACHE)/*" -not -path "./inttest/*" -not -name "*_test.go" -not -name "zz_generated*")
+# find evaluates left-to-right: match the dirs first, -prune them (skip their
+# entire subtree without traversing), then -o match the actual .go files. The
+# explicit -print is needed because without it find's implicit -print applies
+# to both sides of -o and would also print the pruned directory names.
+GO_SRCS := $(shell $(FIND) . \( -path "./$(K0S_GO_BUILD_CACHE)" -o -path "./inttest" \) -prune -o -type f -name "*.go" -not -name "*_test.go" -not -name "zz_generated*" -print)
+
 GO_CHECK_UNIT_DIRS := . ./cmd/... ./pkg/... ./internal/... ./static/... ./hack/...
 
 # Disable Docker build integration if DOCKER is set to the empty string.


### PR DESCRIPTION
-not -path is a filter, not a prune: find still traversed the entire build/cache tree before discarding the results, costing up to ~20 seconds on every make invocation when build cached is big (17 GB, 437K+ files).

Switch to -prune so find skips those directories entirely, bringing make startup time from ~20s to ~0.3s.

<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
