### PR TITLE
Make applyingUpdate reconciler idempotent

### DIFF
--- a/pkg/autopilot/constant/static.go
+++ b/pkg/autopilot/constant/static.go
@@ -7,6 +7,7 @@ const (
 	AutopilotName                      = "autopilot"
 	AutopilotNamespace                 = "k0s-autopilot"
 	K0sTempFilename                    = "k0s.tmp"
+	K0sTempLinkFilename                = "k0s.new"
 	CentralCordoningLabel              = "autopilot.k0sproject.io/central-cordoning"
 	K0SControlNodeModeAnnotation       = "autopilot.k0sproject.io/mode"
 	K0SControlNodeModeController       = "controller"

--- a/pkg/autopilot/constant/static.go
+++ b/pkg/autopilot/constant/static.go
@@ -7,6 +7,7 @@ const (
 	AutopilotName                      = "autopilot"
 	AutopilotNamespace                 = "k0s-autopilot"
 	K0sTempFilename                    = "k0s.tmp"
+	K0sTempLinkFilename                = "k0s.new"
 	CentralCordoningLabel              = "autopilot.k0sproject.io/central-cordoning" // TODO: Remove in v1.37+
 	K0SControlNodeModeAnnotation       = "autopilot.k0sproject.io/mode"
 	K0SControlNodeModeController       = "controller"

--- a/pkg/autopilot/controller/signal/k0s/apply.go
+++ b/pkg/autopilot/controller/signal/k0s/apply.go
@@ -108,21 +108,41 @@ func (r *applyingUpdate) Reconcile(ctx context.Context, req cr.Request) (cr.Resu
 		return cr.Result{}, nil
 	}
 
+	k0sBinaryFilenamePath := filepath.Join(r.k0sBinaryDir, "k0s")
 	updateFilenamePath := filepath.Join(r.k0sBinaryDir, apconst.K0sTempFilename)
+	updateLinkFilenamePath := filepath.Join(r.k0sBinaryDir, apconst.K0sTempLinkFilename)
 
-	// Ensure that the expected file exists
-	if _, err := os.Stat(updateFilenamePath); errors.Is(err, os.ErrNotExist) {
-		return cr.Result{}, fmt.Errorf("unable to find update file '%s': %w", apconst.K0sTempFilename, err)
-	}
+	// Check if the update file still exists. If not, the rename was already
+	// performed in a previous reconciler run whose client.Update failed.
+	// In that case the file operations can be skipped and we can proceed
+	// directly to updating the signaling status to Restart.
+	if _, err := os.Stat(updateFilenamePath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return cr.Result{}, fmt.Errorf("unable to stat update file '%s': %w", updateFilenamePath, err)
+		}
+		logger.Info("Update file already applied, skipping file operations")
+	} else {
+		// Ensure the downloaded temporary file is executable
+		if err := os.Chmod(updateFilenamePath, 0755); err != nil {
+			return cr.Result{}, fmt.Errorf("unable to chmod update file '%s': %w", updateFilenamePath, err)
+		}
 
-	// Ensure that the new file is executable
-	if err := os.Chmod(updateFilenamePath, 0755); err != nil {
-		return cr.Result{}, fmt.Errorf("unable to chmod update file '%s': %w", apconst.K0sTempFilename, err)
-	}
+		// Clean up any stale link file from a previous failed rename attempt
+		os.Remove(updateLinkFilenamePath)
 
-	// Perform the update atomically
-	if err := os.Rename(updateFilenamePath, filepath.Join(r.k0sBinaryDir, "k0s")); err != nil {
-		return cr.Result{}, fmt.Errorf("unable to update (rename) to the new file: %w", err)
+		// Create k0s.new as a hard link to k0s.tmp, sharing the same
+		// inode. This way k0s.tmp survives the subsequent rename,
+		// providing idempotency: if client.Update fails and the
+		// reconciler is re-triggered, k0s.tmp will still exist and
+		// the whole sequence can be replayed.
+		if err := os.Link(updateFilenamePath, updateLinkFilenamePath); err != nil {
+			return cr.Result{}, fmt.Errorf("unable to create hard link '%s' -> '%s': %w", updateLinkFilenamePath, updateFilenamePath, err)
+		}
+
+		// Atomically replace the running k0s binary with the new version
+		if err := os.Rename(updateLinkFilenamePath, k0sBinaryFilenamePath); err != nil {
+			return cr.Result{}, fmt.Errorf("unable to rename '%s' -> '%s': %w", updateLinkFilenamePath, k0sBinaryFilenamePath, err)
+		}
 	}
 
 	// When the k0s process has been terminated, move to 'Restart'
@@ -136,6 +156,14 @@ func (r *applyingUpdate) Reconcile(ctx context.Context, req cr.Request) (cr.Resu
 	logger.Infof("Updating signaling response to '%s'", signalData.Status.Status)
 	if err := r.client.Update(ctx, signalNodeCopy, &crcli.UpdateOptions{}); err != nil {
 		return cr.Result{Requeue: true}, fmt.Errorf("failed to update signal node to status '%s': %w", signalData.Status.Status, err)
+	}
+
+	// Clean up k0s.tmp after a successful apply. If the file does not exist
+	// (e.g. this is a retry where the file was already removed), ignore the error.
+	if err := os.Remove(updateFilenamePath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			logger.WithError(err).Warn("Failed to remove update file")
+		}
 	}
 
 	return cr.Result{}, nil

--- a/pkg/autopilot/controller/signal/k0s/apply.go
+++ b/pkg/autopilot/controller/signal/k0s/apply.go
@@ -111,21 +111,43 @@ func (r *applyingUpdate) Reconcile(ctx context.Context, req cr.Request) (cr.Resu
 		return cr.Result{}, nil
 	}
 
+	k0sBinaryFilenamePath := filepath.Join(r.k0sBinaryDir, "k0s")
 	updateFilenamePath := filepath.Join(r.k0sBinaryDir, apconst.K0sTempFilename)
+	updateLinkFilenamePath := filepath.Join(r.k0sBinaryDir, apconst.K0sTempLinkFilename)
 
-	// Ensure that the expected file exists
-	if _, err := os.Stat(updateFilenamePath); errors.Is(err, os.ErrNotExist) {
-		return cr.Result{}, fmt.Errorf("unable to find update file '%s': %w", apconst.K0sTempFilename, err)
-	}
+	// Check if the update file still exists. If it doesn't, the binary was
+	// already replaced by an earlier apply attempt whose client.Update failed.
+	// In that case the file operations can be skipped and we can proceed
+	// directly to updating the signaling status to Restart.
+	if _, err := os.Stat(updateFilenamePath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return cr.Result{}, fmt.Errorf("unable to stat update file '%s': %w", updateFilenamePath, err)
+		}
+		logger.Info("Update file already applied, skipping file operations")
+	} else {
+		// Ensure the downloaded temporary file is executable
+		if err := os.Chmod(updateFilenamePath, 0755); err != nil {
+			return cr.Result{}, fmt.Errorf("unable to chmod update file '%s': %w", updateFilenamePath, err)
+		}
 
-	// Ensure that the new file is executable
-	if err := os.Chmod(updateFilenamePath, 0755); err != nil {
-		return cr.Result{}, fmt.Errorf("unable to chmod update file '%s': %w", apconst.K0sTempFilename, err)
-	}
+		// Clean up any stale link file from a previous failed rename attempt
+		if err := os.Remove(updateLinkFilenamePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return cr.Result{}, fmt.Errorf("unable to remove stale update link file '%s': %w", updateLinkFilenamePath, err)
+		}
 
-	// Perform the update atomically
-	if err := os.Rename(updateFilenamePath, filepath.Join(r.k0sBinaryDir, "k0s")); err != nil {
-		return cr.Result{}, fmt.Errorf("unable to update (rename) to the new file: %w", err)
+		// Create k0s.new as a hard link to k0s.tmp, sharing the same
+		// inode. This way k0s.tmp survives the subsequent rename,
+		// providing idempotency: if client.Update fails and the
+		// reconciler is re-triggered, k0s.tmp will still exist and
+		// the whole sequence can be replayed.
+		if err := os.Link(updateFilenamePath, updateLinkFilenamePath); err != nil {
+			return cr.Result{}, fmt.Errorf("unable to create hard link '%s' -> '%s': %w", updateLinkFilenamePath, updateFilenamePath, err)
+		}
+
+		// Atomically replace the running k0s binary with the new version
+		if err := os.Rename(updateLinkFilenamePath, k0sBinaryFilenamePath); err != nil {
+			return cr.Result{}, fmt.Errorf("unable to rename '%s' -> '%s': %w", updateLinkFilenamePath, k0sBinaryFilenamePath, err)
+		}
 	}
 
 	// When the k0s process has been terminated, move to 'Restart'
@@ -145,6 +167,14 @@ func (r *applyingUpdate) Reconcile(ctx context.Context, req cr.Request) (cr.Resu
 
 	if err := r.client.Update(ctx, signalNodeCopy, &crcli.UpdateOptions{}); err != nil {
 		return cr.Result{Requeue: true}, fmt.Errorf("failed to update signal node to status '%s': %w", signalData.Status.Status, err)
+	}
+
+	// Clean up k0s.tmp after a successful apply. If the file does not exist
+	// (e.g. this is a retry where the file was already removed), ignore the error.
+	if err := os.Remove(updateFilenamePath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			logger.WithError(err).Warn("Failed to remove update file")
+		}
 	}
 
 	return cr.Result{}, nil

--- a/pkg/autopilot/controller/signal/k0s/apply_test.go
+++ b/pkg/autopilot/controller/signal/k0s/apply_test.go
@@ -6,14 +6,42 @@
 package k0s
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
+	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
+	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
+	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
+	apscheme "github.com/k0sproject/k0s/pkg/client/clientset/scheme"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	crcli "sigs.k8s.io/controller-runtime/pkg/client"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	crev "sigs.k8s.io/controller-runtime/pkg/event"
+	crrec "sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+type failFirstUpdateClient struct {
+	crcli.Client
+	updateAttempts int
+}
+
+func (c *failFirstUpdateClient) Update(ctx context.Context, obj crcli.Object, opts ...crcli.UpdateOption) error {
+	c.updateAttempts++
+	if c.updateAttempts == 1 {
+		return fmt.Errorf("simulated update conflict")
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
 
 // TestApplyingUpdateEventFilter runs through a table of scenarios ensuring that
 // the event-filtering for the 'applying-update' controller works accordingly.
@@ -219,4 +247,81 @@ func TestApplyingUpdateEventFilter(t *testing.T) {
 			assert.Equal(t, test.success, pred.Update(test.event))
 		})
 	}
+}
+
+func TestApplyingUpdateReconcileRetryAfterUpdateFailure(t *testing.T) {
+	commandID := 123
+	signalData := apsigv2.SignalData{
+		PlanID:  "plan-1",
+		Created: "2026-01-01T00:00:00Z",
+		Command: apsigv2.Command{
+			ID: &commandID,
+			K0sUpdate: &apsigv2.CommandK0sUpdate{
+				URL:     "https://updates.example.com/k0s",
+				Version: "v1.2.3",
+			},
+		},
+		Status: &apsigv2.Status{Status: ApplyingUpdate, Timestamp: "2026-01-01T00:00:00Z"},
+	}
+
+	annotations := map[string]string{}
+	require.NoError(t, signalData.Marshal(annotations))
+
+	signalNode := &apv1beta2.ControlNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "node0",
+			Annotations: annotations,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, apscheme.AddToScheme(scheme))
+	baseClient := crfake.NewClientBuilder().WithObjects(signalNode).WithScheme(scheme).Build()
+
+	delegate := apdel.ControlNodeControllerDelegate()
+	client := &failFirstUpdateClient{Client: baseClient}
+	restartInitiated := false
+	reconciler := &applyingUpdate{
+		log:              logrus.NewEntry(logrus.StandardLogger()),
+		client:           client,
+		delegate:         delegate,
+		k0sBinaryDir:     t.TempDir(),
+		restartInitiated: func(apsigv2.SignalData) { restartInitiated = true },
+	}
+
+	updateFilenamePath := filepath.Join(reconciler.k0sBinaryDir, apconst.K0sTempFilename)
+	k0sBinaryFilenamePath := filepath.Join(reconciler.k0sBinaryDir, "k0s")
+	updateLinkFilenamePath := filepath.Join(reconciler.k0sBinaryDir, apconst.K0sTempLinkFilename)
+
+	require.NoError(t, os.WriteFile(updateFilenamePath, []byte("new k0s binary"), 0755))
+	require.NoError(t, os.WriteFile(k0sBinaryFilenamePath, []byte("old k0s binary"), 0755))
+
+	req := crrec.Request{NamespacedName: types.NamespacedName{Name: "node0"}}
+
+	_, err := reconciler.Reconcile(t.Context(), req)
+	require.Error(t, err)
+
+	// The hard link keeps k0s.tmp around even though k0s was replaced, so a
+	// retry can replay the apply sequence without erroring on a missing file.
+	_, err = os.Stat(updateFilenamePath)
+	require.NoError(t, err)
+	replacedBinary, err := os.ReadFile(k0sBinaryFilenamePath)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("new k0s binary"), replacedBinary)
+	_, err = os.Stat(updateLinkFilenamePath)
+	assert.True(t, os.IsNotExist(err))
+
+	_, err = reconciler.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	assert.True(t, restartInitiated)
+
+	updatedNode := delegate.CreateObject()
+	require.NoError(t, baseClient.Get(t.Context(), req.NamespacedName, updatedNode))
+	var updatedData apsigv2.SignalData
+	require.NoError(t, updatedData.Unmarshal(updatedNode.GetAnnotations()))
+	require.NotNil(t, updatedData.Status)
+	assert.Equal(t, Restart, updatedData.Status.Status)
+
+	_, err = os.Stat(updateFilenamePath)
+	assert.True(t, os.IsNotExist(err))
 }

--- a/pkg/autopilot/controller/signal/k0s/apply_test.go
+++ b/pkg/autopilot/controller/signal/k0s/apply_test.go
@@ -7,7 +7,7 @@ package k0s
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,7 +38,7 @@ type failFirstUpdateClient struct {
 func (c *failFirstUpdateClient) Update(ctx context.Context, obj crcli.Object, opts ...crcli.UpdateOption) error {
 	c.updateAttempts++
 	if c.updateAttempts == 1 {
-		return fmt.Errorf("simulated update conflict")
+		return errors.New("simulated update conflict")
 	}
 	return c.Client.Update(ctx, obj, opts...)
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

When the client.Update call fails after successfully renaming k0s.tmp to k0s
(e.g. due to a resourceVersion conflict), the reconciler retries but fails
because k0s.tmp no longer exists. This results in an infinite error loop that
leaves the node stuck in ApplyingUpdate status.

Fix this by checking if the target k0s binary is already in place before
attempting the file rename. If it is, skip the file operations and proceed
directly to updating the signaling status to Restart.

Fixes: https://github.com/k0sproject/k0s/issues/7703

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- `go build` passes
- Existing unit tests pass (`make check-unit`)

The logic follows the same pattern as the fix in PR #6994 for `schedulable.go`,
which addressed a similar non-idempotent reconciler issue.

## Checklist

- [x] My code follows the style of this project
- [x] My commit messages are in the proper format
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings