### PR TITLE
[Backport release-1.33] Use runtime config lock as liveness guard for reset and worker

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -67,6 +67,8 @@ Reads the runtime configuration from standard input.`,
 
 			if runtimeConfig, err := loadRuntimeConfig(cmd.InOrStdin()); err != nil {
 				return err
+			} else if runtimeConfig.Spec.NodeConfig == nil {
+				return fmt.Errorf("%w: node config missing", config.ErrInvalidRuntimeConfig)
 			} else if run, err = buildServer(runtimeConfig.Spec.K0sVars, runtimeConfig.Spec.NodeConfig); err != nil {
 				return err
 			}
@@ -115,14 +117,14 @@ func buildServer(k0sVars *config.CfgVars, nodeConfig *v1beta1.ClusterConfig) (fu
 	mux := http.NewServeMux()
 	storage := nodeConfig.Spec.Storage
 
-	if storage.Type == v1beta1.EtcdStorageType && !storage.Etcd.IsExternalClusterUsed() {
+	if storage == nil || storage.Type == v1beta1.EtcdStorageType && !storage.Etcd.IsExternalClusterUsed() {
 		// Only mount the etcd handler if we're running on internal etcd storage
 		// by default the mux will return 404 back which the caller should handle
 		mux.Handle(prefix+"/etcd/members", mw.AllowMethods(http.MethodPost)(
 			authMiddleware(etcdHandler(k0sVars.CertRootDir, k0sVars.EtcdCertDir), secrets, "controller-join")))
 	}
 
-	if storage.IsJoinable() {
+	if storage == nil || storage.IsJoinable() {
 		mux.Handle(prefix+"/ca", mw.AllowMethods(http.MethodGet)(
 			authMiddleware(caHandler(k0sVars.CertRootDir), secrets, "controller-join")))
 	}

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -124,7 +124,7 @@ func buildServer(k0sVars *config.CfgVars, nodeConfig *v1beta1.ClusterConfig) (fu
 			authMiddleware(etcdHandler(k0sVars.CertRootDir, k0sVars.EtcdCertDir), secrets, "controller-join")))
 	}
 
-	if storage == nil || storage.IsJoinable() {
+	if storage.IsJoinable() {
 		mux.Handle(prefix+"/ca", mw.AllowMethods(http.MethodGet)(
 			authMiddleware(caHandler(k0sVars.CertRootDir), secrets, "controller-join")))
 	}

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -118,9 +118,28 @@ func NewControllerCmd() *cobra.Command {
 				return err
 			}
 
+			nodeConfig, err := c.loadNodeConfig()
+			if err != nil {
+				return err
+			}
+
+			if err := c.initDirs(); err != nil {
+				return err
+			}
+
+			rtc, err := config.NewRuntimeConfig(c.K0sVars, nodeConfig)
+			if err != nil {
+				return fmt.Errorf("failed to initialize runtime config: %w", err)
+			}
+			defer func() {
+				if err := rtc.Spec.Cleanup(); err != nil {
+					logrus.WithError(err).Warn("Failed to cleanup runtime config")
+				}
+			}()
+
 			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 			defer cancel()
-			return c.start(ctx, &controllerFlags, debugFlags.IsDebug())
+			return c.start(ctx, rtc, nodeConfig, &controllerFlags, debugFlags.IsDebug())
 		},
 	}
 
@@ -136,24 +155,20 @@ func NewControllerCmd() *cobra.Command {
 	return cmd
 }
 
-func (c *command) start(ctx context.Context, flags *config.ControllerOptions, debug bool) error {
-	perfTimer := performance.NewTimer("controller-start").Buffer().Start()
-
+func (c *command) loadNodeConfig() (*v1beta1.ClusterConfig, error) {
 	nodeConfig, err := c.K0sVars.NodeConfig()
 	if err != nil {
-		return fmt.Errorf("failed to load node config: %w", err)
+		return nil, fmt.Errorf("failed to load node config: %w", err)
 	}
 
 	if errs := nodeConfig.Validate(); len(errs) > 0 {
-		return fmt.Errorf("invalid node config: %w", errors.Join(errs...))
+		return nil, fmt.Errorf("invalid node config: %w", errors.Join(errs...))
 	}
 
-	// Add the node config to the context so it can be used by components deep in the "stack"
-	ctx = context.WithValue(ctx, k0scontext.ContextNodeConfigKey, nodeConfig)
+	return nodeConfig, nil
+}
 
-	nodeComponents := manager.New(prober.DefaultProber)
-	clusterComponents := manager.New(prober.DefaultProber)
-
+func (c *command) initDirs() error {
 	// create directories early with the proper permissions
 	if err := dir.Init(c.K0sVars.DataDir, constant.DataDirMode); err != nil {
 		return err
@@ -168,15 +183,17 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 		return err
 	}
 
-	rtc, err := config.NewRuntimeConfig(c.K0sVars, nodeConfig)
-	if err != nil {
-		return fmt.Errorf("failed to initialize runtime config: %w", err)
-	}
-	defer func() {
-		if err := rtc.Spec.Cleanup(); err != nil {
-			logrus.WithError(err).Warn("Failed to cleanup runtime config")
-		}
-	}()
+	return nil
+}
+
+func (c *command) start(ctx context.Context, rtc *config.RuntimeConfig, nodeConfig *v1beta1.ClusterConfig, flags *config.ControllerOptions, debug bool) error {
+	perfTimer := performance.NewTimer("controller-start").Buffer().Start()
+
+	// Add the node config to the context so it can be used by components deep in the "stack"
+	ctx = context.WithValue(ctx, k0scontext.ContextNodeConfigKey, nodeConfig)
+
+	nodeComponents := manager.New(prober.DefaultProber)
+	clusterComponents := manager.New(prober.DefaultProber)
 
 	// common factory to get the admin kube client that's needed in many components
 	adminClientFactory := &kubernetes.ClientFactory{LoadRESTConfig: func() (*rest.Config, error) {
@@ -209,6 +226,7 @@ func (c *command) start(ctx context.Context, flags *config.ControllerOptions, de
 			}
 			tokenData = string(data)
 		}
+		var err error
 		joinClient, err = joinController(ctx, tokenData, c.K0sVars.CertRootDir)
 		if err != nil {
 			return fmt.Errorf("failed to join controller: %w", err)

--- a/cmd/reset/reset.go
+++ b/cmd/reset/reset.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/k0sproject/k0s/cmd/internal"
 	"github.com/k0sproject/k0s/pkg/cleanup"
-	"github.com/k0sproject/k0s/pkg/component/status"
 	"github.com/k0sproject/k0s/pkg/config"
 
 	"github.com/sirupsen/logrus"
@@ -68,9 +67,10 @@ func (c *command) reset(debug bool) error {
 		return errors.New("this command must be run as root")
 	}
 
-	k0sStatus, _ := status.GetStatusInfo(c.K0sVars.StatusSocketPath)
-	if k0sStatus != nil && k0sStatus.Pid != 0 {
-		return errors.New("k0s seems to be running, please stop k0s before reset")
+	if locked, err := config.RuntimeConfigLocked(c.K0sVars.RuntimeConfigPath); err != nil {
+		return err
+	} else if locked {
+		return fmt.Errorf("%w, please stop k0s before reset", config.ErrK0sStillRunning)
 	}
 
 	nodeCfg, err := c.K0sVars.NodeConfig()

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -129,6 +129,16 @@ func NewWorkerCmd() *cobra.Command {
 				return err
 			}
 
+			rtc, err := config.NewRuntimeConfig(c.K0sVars, nil)
+			if err != nil {
+				return fmt.Errorf("failed to initialize runtime config: %w", err)
+			}
+			defer func() {
+				if err := rtc.Spec.Cleanup(); err != nil {
+					logrus.WithError(err).Warn("Failed to cleanup runtime config")
+				}
+			}()
+
 			return c.Start(ctx, nodeName, kubeletExtraArgs, getBootstrapKubeconfig, nil)
 		},
 	}

--- a/pkg/apis/k0s/v1beta1/storage.go
+++ b/pkg/apis/k0s/v1beta1/storage.go
@@ -75,7 +75,12 @@ func DefaultStorageSpec() *StorageSpec {
 
 // IsJoinable returns true only if the storage config is such that another controller can join the cluster
 func (s *StorageSpec) IsJoinable() bool {
-	switch s.Type {
+	storageType := EtcdStorageType // assume the default
+	if s != nil {
+		storageType = s.Type
+	}
+
+	switch storageType {
 	case EtcdStorageType:
 		// Controllers will always be able to connect to an etcd backend, either
 		// by joining as a managed etcd node, or by simply connecting to an

--- a/pkg/config/flock_unix.go
+++ b/pkg/config/flock_unix.go
@@ -19,39 +19,24 @@ limitations under the License.
 package config
 
 import (
-	"golang.org/x/sys/unix"
 	"os"
+
+	"golang.org/x/sys/unix"
 )
 
-// tryLock attempts to acquire the lock. Returns *os.File if successful, nil otherwise.
-func tryLock(path string) (*os.File, error) {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
-	if err != nil {
-		return nil, err
+func lockFile(f *os.File, exclusive bool) (bool, error) {
+	how := unix.LOCK_NB
+	if exclusive {
+		how |= unix.LOCK_EX
+	} else {
+		how |= unix.LOCK_SH
 	}
 
-	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
-		_ = file.Close()
-		if err == unix.EWOULDBLOCK {
-			return nil, ErrK0sAlreadyRunning // Lock is already held by another process
-		}
-		return nil, err
+	if err := unix.Flock(int(f.Fd()), how); err == nil {
+		return true, nil
+	} else if err == unix.EWOULDBLOCK {
+		return false, nil
+	} else {
+		return false, os.NewSyscallError("flock", err)
 	}
-	return file, nil
-}
-
-// isLocked checks if the lock is currently held by another process.
-func isLocked(path string) bool {
-	file, err := os.OpenFile(path, os.O_RDWR, 0600)
-	if err != nil {
-		return false
-	}
-	defer file.Close()
-
-	// Attempt a non-blocking shared lock to test the lock state
-	if err := unix.Flock(int(file.Fd()), unix.LOCK_SH|unix.LOCK_NB); err != nil {
-		return err == unix.EWOULDBLOCK
-	}
-
-	return false
 }

--- a/pkg/config/flock_windows.go
+++ b/pkg/config/flock_windows.go
@@ -19,61 +19,33 @@ limitations under the License.
 package config
 
 import (
-	"golang.org/x/sys/windows"
 	"os"
+
+	"golang.org/x/sys/windows"
 )
 
-// tryLock attempts to acquire the lock. Returns true if successful, false otherwise.
-func tryLock(path string) (*os.File, error) {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
-	if err != nil {
-		return nil, err
+func lockFile(f *os.File, exclusive bool) (bool, error) {
+	flags := uint32(windows.LOCKFILE_FAIL_IMMEDIATELY)
+	var overlapped windows.Overlapped // The OVERLAPPED structure, required for asynchronous I/O operations
+	if exclusive {
+		flags |= windows.LOCKFILE_EXCLUSIVE_LOCK
 	}
-
-	handle := windows.Handle(file.Fd())
-	overlapped := new(windows.Overlapped) // The OVERLAPPED structure, required for asynchronous I/O operations
 
 	// Attempt to lock the file exclusively and fail immediately if it's already locked
 	// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
-	err = windows.LockFileEx(
-		handle, // 1. HANDLE hFile: The handle to the file (must have GENERIC_READ or GENERIC_WRITE access)
-		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, // 2. DWORD dwFlags: Specifies the lock type and behavior
-		0,          // 3. DWORD dwReserved: Reserved, must be zero
-		1,          // 4. DWORD nNumberOfBytesToLockLow: Low-order part of the range of bytes to lock (1 byte in this case)
-		0,          // 5. DWORD nNumberOfBytesToLockHigh: High-order part of the range of bytes to lock (0 for single-byte lock)
-		overlapped, // 6. LPOVERLAPPED lpOverlapped: Pointer to an OVERLAPPED structure, required for this function
-	)
-	if err != nil {
-		file.Close()
-		if err == windows.ERROR_LOCK_VIOLATION {
-			return nil, ErrK0sAlreadyRunning // Lock is already held by another process
-		}
-		return nil, err
+	if err := windows.LockFileEx(
+		/* HANDLE hFile                   */ windows.Handle(f.Fd()), // The handle to the file (must have GENERIC_READ or GENERIC_WRITE access)
+		/* DWORD dwFlags                  */ flags, // Specifies the lock type and behavior
+		/* DWORD dwReserved               */ 0, // Reserved, must be zero
+		/* DWORD nNumberOfBytesToLockLow  */ 1, // Low-order part of the range of bytes to lock (1 byte in this case)
+		/* DWORD nNumberOfBytesToLockHigh */ 0, // High-order part of the range of bytes to lock (0 for single-byte lock)
+		/* LPOVERLAPPED lpOverlapped      */ &overlapped, // Pointer to an OVERLAPPED structure, required for this function
+	); err == nil {
+		return true, nil
+	} else if err == windows.ERROR_LOCK_VIOLATION { //nolint:errorlint // safe for syscalls
+		// Lock is already held by another process
+		return false, nil
+	} else {
+		return false, os.NewSyscallError("LockFileEx", err)
 	}
-
-	return file, nil
-}
-
-// isLocked checks if the lock is currently held by another process.
-func isLocked(path string) bool {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
-	if err != nil {
-		return false
-	}
-	defer file.Close()
-
-	handle := windows.Handle(file.Fd())
-	overlapped := new(windows.Overlapped)
-
-	// Try to acquire a shared lock without waiting
-	// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
-	err = windows.LockFileEx(
-		handle,                            // 1. HANDLE hFile: The handle to the file (must have GENERIC_READ or GENERIC_WRITE access)
-		windows.LOCKFILE_FAIL_IMMEDIATELY, // Try without waiting
-		0,                                 // 3. DWORD dwReserved: Reserved, must be zero
-		1,                                 // 4. DWORD nNumberOfBytesToLockLow: Low-order part of the range of bytes to lock (1 byte in this case)
-		0,                                 // 5. DWORD nNumberOfBytesToLockHigh: High-order part of the range of bytes to lock (0 for single-byte lock)
-		overlapped,                        // 6. LPOVERLAPPED lpOverlapped: Pointer to an OVERLAPPED structure, required for this function
-	)
-	return err != nil
 }

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -26,7 +26,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 )
 
@@ -36,7 +35,7 @@ const (
 
 var (
 	ErrK0sNotRunning        = errors.New("k0s is not running")
-	ErrK0sAlreadyRunning    = errors.New("an instance of k0s is already running")
+	ErrK0sStillRunning      = errors.New("another k0s process is still running")
 	ErrInvalidRuntimeConfig = errors.New("invalid runtime configuration")
 )
 
@@ -52,13 +51,15 @@ type RuntimeConfig struct {
 }
 
 type RuntimeConfigSpec struct {
-	NodeConfig *v1beta1.ClusterConfig `json:"nodeConfig"`
+	NodeConfig *v1beta1.ClusterConfig `json:"nodeConfig,omitempty"`
 	K0sVars    *CfgVars               `json:"k0sVars"`
 	lockFile   *os.File
 }
 
 func LoadRuntimeConfig(path string) (*RuntimeConfigSpec, error) {
-	if !isLocked(path + ".lock") {
+	if locked, err := RuntimeConfigLocked(path); err != nil {
+		return nil, err
+	} else if !locked {
 		return nil, ErrK0sNotRunning
 	}
 
@@ -95,6 +96,11 @@ func ParseRuntimeConfig(content []byte) (*RuntimeConfig, error) {
 	}
 
 	return &config, nil
+}
+
+// Reports whether the runtime config lock is currently held.
+func RuntimeConfigLocked(path string) (bool, error) {
+	return isLocked(path + ".lock")
 }
 
 func NewRuntimeConfig(k0sVars *CfgVars, nodeConfig *v1beta1.ClusterConfig) (*RuntimeConfig, error) {
@@ -149,16 +155,39 @@ func (r *RuntimeConfigSpec) Cleanup() error {
 		return nil
 	}
 
+	var errs []error
 	if err := os.Remove(r.K0sVars.RuntimeConfigPath); err != nil {
-		logrus.Warnf("failed to clean up runtime config file: %v", err)
+		errs = append(errs, fmt.Errorf("failed to clean up runtime config file: %w", err))
 	}
-
 	if err := r.lockFile.Close(); err != nil {
-		return fmt.Errorf("failed to close the runtime config file: %w", err)
+		errs = append(errs, fmt.Errorf("failed to close the runtime config lock file: %w", err))
 	}
 
-	if err := os.Remove(r.lockFile.Name()); err != nil {
-		return fmt.Errorf("failed to delete %s: %w", r.lockFile.Name(), err)
+	return errors.Join(errs...)
+}
+
+// tryLock attempts to acquire the lock. Returns *os.File if successful, nil otherwise.
+func tryLock(path string) (*os.File, error) {
+	if file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600); err != nil {
+		return nil, err
+	} else if locked, err := lockFile(file, true); err != nil {
+		return nil, errors.Join(err, file.Close())
+	} else if locked {
+		return file, nil
+	} else {
+		return nil, errors.Join(ErrK0sStillRunning, file.Close())
 	}
-	return nil
+}
+
+// isLocked checks if the lock is currently held by another process.
+func isLocked(path string) (bool, error) {
+	if file, err := os.OpenFile(path, os.O_RDWR, 0); err == nil {
+		// Attempt to acquire a shared lock to test the lock state
+		acquired, err := lockFile(file, false)
+		return !acquired, errors.Join(err, file.Close())
+	} else if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	} else {
+		return false, err
+	}
 }

--- a/pkg/config/runtime_test.go
+++ b/pkg/config/runtime_test.go
@@ -19,12 +19,15 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+
+	"sigs.k8s.io/yaml"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/yaml"
 )
 
 func TestLoadRuntimeConfig(t *testing.T) {
@@ -84,6 +87,30 @@ func TestNewRuntimeConfig(t *testing.T) {
 
 	// try to create a new runtime config when one is already active and check if it returns an error
 	_, err = NewRuntimeConfig(k0sVars, nil)
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, ErrK0sAlreadyRunning)
+	assert.ErrorIs(t, err, ErrK0sStillRunning)
+}
+
+func TestRuntimeConfigLocked(t *testing.T) {
+	tempDir := t.TempDir()
+	runtimeConfigPath := filepath.Join(tempDir, "k0s.yaml")
+
+	if locked, err := RuntimeConfigLocked(runtimeConfigPath); assert.NoError(t, err) {
+		assert.False(t, locked)
+	}
+
+	cfg, err := NewRuntimeConfig(&CfgVars{
+		RuntimeConfigPath: runtimeConfigPath,
+	}, nil)
+	require.NoError(t, err)
+	unlock := sync.OnceFunc(func() { assert.NoError(t, cfg.Spec.Cleanup()) })
+	t.Cleanup(unlock)
+
+	if locked, err := RuntimeConfigLocked(runtimeConfigPath); assert.NoError(t, err) {
+		assert.True(t, locked)
+	}
+
+	unlock()
+	if locked, err := RuntimeConfigLocked(runtimeConfigPath); assert.NoError(t, err) {
+		assert.False(t, locked)
+	}
 }


### PR DESCRIPTION
Backport to `release-1.33`:

* #7691

See:

* #7662