### PR TITLE
Add `--ignore-pre-flight-checks` to install cmds

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -64,9 +64,8 @@ type command config.CLIOptions
 
 func NewControllerCmd() *cobra.Command {
 	var (
-		debugFlags            internal.DebugFlags
-		controllerFlags       config.ControllerOptions
-		ignorePreFlightChecks bool
+		debugFlags      internal.DebugFlags
+		controllerFlags config.ControllerOptions
 	)
 
 	cmd := &cobra.Command{
@@ -107,7 +106,7 @@ func NewControllerCmd() *cobra.Command {
 				ControllerRoleEnabled: true,
 				WorkerRoleEnabled:     controllerFlags.Mode().WorkloadsEnabled(),
 				DataDir:               c.K0sVars.DataDir,
-			}).RunPreFlightChecks(ignorePreFlightChecks); !ignorePreFlightChecks && err != nil {
+			}).RunPreFlightChecks(opts.IgnorePreFlightChecks); !opts.IgnorePreFlightChecks && err != nil {
 				return err
 			}
 
@@ -160,7 +159,6 @@ func NewControllerCmd() *cobra.Command {
 	flags.AddFlagSet(config.GetControllerFlags(&controllerFlags))
 	flags.AddFlagSet(config.GetWorkerFlags())
 	flags.AddFlagSet(config.FileInputFlag())
-	flags.BoolVar(&ignorePreFlightChecks, "ignore-pre-flight-checks", false, "continue even if pre-flight checks fail")
 
 	return cmd
 }

--- a/cmd/install/controller_test.go
+++ b/cmd/install/controller_test.go
@@ -55,6 +55,7 @@ Flags:
       --enable-worker                                  enable worker (default false)
       --feature-gates mapStringBool                    feature gates to enable (comma separated list of key=value pairs)
   -h, --help                                           help for controller
+      --ignore-pre-flight-checks                       continue even if pre-flight checks fail
       --init-only                                      only initialize controller and exit
       --iptables-mode string                           iptables mode (valid values: nft, legacy, auto). default: auto
       --k0s-cloud-provider-port int                    the port that k0s-cloud-provider binds on (default 10258)

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -51,8 +51,7 @@ type EmbeddingController interface {
 
 func NewWorkerCmd() *cobra.Command {
 	var (
-		debugFlags            internal.DebugFlags
-		ignorePreFlightChecks bool
+		debugFlags internal.DebugFlags
 	)
 
 	cmd := &cobra.Command{
@@ -100,7 +99,7 @@ func NewWorkerCmd() *cobra.Command {
 				ControllerRoleEnabled: false,
 				WorkerRoleEnabled:     true,
 				DataDir:               c.K0sVars.DataDir,
-			}).RunPreFlightChecks(ignorePreFlightChecks); !ignorePreFlightChecks && err != nil {
+			}).RunPreFlightChecks(opts.IgnorePreFlightChecks); !opts.IgnorePreFlightChecks && err != nil {
 				return err
 			}
 
@@ -141,7 +140,6 @@ func NewWorkerCmd() *cobra.Command {
 	flags := cmd.Flags()
 	flags.AddFlagSet(config.GetPersistentFlagSet())
 	flags.AddFlagSet(config.GetWorkerFlags())
-	flags.BoolVar(&ignorePreFlightChecks, "ignore-pre-flight-checks", false, "continue even if pre-flight checks fail")
 
 	return cmd
 }

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -65,16 +65,17 @@ type ControllerOptions struct {
 
 // Shared worker cli flags
 type WorkerOptions struct {
-	CloudProvider    bool
-	LogLevels        LogLevels
-	CriSocket        string
-	KubeletExtraArgs string
-	Labels           map[string]string
-	Taints           []string
-	TokenFile        string
-	TokenArg         string
-	WorkerProfile    string
-	IPTablesMode     string
+	CloudProvider         bool
+	IgnorePreFlightChecks bool
+	LogLevels             LogLevels
+	CriSocket             string
+	KubeletExtraArgs      string
+	Labels                map[string]string
+	Taints                []string
+	TokenFile             string
+	TokenArg              string
+	WorkerProfile         string
+	IPTablesMode          string
 }
 
 func (m ControllerMode) WorkloadsEnabled() bool {
@@ -258,6 +259,7 @@ func GetWorkerFlags() *pflag.FlagSet {
 	flagset.StringSliceVarP(&workerOpts.Taints, "taints", "", []string{}, "Node taints, list of key=value:effect strings")
 	flagset.StringVar(&workerOpts.KubeletExtraArgs, "kubelet-extra-args", "", "extra args for kubelet")
 	flagset.StringVar(&workerOpts.IPTablesMode, "iptables-mode", "", "iptables mode (valid values: nft, legacy, auto). default: auto")
+	flagset.BoolVar(&workerOpts.IgnorePreFlightChecks, "ignore-pre-flight-checks", false, "continue even if pre-flight checks fail")
 	flagset.AddFlagSet(GetCriSocketFlag())
 
 	return flagset


### PR DESCRIPTION
## Description

In this PR I use the existing `WorkerOpts` to "smuggle" the flag for all needed places. This I do not have to do all the wiring up as separate flag in multiple commands.

Fixes #7717

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
