### PR TITLE
Fix Autopilot labeling for worker node leases

### DIFF
--- a/inttest/ap-ha3x3/ha3x3_test.go
+++ b/inttest/ap-ha3x3/ha3x3_test.go
@@ -15,6 +15,9 @@ import (
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/k0sproject/k0s/inttest/common"
 	aptest "github.com/k0sproject/k0s/inttest/common/autopilot"
 
@@ -181,6 +184,21 @@ spec:
 
 	if iptablesModeAfterUpdate, err := getIPTablesMode(ctx, sshWorker); s.NoError(err) {
 		s.Equal(iptablesModeBeforeUpdate, iptablesModeAfterUpdate)
+	}
+
+	kubeClient, err := s.KubeClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	for idx := range s.WorkerCount {
+		nodeName := s.WorkerNode(idx)
+		s.Run("kubelet-node-lease-holder-identity/"+nodeName, func() {
+			s.Require().NoError(s.WaitForNodeReady(nodeName, kubeClient))
+			lease, err := kubeClient.CoordinationV1().Leases(corev1.NamespaceNodeLease).Get(ctx, nodeName, metav1.GetOptions{})
+			if s.NoError(err) {
+				if s.NotNil(lease.Spec.HolderIdentity, "No no holder identity") {
+					s.Equal(nodeName, *lease.Spec.HolderIdentity, "Unexpected holder identity")
+				}
+			}
+		})
 	}
 
 	for idx := range s.ControllerCount {

--- a/pkg/autopilot/controller/root_controller.go
+++ b/pkg/autopilot/controller/root_controller.go
@@ -237,7 +237,7 @@ func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *
 	}
 	clusterID := string(ns.UID)
 
-	if err := signal.RegisterControllers(ctx, logger, mgr, delegateMap[apdel.ControllerDelegateController], c.cfg.K0sDataDir, c.enableWorker, clusterID, event, c.cfg.InvocationID); err != nil {
+	if err := signal.RegisterControllers(ctx, logger, mgr, delegateMap[apdel.ControllerDelegateController], c.cfg.K0sDataDir, c.enableWorker, clusterID, event); err != nil {
 		logger.WithError(err).Error("unable to register signal controllers")
 		return err
 	}

--- a/pkg/autopilot/controller/root_worker.go
+++ b/pkg/autopilot/controller/root_worker.go
@@ -111,7 +111,7 @@ func (w *rootWorker) Run(ctx context.Context) error {
 			return fmt.Errorf("unable to register indexers: %w", err)
 		}
 
-		if err := signal.RegisterControllers(ctx, logger, mgr, apdel.NodeControllerDelegate(), w.cfg.K0sDataDir, true, clusterID, leaderelection.StatusPending, w.cfg.InvocationID); err != nil {
+		if err := signal.RegisterControllers(ctx, logger, mgr, apdel.NodeControllerDelegate(), w.cfg.K0sDataDir, true, clusterID, leaderelection.StatusPending); err != nil {
 			return fmt.Errorf("unable to register signal controllers: %w", err)
 		}
 

--- a/pkg/autopilot/controller/signal/init.go
+++ b/pkg/autopilot/controller/signal/init.go
@@ -21,8 +21,8 @@ import (
 
 // RegisterControllers registers all of the autopilot controllers used by both controller
 // and worker modes.
-func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, k0sDataDir string, enableWorker bool, clusterID string, leaseStatus leaderelection.Status, invocationID string) error {
-	if err := k0s.RegisterControllers(ctx, logger, mgr, delegate, enableWorker, clusterID, leaseStatus, invocationID); err != nil {
+func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, k0sDataDir string, enableWorker bool, clusterID string, leaseStatus leaderelection.Status) error {
+	if err := k0s.RegisterControllers(ctx, logger, mgr, delegate, enableWorker, clusterID, leaseStatus); err != nil {
 		return fmt.Errorf("unable to register k0s controllers: %w", err)
 	}
 

--- a/pkg/autopilot/controller/signal/k0s/cordon.go
+++ b/pkg/autopilot/controller/signal/k0s/cordon.go
@@ -167,8 +167,15 @@ func (r *cordonUncordon) isIgnored(ctx context.Context, signalNode crcli.Object)
 			return "", fmt.Errorf("failed to get node lease: %w", err)
 		}
 
-		label, ident := nodeLease.Labels[apconst.CentralCordoningLabel], nodeLease.Spec.HolderIdentity
-		if label == "" || (ident != nil && label != *ident) {
+		// Since the node lease is a heartbeat lease and not a leader lease, the
+		// holder identity is cosmetic and always equals the lease name. Hence,
+		// we can't pull the same trick as we do with the Autopilot controller
+		// lease, where we compare the annotation's value with the current
+		// holder identity. This means we can't detect stale annotations, e.g.
+		// after downgrading from a k0s version that supports central cordoning
+		// to one that doesn't. It's a pity, but there's not much we can do
+		// about it. There's no practical way for us to figure this out.
+		if _, exists := nodeLease.Labels[apconst.CentralCordoningLabel]; !exists {
 			return "node manages cordoning on its own", nil
 		}
 

--- a/pkg/autopilot/controller/signal/k0s/init.go
+++ b/pkg/autopilot/controller/signal/k0s/init.go
@@ -7,6 +7,7 @@ package k0s
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,7 +19,11 @@ import (
 	apsigpred "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common/predicate"
 	"github.com/k0sproject/k0s/pkg/component/status"
 	"github.com/k0sproject/k0s/pkg/leaderelection"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	applycoordinationv1 "k8s.io/client-go/applyconfigurations/coordination/v1"
 
@@ -30,7 +35,7 @@ import (
 
 // RegisterControllers registers all of the autopilot controllers used for updating `k0s`
 // to the controller-runtime manager.
-func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, enableWorker bool, clusterID string, leaseStatus leaderelection.Status, invocationID string) error {
+func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, enableWorker bool, clusterID string, leaseStatus leaderelection.Status) error {
 	logger = logger.WithField("controller", delegate.Name())
 
 	hostname, err := apcomm.FindEffectiveHostname()
@@ -51,11 +56,50 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 	}
 
 	if enableWorker {
-		if err := mgr.GetClient().Apply(ctx, applycoordinationv1.
+		// Stamp the node lease with the central cordoning label to signal to
+		// the autopilot controller that this worker supports central cordoning.
+		// Note that if k0s is downgraded to a version that no longer supports
+		// central cordoning, the label will remain in place, and there will be
+		// no way to detect that this has become stale.
+		c := mgr.GetClient()
+		if err := c.Apply(ctx, applycoordinationv1.
 			Lease(hostname, corev1.NamespaceNodeLease).
-			WithLabels(map[string]string{constant.CentralCordoningLabel: invocationID}),
+			WithLabels(map[string]string{constant.CentralCordoningLabel: ""}),
 			client.FieldOwner("k0s/autopilot"), client.ForceOwnership); err != nil {
 			return fmt.Errorf("unable to apply lease labels: %w", err)
+		}
+
+		// The kubelet only sets the holder identity when creating a new lease
+		// from scratch, not when renewing an existing one. The above apply call
+		// may very well happen before the kubelet has had a chance to create
+		// the lease. As a result, the kubelet finds an existing lease in place
+		// and only updates the renewal time, leaving the holder identity unset.
+		//
+		// Work around this by sending a conditional patch that will set the
+		// holder identity if it has not already been set. If the identity has
+		// already been set, the patch will fail with an "Invalid" error. We
+		// treat this as a success.
+		patch, err := json.Marshal([]struct {
+			Op    string `json:"op"`
+			Path  string `json:"path"`
+			Value string `json:"value,omitempty"`
+		}{
+			{"test", "/spec/holderIdentity", ""},
+			{"add", "/spec/holderIdentity", hostname},
+		})
+		if err != nil {
+			return err
+		}
+
+		if err := c.Patch(
+			ctx,
+			&coordinationv1.Lease{ObjectMeta: metav1.ObjectMeta{
+				Name:      hostname,
+				Namespace: corev1.NamespaceNodeLease,
+			}},
+			client.RawPatch(types.JSONPatchType, patch),
+		); err != nil && !apierrors.IsInvalid(err) {
+			return fmt.Errorf("failed to ensure that a holder identity is set: %w", err)
 		}
 	}
 

--- a/pkg/component/worker/autopilot.go
+++ b/pkg/component/worker/autopilot.go
@@ -74,6 +74,7 @@ func (a *Autopilot) Start(ctx context.Context) error {
 
 	log.Info("Autopilot client factory created, booting up worker root controller")
 	autopilotRoot, err := apcont.NewRootWorker(aproot.RootConfig{
+		InvocationID:        a.K0sVars.InvocationID,
 		KubeConfig:          a.K0sVars.KubeletAuthConfigPath,
 		K0sDataDir:          a.K0sVars.DataDir,
 		Mode:                "worker",


### PR DESCRIPTION
## Description

The original idea was to stamp each worker's node lease with the central-cordoning label set to k0s's current invocation ID, then have the Autopilot controller confirm that the worker is running a compatible k0s version by comparing the label's value against the lease's holder identity. This is the same pattern that is used with the Autopilot controller lease. However, the node leases are very much different from the controller lease. Their holder identity is the node name, not the k0s invocation ID. I completely mixed that up. Moreover, the controller lease is used for leader election, whereas the node leases are used for heartbeats. The holder identity has much less of a meaning for the latter. In particular, the kubelet, which is the component ultimately owning the lease, will only ever set the holder identity when creating the lease for the first time. If it finds an existing lease, it doesn't touch anything but the renewal time. Having Autopilot apply the central-cordoning label during startup results in the holder identity being unset for newly created nodes.

On top of that, the invocation ID was never wired into the worker's Autopilot configuration, so the label value was always set to the empty string on pure worker nodes. Not that it would've helped much if it were.

Fix this by treating the label's presence (not its value) as the signal. Old k0s workers that don't have the label continue to manage their own cordoning; new workers that carry the label are handled centrally. This means that there's no way for k0s to detect downgrades: If k0s is downgraded to a version that predates central cordoning, the label will remain on the lease and the controller will continue to treat the worker as if it supports central cordoning.

Remove the now unused parts of the invocation ID wiring in the Autopilot guts, and, just for completeness, set the invocation ID into the Autopilot worker config.

Additionally, put a little band-aid on the potentially unset holder identity. Patch it to the node name if it's not set after applying the label.

Fixes:

* #6848

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
