### PR TITLE
Remove gold linker for ARM architectures

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,18 +1,11 @@
 ARG BUILDIMAGE
 FROM $BUILDIMAGE
 
-ARG TARGETARCH
 RUN set -ex; \
-# Need to use the gold linker on ARM, Go really wants to have it.
-# https://github.com/golang/go/blob/go1.26.3/src/cmd/link/internal/ld/lib.go#L1702-L1721
-  case "$TARGETARCH" in \
-  arm*) binutils=binutils-gold ;; \
-    *)    binutils=binutils ;; \
-  esac; \
   if [ ! -z "$(which apt)" ]; then \
      apt update && apt install -y make gcc; \
   elif [ ! -z "$(which apk)" ]; then \
-     apk add --no-cache make gcc musl-dev "$binutils"; \
+     apk add --no-cache make gcc musl-dev binutils; \
   else \
      echo "unsupported package manager"; \
      exit 1; \


### PR DESCRIPTION
## Description

Go no longer requires this and is happy to use a recent GNU linker. See upstream Go commit [a8032d4c78](https://github.com/golang/go/commit/a8032d4c781f14fa0bd561d96e719492aee08c23) and its 1.26 backport [0b4d5f85e6](https://github.com/golang/go/commit/0b4d5f85e68ea79b61de9989f9f37a984eb11289).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
