### PR TITLE
Makefile: fix chmod on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ airgap-image-bundle-linux-riscv64.tar \
 airgap-image-bundle-windows2022-amd64.tar: k0s
 	set -- $$(cat -- '$(@:airgap-image-bundle-%.tar=airgap-images-%.txt)') && \
 	$(GO_ENV) ./k0s airgap bundle-artifacts --concurrency=1 -v --platform='$(TARGET_PLATFORM)' -o '$@' "$$@"
-	chmod a+r -- '$@'
+	chmod a+r '$@'
 
 ipv6-test-images-linux-amd64.txt ipv6-test-image-bundle-linux-amd64.tar: TARGET_PLATFORM := linux/amd64
 ipv6-test-images-linux-arm64.txt ipv6-test-image-bundle-linux-arm64.tar: TARGET_PLATFORM := linux/arm64
@@ -383,7 +383,7 @@ check-unit: $(GO_ENV_REQUISITES) go.sum
 
 .PHONY: clean-gocache
 clean-gocache:
-	-chmod -R u+w -- '$(K0S_GO_BUILD_CACHE)/go/mod'
+	-chmod -R u+w '$(K0S_GO_BUILD_CACHE)/go/mod'
 	rm -rf -- '$(K0S_GO_BUILD_CACHE)/go'
 
 .PHONY: clean-docker-image


### PR DESCRIPTION
MacOS's chmod does not support `--`.

Fixes error when building airgap bundle:

> chmod a+r -- 'airgap-image-bundle-linux-arm64.tar'
> chmod: --: No such file or directory

ref: https://www.unix.com/man_page/osx/1/chmod/

<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
