### PR TITLE
inttest/nllb: fix flaky IPv6 tests

### DIFF
--- a/inttest/nllb/nllb_test.go
+++ b/inttest/nllb/nllb_test.go
@@ -39,7 +39,7 @@ type suite struct {
 }
 
 func (s *suite) TestNodeLocalLoadBalancing() {
-	const controllerArgs = "--kube-controller-manager-extra-args='--node-monitor-period=3s --node-monitor-grace-period=9s' --feature-gates=IPv6SingleStack=true"
+	const controllerArgs = "--kube-controller-manager-extra-args='--node-monitor-period=3s --node-monitor-grace-period=9s' --feature-gates=IPv6SingleStack=true --disable-components=metrics-server"
 
 	ctx := s.Context()
 
@@ -313,7 +313,7 @@ func (s *suite) checkClusterReadiness(ctx context.Context, clients *kubernetes.C
 		})
 	}
 
-	for _, deployment := range []string{"coredns", "metrics-server"} {
+	for _, deployment := range []string{"coredns"} {
 		eg.Go(func() error {
 			if err := common.WaitForDeployment(ctx, clients, deployment, metav1.NamespaceSystem); err != nil {
 				return fmt.Errorf("%s did not become ready: %w", deployment, err)


### PR DESCRIPTION
Disable metrics-server as it is not required to verify NLLB functionality. After worker0 is stopped and restarted in each failover cycle, metrics-server takes ~3 minutes to restart, consuming most of the test budget and leaving insufficient time for subsequent controller failover cycles.
    
Removing it from --disable-components and from the cluster readiness check cuts each cluster_ready_without  check from ~181s to ~10s, reducing the happy-path runtime from ~15 min to ~9 min.

<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

Fixes #7742

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings