### PR TITLE
nllb: reduce Envoy unhealthy_threshold from 5 to 2

### DIFF
--- a/pkg/component/worker/nllb/envoy.go
+++ b/pkg/component/worker/nllb/envoy.go
@@ -377,7 +377,7 @@ resources:
     timeout: 1s
     interval: 5s
     healthy_threshold: 3
-    unhealthy_threshold: 5
+    unhealthy_threshold: 2
   {{- if ne $localKonnectivityPort 0 }}
 - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
   name: konnectivity
@@ -401,6 +401,6 @@ resources:
     timeout: 1s
     interval: 5s
     healthy_threshold: 3
-    unhealthy_threshold: 5
+    unhealthy_threshold: 2
 {{- end }}
 `))


### PR DESCRIPTION
With interval: 5s and unhealthy_threshold: 5, Envoy takes 25 seconds after a controller stops to declare it unhealthy and remove it from rotation. During those 25 seconds, konnectivity reconnection attempts are routed to the dead controller and fail, delaying cluster recovery in HA deployments.

Lowering unhealthy_threshold to 2 reduces detection time to 10 seconds (2 × 5s), which is still conservative enough to avoid false positives on transient blips.

Applied to both the apiserver and konnectivity clusters.

Fixes https://github.com/k0sproject/k0s/issues/7743

<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #7743

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
