### PR TITLE
Remove v1.34 upgrade path

### DIFF
--- a/docs/autopilot-multicommand.md
+++ b/docs/autopilot-multicommand.md
@@ -197,7 +197,6 @@ and treats all other states as an error.
 
 ```mermaid
 flowchart TD
-    Errors -. no longer in use .-> InconsistentTargets
     Errors --> IncompleteTargets
     Errors --> Restricted
     Errors -. no longer in use .-> MissingSignalNode
@@ -205,7 +204,6 @@ flowchart TD
 
 | Error State | Command | States | Description |
 | ----------- | ------- | ------ | ----------- |
-| **~~InconsistentTargets~~** | `k0supdate` | **Schedulable** | Legacy state used by older k0s releases to indicate controller readiness failures; no longer in use. |
 | **IncompleteTargets** | `airgapupdate`, `k0supdate` | **NewPlan**, **Schedulable** | Indicates that a **Signal Node** that existed during the discover phase in **NewPlan** no longer exists (ie. no `ControlNode` or `Node` object) |
 | **Restricted** | `airgapupdate`, `k0supdate` | **NewPlan** | Indicates that a **Plan** has requested an update of a **Signal Node** type that contradicts the startup exclusions (the `--exclude-from-plans` argument) |
 | **~~MissingSignalNode~~** | `airgapupdate`, `k0supdate` | **Schedulable** | Legacy state used by older k0s releases to indicate **IncompleteTargets**; no longer in use. |

--- a/docs/autopilot.md
+++ b/docs/autopilot.md
@@ -329,7 +329,6 @@ update operation. There are a number of statuses available:
 | Status | Description | Ends Plan? |
 | ------ | ----------- | ---------- |
 | `IncompleteTargets` | There are nodes in the resolved `Plan` that do not have associated `Node` (worker) or `ControlNode` (controller) objects. | Yes |
-| ~~`InconsistentTargets`~~ | Legacy state used by older k0s releases to indicate controller readiness failures; no longer in use. | Yes |
 | `Schedulable` | Indicates that the `Plan` can be re-evaluated to determine which next node to update. | No |
 | `SchedulableWait` | Scheduling operations are in progress, and no further update scheduling should occur. | No |
 | `Completed` | The `Plan` has run successfully to completion. | Yes |

--- a/inttest/ap-controllerworker/controllerworker_test.go
+++ b/inttest/ap-controllerworker/controllerworker_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"slices"
 	"strings"
@@ -188,41 +187,34 @@ func (s *controllerworkerSuite) TestApply() {
 	kc, err := cf.GetK0sClient()
 	s.Require().NoError(err)
 
-	// TODO: Start those goroutines unconditionally in v1.36+.
-	// These trigger bad behavior in old releases, which this test intentionally tries to uncover.
-	// This behavior has been fixed in k0s v1.35+.
-	if _, updatingFromOtherVersion := os.LookupEnv("K0S_UPDATE_FROM_PATH"); updatingFromOtherVersion {
-		s.T().Log("Updating from another k0s version, skipping goroutines that trigger frequent reconcile events")
-	} else {
-		// Start some goroutines that will touch the ControlNode objects to trigger
-		// a constant flow of reconcile events. This produces high concurrency load
-		// on the Autopilot controllers, in order to test any races.
-		s.T().Log("Starting goroutines to trigger frequent reconcile events")
-		for idx := range s.ControllerCount {
-			controlNodes, nodeName := kc.AutopilotV1beta2().ControlNodes(), s.ControllerNode(idx)
-			wg.Go(func() {
-				wait.UntilWithContext(ctx, func(ctx context.Context) {
-					_ = wait.ExponentialBackoffWithContext(ctx, retry.DefaultRetry, func(ctx context.Context) (bool, error) {
-						cn, err := controlNodes.Get(ctx, nodeName, metav1.GetOptions{})
-						if err == nil {
-							if cn.Annotations == nil {
-								cn.Annotations = map[string]string{}
-							}
-							cn.Annotations["test.k0sproject.io/touch"] = time.Now().Format("2006-01-02T15:04:05.000Z07:00")
-							_, err = controlNodes.Update(ctx, cn, metav1.UpdateOptions{})
-							if apierrors.IsConflict(err) {
-								return false, nil
-							}
+	// Start some goroutines that will touch the ControlNode objects to trigger
+	// a constant flow of reconcile events. This produces high concurrency load
+	// on the Autopilot controllers, in order to test any races.
+	s.T().Log("Starting goroutines to trigger frequent reconcile events")
+	for idx := range s.ControllerCount {
+		controlNodes, nodeName := kc.AutopilotV1beta2().ControlNodes(), s.ControllerNode(idx)
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, func(ctx context.Context) {
+				_ = wait.ExponentialBackoffWithContext(ctx, retry.DefaultRetry, func(ctx context.Context) (bool, error) {
+					cn, err := controlNodes.Get(ctx, nodeName, metav1.GetOptions{})
+					if err == nil {
+						if cn.Annotations == nil {
+							cn.Annotations = map[string]string{}
 						}
-						if err != nil {
-							s.T().Logf("Failed to touch %s: %v", nodeName, err)
+						cn.Annotations["test.k0sproject.io/touch"] = time.Now().Format("2006-01-02T15:04:05.000Z07:00")
+						_, err = controlNodes.Update(ctx, cn, metav1.UpdateOptions{})
+						if apierrors.IsConflict(err) {
+							return false, nil
 						}
+					}
+					if err != nil {
+						s.T().Logf("Failed to touch %s: %v", nodeName, err)
+					}
 
-						return true, nil
-					})
-				}, 1*time.Second)
-			})
-		}
+					return true, nil
+				})
+			}, 1*time.Second)
+		})
 	}
 
 	wg.Go(func() {
@@ -366,17 +358,10 @@ func (s *controllerworkerSuite) TestApply() {
 
 	// The plan has enough information to perform a successful update of k0s, so wait for it.
 	var plan *apv1beta2.Plan
-	var resetTimer *time.Timer
 	err = watch.Plans(kc.AutopilotV1beta2().Plans()).
 		WithObjectName(apconst.AutopilotName).
 		WithErrorCallback(common.RetryWatchErrors(s.T().Logf)).
 		Until(ctx, func(item *apv1beta2.Plan) (bool, error) {
-			if resetTimer != nil {
-				if resetTimer.Stop() {
-					s.T().Log("Canceled reset to", appc.PlanSchedulable)
-				}
-			}
-
 			switch item.Status.State {
 			case appc.PlanSchedulable, appc.PlanSchedulableWait, "":
 				return false, nil
@@ -388,32 +373,10 @@ func (s *controllerworkerSuite) TestApply() {
 				plan = item
 				return true, nil
 
-			// TODO: Remove in v1.36+. This is a transitional helper case to allow
-			// upgrade tests from older k0s versions to succeed.
-			case "InconsistentTargets":
-				if _, updatingFromOtherVersion := os.LookupEnv("K0S_UPDATE_FROM_PATH"); updatingFromOtherVersion {
-					s.T().Log("Updating from another k0s version: InconsistentTargets encountered, resetting to", appc.PlanSchedulable, "after 3 seconds")
-					toUpdate := item.DeepCopy()
-					toUpdate.Status.State = appc.PlanSchedulable
-					resetTimer = time.AfterFunc(3*time.Second, func() {
-						_, err := kc.AutopilotV1beta2().Plans().UpdateStatus(ctx, toUpdate, metav1.UpdateOptions{})
-						if err != nil {
-							cancelTest(fmt.Errorf("failed to reset InconsistentTargets state: %w", err))
-						}
-					})
-					return false, nil
-				}
-				fallthrough // Treat it as error otherwise
-
 			default:
 				return false, fmt.Errorf("unexpected plan state: %s", item.Status.State)
 			}
 		})
-	if resetTimer != nil {
-		if resetTimer.Stop() {
-			s.T().Log("Canceled reset to", appc.PlanSchedulable)
-		}
-	}
 	s.Require().NoError(err)
 
 	if s.Len(plan.Status.Commands, 1) {

--- a/pkg/autopilot/constant/static.go
+++ b/pkg/autopilot/constant/static.go
@@ -7,7 +7,7 @@ const (
 	AutopilotName                      = "autopilot"
 	AutopilotNamespace                 = "k0s-autopilot"
 	K0sTempFilename                    = "k0s.tmp"
-	CentralCordoningLabel              = "autopilot.k0sproject.io/central-cordoning"
+	CentralCordoningLabel              = "autopilot.k0sproject.io/central-cordoning" // TODO: Remove in v1.37+
 	K0SControlNodeModeAnnotation       = "autopilot.k0sproject.io/mode"
 	K0SControlNodeModeController       = "controller"
 	K0SControlNodeModeControllerWorker = "controller+worker"

--- a/pkg/autopilot/controller/root_controller.go
+++ b/pkg/autopilot/controller/root_controller.go
@@ -103,9 +103,11 @@ func (c *rootController) Run(ctx context.Context) error {
 	le, err := c.newLeaderElector(&leaderelection.LeaseConfig{
 		Namespace: apconst.AutopilotNamespace,
 		Name:      apconst.AutopilotNamespace + "-controller",
-		Labels:    map[string]string{apconst.CentralCordoningLabel: c.cfg.InvocationID},
-		Identity:  c.cfg.InvocationID,
-		Client:    kubeClient.CoordinationV1(),
+		// TODO: Remove in v1.37+ and add some cleanup code to remove the
+		// then-unused label.
+		Labels:   map[string]string{apconst.CentralCordoningLabel: c.cfg.InvocationID},
+		Identity: c.cfg.InvocationID,
+		Client:   kubeClient.CoordinationV1(),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create leader elector: %w", err)

--- a/pkg/autopilot/controller/signal/k0s/cordon.go
+++ b/pkg/autopilot/controller/signal/k0s/cordon.go
@@ -73,8 +73,8 @@ type cordonUncordon struct {
 // controller-runtime manager.
 //
 // This controller is only interested when autopilot signaling annotations have
-// moved to a `Cordoning` status. At this point, it will attempt to cordong & drain
-// the node.
+// moved to a `Cordoning` status. At this point, it will attempt to cordon and
+// drain the node.
 func registerCordoning(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, nodeName types.NodeName, leaseStatus leaderelection.Status) error {
 	name := strings.ToLower(delegate.Name()) + "_k0s_cordoning"
 	logger.Info("Registering reconciler: ", name)
@@ -148,7 +148,7 @@ func (r *cordonUncordon) Reconcile(ctx context.Context, req cr.Request) (cr.Resu
 // from Autopilot deployments that manage (un-)cordoning on each individual node
 // to deployments that manage (un-)cordoning via the Autopilot controller.
 //
-// TODO: Remove in v1.36+
+// TODO: Remove in v1.37+
 func (r *cordonUncordon) isIgnored(ctx context.Context, signalNode crcli.Object) (reason string, _ error) {
 	if r.leaseStatus == leaderelection.StatusLeading {
 		if types.NodeName(signalNode.GetName()) == r.nodeName {

--- a/pkg/autopilot/controller/signal/k0s/init.go
+++ b/pkg/autopilot/controller/signal/k0s/init.go
@@ -61,6 +61,9 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 		// Note that if k0s is downgraded to a version that no longer supports
 		// central cordoning, the label will remain in place, and there will be
 		// no way to detect that this has become stale.
+		//
+		// TODO: Remove in v1.37+ and add some cleanup code to remove the
+		// then-unused label.
 		c := mgr.GetClient()
 		if err := c.Apply(ctx, applycoordinationv1.
 			Lease(hostname, corev1.NamespaceNodeLease).
@@ -79,6 +82,9 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 		// holder identity if it has not already been set. If the identity has
 		// already been set, the patch will fail with an "Invalid" error. We
 		// treat this as a success.
+		//
+		// TODO: Remove in v1.37+. This workaround will no longer be necessary
+		// once the apply call above is gone.
 		patch, err := json.Marshal([]struct {
 			Op    string `json:"op"`
 			Path  string `json:"path"`
@@ -111,7 +117,8 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 		return fmt.Errorf("unable to register downloading controller: %w", err)
 	}
 
-	// Man, I wish there would be a saner way to do this!
+	// TODO: Refactor this in v1.37+ so that the (un-)cordoning controllers only
+	// get added for leaders.
 	var nodeDelegate apdel.ControllerDelegate
 	if _, isController := delegate.CreateObject().(*autopilotv1beta2.ControlNode); isController {
 		nodeDelegate = apdel.NodeControllerDelegate()

--- a/pkg/autopilot/controller/signal/k0s/uncordon.go
+++ b/pkg/autopilot/controller/signal/k0s/uncordon.go
@@ -51,7 +51,7 @@ func unCordoningEventFilter(handler apsigpred.ErrorHandler) crpred.Predicate {
 // controller-runtime manager.
 //
 // This controller is only interested when autopilot signaling annotations have
-// moved to a `Cordoning` status. At this point, it will attempt to cordong & drain
+// moved to a `UnCordoning` status. At this point, it will attempt to uncordon
 // the node.
 func registerUncordoning(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, nodeName types.NodeName, leaseStatus leaderelection.Status) error {
 	name := strings.ToLower(delegate.Name()) + "_k0s_uncordoning"

--- a/pkg/component/controller/autopilot.yaml
+++ b/pkg/component/controller/autopilot.yaml
@@ -5,7 +5,7 @@ metadata:
   name: k0s-autopilot
 ---
 # Required to check if the controller is managing cordoning of nodes.
-# TODO: Remove in v1.36+
+# TODO: Remove in v1.37+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/pkg/component/controller/systemrbac-ap.yaml
+++ b/pkg/component/controller/systemrbac-ap.yaml
@@ -10,12 +10,12 @@ rules:
     resources: [nodes]
     verbs: [get, list, watch, update, patch]
   # Needed by drain to list/delete pods scheduled to the node.
-  # TODO: Remove in v1.36+
+  # TODO: Remove in v1.37+
   - apiGroups: [""]
     resources: [pods]
     verbs: [get, list, watch, delete]
   # Drain uses the eviction subresource when available.
-  # TODO: Remove in v1.36+
+  # TODO: Remove in v1.37+
   - apiGroups: [""]
     resources: [pods/eviction]
     verbs: [create]
@@ -25,7 +25,7 @@ rules:
     resourceNames: [kube-system]
     verbs: [get]
   # Required by the drain helper to skip DaemonSet-managed pods.
-  # TODO: Remove in v1.36+
+  # TODO: Remove in v1.37+
   - apiGroups: [apps]
     resources: [daemonsets]
     verbs: [get, list]


### PR DESCRIPTION
## Description

Remove the transitional code that was required to support upgrading k0s from v1.34 to v1.35. Due to the bugs fixed in #7731 and #7762, most of the code that was scheduled for removal in v1.36 needs to stay until v1.37. Adjust the comments accordingly.

With that in mind, the actual removals boil down to

* the workarounds from the Autopilot integration test which were required to test the v1.34 to v1.35 upgrade path, and
* all mentions of `InconsistentTargets` from the docs, as v1.35 no longer produced this state, and neither does v1.36.

See:

* #7762
* #7731

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
