### PR TITLE
Group Renovate PRs for konnectivity and Traefik

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,7 @@
   "prTitleStrict": true,
   "commitMessageAction": "Bump",
   "commitMessageTopic": "{{depName}}",
+  "groupSingleUpdates": false,
   "vulnerabilityAlerts": {
     "enabled": false
   },
@@ -178,7 +179,8 @@
         "sigs.k8s.io/apiserver-network-proxy/*"
       ],
       "groupName": "konnectivity",
-      "groupSlug": "konnectivity"
+      "groupSlug": "konnectivity",
+      "commitMessageExtra": "{{~#if (includes (lookupArray upgrades \"depName\") \"quay.io/k0sproject/apiserver-network-proxy-agent\")}}{{~#each upgrades}}{{~#if (equals depName \"quay.io/k0sproject/apiserver-network-proxy-agent\")}} to {{{prettyNewVersion}}}{{/if}}{{/each~}}{{~else}}{{~#each (distinct (lookupArray upgrades \"prettyNewVersion\"))}} to {{{.}}}{{/each~}}{{/if~}}"
     },
     {
       "description": "Group all Helm bumps",
@@ -198,6 +200,16 @@
       ],
       "groupName": "sonobuoy",
       "groupSlug": "sonobuoy"
+    },
+    {
+      "description": "Group all Traefik bumps",
+      "enabled": true,
+      "matchDepNames": [
+        "**/traefik"
+      ],
+      "groupName": "Traefik",
+      "groupSlug": "traefik",
+      "commitMessageExtra": "{{~#if (includes (lookupArray upgrades \"depName\") \"quay.io/k0sproject/traefik\")}}{{~#each upgrades}}{{~#if (equals depName \"quay.io/k0sproject/traefik\")}} to {{{prettyNewVersion}}}{{/if}}{{/each~}}{{~else}}{{~#each (distinct (lookupArray upgrades \"prettyNewVersion\"))}} to {{{.}}}{{/each~}}{{/if~}}"
     },
     {
       "description": "Run codegen if required",


### PR DESCRIPTION
## Description

When a grouped update includes the k0sproject image, use that image's pretty version in the PR title, including the k0s suffix. Otherwise, fall back to the distinct pretty versions from the grouped updates.

Also disable group settings for single dependency updates so single bumps keep their dependency-specific title.

For example, grouped updates that include the k0sproject image now produce titles like:

- Bump konnectivity to v0.36.0-k0s.0
- Bump Traefik to v3.7.3-k0s.0

If the k0sproject image is not part of the grouped update, Renovate falls back to distinct pretty versions from the update set, for example:

- Bump konnectivity to v0.36.0
- Bump Traefik to v3.7.4

For mixed-versions:

- Bump Traefik to v3.7.4 to v3.7.5

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
