### PR TITLE
Correctly set lease labels

### DIFF
--- a/inttest/ap-controllerworker/controllerworker_test.go
+++ b/inttest/ap-controllerworker/controllerworker_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
 
 	appsv1 "k8s.io/api/apps/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -290,6 +291,24 @@ func (s *controllerworkerSuite) TestApply() {
 
 		if !s.NoError(err, "While monitoring ControlNodes to reach the %s phase", apsigcomm.Completed) {
 			cancelTest(fmt.Errorf("failed to monitor ControlNodes to reach the %s phase", apsigcomm.Completed))
+		}
+	})
+
+	wg.Go(func() {
+		err := watch.FromClient[*coordinationv1.LeaseList, coordinationv1.Lease](
+			c.CoordinationV1().Leases(apconst.AutopilotNamespace),
+		).
+			WithObjectName(apconst.AutopilotNamespace+"-controller").
+			WithErrorCallback(common.RetryWatchErrors(s.T().Logf)).
+			Until(ctx, func(lease *coordinationv1.Lease) (bool, error) {
+				ident := lease.Spec.HolderIdentity
+				if ident == nil || *ident == "" {
+					return false, nil
+				}
+				return lease.Labels[apconst.CentralCordoningLabel] == *ident, nil
+			})
+		if !s.NoError(err, "Autopilot controller lease must carry the central cordoning label matching its holder identity") {
+			cancelTest(errors.New("autopilot controller lease is missing the central cordoning label"))
 		}
 	})
 

--- a/pkg/leaderelection/client.go
+++ b/pkg/leaderelection/client.go
@@ -73,8 +73,8 @@ func (c *LeaseConfig) buildLock() (resourcelock.Interface, error) {
 		LeaseMeta: metav1.ObjectMeta{
 			Namespace: c.Namespace,
 			Name:      c.Name,
-			Labels:    maps.Clone(c.Labels),
 		},
+		Labels: maps.Clone(c.Labels),
 		Client: c.Client,
 		LockConfig: resourcelock.ResourceLockConfig{
 			Identity: c.Identity,


### PR DESCRIPTION
## Description

The Kubernetes leader election client's `LeaseLock` expects the labels to be set on the `Lease` object directly in the `Labels` field, rather than in the `LeaseMeta`'s `Labels` field. The `LeaseConfig` struct was doing it the wrong way. Because of this, k0s never set any labels on the lease objects it held.

Due to a similar bug in how the corresponding label on the node's Lease object was handled that got fixed in #7731, Autopilot's central cordoning mechanism never worked. It always fell back to local (un-)cordoning by accident.

With both fixes in place, central cordoning becomes effective. As long as a flawed, central cordoning-aware k0s controller is the Autopilot leader, local (un-)cordoning accidentally wins. As soon as a fixed controller takes over, central cordoning wins. This is independent of the target node's patch level.

Fixes:

* #6848

See:

* #7731

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
