### PR TITLE
Wait for k0s api to boot before checking the cert in customca inttest

### DIFF
--- a/inttest/customca/customca_test.go
+++ b/inttest/customca/customca_test.go
@@ -64,8 +64,7 @@ func (s *CustomCASuite) TestK0sGetsUp() {
 	s.Require().NoError(s.StopController(s.ControllerNode(0)))
 	s.Require().NoError(s.StartController(s.ControllerNode(0)))
 
-	_, err = s.KubeClient(s.ControllerNode(0)) // Wait for the API to be ready after restart
-	s.Require().NoError(err, "Failed to obtain Kubernetes client after controller restart")
+	s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(0))) // Wait for the k0s join API to be ready after restart
 	newK0sAPICert, err := ssh.ExecWithOutput(s.Context(), "cat /var/lib/k0s/pki/k0s-api.crt")
 	s.Require().NoError(err, "Failed to obtain new k0s certificate")
 	s.Require().NotEqual(k0sAPICert, newK0sAPICert, "k0s-api certificate was not renewed")


### PR DESCRIPTION
## Description

Previously we waited only for k8s API to be up but that does NOT guarantee the cert even should've renewed.

Fixes https://github.com/k0sproject/k0s/actions/runs/27191023287/job/80272516285?pr=7764

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
