### PR TITLE
Remove dead Helm Repository's IsInsecure method

### DIFF
--- a/pkg/apis/k0s/v1beta1/extensions.go
+++ b/pkg/apis/k0s/v1beta1/extensions.go
@@ -181,12 +181,6 @@ type Repository struct {
 	Password string `json:"password,omitempty"`
 }
 
-func (r *Repository) IsInsecure() bool {
-	// This defaults to true when not explicitly set to false.
-	// Better have this the other way round in the next API version.
-	return r == nil || r.Insecure == nil || *r.Insecure
-}
-
 // Validate performs validation
 func (r *Repository) Validate() error {
 	if r.Name == "" {


### PR DESCRIPTION
## Description

In #7083, the evaluation of the insecure field was moved from the API's struct to a struct owned by the extensions controller. This left the `IsInsecure` method without any callers. Remove it.

See:

* #7083

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
