### PR TITLE
Always use node config when retrieving service CIDR and primary address family

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -536,7 +536,7 @@ func (c *command) start(ctx context.Context, rtc *config.RuntimeConfig, nodeConf
 			return fmt.Errorf("failed to create Calico component: %w", err)
 		}
 		clusterComponents.Add(ctx, calico)
-		clusterComponents.Add(ctx, controller.NewKubeRouter(c.K0sVars, nodeConfig.Spec.PrimaryAddressFamily()))
+		clusterComponents.Add(ctx, controller.NewKubeRouter(c.K0sVars, nodeConfig.Spec.PrimaryAddressFamily(), nodeConfig.Spec.Network.BuildServiceCIDR(nodeConfig.Spec.PrimaryAddressFamily())))
 	}
 
 	if !slices.Contains(flags.DisableComponents, constant.MetricsServerComponentName) {
@@ -604,6 +604,7 @@ func (c *command) start(ctx context.Context, rtc *config.RuntimeConfig, nodeConf
 			K0sVars:               c.K0sVars,
 			DisableLeaderElection: singleController,
 			ServiceClusterIPRange: nodeConfig.Spec.Network.BuildServiceCIDR(nodeConfig.Spec.PrimaryAddressFamily()),
+			PrimaryAddressFamily:  nodeConfig.Spec.PrimaryAddressFamily(),
 			ExtraArgs:             flags.KubeControllerManagerExtraArgs,
 		})
 	}

--- a/docs/dynamic-configuration.md
+++ b/docs/dynamic-configuration.md
@@ -53,6 +53,11 @@ The configuration object is a 1-to-1 mapping with the existing [configuration YA
 
 As with any Kubernetes cluster there are certain things that just cannot be changed on-the-fly, this is the list of non-changeable options:
 
+<!--
+Technically, k0s currently supports reconciling the pod CIDR from dynamic
+config. This has supposedly been an oversight during implementation. Actually
+attempting to change it on a live cluster would likely wreak havoc.
+-->
 - `network.podCIDR`
 - `network.serviceCIDR`
 - `network.provider`

--- a/inttest/custom-cidrs/customcidrs_test.go
+++ b/inttest/custom-cidrs/customcidrs_test.go
@@ -39,11 +39,10 @@ func (s *CustomCIDRsSuite) TestK0sGetsUp() {
 		s.FailNow("failed to obtain Kubernetes client", err)
 	}
 
-	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
-	s.Require().NoError(err)
-
-	err = s.WaitForNodeReady(s.WorkerNode(1), kc)
-	s.Require().NoError(err)
+	for i := range s.WorkerCount {
+		err = s.WaitForNodeReady(s.WorkerNode(i), kc)
+		s.Require().NoError(err)
+	}
 
 	s.AssertSomeKubeSystemPods(kc)
 
@@ -71,7 +70,7 @@ func (s *CustomCIDRsSuite) TestK0sGetsUp() {
 				},
 			}},
 			NodeSelector: map[string]string{
-				"kubernetes.io/hostname": "worker0",
+				"kubernetes.io/hostname": s.WorkerNode(0),
 			},
 		},
 	}, metav1.CreateOptions{})
@@ -93,13 +92,17 @@ func (s *CustomCIDRsSuite) TestK0sGetsUp() {
 	// Verify lookup actually works
 	nslookup, err := common.PodExecCmdOutput(kc, restConfig, "nginx", metav1.NamespaceDefault, "nslookup kubernetes.default.svc.cluster.local")
 	s.Require().NoError(err)
-	s.Require().Contains(nslookup, "Address: 10.152.184.1")
+	s.Contains(nslookup, "Address: 10.152.184.1")
 
 	// Check that we can access the kubernetes svc via DNS name
 	kubeSvcOutput, err := common.PodExecCmdOutput(kc, restConfig, "nginx", metav1.NamespaceDefault, `curl -v -k --connect-timeout 2 -s -I https://kubernetes.default.svc.cluster.local`)
 	s.Require().NoError(err)
+	s.Contains(kubeSvcOutput, "HTTP/2 401")
 
-	s.Require().Contains(kubeSvcOutput, "HTTP/2 401")
+	// Check that kube-router has the right service CIDR set
+	ds, err := kc.AppsV1().DaemonSets(metav1.NamespaceSystem).Get(ctx, "kube-router", metav1.GetOptions{})
+	s.Require().NoError(err)
+	s.Contains(ds.Spec.Template.Spec.Containers[0].Args, "--service-cluster-ip-range=10.152.184.0/24")
 }
 
 func TestCustomCIDRsSuite(t *testing.T) {

--- a/inttest/dualstack/dualstack_test.go
+++ b/inttest/dualstack/dualstack_test.go
@@ -11,32 +11,34 @@ package dualstack
 // have proper values for spec.PodCIDRs
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"strings"
-
-	"github.com/stretchr/testify/suite"
-
 	"testing"
-
 	"time"
 
 	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/k0sproject/k0s/pkg/applier"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8s "k8s.io/client-go/kubernetes"
-
-	"context"
-
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	kubeproxyv1alpha1 "k8s.io/kube-proxy/config/v1alpha1"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type DualstackSuite struct {
 	common.BootlooseSuite
 
-	client      *k8s.Clientset
-	defaultIPv6 bool
+	client        *kubernetes.Clientset
+	cni           string
+	defaultIPv6   bool
+	dynamicConfig bool
 }
 
 func (s *DualstackSuite) TestDualStackNodesHavePodCIDRs() {
@@ -47,34 +49,95 @@ func (s *DualstackSuite) TestDualStackNodesHavePodCIDRs() {
 	}
 }
 
-func (s *DualstackSuite) TestDualStackControlPlaneComponentsHaveServiceCIDRs() {
-	const expectedIPv4 = "--service-cluster-ip-range=10.96.0.0/12,fd01::/108"
-	const expectedIPv6 = "--service-cluster-ip-range=fd01::/108,10.96.0.0/12"
+func (s *DualstackSuite) TestComponentsHaveCorrectCIDRs() {
+	ctx := s.Context()
+	expectedPodCIDRs := "10.233.0.0/16,fd00::/108"
+	expectedServiceCIDRs := "10.112.0.0/12,fd01::/108"
+	if s.defaultIPv6 {
+		expectedPodCIDRs = "fd00::/108,10.233.0.0/16"
+		expectedServiceCIDRs = "fd01::/108,10.112.0.0/12"
+	}
+
 	node := s.ControllerNode(0)
 
-	expected := expectedIPv4
-	if s.defaultIPv6 {
-		expected = expectedIPv6
+	ssh, err := s.SSH(ctx, node)
+	if !s.NoError(err) {
+		return
 	}
-	s.Contains(s.cmdlineForExecutable(node, "kube-apiserver"), expected)
-	s.Contains(s.cmdlineForExecutable(node, "kube-controller-manager"), expected)
-}
-
-func (s *DualstackSuite) cmdlineForExecutable(node, binary string) []string {
-	require := s.Require()
-	ssh, err := s.SSH(s.Context(), node)
-	require.NoError(err)
 	defer ssh.Disconnect()
 
-	output, err := ssh.ExecWithOutput(s.Context(), fmt.Sprintf("pidof -- %q", binary))
-	require.NoError(err)
+	s.Run("kube-apiserver", func() {
+		if args, err := cmdlineForExecutable(ctx, ssh, "kube-apiserver"); s.NoError(err) {
+			s.Contains(args, "--service-cluster-ip-range="+expectedServiceCIDRs)
+		}
+	})
 
-	pids := strings.Split(output, " ")
-	require.Len(pids, 1, "Expected a single pid")
+	s.Run("kube-controller-manager", func() {
+		if args, err := cmdlineForExecutable(ctx, ssh, "kube-controller-manager"); s.NoError(err) {
+			s.Contains(args, "--service-cluster-ip-range="+expectedServiceCIDRs)
+			s.Contains(args, "--cluster-cidr="+expectedPodCIDRs)
+		}
+	})
 
-	output, err = ssh.ExecWithOutput(s.Context(), fmt.Sprintf("cat /proc/%q/cmdline", pids[0]))
-	require.NoErrorf(err, "Failed to get cmdline for PID %s", pids[0])
-	return strings.Split(output, "\x00")
+	kc, err := s.KubeClient(node)
+	if !s.NoError(err) {
+		return
+	}
+
+	s.Run("kube-proxy", func() {
+		cm, err := kc.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(s.Context(), "kube-proxy", metav1.GetOptions{})
+		if !s.NoError(err) {
+			return
+		}
+
+		var config kubeproxyv1alpha1.KubeProxyConfiguration
+		codec := applier.CodecFor(applier.BuildScheme(kubeproxyv1alpha1.AddToScheme))
+		obj, gvk, err := codec.Decode([]byte(cm.Data["config.conf"]), nil, &config)
+		if !s.NoError(err) {
+			return
+		}
+
+		if config, ok := obj.(*kubeproxyv1alpha1.KubeProxyConfiguration); s.Truef(ok, "Unexpected type: %s", gvk) {
+			s.Equal(expectedPodCIDRs, config.ClusterCIDR)
+		}
+	})
+
+	s.Run("kube-router", func() {
+		if s.cni != "kuberouter" {
+			s.T().Skip("Using", s.cni)
+		}
+
+		kc, err := s.KubeClient(node)
+		if !s.NoError(err) {
+			return
+		}
+
+		ds, err := kc.AppsV1().DaemonSets(metav1.NamespaceSystem).Get(s.Context(), "kube-router", metav1.GetOptions{})
+		if !s.NoError(err) {
+			return
+		}
+
+		s.Contains(ds.Spec.Template.Spec.Containers[0].Args, "--service-cluster-ip-range="+expectedServiceCIDRs)
+	})
+}
+
+func cmdlineForExecutable(ctx context.Context, ssh *common.SSHConnection, binary string) ([]string, error) {
+	output, err := ssh.ExecWithOutput(ctx, fmt.Sprintf("pidof -- %q", binary))
+	if err != nil {
+		return nil, err
+	}
+
+	pid, _, multiplePids := strings.Cut(output, " ")
+	if multiplePids {
+		return nil, errors.New("expected a single PID: " + output)
+	}
+
+	output, err = ssh.ExecWithOutput(ctx, fmt.Sprintf("cat /proc/%q/cmdline", pid))
+	if err != nil {
+		return nil, errors.New("failed to get cmdline for PID " + output)
+	}
+
+	return strings.Split(output, "\x00"), nil
 }
 
 func (s *DualstackSuite) SetupSuite() {
@@ -83,19 +146,20 @@ func (s *DualstackSuite) SetupSuite() {
 	s.Require().True(isDockerIPv6Enabled, "Please enable IPv6 in docker before running this test")
 	s.BootlooseSuite.SetupSuite()
 
-	target := os.Getenv("K0S_INTTEST_TARGET")
-
 	k0sConfig := k0sConfigWithCalicoDualStack
-
-	if strings.Contains(target, "kuberouter") {
+	if s.cni == "kuberouter" {
 		s.T().Log("Using kube-router network")
-		ipv6Address := s.getIPv6Address(s.ControllerNode(0))
-		k0sConfig = fmt.Sprintf(k0sConfigWithKuberouterDualStack, ipv6Address)
-		s.defaultIPv6 = true
+		var ipAddress string
+		if s.defaultIPv6 {
+			ipAddress = s.getIPv6Address(s.ControllerNode(0))
+		} else {
+			ipAddress = s.GetIPAddress(s.ControllerNode(0))
+		}
+		k0sConfig = fmt.Sprintf(k0sConfigWithKuberouterDualStack, ipAddress)
 	}
 	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfig)
 	controllerArgs := []string{"--config=/tmp/k0s.yaml"}
-	if strings.Contains(os.Getenv("K0S_INTTEST_TARGET"), "dynamicconfig") {
+	if s.dynamicConfig {
 		s.T().Log("Enabling dynamic config for controller")
 		controllerArgs = append(controllerArgs, "--enable-dynamic-config")
 	}
@@ -103,13 +167,9 @@ func (s *DualstackSuite) SetupSuite() {
 	s.Require().NoError(s.RunWorkers())
 	client, err := s.KubeClient(s.ControllerNode(0))
 	s.Require().NoError(err)
-	err = s.WaitForNodeReady(s.WorkerNode(0), client)
-	s.Require().NoError(err)
-
-	err = s.WaitForNodeReady(s.WorkerNode(1), client)
-	s.Require().NoError(err)
-
 	for i := range s.WorkerCount {
+		err = s.WaitForNodeReady(s.WorkerNode(i), client)
+		s.Require().NoError(err)
 		ssh, err := s.SSH(s.Context(), s.WorkerNode(i))
 		s.Require().NoError(err)
 		defer ssh.Disconnect()
@@ -118,54 +178,62 @@ func (s *DualstackSuite) SetupSuite() {
 		s.T().Logf("worker%d: /proc/sys/net/ipv6/conf/all/disable_ipv6=%s", i, output)
 	}
 
-	kc, err := s.KubeClient("controller0", "")
+	kc, err := s.KubeClient(s.ControllerNode(0), "")
 	s.Require().NoError(err)
-	restConfig, err := s.GetKubeConfig("controller0", "")
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0), "")
 	s.Require().NoError(err)
 
-	createdTargetPod, err := kc.CoreV1().Pods(metav1.NamespaceDefault).Create(s.Context(), &corev1.Pod{
+	targetPod, err := kc.CoreV1().Pods(metav1.NamespaceDefault).Create(s.Context(), &corev1.Pod{
 		TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-worker0"},
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-" + s.WorkerNode(0)},
 		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{Name: "nginx-worker0", Image: "docker.io/library/nginx:1.31.1-alpine"}},
+			Containers: []corev1.Container{{Name: "nginx", Image: "docker.io/library/nginx:1.31.1-alpine"}},
 			NodeSelector: map[string]string{
-				"kubernetes.io/hostname": "worker0",
+				"kubernetes.io/hostname": s.WorkerNode(0),
 			},
 		},
 	}, metav1.CreateOptions{})
-	s.Require().NoError(err)
-	s.Require().NoError(common.WaitForPod(s.Context(), kc, "nginx-worker0", metav1.NamespaceDefault), "nginx-worker0 pod did not start")
-
-	targetPod, err := kc.CoreV1().Pods(createdTargetPod.Namespace).Get(s.Context(), createdTargetPod.Name, metav1.GetOptions{})
 	s.Require().NoError(err)
 
 	sourcePod, err := kc.CoreV1().Pods(metav1.NamespaceDefault).Create(s.Context(), &corev1.Pod{
 		TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-worker1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-" + s.WorkerNode(1)},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{Name: "alpine", Image: "docker.io/library/nginx:1.31.1-alpine"}},
 			NodeSelector: map[string]string{
-				"kubernetes.io/hostname": "worker1",
+				"kubernetes.io/hostname": s.WorkerNode(1),
 			},
 		},
 	}, metav1.CreateOptions{})
 	s.Require().NoError(err)
-	s.NoError(common.WaitForPod(s.Context(), kc, "nginx-worker1", metav1.NamespaceDefault), "nginx-worker1 pod did not start")
+
+	s.T().Logf("Waiting for pod: %s", targetPod.Name)
+	s.Require().NoErrorf(common.WaitForPod(s.Context(), kc, targetPod.Name, metav1.NamespaceDefault), "%s pod did not start", targetPod.Name)
+	targetPod, err = kc.CoreV1().Pods(targetPod.Namespace).Get(s.Context(), targetPod.Name, metav1.GetOptions{})
+	s.Require().NoError(err)
+
+	s.T().Logf("Waiting for pod: %s", sourcePod.Name)
+	s.NoErrorf(common.WaitForPod(s.Context(), kc, sourcePod.Name, metav1.NamespaceDefault), "%s pod did not start", sourcePod.Name)
 
 	// test both ipv4 and ipv6 addresses
 	podIPs := map[string]string{}
 	podIPs["ipv4"], podIPs["ipv6"] = s.getPodIPs(targetPod)
 	for ipVersion, podIP := range podIPs {
+		target := net.JoinHostPort(podIP, "80")
+		s.T().Logf("Trying to access %s address %s of pod %s from pod %s", ipVersion, target, targetPod.Name, sourcePod.Name)
 		err := wait.PollUntilContextTimeout(s.Context(), 100*time.Millisecond, time.Minute, true, func(ctx context.Context) (done bool, err error) {
-			target := net.JoinHostPort(podIP, "80")
 			out, err := common.PodExecCmdOutput(kc, restConfig, sourcePod.Name, sourcePod.Namespace, "/usr/bin/wget -qO- http://"+target)
-			s.T().Logf("Trying to access %s address %s: %s", ipVersion, target, out)
 			if err != nil {
-				s.T().Logf("error calling %s address: %v", ipVersion, err)
+				s.T().Logf("Error calling %s address of pod %s: %v", ipVersion, targetPod.Name, err)
 				return false, nil
 			}
-			s.T().Logf("server response from %s address: %s", ipVersion, out)
-			return strings.Contains(out, "Welcome to nginx"), nil
+			if !strings.Contains(out, "Welcome to nginx") {
+				s.T().Logf("Server response from %s address of pod %s: %s", ipVersion, targetPod.Name, out)
+				return false, nil
+			}
+
+			s.T().Logf("Connection to %s address of pod %s from pod %s was successful", ipVersion, targetPod.Name, sourcePod.Name)
+			return true, nil
 		})
 		s.Require().NoErrorf(err, "failed to access nginx server via %s address", ipVersion)
 	}
@@ -198,7 +266,7 @@ func (s *DualstackSuite) getPodIPs(pod *corev1.Pod) (string, string) {
 	return ipv4, ipv6
 }
 
-func (s *DualstackSuite) validateKubeDNSIP(client *k8s.Clientset) {
+func (s *DualstackSuite) validateKubeDNSIP(client *kubernetes.Clientset) {
 	svc, err := client.CoreV1().Services(metav1.NamespaceSystem).Get(s.Context(), "kube-dns", metav1.GetOptions{})
 	s.NoError(err, "failed to get service kube-dns")
 	svcIP := net.ParseIP(svc.Spec.ClusterIP)
@@ -222,14 +290,19 @@ func (s *DualstackSuite) getIPv6Address(nodeName string) string {
 }
 
 func TestDualStack(t *testing.T) {
-
+	target := os.Getenv("K0S_INTTEST_TARGET")
 	s := DualstackSuite{
-		common.BootlooseSuite{
+		BootlooseSuite: common.BootlooseSuite{
 			ControllerCount: 1,
 			WorkerCount:     2,
 		},
-		nil,
-		false,
+		cni:           "calico",
+		dynamicConfig: strings.Contains(target, "dynamicconfig"),
+	}
+
+	if strings.Contains(target, "kuberouter") {
+		s.cni = "kuberouter"
+		s.defaultIPv6 = true
 	}
 
 	suite.Run(t, &s)
@@ -248,8 +321,8 @@ spec:
       enabled: true
       IPv6podCIDR: "fd00::/108"
       IPv6serviceCIDR: "fd01::/108"
-    podCIDR: 10.244.0.0/16
-    serviceCIDR: 10.96.0.0/12
+    podCIDR: 10.233.0.0/16
+    serviceCIDR: 10.112.0.0/12
 `
 
 const k0sConfigWithKuberouterDualStack = `
@@ -262,6 +335,6 @@ spec:
       enabled: true
       IPv6podCIDR: "fd00::/108"
       IPv6serviceCIDR: "fd01::/108"
-    podCIDR: 10.244.0.0/16
-    serviceCIDR: 10.96.0.0/12
+    podCIDR: 10.233.0.0/16
+    serviceCIDR: 10.112.0.0/12
 `

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -29,6 +29,7 @@ type Manager struct {
 	LogLevel              string
 	DisableLeaderElection bool
 	ServiceClusterIPRange string
+	PrimaryAddressFamily  v1beta1.PrimaryAddressFamilyType
 	ExtraArgs             string
 
 	supervisor     *supervisor.Supervisor
@@ -89,7 +90,7 @@ func (a *Manager) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterC
 		"requestheader-client-ca-file":     filepath.Join(a.K0sVars.CertRootDir, "front-proxy-ca.crt"),
 		"root-ca-file":                     filepath.Join(a.K0sVars.CertRootDir, "ca.crt"),
 		"service-account-private-key-file": filepath.Join(a.K0sVars.CertRootDir, "sa.key"),
-		"cluster-cidr":                     clusterConfig.Spec.Network.BuildPodCIDR(clusterConfig.Spec.PrimaryAddressFamily()),
+		"cluster-cidr":                     clusterConfig.Spec.Network.BuildPodCIDR(a.PrimaryAddressFamily),
 		"service-cluster-ip-range":         a.ServiceClusterIPRange,
 		"profiling":                        "false",
 		"terminated-pod-gc-threshold":      "12500",

--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -283,7 +283,7 @@ func (k *KubeProxy) getConfig(clusterConfig *v1beta1.ClusterConfig) *proxyConfig
 				ClientConnection: configv1alpha1.ClientConnectionConfiguration{
 					Kubeconfig: "/var/lib/kube-proxy/kubeconfig.conf",
 				},
-				ClusterCIDR:        clusterConfig.Spec.Network.BuildPodCIDR(clusterConfig.Spec.PrimaryAddressFamily()),
+				ClusterCIDR:        clusterConfig.Spec.Network.BuildPodCIDR(k.nodeConf.Spec.PrimaryAddressFamily()),
 				FeatureGates:       clusterConfig.Spec.FeatureGates.AsMap("kube-proxy"),
 				Mode:               kubeproxyv1alpha1.ProxyMode(kubeProxy.Mode),
 				MetricsBindAddress: kubeProxy.MetricsBindAddress,

--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -29,6 +29,7 @@ type KubeRouter struct {
 
 	k0sVars              *config.CfgVars
 	primaryAddressFamily v1beta1.PrimaryAddressFamilyType
+	serviceCIDRs         string
 
 	previousConfig  kubeRouterConfig
 	previousPatches v1beta1.Patches
@@ -52,12 +53,13 @@ type kubeRouterConfig struct {
 }
 
 // NewKubeRouter creates new KubeRouter reconciler component
-func NewKubeRouter(k0sVars *config.CfgVars, primaryAddressFamily v1beta1.PrimaryAddressFamilyType) *KubeRouter {
+func NewKubeRouter(k0sVars *config.CfgVars, primaryAddressFamily v1beta1.PrimaryAddressFamilyType, serviceCIDRs string) *KubeRouter {
 	return &KubeRouter{
 		log: logrus.WithFields(logrus.Fields{"component": "kube-router"}),
 
 		k0sVars:              k0sVars,
 		primaryAddressFamily: primaryAddressFamily,
+		serviceCIDRs:         serviceCIDRs,
 	}
 }
 
@@ -118,7 +120,7 @@ func (k *KubeRouter) Reconcile(_ context.Context, clusterConfig *v1beta1.Cluster
 		"auto-mtu":                 strconv.FormatBool(clusterConfig.Spec.Network.KubeRouter.IsAutoMTU()),
 		"metrics-port":             strconv.Itoa(clusterConfig.Spec.Network.KubeRouter.MetricsPort),
 		"hairpin-mode":             strconv.FormatBool(globalHairpin),
-		"service-cluster-ip-range": clusterConfig.Spec.Network.BuildServiceCIDR(clusterConfig.Spec.PrimaryAddressFamily()),
+		"service-cluster-ip-range": k.serviceCIDRs,
 	}
 
 	// IPv6 requires a router ID, instead of generating one ourselves, rely on kube-router logic

--- a/pkg/component/controller/kuberouter_test.go
+++ b/pkg/component/controller/kuberouter_test.go
@@ -38,7 +38,7 @@ func TestKubeRouterConfig(t *testing.T) {
 	cfg.Spec.Network.KubeRouter.IPMasq = true
 
 	ctx := t.Context()
-	kr := NewKubeRouter(k0sVars, v1beta1.PrimaryFamilyIPv4)
+	kr := NewKubeRouter(k0sVars, v1beta1.PrimaryFamilyIPv4, cfg.Spec.Network.BuildServiceCIDR(cfg.Spec.PrimaryAddressFamily()))
 	require.NoError(t, kr.Init(ctx))
 	require.NoError(t, kr.Start(ctx))
 	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
@@ -123,7 +123,7 @@ func TestKubeRouterDefaultManifests(t *testing.T) {
 	cfg.Spec.Network.Provider = "kuberouter"
 	cfg.Spec.Network.KubeRouter = v1beta1.DefaultKubeRouter()
 	ctx := t.Context()
-	kr := NewKubeRouter(k0sVars, v1beta1.PrimaryFamilyIPv4)
+	kr := NewKubeRouter(k0sVars, v1beta1.PrimaryFamilyIPv4, cfg.Spec.Network.BuildServiceCIDR(cfg.Spec.PrimaryAddressFamily()))
 	require.NoError(t, kr.Init(ctx))
 	require.NoError(t, kr.Start(ctx))
 	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
@@ -161,7 +161,7 @@ func TestKubeRouterManualMTUManifests(t *testing.T) {
 	cfg.Spec.Network.KubeRouter.AutoMTU = ptr.To(false)
 	cfg.Spec.Network.KubeRouter.MTU = 1234
 	ctx := t.Context()
-	kr := NewKubeRouter(k0sVars, v1beta1.PrimaryFamilyIPv4)
+	kr := NewKubeRouter(k0sVars, v1beta1.PrimaryFamilyIPv4, cfg.Spec.Network.BuildServiceCIDR(cfg.Spec.PrimaryAddressFamily()))
 	require.NoError(t, kr.Init(ctx))
 	require.NoError(t, kr.Start(ctx))
 	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
@@ -202,7 +202,7 @@ func TestExtraArgs(t *testing.T) {
 	}
 
 	ctx := t.Context()
-	kr := NewKubeRouter(k0sVars, v1beta1.PrimaryFamilyIPv6)
+	kr := NewKubeRouter(k0sVars, v1beta1.PrimaryFamilyIPv6, cfg.Spec.Network.BuildServiceCIDR(cfg.Spec.PrimaryAddressFamily()))
 	require.NoError(t, kr.Init(ctx))
 	require.NoError(t, kr.Start(ctx))
 	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })
@@ -238,7 +238,7 @@ func TestRawArgs(t *testing.T) {
 	}
 
 	ctx := t.Context()
-	kr := NewKubeRouter(k0sVars, v1beta1.PrimaryFamilyIPv4)
+	kr := NewKubeRouter(k0sVars, v1beta1.PrimaryFamilyIPv4, cfg.Spec.Network.BuildServiceCIDR(cfg.Spec.PrimaryAddressFamily()))
 	require.NoError(t, kr.Init(ctx))
 	require.NoError(t, kr.Start(ctx))
 	t.Cleanup(func() { assert.NoError(t, kr.Stop()) })


### PR DESCRIPTION
## Description

The service CIDR and the primary address family are part of the node config, and not reconciled via cluster config. Reading them back from cluster config will return their default values, not the ones that have been configured in the node config. Since these fields aren't typically changed from their defaults anyways, this got unnoticed for quite some time.

Revisit all components that rely on these values to ensure they are picking them up from the right places.

Augment the dual-stack integration test so that it uses non-standard CIDRs. Check the kube-router arguments for correctness both in the dual-stack and in the custom CIDR tests. Tweak the test logging and test scenario decision making on the way.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
