### PR TITLE
Adapt new cosign flag for 3.x in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,11 +96,13 @@ jobs:
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob \
             --key=env://COSIGN_KEY --use-signing-config=false \
             --tlog-upload=true --yes \
-            --output-file=k0s.sig k0s
+            --output-file=k0s.sig k0s \
+            --bundle k0s.sig.bundle
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob \
             --key=env://COSIGN_KEY --use-signing-config=false \
             --tlog-upload=true --yes \
-            --output-file=spdx.json.sig spdx.json
+            --output-file=spdx.json.sig spdx.json \
+            --bundle spdx.json.sig.bundle
 
       - name: Set up Go for smoke tests
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -247,7 +249,8 @@ jobs:
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob \
             --key=env://COSIGN_KEY --use-signing-config=false \
             --tlog-upload=true --yes \
-            --output-file=k0s.exe.sig k0s.exe
+            --output-file=k0s.exe.sig k0s.exe \
+            --bundle k0s.exe.sig.bundle
           cat k0s.exe.sig
 
       - name: Upload Release Assets - Binary
@@ -343,7 +346,8 @@ jobs:
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob \
             --key=env://COSIGN_KEY --use-signing-config=false \
             --tlog-upload=true --yes \
-            --output-file=k0s.sig k0s
+            --output-file=k0s.sig k0s \
+            --bundle k0s.sig.bundle
           cat k0s.sig
 
       - name: Set up Go for smoke tests
@@ -458,7 +462,8 @@ jobs:
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob \
             --key=env://COSIGN_KEY --use-signing-config=false \
             --tlog-upload=true --yes \
-            --output-file=k0s.sig k0s
+            --output-file=k0s.sig k0s \
+            --bundle k0s.sig.bundle
           cat k0s.sig
 
       - name: Set up Go for smoke tests


### PR DESCRIPTION
Cosign now needs the bundle output as a cli flag.

Fixes https://github.com/k0sproject/k0s/actions/runs/27361596456

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
