### PR TITLE
Fix release signing with cosign v3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,13 +93,14 @@ jobs:
           chmod +x ./cosign
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign public-key \
             --key=env://COSIGN_KEY --output-file=cosign.pub
+
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob \
             --key=env://COSIGN_KEY --use-signing-config=false \
-            --tlog-upload=true --yes \
+            --new-bundle-format=false --yes \
             --output-file=k0s.sig k0s
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob \
             --key=env://COSIGN_KEY --use-signing-config=false \
-            --tlog-upload=true --yes \
+            --new-bundle-format=false --yes \
             --output-file=spdx.json.sig spdx.json
 
       - name: Set up Go for smoke tests
@@ -246,7 +247,7 @@ jobs:
           chmod +x ./cosign
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob \
             --key=env://COSIGN_KEY --use-signing-config=false \
-            --tlog-upload=true --yes \
+            --new-bundle-format=false --yes \
             --output-file=k0s.exe.sig k0s.exe
           cat k0s.exe.sig
 
@@ -342,7 +343,7 @@ jobs:
           chmod +x ./cosign
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob \
             --key=env://COSIGN_KEY --use-signing-config=false \
-            --tlog-upload=true --yes \
+            --new-bundle-format=false --yes \
             --output-file=k0s.sig k0s
           cat k0s.sig
 
@@ -457,7 +458,7 @@ jobs:
           chmod +x ./cosign
           COSIGN_KEY="$(printf %s "$COSIGN_KEY" | base64 -d)" ./cosign sign-blob \
             --key=env://COSIGN_KEY --use-signing-config=false \
-            --tlog-upload=true --yes \
+            --new-bundle-format=false --yes \
             --output-file=k0s.sig k0s
           cat k0s.sig
 


### PR DESCRIPTION
## Description

Cosign v3.1 enables the new bundle format by default for blob signing. Without an explicit bundle output, the existing release signing commands fail before producing the detached .sig assets.

For now, keep using the old blob signature format. We can add Sigstore bundles in the next minor release and switch to using ECDSA keys to create them.

Fixes:

* #7773

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
