### PR TITLE
fix: change priorityclass default for nllb pod

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -95,8 +95,8 @@ check-network-conformance-kuberouter-ipv6-nft: TIMEOUT=15m
 
 check-nllb: TIMEOUT=15m
 check-nllb-traefik: TIMEOUT=15m
-check-nllb-ipv6: TIMEOUT=15m
-check-nllb-traefik-ipv6: TIMEOUT=15m
+check-nllb-ipv6: TIMEOUT=20m
+check-nllb-traefik-ipv6: TIMEOUT=20m
 
 .PHONY: $(smoketests)
 

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -95,8 +95,8 @@ check-network-conformance-kuberouter-ipv6-nft: TIMEOUT=15m
 
 check-nllb: TIMEOUT=15m
 check-nllb-traefik: TIMEOUT=15m
-check-nllb-ipv6: TIMEOUT=20m
-check-nllb-traefik-ipv6: TIMEOUT=20m
+check-nllb-ipv6: TIMEOUT=15m
+check-nllb-traefik-ipv6: TIMEOUT=15m
 
 .PHONY: $(smoketests)
 

--- a/pkg/component/worker/nllb/envoy.go
+++ b/pkg/component/worker/nllb/envoy.go
@@ -266,8 +266,10 @@ func makePodManifest(params *envoyParams, podParams *envoyPodParams) corev1.Pod 
 			HostNetwork: true,
 			// The Envoy Pod is the worker's load-balanced path to the control
 			// plane, so it must outlive ordinary workloads during graceful node
-			// shutdown and be protected from node-pressure eviction.
-			PriorityClassName: "system-node-critical",
+			// shutdown and be protected from node-pressure eviction. As a static
+			// Pod, the kubelet doesn't resolve PriorityClassName, so the numeric
+			// Priority is set directly to the value of system-node-critical.
+			Priority: ptr.To(int32(2000001000)),
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: ptr.To(true),
 			},

--- a/pkg/component/worker/nllb/envoy.go
+++ b/pkg/component/worker/nllb/envoy.go
@@ -264,6 +264,10 @@ func makePodManifest(params *envoyParams, podParams *envoyPodParams) corev1.Pod 
 		},
 		Spec: corev1.PodSpec{
 			HostNetwork: true,
+			// The Envoy Pod is the worker's load-balanced path to the control
+			// plane, so it must outlive ordinary workloads during graceful node
+			// shutdown and be protected from node-pressure eviction.
+			PriorityClassName: "system-node-critical",
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: ptr.To(true),
 			},

--- a/pkg/component/worker/nllb/envoy.go
+++ b/pkg/component/worker/nllb/envoy.go
@@ -266,10 +266,17 @@ func makePodManifest(params *envoyParams, podParams *envoyPodParams) corev1.Pod 
 			HostNetwork: true,
 			// The Envoy Pod is the worker's load-balanced path to the control
 			// plane, so it must outlive ordinary workloads during graceful node
-			// shutdown and be protected from node-pressure eviction. As a static
-			// Pod, the kubelet doesn't resolve PriorityClassName, so the numeric
-			// Priority is set directly to the value of system-node-critical.
-			Priority: ptr.To(int32(2000001000)),
+			// shutdown and be protected from node-pressure eviction.
+			//
+			// PriorityClassName satisfies the kube-apiserver Priority admission
+			// controller, which validates the mirror Pod the kubelet registers
+			// for this static Pod. The numeric Priority is also set so the local
+			// kubelet (which does not resolve PriorityClassName for static Pods)
+			// uses it for shutdown/eviction ordering. The two must agree:
+			// admission computes the integer from the class name and rejects the
+			// mirror Pod if an explicit, mismatched Priority is provided.
+			PriorityClassName: "system-node-critical",
+			Priority:          ptr.To(int32(2000001000)),
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: ptr.To(true),
 			},

--- a/pkg/component/worker/nllb/traefik.go
+++ b/pkg/component/worker/nllb/traefik.go
@@ -238,10 +238,17 @@ func makeTraefikPodManifest(podParams *traefikPodParams, installConfig *traefikI
 			HostNetwork: true,
 			// The Traefik Pod is the worker's load-balanced path to the control
 			// plane, so it must outlive ordinary workloads during graceful node
-			// shutdown and be protected from node-pressure eviction. As a static
-			// Pod, the kubelet doesn't resolve PriorityClassName, so the numeric
-			// Priority is set directly to the value of system-node-critical.
-			Priority: ptr.To(int32(2000001000)),
+			// shutdown and be protected from node-pressure eviction.
+			//
+			// PriorityClassName satisfies the kube-apiserver Priority admission
+			// controller, which validates the mirror Pod the kubelet registers
+			// for this static Pod. The numeric Priority is also set so the local
+			// kubelet (which does not resolve PriorityClassName for static Pods)
+			// uses it for shutdown/eviction ordering. The two must agree:
+			// admission computes the integer from the class name and rejects the
+			// mirror Pod if an explicit, mismatched Priority is provided.
+			PriorityClassName: "system-node-critical",
+			Priority:          ptr.To(int32(2000001000)),
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: ptr.To(true),
 				// https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/

--- a/pkg/component/worker/nllb/traefik.go
+++ b/pkg/component/worker/nllb/traefik.go
@@ -236,6 +236,12 @@ func makeTraefikPodManifest(podParams *traefikPodParams, installConfig *traefikI
 		},
 		Spec: corev1.PodSpec{
 			HostNetwork: true,
+			// The Traefik Pod is the worker's load-balanced path to the control
+			// plane, so it must outlive ordinary workloads during graceful node
+			// shutdown and be protected from node-pressure eviction. As a static
+			// Pod, the kubelet doesn't resolve PriorityClassName, so the numeric
+			// Priority is set directly to the value of system-node-critical.
+			Priority: ptr.To(int32(2000001000)),
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: ptr.To(true),
 				// https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

The nllb pod has a very low priority class, during a graceful shutdown kubelet removes it first which results in a severed path from the worker to the kas (kube-apiserver) before the other pods can drain or report statuses.

This was a [suggestion](https://github.com/k0sproject/k0s/pull/7783#issuecomment-4684615274) from @jnummelin. I still think we need a way to add graceful shutdown too (7783) but @jnummelin suggests there may be another way. 

Noticed an error in the tests when setting only the numeric `Priority` on the static Pod broke the `check-nllb` jobs. Tthe kubelet runs the static Pod fine locally, but for every static Pod it also creates a read-only "mirror" Pod in the API so the Pod is visible to `kubectl` in  the cluster, and that create call goes through normal admission. When it registers the mirror Pod in the kas, the Priority admission controller rejects an explicit integer priority that doesn't match a `priorityClassName` (`priority admission controller computed 0 from the given PriorityClass name`). So the Pod never became ready and the tests timed out. So that is why i needed to add the `priorityClassName` too 

Fixes #7786 
Relates to #7783

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [n/a] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
