### PR TITLE
Tune OS test timeouts for e2e runs

### DIFF
--- a/.github/workflows/ostests-e2e.yaml
+++ b/.github/workflows/ostests-e2e.yaml
@@ -202,14 +202,17 @@ jobs:
 
       - name: "e2e tests :: Run serial tests"
         working-directory: inttest
-        timeout-minutes: 180 # three hours
+        timeout-minutes: ${{ inputs.e2e-concurrency-level > 1 && 60 || 240 }} # 1 hour in parallel mode, 4 hours in serial mode
+        env:
+          K0S_SONOBUOY_WAIT: "${{ inputs.e2e-concurrency-level > 1 && 45 || 210 }}" # 45 mins in parallel mode, 3.5 hours in serial mode
+          K0S_GINKGO_TIMEOUT: "${{ inputs.e2e-concurrency-level > 1 && '30m' || '3h' }}" # 30 mins in parallel mode, 3 hours in serial mode
         run: |
           make bin/sonobuoy
-          ginkgoArgs="-v --timeout=120m"
+          ginkgoArgs="-v --timeout=$K0S_GINKGO_TIMEOUT"
           if [ "$E2E_FAIL_FAST" = true ]; then
             ginkgoArgs="$ginkgoArgs --fail-fast"
           fi
-          bin/sonobuoy run -p e2e --wait=150 \
+          bin/sonobuoy run -p e2e --wait="$K0S_SONOBUOY_WAIT" \
             --kubernetes-version=v"$KUBERNETES_VERSION" \
             --plugin-env=e2e.E2E_FOCUS="$E2E_FOCUS" \
             --plugin-env=e2e.E2E_SKIP='' \

--- a/.github/workflows/ostests-e2e.yaml
+++ b/.github/workflows/ostests-e2e.yaml
@@ -16,6 +16,10 @@ on:
         type: string
         description: The selector for the e2e tests to be run.
         default: \[Conformance\]
+      fail-fast:
+        type: boolean
+        description: Stop the e2e test suite after the first test failure.
+        default: false
       os:
         type: string
         description: The operating system to test.
@@ -64,6 +68,7 @@ jobs:
 
     env:
       E2E_FOCUS: ${{ inputs.e2e-focus }}
+      E2E_FAIL_FAST: ${{ inputs.fail-fast }}
       TF_VAR_os: ${{ inputs.os }}
       TF_VAR_additional_tags: '{
         "ostests.k0sproject.io/github-run-id"="${{ github.run_id }}",
@@ -168,12 +173,16 @@ jobs:
           E2E_CONCURRENCY_LEVEL: ${{ inputs.e2e-concurrency-level }}
         run: |
           make bin/sonobuoy
+          ginkgoArgs="-v --timeout=120m --procs=$E2E_CONCURRENCY_LEVEL"
+          if [ "$E2E_FAIL_FAST" = true ]; then
+            ginkgoArgs="$ginkgoArgs --fail-fast"
+          fi
           bin/sonobuoy run -p e2e --wait=150 \
             --kubernetes-version=v"$KUBERNETES_VERSION" \
             --plugin-env=e2e.E2E_PARALLEL=true \
             --plugin-env=e2e.E2E_FOCUS="$E2E_FOCUS" \
             --plugin-env=e2e.E2E_SKIP='\[Serial\]' \
-            --plugin-env=e2e.E2E_EXTRA_GINKGO_ARGS="-v --timeout=120m --procs=$E2E_CONCURRENCY_LEVEL"
+            --plugin-env=e2e.E2E_EXTRA_GINKGO_ARGS="$ginkgoArgs"
 
       - name: "e2e tests :: Retrieve parallel results"
         id: e2e-retrieve-parallel
@@ -196,11 +205,15 @@ jobs:
         timeout-minutes: 180 # three hours
         run: |
           make bin/sonobuoy
+          ginkgoArgs="-v --timeout=120m"
+          if [ "$E2E_FAIL_FAST" = true ]; then
+            ginkgoArgs="$ginkgoArgs --fail-fast"
+          fi
           bin/sonobuoy run -p e2e --wait=150 \
             --kubernetes-version=v"$KUBERNETES_VERSION" \
             --plugin-env=e2e.E2E_FOCUS="$E2E_FOCUS" \
             --plugin-env=e2e.E2E_SKIP='' \
-            --plugin-env=e2e.E2E_EXTRA_GINKGO_ARGS='-v --timeout=120m'
+            --plugin-env=e2e.E2E_EXTRA_GINKGO_ARGS="$ginkgoArgs"
 
       - name: "e2e tests :: Retrieve serial results"
         id: e2e-retrieve-serial

--- a/.github/workflows/ostests-e2e.yaml
+++ b/.github/workflows/ostests-e2e.yaml
@@ -247,11 +247,18 @@ jobs:
         run: |
           fail=0
           for f in sonobuoy-e2e-*.tar.gz; do
-            echo "::group::$f"
-            bin/sonobuoy results "$f"
-            numNotPassedOrSkipped=$(bin/sonobuoy results "$f" -p=e2e --mode=detailed | jq --slurp '[.[] | select(.status != "passed" and .status != "skipped")] | length')
-            echo "Number of tests that didn't pass and weren't skipped: $numNotPassedOrSkipped"
-            echo ::endgroup::
+            {
+              echo "### $f"
+              numNotPassedOrSkipped=$(bin/sonobuoy results "$f" -p=e2e --mode=detailed | jq --slurp '[.[] | select(.status != "passed" and .status != "skipped")] | length')
+              echo '<details>'
+              echo '<summary>'
+              echo "Number of tests that didn't pass and weren't skipped: $numNotPassedOrSkipped"
+              echo '</summary>'
+              echo
+              echo '```text'
+              bin/sonobuoy results "$f"
+              echo '```'
+            } >>"$GITHUB_STEP_SUMMARY"
             [ "$numNotPassedOrSkipped" = 0 ] || fail=1
           done
           [ "$fail" = 0 ] || exit 1

--- a/.github/workflows/ostests-matrix.yaml
+++ b/.github/workflows/ostests-matrix.yaml
@@ -20,6 +20,10 @@ on:
         type: string
         description: The selector for the e2e tests to be run.
         default: \[Conformance\]
+      fail-fast:
+        type: boolean
+        description: Stop each e2e test suite after the first test failure.
+        default: false
       oses:
         type: string
         description: The operating systems to test.
@@ -89,6 +93,7 @@ jobs:
       k0sctl-version: ${{ inputs.k0sctl-version }}
       e2e-concurrency-level: ${{ fromJSON(inputs.e2e-concurrency-level) }} # infamous GH workflows bug that looses type information (actions/runner#2206)
       e2e-focus: ${{ inputs.e2e-focus }}
+      fail-fast: ${{ inputs.fail-fast }}
       os: ${{ matrix.os }}
       arch: ${{ inputs.arch }}
       network-provider: ${{ matrix.network-provider }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -656,6 +656,7 @@ jobs:
       os: debian_12
       arch: ${{ matrix.arch }}
       network-provider: kuberouter
+      fail-fast: true
     secrets:
       aws-access-key-id: ${{ secrets.AWS_TERRAFORM_ID }}
       aws-secret-access-key: ${{ secrets.AWS_TERRAFORM_KEY }}

--- a/hack/ostests/README.md
+++ b/hack/ostests/README.md
@@ -195,6 +195,9 @@ $ gh workflow run ostests-matrix.yaml --ref some/experimental/branch \
 To see runs for this workflow, try: gh run list --workflow=ostests-matrix.yaml
 ```
 
+Add `-f fail-fast=true` to the above command line to stop the e2e test suite
+after the first test failure has been recorded.
+
 [gh]: https://github.com/cli/cli
 
 ## TODO


### PR DESCRIPTION
## Description

This mostly applies to full conformance test runs that are called from the release workflow. In order to obtain the "Certified Kubernetes" badge, these cannot be run in parallel. They currently take around two hours to complete, close to the Ginkgo test timeout. Funnily enough, the 64-bit ARM VMs are slightly faster than the 64-bit x86_64 VMs, resulting in mostly successful arm64 runs and very unreliable amd64 runs. Moreover, Ginkgo/sonobuoy simply report any overall test timeouts as failures of the pending tests, with no indication that the tests did not even complete. This makes it very difficult to realize that this is a timeout issue rather than a flaky test.

For an all-serial workflow step, use the following timeouts:

* three hours for Ginkgo,
* three and a half hours for Sonobuoy
* and four hours for the workflow step.

When the serial step follows a parallel step, use tighter timeouts because only the remaining serial tests should run:

* thirty minutes for Ginkgo,
* forty-five minutes for Sonobuoy,
* and one hur for the workflow step.

See:

* #6030

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
