### PR TITLE
Modernize inttest HAProxy config

### DIFF
--- a/inttest/common/bootloosesuite.go
+++ b/inttest/common/bootloosesuite.go
@@ -563,7 +563,7 @@ func (s *BootlooseSuite) startHAProxy() {
 
 	s.Require().NoError(err)
 	_, err = ssh.ExecWithOutput(s.Context(), "haproxy -c -f /tmp/haproxy.cfg")
-	s.Require().NoError(err, "LB configuration is broken", err)
+	s.Require().NoError(err, "LB configuration is broken")
 	_, err = ssh.ExecWithOutput(s.Context(), "haproxy -D -f /tmp/haproxy.cfg")
 	s.Require().NoError(err, "Can't start LB")
 }
@@ -577,23 +577,17 @@ defaults
     timeout client 30s
     timeout server 30s
 
-frontend kubeapi
-
+frontend kubeapi_frontend
     bind :{{ .KubeAPIExternalPort }}
     default_backend kubeapi
 
-frontend k0sapi
+frontend k0sapi_frontend
     bind :{{ .K0sAPIExternalPort }}
     default_backend k0sapi
 
-frontend konnectivityAdmin
-    bind :{{ .KonnectivityAdminPort }}
-    default_backend admin
-
-
-frontend konnectivityAgent
+frontend konnectivity_server_frontend
     bind :{{ .KonnectivityAgentPort }}
-    default_backend agent
+    default_backend konnectivity_server
 
 
 {{ $OUT := .}}
@@ -608,12 +602,7 @@ backend k0sapi
 	server {{ $addr }} {{ $addr }}:{{ $OUT.K0sAPIExternalPort }}
 {{ end }}
 
-backend admin
-{{ range $addr := .IPAddresses }}
-	server {{ $addr }} {{ $addr }}:{{ $OUT.KonnectivityAdminPort }}
-{{ end }}
-
-backend agent
+backend konnectivity_server
 {{ range $addr := .IPAddresses }}
 	server {{ $addr }} {{ $addr }}:{{ $OUT.KonnectivityAgentPort }}
 {{ end }}


### PR DESCRIPTION
## Description

In newer HAProxy versions, it's no longer allowed to share names between frontends and backends. Also remove the superfluous config for the admin port and fix the testify assertion to detect broken LB configs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
