### PR TITLE
Revert "Have a constant to indicate Kubernetes pre-releases"

### DIFF
--- a/inttest/kubectl/kubectl_test.go
+++ b/inttest/kubectl/kubectl_test.go
@@ -198,12 +198,8 @@ func checkClientVersion(t *testing.T, v map[string]any) {
 }
 
 func checkServerVersion(t *testing.T, v map[string]any) {
-	expectedVersion := constant.KubernetesMajorMinorVersion
-	if constant.KubernetesPreRelease {
-		expectedVersion += "+"
-	}
 	assert.Equal(t,
-		expectedVersion,
+		constant.KubernetesMajorMinorVersion,
 		fmt.Sprintf("%v.%v", requiredValue[string](t, v, "major"), requiredValue[string](t, v, "minor")),
 	)
 	assert.Contains(t,

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -64,8 +64,6 @@ const (
 
 	// KubernetesMajorMinorVersion defines the current embedded major.minor version info
 	KubernetesMajorMinorVersion = "1.36"
-	// Indicates if k0s is using a Kubernetes pre-release or a GA version.
-	KubernetesPreRelease = false
 
 	/* Image Constants */
 


### PR DESCRIPTION
## Description

This reverts PR #4229. As of Kubernetes 1.33, this is no longer necessary. The plus suffix is no longer appended. Not sure if this was entirely intentional, but it was a side effect of the implementation of [KEP-4330](https://www.kubernetes.dev/resources/keps/4330/).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
