### PR TITLE
Add a warning box about the cgroupv1 escape hatch

### DIFF
--- a/docs/external-runtime-deps.md
+++ b/docs/external-runtime-deps.md
@@ -100,20 +100,32 @@ and, if enabled as a module, to load the `configs` module: `modprobe configs`.
 
 ### Control Groups (cgroups)
 
-[cgroup v2] is required. k0s rejects [cgroup v1] during pre-flight checks.
+[cgroup v2] is required by default, k0s will fail its pre-flight checks if it's
+unavailable on the node.
 
-Starting with Kubernetes 1.31 already, [cgroup v1] is in [maintenance mode] and starting in Kubernetes 1.35 by default kubelet will fail to start if
-[cgroup v1] is detected on the system. If you want to run Kubernetes with [cgroup v1], you need to bypass k0s pre-flight checks and explicitly enable it by
-setting `failCgroupV1: false` in kubelet configuration, via k0s [worker profile](worker-node-config.md#kubelet-configuration):
+As of Kubernetes 1.31, [cgroup v1] is in [maintenance mode] ([KEP-4569]). As of
+Kubernetes 1.35, the kubelet will fail to start by default if cgroup v2 is not
+detected on the node. In order to run Kubernetes with cgroup v1, bypass the k0s
+pre-flight checks via `--ignore-pre-flight-checks` and set `failCgroupV1: false`
+in the kubelet configuration via the k0s [worker profiles]:
 
 ```yaml
 ...
 spec:
   workerProfiles:
-    - name: default # Applies to the default profile which all workers pick up if no profile is specified in the worker startup
+    # By default, workers will pick up the default profile.
+    - name: default
       values:
         failCgroupV1: false
 ```
+
+!!! warning "Migrate to cgroup v2 now!"
+    The above escape hatch will not be available indefinitely, so plan
+    accordingly. [KEP-5573] states:
+    <!-- markdownlint-disable-next-line MD046 -->
+    > We will commit to removing cgroup v1 code but there is not yet a timeline for
+    > removal. The removal will be done no earlier than 1.38 to maintain the k8s
+    > deprecation policy.
 
 Required [cgroup] controllers:
 
@@ -138,6 +150,9 @@ Optional cgroup controllers:
 [kubernetes/kubeadm#2335 (comment)]: https://github.com/kubernetes/kubeadm/issues/2335#issuecomment-722405527
 [kubernetes/kubernetes#92287 (comment)]: https://github.com/kubernetes/kubernetes/issues/92287#issuecomment-1010723587
 [maintenance mode]: https://kubernetes.io/blog/2024/08/14/kubernetes-1-31-moving-cgroup-v1-support-maintenance-mode/
+[KEP-4569]: https://www.kubernetes.dev/resources/keps/4569/
+[KEP-5573]: https://www.kubernetes.dev/resources/keps/5573/
+[worker profiles]: worker-node-config.md#kubelet-configuration
 
 ### No integration with Name Service Switch (NSS) APIs
 


### PR DESCRIPTION
## Description

KEP-5573 states that cgroup v1 support will be removed eventually. Make that clear in the docs by adding a warning box with the respective quote. Also reword the paragraph above a little bit and hard-wrap it.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
