### PR TITLE
Replace removed flag in extraargs inttest

### DIFF
--- a/inttest/extraargs/extraargs_test.go
+++ b/inttest/extraargs/extraargs_test.go
@@ -41,7 +41,7 @@ func (s *ExtraArgsSuite) TestK0sGetsUp() {
 
 	s.checkFlag(sshCtrl, "/var/lib/k0s/bin/kube-apiserver", "--disable-admission-plugins=PodSecurity")
 	s.checkFlag(sshCtrl, "/var/lib/k0s/bin/kube-controller-manager", "--terminated-pod-gc-threshold=1000")
-	s.checkFlag(sshCtrl, "/var/lib/k0s/bin/kube-controller-manager", "--concurrent-service-syncs=5")
+	s.checkFlag(sshCtrl, "/var/lib/k0s/bin/kube-controller-manager", "--concurrent-deployment-syncs=1")
 	s.checkFlag(sshCtrl, "/var/lib/k0s/bin/kube-scheduler", "--v=4")
 	s.checkFlag(sshCtrl, "/var/lib/k0s/bin/kube-scheduler", "--bind-address=0.0.0.0")
 	s.checkFlag(sshCtrl, "/var/lib/k0s/bin/etcd", "--log-level=warn")
@@ -104,7 +104,7 @@ spec:
     extraArgs:
       terminated-pod-gc-threshold: "1000"
     rawArgs:
-    - --concurrent-service-syncs=5
+    - --concurrent-deployment-syncs=1
   scheduler:
     extraArgs:
       v: "4"


### PR DESCRIPTION
## Description

It was a no-op for quite some time, and, as of Kubernetes 1.37, will make kube-controller-manager fail to start.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
