### PR TITLE
Don't continue on errors in extraargs inttest

### DIFF
--- a/inttest/extraargs/extraargs_test.go
+++ b/inttest/extraargs/extraargs_test.go
@@ -5,7 +5,7 @@ package extraargs
 
 import (
 	"fmt"
-	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/k0sproject/k0s/inttest/common"
@@ -23,21 +23,21 @@ func (s *ExtraArgsSuite) TestK0sGetsUp() {
 	ctx := s.Context()
 
 	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfig)
-	s.NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
+	s.Require().NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
 
-	s.NoError(s.RunWorkers())
+	s.Require().NoError(s.RunWorkers())
 
 	kc, err := s.KubeClient(s.ControllerNode(0))
 	s.Require().NoError(err)
 
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.AssertSomeKubeSystemPods(kc)
 
 	sshCtrl, err := s.SSH(ctx, s.ControllerNode(0))
+	s.Require().NoError(err)
 	defer sshCtrl.Disconnect()
-	s.NoError(err)
 
 	s.checkFlag(sshCtrl, "/var/lib/k0s/bin/kube-apiserver", "--disable-admission-plugins=PodSecurity")
 	s.checkFlag(sshCtrl, "/var/lib/k0s/bin/kube-controller-manager", "--terminated-pod-gc-threshold=1000")
@@ -48,34 +48,40 @@ func (s *ExtraArgsSuite) TestK0sGetsUp() {
 	s.checkFlagCount(sshCtrl, "/var/lib/k0s/bin/etcd", "--logger=zap", 3)
 
 	sshWorker, err := s.SSH(ctx, s.WorkerNode(0))
+	s.Require().NoError(err)
 	defer sshWorker.Disconnect()
-	s.NoError(err)
 
 	s.T().Log("waiting to see kube-proxy pods ready")
-	s.NoError(common.WaitForDaemonSet(ctx, kc, "kube-proxy", metav1.NamespaceSystem), "kube-proxy did not start")
+	s.Require().NoError(common.WaitForDaemonSet(ctx, kc, "kube-proxy", metav1.NamespaceSystem), "kube-proxy did not start")
 	s.checkFlag(sshWorker, "/usr/local/bin/kube-proxy", "--config-sync-period=12m0s")
 	s.checkFlag(sshWorker, "/usr/local/bin/kube-proxy", "-v=2")
 
 	s.T().Log("waiting to see kube-router pods ready")
-	s.NoError(common.WaitForKubeRouterReady(ctx, kc), "kube-router did not start")
+	s.Require().NoError(common.WaitForKubeRouterReady(ctx, kc), "kube-router did not start")
 	s.checkFlag(sshWorker, "kube-router", "--enable-cni=true")
 	s.checkFlag(sshWorker, "kube-router", "-v=0")
 }
 
-func (s *ExtraArgsSuite) checkFlagCount(ssh *common.SSHConnection, processName string, flag string, expectedCount int) {
+func (s *ExtraArgsSuite) checkFlagCount(ssh *common.SSHConnection, processName string, flag string, expectedCount uint) {
 	s.T().Logf("Checking flag %s in process %s", flag, processName)
-	pid, err := ssh.ExecWithOutput(s.Context(), "/usr/bin/pgrep "+processName)
-	s.NoError(err)
-
-	flagCount, err := ssh.ExecWithOutput(s.Context(), fmt.Sprintf("/bin/grep -c -- %s /proc/%s/cmdline", flag, pid))
-	// If there are no flags, grep returns 1, so we need to ignore this error. Checking the output should beenough.
-	if expectedCount > 0 {
-		s.NoError(err)
-	}
-	if flagCount != strconv.Itoa(expectedCount) {
-		s.T().Fatalf("%s flag %s found %s, expected %d", processName, flag, flagCount, expectedCount)
+	cmdline, err := ssh.ExecWithOutput(s.Context(), fmt.Sprintf(`cat /proc/$(pidof -s -- '%s')/cmdline`, processName))
+	if !s.NoError(err) {
+		return
 	}
 
+	cmdline, hadTrailingNUL := strings.CutSuffix(cmdline, "\x00")
+	if !s.True(hadTrailingNUL, "No trailing NUL byte") {
+		return
+	}
+
+	var matches uint
+	for arg := range strings.SplitSeq(cmdline, "\x00") {
+		if strings.Contains(arg, flag) {
+			matches++
+		}
+	}
+
+	s.Equalf(expectedCount, matches, "%s's cmdline doesn't have the right amount of %s", processName, flag)
 }
 
 func (s *ExtraArgsSuite) checkFlag(ssh *common.SSHConnection, processName string, flag string) {


### PR DESCRIPTION
## Description

Otherwise, the tests may panic later on. Also clean up the flag counting a bit.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
