### PR TITLE
fix: avoid recursive API error writes

### DIFF
--- a/cmd/api/util.go
+++ b/cmd/api/util.go
@@ -18,7 +18,7 @@ func sendError(err error, resp http.ResponseWriter, status ...int) {
 	resp.Header().Set("Content-Type", "text/plain")
 	resp.WriteHeader(code)
 	if _, err := resp.Write([]byte(err.Error())); err != nil {
-		sendError(err, resp)
+		logrus.WithError(err).Error("failed to write error response")
 		return
 	}
 }

--- a/cmd/api/util_test.go
+++ b/cmd/api/util_test.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type failingResponseWriter struct {
+	header     http.Header
+	statusCode int
+	writeCalls int
+}
+
+func (w *failingResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *failingResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+}
+
+func (w *failingResponseWriter) Write(_ []byte) (int, error) {
+	w.writeCalls++
+	return 0, errors.New("write failed")
+}
+
+func TestSendErrorDoesNotRetryWriteFailure(t *testing.T) {
+	resp := &failingResponseWriter{}
+
+	sendError(errors.New("boom"), resp, http.StatusBadRequest)
+
+	assert.Equal(t, "text/plain", resp.Header().Get("Content-Type"))
+	assert.Equal(t, http.StatusBadRequest, resp.statusCode)
+	assert.Equal(t, 1, resp.writeCalls, "sendError should not recurse on write failure")
+}
+
+func TestSendErrorWritesStatusAndBody(t *testing.T) {
+	resp := httptest.NewRecorder()
+
+	sendError(errors.New("boom"), resp, http.StatusBadRequest)
+
+	assert.Equal(t, "text/plain", resp.Header().Get("Content-Type"))
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Equal(t, "boom", resp.Body.String())
+}


### PR DESCRIPTION
## Description

`sendError` called itself again if `ResponseWriter.Write` failed.
A client disconnect can hit that path for real. I reproduced it with a tiny HTTP server: send a request, read the status line, close the socket early, then the server write fails with `connection reset by peer`.

This patch keeps the same status and body on the normal path, but on write failure it just logs and stops. no more looping on the same broken writer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

`go test ./cmd/api`
`go test $(go list ./... | grep -v '/inttest/')`

Repro:
1. Start a handler that sleeps, then writes a response body.
2. Send a request and close the client connection before the write completes.
3. The server write fails.
4. Before this patch, `sendError` called itself again on that same writer.
5. With this patch, it logs the write failure and bails out. pretty much it.

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
