### PR TITLE
Fix cluster SANs generation with proper cluster domain

### DIFF
--- a/cmd/controller/certificates.go
+++ b/cmd/controller/certificates.go
@@ -232,8 +232,8 @@ func (c *Certificates) generateSANList(ctx context.Context) ([]string, error) {
 		"kubernetes",
 		"kubernetes.default",
 		"kubernetes.default.svc",
-		"kubernetes.default.svc.cluster",
-		"kubernetes.svc." + c.ClusterSpec.Network.ClusterDomain,
+		"kubernetes.default.svc." + c.ClusterSpec.Network.ClusterDomain,
+		"kubernetes.default.svc." + c.ClusterSpec.Network.ClusterDomain + ".",
 		"localhost",
 		"127.0.0.1",
 	}


### PR DESCRIPTION
## Description

Fix SANs creation by using cluster domain properly. Also add a SAN with a trailing dot.

Fixes #7803


## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
