### PR TITLE
Only remove PID file if process actually terminated

### DIFF
--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -57,10 +57,13 @@ const k0sManaged = "_K0S_MANAGED=yes"
 func (s *Supervisor) processWaitQuit(ctx context.Context, cmd *exec.Cmd) bool {
 	waitresult := make(chan error, 1)
 	go func() {
-		waitresult <- cmd.Wait()
+		defer close(waitresult)
+		err := cmd.Wait()
+		defer func() { waitresult <- err }()
+		if err := os.Remove(s.PidFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+			s.log.WithError(err).Error("Failed to remove PID file")
+		}
 	}()
-
-	defer os.Remove(s.PidFile)
 
 	select {
 	case <-ctx.Done():
@@ -77,10 +80,12 @@ func (s *Supervisor) processWaitQuit(ctx context.Context, cmd *exec.Cmd) bool {
 		}
 		return true
 
-	case err := <-waitresult:
+	case err, ok := <-waitresult:
 		var exitErr *exec.ExitError
 		state := cmd.ProcessState
 		switch {
+		case !ok:
+			s.log.Error("Failed to wait for process: ", state)
 		case errors.As(err, &exitErr):
 			state = exitErr.ProcessState
 			fallthrough

--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -461,6 +461,51 @@ func TestCleanupPIDFile_BogusPIDFile(t *testing.T) {
 	assert.ErrorContains(t, s.Supervise(t.Context()), `"rubbish": invalid`)
 }
 
+func TestStop_PIDFileRemainsOnTerminationTimeout(t *testing.T) {
+	switch runtime.GOOS {
+	case "darwin":
+		t.Skip("PID file cleanup not implemented on macOS")
+	}
+
+	// Prepare a process that won't terminate gracefully.
+	pingPong := pingpong.New(t)
+	pingPong.IgnoreGracefulTerminationRequests = true
+
+	// Start to supervise the process.
+	runDir := t.TempDir()
+	s := Supervisor{
+		Name:           t.Name(),
+		BinPath:        pingPong.BinPath(),
+		RunDir:         runDir,
+		Args:           pingPong.BinArgs(),
+		TimeoutStop:    10 * time.Millisecond,
+		TimeoutRespawn: 1 * time.Hour,
+	}
+
+	// Await process startup.
+	require.NoError(t, s.Supervise(t.Context()))
+	require.NoError(t, pingPong.AwaitPing())
+
+	// Expect the previous process to still be alive at the end of the test.
+	t.Cleanup(func() {
+		assert.NoError(t, pingPong.SendPong())
+	})
+
+	// Ensure the PID file is present on disk.
+	pidFilePath := filepath.Join(s.RunDir, s.Name+".pid")
+	pidStat, err := os.Stat(pidFilePath)
+	require.NoError(t, err)
+	require.True(t, pidStat.Mode().IsRegular())
+
+	// Stop the supervisor. The process should survive that.
+	assert.NoError(t, s.Stop())
+
+	// PID file should be unchanged.
+	if newPidStat, err := os.Stat(pidFilePath); assert.NoError(t, err, "While ensuring the existence of the PID file") {
+		assert.Equal(t, pidStat, newPidStat)
+	}
+}
+
 type cmd struct {
 	binPath string
 	binArgs []string


### PR DESCRIPTION
## Description

The supervisor removed the PID file unconditionally whenever the processWaitQuit method returned. After removing the kill path from the supervisor, supervised processes could remain alive after returning, making all the PID file cleanup logic during supervisor startup mostly futile.

Move the file removal into the goroutine that reaps the process. That's supposedly the best place for it.

Fixes: 

* #6312

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
