### PR TITLE
Reconcile etcd endpoint's peer URL for single-member clusters

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -53,6 +53,17 @@ k0s restore /tmp/k0s_backup_2021-04-26T19_51_57_000Z.tar.gz
 The command would fail if the data directory for the current controller has overlapping data with the backup archive content.
 
 The command would use the archived `k0s.yaml` as the cluster configuration description.
+It is written to the current working directory as `k0s_<archive timestamp>.yaml`
+(use `--config-out` to change this).
+
+If the backup is restored onto a node with a different IP address than the one
+it was taken on, and the archived configuration pins the etcd peer address via
+`spec.storage.etcd.peerAddress`, adjust it before starting the controller:
+either set it to the new node's address or remove it to have it detected
+automatically. Then start the controller with `--config` pointing at the
+adjusted file. k0s will update the peer URL of the restored etcd member
+accordingly on startup. This only works as long as the restored controller is
+the sole etcd member, i.e. before any additional controllers are joined.
 
 In case if your cluster is HA, after restoring single controller node, join the rest of the controller nodes to the cluster.
 E.g. steps for N nodes cluster would be:

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -84,6 +84,7 @@ smoketests := \
 	check-patches \
 	check-psp \
 	check-reset \
+	check-restore-ipchange \
 	check-singlenode \
 	check-stackapplier \
 	check-statussocket \

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -85,6 +85,7 @@ smoketests := \
 	check-privileged-port \
 	check-psp \
 	check-reset \
+	check-restore-ipchange \
 	check-singlenode \
 	check-stackapplier \
 	check-statussocket \

--- a/inttest/common/bootloosesuite.go
+++ b/inttest/common/bootloosesuite.go
@@ -676,8 +676,11 @@ func (s *BootlooseSuite) InitController(idx int, k0sArgs ...string) error {
 func (s *BootlooseSuite) GetJoinToken(role string, extraArgs ...string) (string, error) {
 	// assume we have main on node 0 always
 	controllerNode := s.ControllerNode(0)
-	s.Contains([]string{"controller", "worker"}, role, "Bad role")
-	ssh, err := s.SSH(s.Context(), controllerNode)
+	return s.JoinToken(s.Context(), controllerNode, role, extraArgs...)
+}
+
+func (s *BootlooseSuite) JoinToken(ctx context.Context, nodeName, role string, extraArgs ...string) (string, error) {
+	ssh, err := s.SSH(ctx, nodeName)
 	if err != nil {
 		return "", err
 	}
@@ -685,7 +688,7 @@ func (s *BootlooseSuite) GetJoinToken(role string, extraArgs ...string) (string,
 
 	tokenCmd := fmt.Sprintf("%s token create --role=%s %s", s.K0sFullPath, role, strings.Join(extraArgs, " "))
 	var tokenBuf bytes.Buffer
-	if err := ssh.Exec(s.Context(), tokenCmd, SSHStreams{Out: &tokenBuf}); err != nil {
+	if err := ssh.Exec(ctx, tokenCmd, SSHStreams{Out: &tokenBuf}); err != nil {
 		return "", fmt.Errorf("can't get join token: %w", err)
 	}
 

--- a/inttest/restore-ipchange/restore_test.go
+++ b/inttest/restore-ipchange/restore_test.go
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package basic
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	testifysuite "github.com/stretchr/testify/suite"
+)
+
+type suite struct {
+	common.BootlooseSuite
+}
+
+func (s *suite) TestRestoreIPChange() {
+	ctx := s.TContext()
+
+	{ // Pin the etcd peer address on all nodes.
+		for i := range s.ControllerCount {
+			config, err := yaml.Marshal(&k0sv1beta1.ClusterConfig{
+				Spec: &k0sv1beta1.ClusterSpec{
+					Storage: &k0sv1beta1.StorageSpec{
+						Etcd: &k0sv1beta1.EtcdConfig{
+							PeerAddress: s.GetIPAddress(s.ControllerNode(i)),
+						},
+					},
+					Network: &k0sv1beta1.Network{
+						NodeLocalLoadBalancing: &k0sv1beta1.NodeLocalLoadBalancing{
+							Enabled: true,
+						},
+					},
+				},
+			})
+			s.Require().NoError(err)
+			s.WriteFileContent(s.ControllerNode(i), "/tmp/k0s.yaml", config)
+		}
+	}
+
+	s.T().Log("Start first controller and wait for the cluster to become ready")
+	s.Require().NoError(s.InitController(0, "--config=/tmp/k0s.yaml", "--enable-worker"))
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.Require().NoError(s.WaitForNodeReady(s.ControllerNode(0), kc))
+	s.Require().NoError(common.WaitForKubeRouterReady(ctx, kc), "kube-router did not start")
+	s.Require().NoError(common.WaitForDaemonSet(ctx, kc, "konnectivity-agent", metav1.NamespaceSystem))
+
+	s.T().Log("Make a snapshot, take a backup and wipe the first controller")
+	snapshot, err := makeSnapshot(ctx, kc)
+	s.Require().NoError(err)
+	backup, err := s.takeBackup(ctx, s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.Require().NoError(s.StopController(s.ControllerNode(0)))
+	s.reset(ctx, s.ControllerNode(0))
+
+	s.T().Log("Restore the backup on the second controller and launch it")
+	s.Require().NoError(s.restoreBackup(ctx, s.ControllerNode(1), backup))
+	s.Require().NoError(s.InitController(1, "--config=/tmp/k0s.yaml", "--enable-worker"))
+
+	s.T().Log("Get a join token from the second controller")
+	kc, err = s.KubeClient(s.ControllerNode(1))
+	s.Require().NoError(err)
+
+	s.T().Log("Join the other controllers in the usual way")
+	token, err := s.JoinToken(ctx, s.ControllerNode(1), "controller")
+	s.Require().NoError(err)
+
+	s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(1)))
+	for _, i := range [...]int{2, 0} {
+		s.Require().NoError(s.InitController(i, "--enable-worker", token))
+	}
+	for i := range s.ControllerCount {
+		s.Require().NoError(s.WaitForNodeReady(s.ControllerNode(i), kc))
+	}
+
+	s.T().Log("Wait until the cluster becomes ready")
+	s.Require().NoError(common.WaitForKubeRouterReady(ctx, kc), "kube-router did not start")
+	s.Require().NoError(common.WaitForDaemonSet(ctx, kc, "konnectivity-agent", metav1.NamespaceSystem))
+
+	s.T().Log("Take another snapshot and compare it")
+	snapshotAfterBackup, err := makeSnapshot(ctx, kc)
+	s.Require().NoError(err)
+	// Retain only the initial node
+	for uid, name := range snapshotAfterBackup.nodes {
+		if name != s.ControllerNode(0) {
+			delete(snapshotAfterBackup.nodes, uid)
+		}
+	}
+	s.Require().Equal(snapshot, snapshotAfterBackup)
+}
+
+func (s *suite) takeBackup(ctx context.Context, nodeName string) (_ []byte, err error) {
+	ssh, err := s.SSH(ctx, nodeName)
+	if err != nil {
+		return nil, err
+	}
+	defer ssh.Disconnect()
+
+	var buf bytes.Buffer
+	if err := ssh.Exec(ctx, "/usr/local/bin/k0s backup --debug --save-path -", common.SSHStreams{
+		Out: &buf,
+	}); err != nil {
+		return nil, err
+	}
+	data := buf.Bytes()
+
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("bad backup: %w", err)
+	}
+	defer func() { err = errors.Join(err, gz.Close()) }()
+	r := tar.NewReader(gz)
+
+	for {
+		if _, err := r.Next(); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("bad backup: %w", err)
+		}
+		if _, err := io.Copy(io.Discard, r); err != nil {
+			return nil, fmt.Errorf("bad backup: %w", err)
+		}
+	}
+
+	return data, nil
+}
+
+func (s *suite) restoreBackup(ctx context.Context, nodeName string, backup []byte) error {
+	ssh, err := s.SSH(ctx, nodeName)
+	if err != nil {
+		return err
+	}
+	defer ssh.Disconnect()
+
+	if err = ssh.Exec(ctx, "k0s restore --debug -", common.SSHStreams{
+		In: bytes.NewReader(backup),
+	}); err != nil {
+		return fmt.Errorf("restore failed: %w", err)
+	}
+
+	return nil
+}
+
+func (s *suite) reset(ctx context.Context, name string) {
+	ssh, err := s.SSH(ctx, name)
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+	s.Require().NoError(ssh.Exec(ctx, "k0s reset --debug", common.SSHStreams{}))
+}
+
+type snapshot struct {
+	namespaces map[types.UID]string
+	services   map[types.UID]string
+	nodes      map[types.UID]string
+}
+
+func makeSnapshot(ctx context.Context, kc *kubernetes.Clientset) (s snapshot, err error) {
+	// Take some UIDs to be able to verify state has restored properly
+	if namespaces, err := kc.CoreV1().Namespaces().List(ctx, metav1.ListOptions{}); err != nil {
+		return s, err
+	} else {
+		s.namespaces = make(map[types.UID]string, len(namespaces.Items))
+		for _, n := range namespaces.Items {
+			s.namespaces[n.UID] = n.Name
+		}
+	}
+
+	if services, err := kc.CoreV1().Services(metav1.NamespaceDefault).List(ctx, metav1.ListOptions{}); err != nil {
+		return s, err
+	} else {
+		s.services = make(map[types.UID]string, len(services.Items))
+		for _, svc := range services.Items {
+			s.services[svc.UID] = svc.Name
+		}
+	}
+
+	if nodes, err := kc.CoreV1().Nodes().List(ctx, metav1.ListOptions{}); err != nil {
+		return s, err
+	} else {
+		s.nodes = make(map[types.UID]string)
+		for _, n := range nodes.Items {
+			s.nodes[n.UID] = n.Name
+		}
+	}
+
+	return s, nil
+}
+
+func TestRestoreSuite(t *testing.T) {
+	s := suite{
+		BootlooseSuite: common.BootlooseSuite{
+			ControllerCount: 3,
+			WorkerCount:     0,
+		},
+	}
+
+	testifysuite.Run(t, &s)
+}

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -145,7 +145,7 @@ func (e *Etcd) syncEtcdConfig(ctx context.Context, etcdRequest v1beta1.EtcdReque
 }
 
 // Run runs etcd if external cluster is not configured
-func (e *Etcd) Start(ctx context.Context) error {
+func (e *Etcd) Start(ctx context.Context) (err error) {
 	etcdCaCert := filepath.Join(e.K0sVars.EtcdCertDir, "ca.crt")
 	etcdCaCertKey := filepath.Join(e.K0sVars.EtcdCertDir, "ca.key")
 	etcdServerCert := filepath.Join(e.K0sVars.EtcdCertDir, "server.crt")
@@ -243,7 +243,77 @@ func (e *Etcd) Start(ctx context.Context) error {
 		KeepEnvPrefix: true,
 	}
 
-	return e.supervisor.Supervise(ctx)
+	if err := e.supervisor.Supervise(ctx); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, e.supervisor.Stop())
+		}
+	}()
+
+	for {
+		select {
+		case <-time.After(1 * time.Second):
+		case <-ctx.Done():
+			return fmt.Errorf("while checking peer URL: %w", context.Cause(ctx))
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		err := e.fixupPeerURL(ctx)
+		cancel()
+		if err == nil {
+			return nil
+		}
+
+		logrus.WithError(err).Debug("Failed to check peer URL")
+	}
+}
+
+func (e *Etcd) fixupPeerURL(ctx context.Context) (err error) {
+	c, err := etcd.NewClient(e.K0sVars.CertRootDir, e.K0sVars.EtcdCertDir, e.Config)
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, c.Close()) }()
+
+	status, err := c.Status(ctx)
+	if err != nil {
+		return err
+	}
+
+	memberList, err := c.ListMembers(ctx)
+	if err != nil {
+		return err
+	}
+
+	var clusterPeerURL string
+	for _, member := range memberList {
+		if member.ID == status.ID {
+			clusterPeerURL = member.PeerURL
+			break
+		}
+	}
+	if clusterPeerURL == "" {
+		return fmt.Errorf("local endpoint %x not in member list", status.ID)
+	}
+
+	peerURL := e.Config.GetPeerURL()
+	if clusterPeerURL == peerURL {
+		return nil
+	}
+
+	if len(memberList) != 1 {
+		logrus.Warnf("Unexpected peer URL for local etcd endpoint %x: %s", status.ID, clusterPeerURL)
+		return nil
+	}
+
+	if err := c.SetPeerURL(ctx, status.ID, peerURL); err != nil {
+		return fmt.Errorf("failed to change peer URL for local endpoint %x from %s to %s: %w", status.ID, clusterPeerURL, peerURL, err)
+	}
+	logrus.Infof("Changed peer URL for local etcd endpoint %x from %s to %s", status.ID, clusterPeerURL, peerURL)
+
+	return nil
 }
 
 // Stop stops etcd

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -145,7 +145,7 @@ func (e *Etcd) syncEtcdConfig(ctx context.Context, etcdRequest v1beta1.EtcdReque
 }
 
 // Run runs etcd if external cluster is not configured
-func (e *Etcd) Start(ctx context.Context) error {
+func (e *Etcd) Start(ctx context.Context) (err error) {
 	etcdCaCert := filepath.Join(e.K0sVars.EtcdCertDir, "ca.crt")
 	etcdCaCertKey := filepath.Join(e.K0sVars.EtcdCertDir, "ca.key")
 	etcdServerCert := filepath.Join(e.K0sVars.EtcdCertDir, "server.crt")
@@ -243,7 +243,85 @@ func (e *Etcd) Start(ctx context.Context) error {
 		KeepEnvPrefix: true,
 	}
 
-	return e.supervisor.Supervise(ctx)
+	if err := e.supervisor.Supervise(ctx); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, e.supervisor.Stop())
+		}
+	}()
+
+	for nextWarn := time.Now().Add(10 * time.Second); ; {
+		select {
+		case <-time.After(1 * time.Second):
+		case <-ctx.Done():
+			return fmt.Errorf("while checking peer URL: %w", context.Cause(ctx))
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		err := e.fixupPeerURL(ctx)
+		cancel()
+		if err == nil {
+			return nil
+		}
+
+		// Failures are expected while etcd is still starting up. Log them
+		// quietly at first, but raise the log level now and then if this takes
+		// longer than usual, so that a stalled startup (e.g. an etcd cluster
+		// waiting for quorum) doesn't go unnoticed in non-debug logs.
+		level := logrus.DebugLevel
+		if now := time.Now(); !now.Before(nextWarn) {
+			level, nextWarn = logrus.WarnLevel, now.Add(10*time.Second)
+		}
+		logrus.WithError(err).Log(level, "Failed to check peer URL, retrying")
+	}
+}
+
+func (e *Etcd) fixupPeerURL(ctx context.Context) (err error) {
+	c, err := etcd.NewClient(e.K0sVars.CertRootDir, e.K0sVars.EtcdCertDir, e.Config)
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, c.Close()) }()
+
+	status, err := c.Status(ctx)
+	if err != nil {
+		return err
+	}
+
+	memberList, err := c.ListMembers(ctx)
+	if err != nil {
+		return err
+	}
+
+	var clusterPeerURL string
+	for _, member := range memberList {
+		if member.ID == status.ID {
+			clusterPeerURL = member.PeerURL
+			break
+		}
+	}
+	if clusterPeerURL == "" {
+		return fmt.Errorf("local endpoint %x not in member list", status.ID)
+	}
+
+	peerURL := e.Config.GetPeerURL()
+	if clusterPeerURL == peerURL {
+		return nil
+	}
+
+	if len(memberList) != 1 {
+		logrus.Warnf("Unexpected peer URL for local etcd endpoint %x: %s", status.ID, clusterPeerURL)
+		return nil
+	}
+
+	if err := c.SetPeerURL(ctx, status.ID, peerURL); err != nil {
+		return fmt.Errorf("failed to change peer URL for local endpoint %x from %s to %s: %w", status.ID, clusterPeerURL, peerURL, err)
+	}
+	logrus.Infof("Changed peer URL for local etcd endpoint %x from %s to %s", status.ID, clusterPeerURL, peerURL)
+
+	return nil
 }
 
 // Stop stops etcd

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -207,6 +207,11 @@ func (c *Client) PromoteMember(ctx context.Context, memberID uint64) error {
 	return err
 }
 
+func (c *Client) SetPeerURL(ctx context.Context, memberID uint64, peerURL string) error {
+	_, err := c.client.MemberUpdate(ctx, memberID, []string{peerURL})
+	return err
+}
+
 // Close closes the etcd client
 func (c *Client) Close() error {
 	return c.client.Close()


### PR DESCRIPTION
## Description

Previously, k0s only ever used the etcd peer address during local etcd member initialization, either during etcd cluster bootstrap, or when joining a new member into an existing cluster.

During k0s startup, allow for the peer address to be changed automatically for single-node clusters. This addresses a design issue in k0s restore where the etcd cluster is restored using either the backed-up etcd peer address or the auto-detected node's peer address if the backed-up node didn't specify one. Without this change, there was no way of restoring a node while also changing the node IP. This is now possible by simply modifying the local k0s config before starting the restored node.

Note that this is _only_ done for single-member etcd clusters. For multi-member etcd clusters, the join API performs a basic reachability check before adding a new member, to prevent cluster outages caused by bad configuration values. While this might be doable here as well, it would require significantly more effort, like trying to communicate with the join API, potentially adding a new endpoint. Postpone that decision for now.

Fixes:

* #7876

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
