### PR TITLE
Replace WaitForPodLogs with VerifyKonnectivityMesh

### DIFF
--- a/internal/testutil/portforward.go
+++ b/internal/testutil/portforward.go
@@ -169,6 +169,11 @@ func (d *PodDialer) dialPod(ctx context.Context, pod types.NamespacedName) (*Pod
 	if err != nil {
 		var statusErr *apierrors.StatusError
 		if !errors.As(err, &statusErr) {
+			// https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/v0.36.0/pkg/server/backend_manager.go#L351
+			if strings.HasSuffix(err.Error(), ": No agent available") {
+				return nil, &APIServerEgressProxyError{Type: ErrNoKonnectivityAgent, Err: err}
+			}
+
 			return nil, fmt.Errorf("failed to negotiate: %w", err)
 		}
 		if d := statusErr.ErrStatus.Details; d != nil && d.Kind == "pods" && statusErr.ErrStatus.Reason == metav1.StatusReasonNotFound {
@@ -251,6 +256,16 @@ func (*PodNotFoundError) Error() string   { return "pod not found" }
 func (e *PodNotFoundError) Unwrap() error { return (*apierrors.StatusError)(e) }
 
 var errPodConnectionClosed = errors.New("pod connection closed")
+
+var ErrNoKonnectivityAgent = errors.New("no suitable konnectivity agent connected")
+
+type APIServerEgressProxyError struct {
+	Type error
+	Err  error
+}
+
+func (e *APIServerEgressProxyError) Error() string   { return e.Type.Error() }
+func (e *APIServerEgressProxyError) Unwrap() []error { return []error{e.Type, e.Err} }
 
 // A port-forwarded connection to a specific port on a pod.
 type PodPortConnection struct {

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -93,10 +93,10 @@ check-network-conformance-kuberouter-nft: TIMEOUT=15m
 check-network-conformance-kuberouter-ipv6: TIMEOUT=15m
 check-network-conformance-kuberouter-ipv6-nft: TIMEOUT=15m
 
-check-nllb: TIMEOUT=15m
-check-nllb-traefik: TIMEOUT=15m
-check-nllb-ipv6: TIMEOUT=15m
-check-nllb-traefik-ipv6: TIMEOUT=15m
+check-nllb: TIMEOUT=20m
+check-nllb-traefik: TIMEOUT=20m
+check-nllb-ipv6: TIMEOUT=20m
+check-nllb-traefik-ipv6: TIMEOUT=20m
 
 .PHONY: $(smoketests)
 

--- a/inttest/airgap/airgap_test.go
+++ b/inttest/airgap/airgap_test.go
@@ -14,6 +14,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/containerd/platforms"
 
@@ -44,7 +45,9 @@ func (s *AirgapSuite) TestK0sGetsUp() {
 	s.NoError(s.InitController(0, "--config=/tmp/k0s.yaml"))
 	s.NoError(s.RunWorkers(`--labels="k0sproject.io/foo=bar"`, `--kubelet-extra-args="--address=0.0.0.0 --event-burst=10 --image-gc-high-threshold=100"`))
 
-	kc, err := s.KubeClient(s.ControllerNode(0))
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
+	s.Require().NoError(err)
+	kc, err := kubernetes.NewForConfig(restConfig)
 	s.Require().NoError(err)
 
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
@@ -56,7 +59,7 @@ func (s *AirgapSuite) TestK0sGetsUp() {
 
 	s.Require().NoError(common.WaitForKubeRouterReady(ctx, kc), "While waiting for kube-router to become ready")
 	s.Require().NoError(common.WaitForCoreDNSReady(ctx, kc), "While waiting for CoreDNS to become ready")
-	s.Require().NoError(common.WaitForPodLogs(ctx, kc, metav1.NamespaceSystem), "While waiting for some pod logs")
+	s.Require().NoError(common.VerifyKonnectivityMesh(ctx, restConfig, kc, s.T(), uint(s.ControllerCount), uint(s.WorkerCount)), "While verifying konnectivity mesh")
 
 	// At that moment we can assume that all pods have at least started
 	// We're interested only in image pull events

--- a/inttest/ap-airgap/airgap_test.go
+++ b/inttest/ap-airgap/airgap_test.go
@@ -16,8 +16,10 @@ import (
 	k0sclientset "github.com/k0sproject/k0s/pkg/client/clientset"
 	"github.com/k0sproject/k0s/pkg/constant"
 
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/containerd/platforms"
 
@@ -40,13 +42,15 @@ func (s *airgapSuite) SetupTest() {
 	s.Require().NoError(s.InitController(0, "--disable-components=metrics-server"))
 	s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(0)))
 
-	cClient, err := s.ExtensionsClient(s.ControllerNode(0))
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
+	s.Require().NoError(err)
+	cClient, err := apiextensionsclient.NewForConfig(restConfig)
 	s.Require().NoError(err)
 
 	s.Require().NoError(aptest.WaitForCRDByName(ctx, cClient, "plans"))
 	s.Require().NoError(aptest.WaitForCRDByName(ctx, cClient, "controlnodes"))
 
-	wClient, err := s.KubeClient(s.ControllerNode(0))
+	wClient, err := kubernetes.NewForConfig(restConfig)
 	s.Require().NoError(err)
 
 	// Create a worker join token
@@ -61,7 +65,7 @@ func (s *airgapSuite) SetupTest() {
 	// Wait until all the cluster components are up.
 	s.Require().NoError(common.WaitForKubeRouterReady(ctx, wClient), "While waiting for kube-router to become ready")
 	s.Require().NoError(common.WaitForCoreDNSReady(ctx, wClient), "While waiting for CoreDNS to become ready")
-	s.Require().NoError(common.WaitForPodLogs(ctx, wClient, metav1.NamespaceSystem), "While waiting for some pod logs")
+	s.Require().NoError(common.VerifyKonnectivityMesh(ctx, restConfig, wClient, s.T(), uint(s.ControllerCount), uint(s.WorkerCount)), "While verifying konnectivity mesh")
 
 	// Check that none of the images in the airgap bundle are pinned.
 	// This will happen as soon as k0s imports them after the Autopilot update.
@@ -158,11 +162,11 @@ spec:
 	s.NotEmpty(lsout)
 
 	// Wait until all the cluster components are up.
-	kc, err := s.KubeClient(s.ControllerNode(0))
+	kc, err := kubernetes.NewForConfig(restConfig)
 	s.Require().NoError(err)
 	s.Require().NoError(common.WaitForKubeRouterReady(ctx, kc), "While waiting for kube-router to become ready")
 	s.Require().NoError(common.WaitForCoreDNSReady(ctx, kc), "While waiting for CoreDNS to become ready")
-	s.Require().NoError(common.WaitForPodLogs(ctx, kc, metav1.NamespaceSystem), "While waiting for some pod logs")
+	s.Require().NoError(common.VerifyKonnectivityMesh(ctx, restConfig, kc, s.T(), uint(s.ControllerCount), uint(s.WorkerCount)), "While verifying konnectivity mesh")
 
 	// At that moment we can assume that all pods have at least started.
 	// Inspect the Pulled events if there are some unexpected image pulls.

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -93,9 +93,7 @@ func (s *BasicSuite) TestK0sGetsUp() {
 		s.Require().NoError(err, lease)
 	}
 
-	// We need to first wait till we see pod logs, that's a signal that konnectivity tunnels are up and thus we can then connect to kubelet
-	// via the API.
-	s.Require().NoError(common.WaitForPodLogs(ctx, kc, metav1.NamespaceSystem))
+	s.Require().NoError(common.VerifyKonnectivityMesh(ctx, restConfig, kc, s.T(), uint(s.ControllerCount), uint(s.WorkerCount)), "While verifying konnectivity mesh")
 	for i := range s.WorkerCount {
 		node := s.WorkerNode(i)
 		s.T().Logf("checking that we can connect to kubelet metrics on %s", node)

--- a/inttest/calico/calico_test.go
+++ b/inttest/calico/calico_test.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
 
 	"github.com/k0sproject/k0s/inttest/common"
@@ -30,6 +31,7 @@ type CalicoSuite struct {
 }
 
 func (s *CalicoSuite) TestK0sGetsUp() {
+	ctx := s.Context()
 
 	{
 		clusterCfg := &v1beta1.ClusterConfig{
@@ -66,10 +68,10 @@ func (s *CalicoSuite) TestK0sGetsUp() {
 	}
 	s.Require().NoError(s.RunWorkers())
 
-	kc, err := s.KubeClient("controller0", "")
-	s.Require().NoError(err)
-	restConfig, err := s.GetKubeConfig("controller0", "")
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0), "")
 	s.NoError(err)
+	kc, err := kubernetes.NewForConfig(restConfig)
+	s.Require().NoError(err)
 
 	err = s.WaitForNodeReady("worker0", kc)
 	s.NoError(err)
@@ -77,7 +79,7 @@ func (s *CalicoSuite) TestK0sGetsUp() {
 	err = s.WaitForNodeReady("worker1", kc)
 	s.NoError(err)
 
-	calicoDaemonset, err := kc.AppsV1().DaemonSets(metav1.NamespaceSystem).Get(context.TODO(), "calico-node", metav1.GetOptions{})
+	calicoDaemonset, err := kc.AppsV1().DaemonSets(metav1.NamespaceSystem).Get(ctx, "calico-node", metav1.GetOptions{})
 	s.Require().NoError(err)
 	var calicoCustomEnvVarsFound int
 	for _, v := range calicoDaemonset.Spec.Template.Spec.Containers[0].Env {
@@ -90,10 +92,10 @@ func (s *CalicoSuite) TestK0sGetsUp() {
 	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see calico pods ready")
-	s.NoError(common.WaitForDaemonSet(s.Context(), kc, "calico-node", metav1.NamespaceSystem), "calico did not start")
-	s.NoError(common.WaitForPodLogs(s.Context(), kc, metav1.NamespaceSystem))
+	s.NoError(common.WaitForDaemonSet(ctx, kc, "calico-node", metav1.NamespaceSystem), "calico did not start")
+	s.Require().NoError(common.VerifyKonnectivityMesh(ctx, restConfig, kc, s.T(), uint(s.ControllerCount), uint(s.WorkerCount)), "While verifying konnectivity mesh")
 
-	createdTargetPod, err := kc.CoreV1().Pods(metav1.NamespaceDefault).Create(s.Context(), &corev1.Pod{
+	createdTargetPod, err := kc.CoreV1().Pods(metav1.NamespaceDefault).Create(ctx, &corev1.Pod{
 		TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 		Spec: corev1.PodSpec{
@@ -104,12 +106,12 @@ func (s *CalicoSuite) TestK0sGetsUp() {
 		},
 	}, metav1.CreateOptions{})
 	s.Require().NoError(err)
-	s.Require().NoError(common.WaitForPod(s.Context(), kc, "nginx", metav1.NamespaceDefault), "nginx pod did not start")
+	s.Require().NoError(common.WaitForPod(ctx, kc, "nginx", metav1.NamespaceDefault), "nginx pod did not start")
 
-	targetPod, err := kc.CoreV1().Pods(createdTargetPod.Namespace).Get(s.Context(), createdTargetPod.Name, metav1.GetOptions{})
+	targetPod, err := kc.CoreV1().Pods(createdTargetPod.Namespace).Get(ctx, createdTargetPod.Name, metav1.GetOptions{})
 	s.Require().NoError(err)
 
-	sourcePod, err := kc.CoreV1().Pods(metav1.NamespaceDefault).Create(s.Context(), &corev1.Pod{
+	sourcePod, err := kc.CoreV1().Pods(metav1.NamespaceDefault).Create(ctx, &corev1.Pod{
 		TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: "alpine"},
 		Spec: corev1.PodSpec{
@@ -124,9 +126,9 @@ func (s *CalicoSuite) TestK0sGetsUp() {
 		},
 	}, metav1.CreateOptions{})
 	s.Require().NoError(err)
-	s.NoError(common.WaitForPod(s.Context(), kc, "alpine", metav1.NamespaceDefault), "alpine pod did not start")
+	s.NoError(common.WaitForPod(ctx, kc, "alpine", metav1.NamespaceDefault), "alpine pod did not start")
 
-	err = wait.PollImmediateWithContext(s.Context(), 100*time.Millisecond, time.Minute, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollImmediateWithContext(ctx, 100*time.Millisecond, time.Minute, func(ctx context.Context) (done bool, err error) {
 		out, err := common.PodExecCmdOutput(kc, restConfig, sourcePod.Name, sourcePod.Namespace,
 			"/usr/bin/wget -qO- "+net.JoinHostPort(targetPod.Status.PodIP, "80"))
 		if err != nil {
@@ -138,7 +140,7 @@ func (s *CalicoSuite) TestK0sGetsUp() {
 	s.Require().NoError(err)
 
 	// After the tests finished, verify that there are no restarted pods
-	for _, err := range common.VerifyNoRestartedPods(s.Context(), kc) {
+	for _, err := range common.VerifyNoRestartedPods(ctx, kc) {
 		s.NoError(err)
 	}
 }

--- a/inttest/capitalhostnames/capitalhostnames_test.go
+++ b/inttest/capitalhostnames/capitalhostnames_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/k0sproject/k0s/inttest/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 type CapitalHostnamesSuite struct {
@@ -18,6 +19,7 @@ type CapitalHostnamesSuite struct {
 }
 
 func (s *CapitalHostnamesSuite) TestK0sGetsUp() {
+	ctx := s.Context()
 
 	s.NoError(s.setHostname(s.ControllerNode(0), "k0s-CONTROLLER"))
 	s.NoError(s.setHostname(s.WorkerNode(0), "k0s-WORKER"))
@@ -28,10 +30,10 @@ func (s *CapitalHostnamesSuite) TestK0sGetsUp() {
 	s.Require().NoError(err)
 	s.NoError(s.RunWorkersWithToken(token))
 
-	kc, err := s.KubeClient(s.ControllerNode(0))
-	if err != nil {
-		s.FailNow("failed to obtain Kubernetes client", err)
-	}
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
+	s.Require().NoError(err)
+	kc, err := kubernetes.NewForConfig(restConfig)
+	s.Require().NoError(err)
 
 	err = s.WaitForNodeReady("k0s-worker", kc)
 	s.NoError(err)
@@ -39,21 +41,20 @@ func (s *CapitalHostnamesSuite) TestK0sGetsUp() {
 	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see kube-router pods ready")
-	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "kube-router did not start")
+	s.NoError(common.WaitForKubeRouterReady(ctx, kc), "kube-router did not start")
 
-	// Test that we get logs, it's a signal that konnectivity tunnels work
-	s.T().Log("waiting to get logs from pods")
-	s.Require().NoError(common.WaitForPodLogs(s.Context(), kc, metav1.NamespaceSystem))
+	s.T().Log("waiting for konnectivity")
+	s.Require().NoError(common.VerifyKonnectivityMesh(ctx, restConfig, kc, s.T(), uint(s.ControllerCount), uint(s.WorkerCount)), "While verifying konnectivity mesh")
 
 	// Verify API that we get proper controller counter lease
-	_, err = kc.CoordinationV1().Leases(corev1.NamespaceNodeLease).Get(s.Context(), "k0s-ctrl-k0s-controller", metav1.GetOptions{})
+	_, err = kc.CoordinationV1().Leases(corev1.NamespaceNodeLease).Get(ctx, "k0s-ctrl-k0s-controller", metav1.GetOptions{})
 	s.NoError(err)
 
 	// Verify the autopilot controller node is created
 	apClient, err := s.AutopilotClient(s.ControllerNode(0))
 	s.Require().NoError(err)
 	s.NotEmpty(apClient)
-	_, err = apClient.AutopilotV1beta2().ControlNodes().Get(s.Context(), "k0s-controller", metav1.GetOptions{})
+	_, err = apClient.AutopilotV1beta2().ControlNodes().Get(ctx, "k0s-controller", metav1.GetOptions{})
 	s.NoError(err)
 }
 

--- a/inttest/common/konnectivity.go
+++ b/inttest/common/konnectivity.go
@@ -6,23 +6,28 @@ package common
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"math/bits"
 	"net/http"
+	"slices"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	"github.com/k0sproject/k0s/internal/testutil"
+	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
 )
 
 func VerifyKonnectivityMesh(ctx context.Context, config *rest.Config, kc kubernetes.Interface, t *testing.T, numControllers, numWorkers uint) error {
@@ -39,39 +44,156 @@ func VerifyKonnectivityMesh(ctx context.Context, config *rest.Config, kc kuberne
 	}
 	t.Cleanup(client.CloseIdleConnections)
 
-	return wait.PollUntilContextCancel(ctx, 3*time.Second, true, func(ctx context.Context) (bool, error) {
-		pods, err := kc.CoreV1().Pods(metav1.NamespaceSystem).List(ctx, metav1.ListOptions{
-			LabelSelector: fields.OneTermEqualSelector("k8s-app", "konnectivity-agent").String(),
-		})
-		if err != nil {
-			t.Logf("Failed to get konnectivity pods: %v", err)
-			return false, nil
-		}
+	type monitor struct {
+		node, pod string
+		cancel    context.CancelCauseFunc
+		mu        sync.Mutex
+	}
 
-		if len := uint(len(pods.Items)); len > numWorkers {
-			return false, fmt.Errorf("unexpected number of konnectivity pods: %d", len)
-		}
+	var (
+		monitors []*monitor
+		goodPods atomic.Int32
+	)
 
-		var goodPods uint
-		for _, pod := range pods.Items {
-			openServerConnections, err := fetchOpenKonnectivityServerConnections(ctx, &client, &pod)
-			if err != nil {
-				t.Logf("Failed to fetch konnectivity metrics from pod %s on node %s: %v", pod.Name, pod.Spec.NodeName, err)
+	allGood := errors.New("all good")
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return watch.Pods(kc.CoreV1().Pods(metav1.NamespaceSystem)).
+			WithLabels(labels.Set{"k8s-app": "konnectivity-agent"}).
+			WithErrorCallback(RetryWatchErrors(t.Logf)).
+			IncludingDeletions().
+			Until(ctx, func(pod *corev1.Pod) (bool, error) {
+				var badMsg string
+				if pod.DeletionTimestamp != nil {
+					badMsg = "pod deleted"
+				} else if idx := slices.IndexFunc(pod.Status.Conditions, func(cond corev1.PodCondition) bool {
+					return cond.Type == corev1.PodReady
+				}); idx < 0 || pod.Status.Conditions[idx].Status != corev1.ConditionTrue {
+					badMsg = "pod not ready"
+				} else if pod.Spec.NodeName == "" {
+					badMsg = "pod is not assigned to a node"
+				}
+
+				if badMsg != "" {
+					for _, monitor := range monitors {
+						if monitor.pod == pod.Name {
+							if monitor.cancel != nil {
+								monitor.cancel(errors.New(badMsg))
+								monitor.cancel = nil
+							}
+							break
+						}
+					}
+					return false, nil
+				}
+
+				var monitorForNode *monitor
+				for _, monitor := range monitors {
+					if monitor.node == pod.Spec.NodeName {
+						monitorForNode = monitor
+						break
+					}
+				}
+				if monitorForNode == nil {
+					monitorForNode = &monitor{node: pod.Spec.NodeName, pod: pod.Name}
+					monitors = append(monitors, monitorForNode)
+				} else if monitorForNode.pod != pod.Name {
+					if monitorForNode.cancel != nil {
+						monitorForNode.cancel(errors.New("pod has been replaced"))
+					}
+					monitorForNode.pod = pod.Name
+				} else if monitorForNode.cancel != nil {
+					return false, nil
+				}
+
+				ctx, cancelPod := context.WithCancelCause(ctx)
+				monitorForNode.cancel = func(cause error) {
+					t.Logf("Canceling monitoring konnectivity metrics from %s on %s: %v", monitorForNode.pod, monitorForNode.node, cause)
+					cancelPod(cause)
+				}
+
+				eg.Go(func() (err error) {
+					monitorForNode.mu.Lock()
+					defer monitorForNode.mu.Unlock()
+
+					t.Logf("Monitoring konnectivity metrics from %s on %s", pod.Name, pod.Spec.NodeName)
+
+					var (
+						openServerConnections uint
+						good                  bool
+						lastErrMsg            string
+					)
+					defer func() {
+						if good {
+							numGood := goodPods.Add(-1)
+							if err != nil && !errors.Is(err, allGood) {
+								t.Logf(
+									"Fully connected konnectivity agents: %d/%d (%s on %s: %v)",
+									numGood, numWorkers, pod.Name, pod.Spec.NodeName, err,
+								)
+							}
+						}
+					}()
+
+					for {
+						select {
+						case <-time.After(1 * time.Second):
+						case <-ctx.Done():
+							return nil
+						}
+
+						if conns, err := func() (uint, error) {
+							ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+							defer cancel()
+							return fetchOpenKonnectivityServerConnections(ctx, &client, pod)
+						}(); err != nil {
+							// More concise message for an expected failure case.
+							if errors.Is(err, testutil.ErrNoKonnectivityAgent) {
+								err = testutil.ErrNoKonnectivityAgent
+							}
+							if errMsg := err.Error(); errMsg != lastErrMsg {
+								t.Logf("Failed to fetch konnectivity metrics from %s on node %s: %s", pod.Name, pod.Spec.NodeName, errMsg)
+								lastErrMsg = errMsg
+							}
+							if good {
+								good = false
+								goodPods.Add(-1)
+							}
+							continue
+						} else {
+							if conns == openServerConnections && lastErrMsg == "" {
+								continue
+							}
+							openServerConnections, lastErrMsg = conns, ""
+						}
+
+						t.Logf("Open konnectivity server connections for %s on %s: %d/%d", pod.Name, pod.Spec.NodeName, openServerConnections, numControllers)
+						if openServerConnections == numControllers {
+							if !good {
+								good = true
+								numGood := uint(goodPods.Add(1))
+								t.Logf("Fully connected konnectivity agents: %d/%d", numGood, numWorkers)
+								if numGood == numWorkers {
+									return allGood
+								}
+							}
+						} else if good {
+							good = false
+							goodPods.Add(-1)
+						}
+					}
+				})
+
 				return false, nil
-			}
-
-			t.Logf("Open konnectivity server connections for %s on %s: %d", pod.Name, pod.Spec.NodeName, openServerConnections)
-			if openServerConnections > numControllers {
-				return false, fmt.Errorf("too many open server connections for pod %s on node %s: %d exceeds the number of controllers (%d)", pod.Name, pod.Spec.NodeName, openServerConnections, numControllers)
-			}
-			if openServerConnections == numControllers {
-				goodPods++
-			}
-		}
-
-		t.Logf("Pods with the desired amount of konnectivity server connections: %d/%d", goodPods, len(pods.Items))
-		return goodPods == numWorkers, nil
+			})
 	})
+
+	if err := eg.Wait(); !errors.Is(err, allGood) {
+		return cmp.Or(err, ctx.Err())
+	}
+
+	t.Log("Konnectivity mesh is complete")
+	return nil
 }
 
 func fetchOpenKonnectivityServerConnections(ctx context.Context, client *http.Client, pod *corev1.Pod) (_ uint, err error) {

--- a/inttest/common/konnectivity.go
+++ b/inttest/common/konnectivity.go
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math/bits"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/k0sproject/k0s/internal/testutil"
+)
+
+func VerifyKonnectivityMesh(ctx context.Context, config *rest.Config, kc kubernetes.Interface, t *testing.T, numControllers, numWorkers uint) error {
+	podDialer, err := testutil.NewPodDialer(config)
+	if err != nil {
+		return err
+	}
+
+	client := http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			DialContext: podDialer.DialContext,
+		},
+	}
+	t.Cleanup(client.CloseIdleConnections)
+
+	return wait.PollUntilContextCancel(ctx, 3*time.Second, true, func(ctx context.Context) (bool, error) {
+		pods, err := kc.CoreV1().Pods(metav1.NamespaceSystem).List(ctx, metav1.ListOptions{
+			LabelSelector: fields.OneTermEqualSelector("k8s-app", "konnectivity-agent").String(),
+		})
+		if err != nil {
+			t.Logf("Failed to get konnectivity pods: %v", err)
+			return false, nil
+		}
+
+		if len := uint(len(pods.Items)); len > numWorkers {
+			return false, fmt.Errorf("unexpected number of konnectivity pods: %d", len)
+		}
+
+		var goodPods uint
+		for _, pod := range pods.Items {
+			openServerConnections, err := fetchOpenKonnectivityServerConnections(ctx, &client, &pod)
+			if err != nil {
+				t.Logf("Failed to fetch konnectivity metrics from pod %s on node %s: %v", pod.Name, pod.Spec.NodeName, err)
+				return false, nil
+			}
+
+			t.Logf("Open konnectivity server connections for %s on %s: %d", pod.Name, pod.Spec.NodeName, openServerConnections)
+			if openServerConnections > numControllers {
+				return false, fmt.Errorf("too many open server connections for pod %s on node %s: %d exceeds the number of controllers (%d)", pod.Name, pod.Spec.NodeName, openServerConnections, numControllers)
+			}
+			if openServerConnections == numControllers {
+				goodPods++
+			}
+		}
+
+		t.Logf("Pods with the desired amount of konnectivity server connections: %d/%d", goodPods, len(pods.Items))
+		return goodPods == numWorkers, nil
+	})
+}
+
+func fetchOpenKonnectivityServerConnections(ctx context.Context, client *http.Client, pod *corev1.Pod) (_ uint, err error) {
+	var port uint16
+	for k, v := range pod.Annotations {
+		if k == "prometheus.io/port" {
+			parsed, err := strconv.ParseUint(v, 10, 16)
+			if err != nil {
+				return 0, fmt.Errorf("invalid port: %w", err)
+			}
+			if parsed == 0 {
+				return 0, errors.New("zero port")
+			}
+			port = uint16(parsed)
+		}
+	}
+
+	if port == 0 {
+		return 0, errors.New("no port")
+	}
+
+	url := fmt.Sprintf("http://%s.%s:%d/metrics", pod.Name, pod.Namespace, port)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("failed to send HTTP request: %w", err)
+	}
+
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to close HTTP response body: %w", closeErr))
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("non-OK HTTP response status: %s", resp.Status)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		key, val, found := bytes.Cut(scanner.Bytes(), []byte{' '})
+		if !found || !bytes.Equal(key, []byte("konnectivity_network_proxy_agent_open_server_connections")) {
+			continue
+		}
+
+		val, _, _ = bytes.Cut(val, []byte{' '})
+		count, err := strconv.ParseUint(string(val), 10, bits.UintSize)
+		if err != nil {
+			return 0, fmt.Errorf("invalid metric: %s %s: %w", key, val, err)
+		}
+		return uint(count), nil
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("failed to read HTTP response body: %w", err)
+	}
+
+	return 0, errors.New("metric konnectivity_network_proxy_agent_open_server_connections not found")
+}

--- a/inttest/common/util.go
+++ b/inttest/common/util.go
@@ -26,7 +26,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
@@ -246,33 +245,6 @@ func WaitForPod(ctx context.Context, kc kubernetes.Interface, name, namespace st
 
 			return false, nil
 		})
-}
-
-// WaitForPodLogs waits until it can stream the logs of the first running pod
-// that comes along in the given namespace as long as the given context isn't
-// canceled.
-func WaitForPodLogs(ctx context.Context, kc kubernetes.Interface, namespace string) error {
-	return Poll(ctx, func(ctx context.Context) (done bool, err error) {
-		pods, err := kc.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
-			Limit:         100,
-			FieldSelector: fields.OneTermEqualSelector("status.phase", string(corev1.PodRunning)).String(),
-		})
-		if err != nil {
-			return false, err // stop polling with error in case the pod listing fails
-		}
-		if len(pods.Items) < 1 {
-			return false, nil
-		}
-
-		pod := &pods.Items[0]
-		logs, err := kc.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Container: pod.Spec.Containers[0].Name}).Stream(ctx)
-		if err != nil {
-			return false, nil // do not return the error so we keep on polling
-		}
-		defer logs.Close()
-
-		return true, nil
-	})
 }
 
 func WaitForLease(ctx context.Context, kc kubernetes.Interface, name string, namespace string) (string, error) {

--- a/inttest/cplb-userspace/cplbuserspace_test.go
+++ b/inttest/cplb-userspace/cplbuserspace_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/token"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/k0sproject/k0s/inttest/common"
 	"github.com/stretchr/testify/suite"
@@ -146,7 +147,9 @@ func (s *CPLBUserSpaceSuite) TestK0sGetsUp() {
 	// Start the workers using the join token
 	s.Require().NoError(s.RunWorkersWithToken(workerJoinToken))
 
-	client, err := s.KubeClient(s.ControllerNode(0))
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
+	s.Require().NoError(err)
+	client, err := kubernetes.NewForConfig(restConfig)
 	s.Require().NoError(err)
 
 	for idx := range s.ControllerCount {
@@ -178,8 +181,15 @@ func (s *CPLBUserSpaceSuite) TestK0sGetsUp() {
 
 	s.T().Log("waiting to see konnectivity-agent pods ready")
 	s.Require().NoError(common.WaitForDaemonSet(ctx, client, "konnectivity-agent", metav1.NamespaceSystem), "konnectivity-agent did not start")
-	s.T().Log("waiting to get logs from pods")
-	s.Require().NoError(common.WaitForPodLogs(ctx, client, metav1.NamespaceSystem))
+	{
+		s.T().Log("waiting for konnectivity")
+		controllerCount := uint(s.ControllerCount)
+		// FIXME: Currently, the external address doesn't load-balance konnectivity properly.
+		if s.useExternalAddress {
+			controllerCount = 1
+		}
+		s.Require().NoError(common.VerifyKonnectivityMesh(ctx, restConfig, client, s.T(), controllerCount, uint(s.ControllerCount+s.WorkerCount)), "While verifying konnectivity mesh")
+	}
 
 	s.T().Log("Testing that the load balancer is actually balancing the load")
 	// Other stuff may be querying the controller, running the HTTPS request 15 times

--- a/inttest/custom-cidrs/customcidrs_test.go
+++ b/inttest/custom-cidrs/customcidrs_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/k0sproject/k0s/inttest/common"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/stretchr/testify/suite"
 
@@ -34,10 +35,10 @@ func (s *CustomCIDRsSuite) TestK0sGetsUp() {
 	s.Require().NoError(s.InitController(0, "--config=/tmp/k0s.yaml", "--disable-components metrics-server", "--enable-dynamic-config"))
 	s.Require().NoError(s.RunWorkers())
 
-	kc, err := s.KubeClient(s.ControllerNode(0))
-	if err != nil {
-		s.FailNow("failed to obtain Kubernetes client", err)
-	}
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
+	s.Require().NoError(err)
+	kc, err := kubernetes.NewForConfig(restConfig)
+	s.Require().NoError(err)
 
 	for i := range s.WorkerCount {
 		err = s.WaitForNodeReady(s.WorkerNode(i), kc)
@@ -75,14 +76,8 @@ func (s *CustomCIDRsSuite) TestK0sGetsUp() {
 		},
 	}, metav1.CreateOptions{})
 	s.Require().NoError(err)
-	// Wait till we see the pod ready and are able to get logs
-	// Getting logs means konnectivity tunnels are up and running
 	s.Require().NoError(common.WaitForPod(ctx, kc, "nginx", metav1.NamespaceDefault))
-	s.Require().NoError(common.WaitForPodLogs(ctx, kc, metav1.NamespaceDefault))
-
-	restConfig, err := s.GetKubeConfig("controller0", "")
-	s.Require().NoError(err)
-	s.Require().NotNil(restConfig)
+	s.Require().NoError(common.VerifyKonnectivityMesh(ctx, restConfig, kc, s.T(), uint(s.ControllerCount), uint(s.WorkerCount)), "While verifying konnectivity mesh")
 
 	// Check the pod resolv.conf is correct
 	resolv, err := common.PodExecCmdOutput(kc, restConfig, "nginx", metav1.NamespaceDefault, "cat /etc/resolv.conf")

--- a/inttest/customdomain/customdomain_test.go
+++ b/inttest/customdomain/customdomain_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/k0sproject/k0s/inttest/common"
 	"github.com/stretchr/testify/suite"
@@ -17,12 +18,16 @@ type CustomDomainSuite struct {
 }
 
 func (s *CustomDomainSuite) TestK0sGetsUpWithCustomDomain() {
+	ctx := s.Context()
+
 	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfig)
 	// Metrics disabled as it's super slow to get up properly and interferes with API discovery etc. while it's getting up
 	s.Require().NoError(s.InitController(0, "--config=/tmp/k0s.yaml", "--disable-components metrics-server"))
 	s.Require().NoError(s.RunWorkers())
 
-	kc, err := s.KubeClient(s.ControllerNode(0))
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
+	s.Require().NoError(err)
+	kc, err := kubernetes.NewForConfig(restConfig)
 	s.Require().NoError(err)
 
 	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
@@ -34,19 +39,19 @@ func (s *CustomDomainSuite) TestK0sGetsUpWithCustomDomain() {
 	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see CNI pods ready")
-	s.NoError(common.WaitForKubeRouterReady(s.Context(), kc), "CNI did not start")
+	s.NoError(common.WaitForKubeRouterReady(ctx, kc), "CNI did not start")
 
 	s.Run("check custom domain existence in pod", func() {
 		// All done via SSH as it's much simpler :)
 		// e.g. execing via client-go is super complex and would require too much wiring
-		ssh, err := s.SSH(s.Context(), s.ControllerNode(0))
+		ssh, err := s.SSH(ctx, s.ControllerNode(0))
 		s.Require().NoError(err)
 		defer ssh.Disconnect()
-		_, err = ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s kc run nginx --image docker.io/library/nginx:1.31.2-alpine")
+		_, err = ssh.ExecWithOutput(ctx, "/usr/local/bin/k0s kc run nginx --image docker.io/library/nginx:1.31.2-alpine")
 		s.Require().NoError(err)
-		s.NoError(common.WaitForPod(s.Context(), kc, "nginx", metav1.NamespaceDefault))
-		s.NoError(common.WaitForPodLogs(s.Context(), kc, metav1.NamespaceDefault))
-		output, err := ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s kc exec nginx -- cat /etc/resolv.conf")
+		s.NoError(common.WaitForPod(ctx, kc, "nginx", metav1.NamespaceDefault))
+		s.Require().NoError(common.VerifyKonnectivityMesh(ctx, restConfig, kc, s.T(), uint(s.ControllerCount), uint(s.WorkerCount)), "While verifying konnectivity mesh")
+		output, err := ssh.ExecWithOutput(ctx, "/usr/local/bin/k0s kc exec nginx -- cat /etc/resolv.conf")
 		s.Require().NoError(err)
 		s.Contains(output, "search default.svc.something.local svc.something.local something.local")
 	})

--- a/inttest/customports/customports_test.go
+++ b/inttest/customports/customports_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/k0sproject/k0s/inttest/common"
 	"github.com/stretchr/testify/suite"
@@ -23,7 +23,7 @@ import (
 type customPortsSuite struct {
 	common.BootlooseSuite
 
-	client *k8s.Clientset
+	client *kubernetes.Clientset
 }
 
 const configWithExternaladdress = `
@@ -83,6 +83,8 @@ func (s *customPortsSuite) getControllerConfig(ipAddress string) string {
 }
 
 func (s *customPortsSuite) TestControllerJoinsWithCustomPort() {
+	ctx := s.Context()
+
 	ipAddress := s.GetLBAddress()
 	s.T().Logf("ip address: %s", ipAddress)
 	config := s.getControllerConfig(ipAddress)
@@ -102,7 +104,9 @@ func (s *customPortsSuite) TestControllerJoinsWithCustomPort() {
 	s.Require().NoError(err)
 	s.Require().NoError(s.RunWorkersWithToken(workerToken))
 
-	kc, err := s.KubeClient("controller0")
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
+	s.Require().NoError(err)
+	kc, err := kubernetes.NewForConfig(restConfig)
 	s.Require().NoError(err)
 
 	err = s.WaitForNodeReady("worker0", kc)
@@ -119,21 +123,21 @@ func (s *customPortsSuite) TestControllerJoinsWithCustomPort() {
 	s.AssertSomeKubeSystemPods(kc)
 
 	s.T().Log("waiting to see CNI pods ready")
-	s.Require().NoError(common.WaitForKubeRouterReady(s.Context(), kc), "kube-router did not start")
+	s.Require().NoError(common.WaitForKubeRouterReady(ctx, kc), "kube-router did not start")
 	s.T().Log("waiting to see konnectivity-agent pods ready")
-	s.Require().NoError(common.WaitForDaemonSet(s.Context(), kc, "konnectivity-agent", metav1.NamespaceSystem), "konnectivity-agent did not start")
+	s.Require().NoError(common.WaitForDaemonSet(ctx, kc, "konnectivity-agent", metav1.NamespaceSystem), "konnectivity-agent did not start")
 
-	s.T().Log("waiting to get logs from pods")
-	s.Require().NoError(common.WaitForPodLogs(s.Context(), kc, metav1.NamespaceSystem))
+	s.T().Log("waiting for konnectivity")
+	s.Require().NoError(common.VerifyKonnectivityMesh(ctx, restConfig, kc, s.T(), uint(s.ControllerCount), uint(s.WorkerCount)), "While verifying konnectivity mesh")
 
 	// https://github.com/k0sproject/k0s/issues/1202
 	s.Run("kubeconfigIncludesExternalAddress", func() {
 		expectedURL := url.URL{Scheme: "https", Host: net.JoinHostPort(ipAddress, strconv.Itoa(kubeAPIPort))}
-		ssh, err := s.SSH(s.Context(), s.ControllerNode(0))
+		ssh, err := s.SSH(ctx, s.ControllerNode(0))
 		s.Require().NoError(err)
 		defer ssh.Disconnect()
 
-		out, err := ssh.ExecWithOutput(s.Context(), "/usr/local/bin/k0s kubeconfig create user | awk '$1 == \"server:\" {print $2}'")
+		out, err := ssh.ExecWithOutput(ctx, "/usr/local/bin/k0s kubeconfig create user | awk '$1 == \"server:\" {print $2}'")
 		s.Require().NoError(err)
 		s.Require().Equal(expectedURL.String(), out)
 	})

--- a/inttest/nllb/nllb_test.go
+++ b/inttest/nllb/nllb_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -23,8 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	testifysuite "github.com/stretchr/testify/suite"
@@ -99,7 +100,9 @@ func (s *suite) TestNodeLocalLoadBalancing() {
 		s.Require().NoError(err)
 		s.Require().NoError(s.RunWorkersWithToken(token))
 
-		clients, err := s.KubeClient(s.ControllerNode(0))
+		restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
+		s.Require().NoError(err)
+		clients, err := kubernetes.NewForConfig(restConfig)
 		s.Require().NoError(err)
 
 		eg, _ := errgroup.WithContext(ctx)
@@ -114,7 +117,7 @@ func (s *suite) TestNodeLocalLoadBalancing() {
 		}
 		s.Require().NoError(eg.Wait())
 
-		s.Require().NoError(s.checkClusterReadiness(ctx, clients, 1))
+		s.Require().NoError(s.checkClusterReadiness(ctx, restConfig, clients, 1))
 	})
 
 	s.Run("join_new_controllers", func() {
@@ -127,12 +130,24 @@ func (s *suite) TestNodeLocalLoadBalancing() {
 
 		s.Require().NoError(eg.Wait())
 
-		clients, err := s.KubeClient(s.ControllerNode(1))
+		restConfig, err := s.GetKubeConfig(s.ControllerNode(1))
+		s.Require().NoError(err)
+		clients, err := kubernetes.NewForConfig(restConfig)
 		s.Require().NoError(err)
 
 		s.T().Logf("Checking if HA cluster is ready")
-		s.Require().NoError(s.checkClusterReadiness(ctx, clients, s.ControllerCount))
+		s.Require().NoError(s.checkClusterReadiness(ctx, restConfig, clients, s.ControllerCount))
 	})
+
+	// At the time of writing, reaching this point will take ~4m.
+	//
+	// Each controller iteration below will again take ~4m:
+	//
+	// - stopping nodes ~30s
+	// - Two agent rollouts after controller removal and restart ~100s each
+	//
+	// So the overall test timeout should be no less than 20m (including 4m
+	// buffer).
 
 	workerNameToRestart := s.WorkerNode(0)
 	for i := range s.ControllerCount {
@@ -169,11 +184,13 @@ func (s *suite) TestNodeLocalLoadBalancing() {
 			s.Require().NoError(err)
 		})
 
-		clients, err := s.KubeClient(s.ControllerNode((i + 1) % s.ControllerCount))
+		restConfig, err := s.GetKubeConfig(s.ControllerNode((i + 1) % s.ControllerCount))
+		s.Require().NoError(err)
+		clients, err := kubernetes.NewForConfig(restConfig)
 		s.Require().NoError(err)
 
 		s.Run("cluster_ready_without_"+controllerName, func() {
-			s.Require().NoError(s.checkClusterReadiness(ctx, clients, s.ControllerCount, controllerName))
+			s.Require().NoError(s.checkClusterReadiness(ctx, restConfig, clients, s.ControllerCount, controllerName))
 		})
 
 		s.Run("workloads_still_runnable_without_"+controllerName, func() {
@@ -207,18 +224,20 @@ func (s *suite) TestNodeLocalLoadBalancing() {
 			s.Require().NoError(s.StartController(controllerName))
 			clients, err := s.KubeClient(controllerName)
 			s.Require().NoError(err)
-			s.Require().NoError(s.checkClusterReadiness(ctx, clients, s.ControllerCount))
+			s.Require().NoError(s.checkClusterReadiness(ctx, restConfig, clients, s.ControllerCount))
 		})
 	}
 
 	s.Run("cluster_ready_after_all_controllers_restarted", func() {
-		clients, err := s.KubeClient(s.ControllerNode(0))
+		restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
 		s.Require().NoError(err)
-		s.Require().NoError(s.checkClusterReadiness(ctx, clients, s.ControllerCount))
+		clients, err := kubernetes.NewForConfig(restConfig)
+		s.Require().NoError(err)
+		s.Require().NoError(s.checkClusterReadiness(ctx, restConfig, clients, s.ControllerCount))
 	})
 }
 
-func (s *suite) checkClusterReadiness(ctx context.Context, clients *kubernetes.Clientset, numControllers int, degradedControllers ...string) error {
+func (s *suite) checkClusterReadiness(ctx context.Context, restConfig *rest.Config, clients *kubernetes.Clientset, numControllers int, degradedControllers ...string) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
 	for i := range numControllers {
@@ -245,6 +264,9 @@ func (s *suite) checkClusterReadiness(ctx context.Context, clients *kubernetes.C
 		})
 	}
 
+	var pendingWorkers atomic.Int64
+	pendingWorkers.Store(int64(s.WorkerCount))
+	workersReady := make(chan struct{})
 	for i := range s.WorkerCount {
 		nodeName := s.WorkerNode(i)
 
@@ -261,25 +283,10 @@ func (s *suite) checkClusterReadiness(ctx context.Context, clients *kubernetes.C
 			}
 			s.T().Logf("Pod %s/%s is ready", metav1.NamespaceSystem, nllbPodName)
 
-			// Test that we get logs, it's a signal that konnectivity tunnels work.
-			var logsErr error
-			if err := wait.PollImmediateUntilWithContext(ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
-				ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-				defer cancel()
-				logs, err := clients.CoreV1().Pods(metav1.NamespaceSystem).GetLogs(nllbPodName, &corev1.PodLogOptions{}).Stream(ctx)
-				if err != nil {
-					if logsErr == nil || err.Error() != logsErr.Error() {
-						s.T().Logf("No logs yet from %s/%s: %v", metav1.NamespaceSystem, nllbPodName, err)
-					}
-					logsErr = err
-					return false, nil
-				}
-				return true, logs.Close()
-			}); err != nil {
-				return fmt.Errorf("failed to get pod logs from %s/%s: %w", metav1.NamespaceSystem, nllbPodName, logsErr)
+			if pendingWorkers.Add(-1) < 1 {
+				close(workersReady)
 			}
 
-			s.T().Logf("Got some pod logs from %s/%s", metav1.NamespaceSystem, nllbPodName)
 			return nil
 		})
 	}
@@ -303,15 +310,33 @@ func (s *suite) checkClusterReadiness(ctx context.Context, clients *kubernetes.C
 		})
 	}
 
-	for _, daemonSet := range []string{"kube-proxy", "konnectivity-agent"} {
-		eg.Go(func() error {
-			if err := common.WaitForDaemonSet(ctx, clients, daemonSet, metav1.NamespaceSystem); err != nil {
-				return fmt.Errorf("%s is not ready: %w", daemonSet, err)
-			}
-			s.T().Log(daemonSet, "is ready")
-			return nil
-		})
+	select {
+	case <-workersReady:
+	case <-ctx.Done():
+		return context.Cause(ctx)
 	}
+
+	eg.Go(func() error {
+		if err := common.WaitForDaemonSet(ctx, clients, "konnectivity-agent", metav1.NamespaceSystem); err != nil {
+			return fmt.Errorf("konnectivity-agent is not ready: %w", err)
+		}
+		s.T().Log("konnectivity-agent is ready")
+
+		if err := common.VerifyKonnectivityMesh(ctx, restConfig, clients, s.T(), uint(max(0, numControllers-len(degradedControllers))), uint(s.WorkerCount)); err != nil {
+			return fmt.Errorf("failed to verify konnectivity mesh: %w", err)
+		}
+		s.T().Log("Konnectivity mesh is complete")
+
+		return nil
+	})
+
+	eg.Go(func() error {
+		if err := common.WaitForDaemonSet(ctx, clients, "kube-proxy", metav1.NamespaceSystem); err != nil {
+			return fmt.Errorf("kube-proxy is not ready: %w", err)
+		}
+		s.T().Log("kube-proxy is ready")
+		return nil
+	})
 
 	for _, deployment := range []string{"coredns", "metrics-server"} {
 		eg.Go(func() error {

--- a/inttest/windows/windows_test.go
+++ b/inttest/windows/windows_test.go
@@ -4,28 +4,16 @@
 package windows
 
 import (
-	"bufio"
-	"bytes"
 	"context"
-	"errors"
-	"fmt"
-	"math/bits"
-	"net/http"
 	"os"
-	"strconv"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/k0sproject/k0s/internal/testutil"
 	"github.com/k0sproject/k0s/inttest/common"
 	"github.com/stretchr/testify/require"
 )
@@ -116,7 +104,8 @@ func TestWindows(t *testing.T) {
 	})
 
 	t.Run("Verify konnectivity is operational", func(t *testing.T) {
-		require.NoError(verifyKonnectivityPods(t.Context(), restConfig, kc, t))
+		require.NoError(common.VerifyKonnectivityMesh(t.Context(), restConfig, kc, t, 1, 2))
+		t.Log("Konnectivity mesh is complete")
 	})
 
 	t.Run("Verify pods can be scheduled on Windows node", func(t *testing.T) {
@@ -133,117 +122,6 @@ func TestWindows(t *testing.T) {
 
 	})
 
-}
-
-func verifyKonnectivityPods(ctx context.Context, config *rest.Config, kc kubernetes.Interface, t *testing.T) error {
-	podDialer, err := testutil.NewPodDialer(config)
-	if err != nil {
-		return err
-	}
-
-	client := http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			DialContext: podDialer.DialContext,
-		},
-	}
-	t.Cleanup(client.CloseIdleConnections)
-
-	return wait.PollUntilContextCancel(ctx, 3*time.Second, true, func(ctx context.Context) (bool, error) {
-		pods, err := kc.CoreV1().Pods(metav1.NamespaceSystem).List(ctx, metav1.ListOptions{
-			LabelSelector: fields.OneTermEqualSelector("k8s-app", "konnectivity-agent").String(),
-		})
-		if err != nil {
-			t.Logf("Failed to get konnectivity pods: %v", err)
-			return false, nil
-		}
-
-		if len := len(pods.Items); len > 2 {
-			return false, fmt.Errorf("unexpected number of konnectivity pods: %d", len)
-		}
-
-		var goodPods uint
-		for _, pod := range pods.Items {
-			openServerConnections, err := fetchOpenServerConnections(ctx, &client, &pod)
-			if err != nil {
-				t.Logf("Failed to fetch konnectivity metrics from pod %s on node %s: %v", pod.Name, pod.Spec.NodeName, err)
-				return false, nil
-			}
-
-			switch openServerConnections {
-			case 0:
-				t.Logf("Pod %s on node %s has no open konnectivity server connections", pod.Name, pod.Spec.NodeName)
-			case 1:
-				t.Logf("Pod %s on node %s has one open konnectivity server connection", pod.Name, pod.Spec.NodeName)
-				goodPods++
-			default:
-				return false, fmt.Errorf("unexpected number of open server connections for pod %s on node %s: %d", pod.Name, pod.Spec.NodeName, openServerConnections)
-			}
-		}
-
-		t.Logf("Pods with one open konnectivity server connection: %d/%d", goodPods, len(pods.Items))
-		return goodPods == 2, nil
-	})
-}
-
-func fetchOpenServerConnections(ctx context.Context, client *http.Client, pod *corev1.Pod) (_ uint, err error) {
-	var port uint16
-	for k, v := range pod.Annotations {
-		if k == "prometheus.io/port" {
-			parsed, err := strconv.ParseUint(v, 10, 16)
-			if err != nil {
-				return 0, fmt.Errorf("invalid port: %w", err)
-			}
-			if parsed == 0 {
-				return 0, errors.New("zero port")
-			}
-			port = uint16(parsed)
-		}
-	}
-
-	if port == 0 {
-		return 0, errors.New("no port")
-	}
-
-	url := fmt.Sprintf("http://%s.%s:%d/metrics", pod.Name, pod.Namespace, port)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return 0, fmt.Errorf("failed to create HTTP request: %w", err)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return 0, fmt.Errorf("failed to send HTTP request: %w", err)
-	}
-
-	defer func() {
-		if closeErr := resp.Body.Close(); closeErr != nil {
-			err = errors.Join(err, fmt.Errorf("failed to close HTTP response body: %w", closeErr))
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("non-OK HTTP response status: %s", resp.Status)
-	}
-
-	scanner := bufio.NewScanner(resp.Body)
-	for scanner.Scan() {
-		key, val, found := bytes.Cut(scanner.Bytes(), []byte{' '})
-		if !found || !bytes.Equal(key, []byte("konnectivity_network_proxy_agent_open_server_connections")) {
-			continue
-		}
-
-		val, _, _ = bytes.Cut(val, []byte{' '})
-		count, err := strconv.ParseUint(string(val), 10, bits.UintSize)
-		if err != nil {
-			return 0, fmt.Errorf("invalid metric: %s %s: %w", key, val, err)
-		}
-		return uint(count), nil
-	}
-	if err := scanner.Err(); err != nil {
-		return 0, fmt.Errorf("failed to read HTTP response body: %w", err)
-	}
-
-	return 0, errors.New("metric konnectivity_network_proxy_agent_open_server_connections not found")
 }
 
 func runLinuxDeployment(ctx context.Context, kc *kubernetes.Clientset) error {


### PR DESCRIPTION
## Description

Move the konnectivity pod check from the Windows WSL test to the common inttest package, so it can be reused by other integration tests. Rewrite it, so that it watches the konnectivity-agent pods and monitors the konnectivity metrics per node until every agent is connected to every controller.

Replace the old "try to get some logs" check with the new konnectivity mesh checker across all the integration tests. This has richer diagnostic messages and verifies that the whole cluster is interconnected. Increase the timeout for the NLLB test to 20 minutes, as the new mesh checker now waits for the whole cluster to be interconnected, whereas the previous log check only verified that all workers were connected to the controller that's currently in use.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
