### PR TITLE
Bump tcpproxy

### DIFF
--- a/pkg/component/controller/cplb/tcpproxy/tcpproxy.go
+++ b/pkg/component/controller/cplb/tcpproxy/tcpproxy.go
@@ -273,16 +273,21 @@ func tcpConn(c net.Conn) (t *net.TCPConn, ok bool) {
 	return nil, false
 }
 
+type closeReader interface{ CloseRead() error }
+type closeWriter interface{ CloseWrite() error }
+
 func goCloseConn(c net.Conn) { go c.Close() }
 
 func closeRead(c net.Conn) {
-	if c, ok := tcpConn(c); ok {
+	// prefer the interfaces, for compatibility with e.g. gvisor/netstack.
+	if c, ok := UnderlyingConn(c).(closeReader); ok {
 		_ = c.CloseRead()
 	}
 }
 
 func closeWrite(c net.Conn) {
-	if c, ok := tcpConn(c); ok {
+	// prefer the interfaces, for compatibility with e.g. gvisor/netstack.
+	if c, ok := UnderlyingConn(c).(closeWriter); ok {
 		_ = c.CloseWrite()
 	}
 }

--- a/pkg/component/controller/cplb/tcpproxy/tcpproxy.go
+++ b/pkg/component/controller/cplb/tcpproxy/tcpproxy.go
@@ -413,7 +413,13 @@ func (r *Route) onDialError() func(src net.Conn, dstDialErr error) {
 		return r.OnDialError
 	}
 	return func(src net.Conn, dstDialErr error) {
-		logrus.WithFields(logrus.Fields{"component": "tcpproxy"}).Errorf("for incoming conn %v, error dialing %q: %v", src.RemoteAddr().String(), r.Addr, dstDialErr)
+		var remoteAddr string
+		if ra := src.RemoteAddr(); ra != nil {
+			remoteAddr = ra.String()
+		} else {
+			remoteAddr = fmt.Sprintf("[%T with nil RemoteAddr]", src)
+		}
+		logrus.WithFields(logrus.Fields{"component": "tcpproxy"}).Errorf("for incoming conn %v, error dialing %q: %v", remoteAddr, r.Addr, dstDialErr)
 		src.Close()
 	}
 }

--- a/pkg/component/controller/cplb/tcpproxy/tcpproxy.go
+++ b/pkg/component/controller/cplb/tcpproxy/tcpproxy.go
@@ -276,8 +276,6 @@ func tcpConn(c net.Conn) (t *net.TCPConn, ok bool) {
 type closeReader interface{ CloseRead() error }
 type closeWriter interface{ CloseWrite() error }
 
-func goCloseConn(c net.Conn) { go c.Close() }
-
 func closeRead(c net.Conn) {
 	// prefer the interfaces, for compatibility with e.g. gvisor/netstack.
 	if c, ok := UnderlyingConn(c).(closeReader); ok {
@@ -307,13 +305,13 @@ func (r *Route) HandleConn(src net.Conn) {
 		r.onDialError()(src, err)
 		return
 	}
-	defer goCloseConn(dst)
+	defer dst.Close()
 
 	if err = r.sendProxyHeader(dst, src); err != nil {
 		r.onDialError()(src, err)
 		return
 	}
-	defer goCloseConn(src)
+	defer src.Close()
 
 	if ka := r.keepAlivePeriod(); ka > 0 {
 		for _, c := range []net.Conn{src, dst} {


### PR DESCRIPTION
## Description

This pulls in the [latest upstream changes][diff] to tcpproxy since k0s forked it in November 2024. Note that [c159a60] has been skipped, since k0s has no need for it. [ded522c] and [48c7e53] don't look directly relevant for k0s either, but they seem to address overall correctness.

[diff]: https://github.com/inetaf/tcpproxy/compare/3ce58045626c8bc343a593c90354975e61b1817a...c159a60511096e475e3489ce13ae57e752c78f99
[c159a60]: https://github.com/inetaf/tcpproxy/commit/c159a60511096e475e3489ce13ae57e752c78f99
[ded522c]: https://github.com/inetaf/tcpproxy/commit/ded522cbd03fff60f35b89361ce923a4251240f9
[48c7e53]: https://github.com/inetaf/tcpproxy/commit/48c7e53d7ac496fcc5c4cb44fdfffb00a696ef53


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
