### PR TITLE
Keep konnectivity server count above zero

### DIFF
--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -104,6 +104,8 @@ func (k *Konnectivity) Start(ctx context.Context) error {
 			case <-serverCountChanged:
 				prevServerCount := serverCount
 				serverCount, serverCountChanged = k.ServerCount()
+				// Never drop below one server: the agent treats zero as one internally anyways.
+				serverCount = max(1, serverCount)
 				// restart only if the server count actually changed
 				if serverCount == prevServerCount {
 					continue

--- a/pkg/component/controller/konnectivityagent.go
+++ b/pkg/component/controller/konnectivityagent.go
@@ -57,6 +57,8 @@ func (k *KonnectivityAgent) Start(ctx context.Context) error {
 			case <-serverCountChanged:
 				prevServerCount := serverCount
 				serverCount, serverCountChanged = k.ServerCount()
+				// Never drop below one server: the agent treats zero as one internally anyways.
+				serverCount = max(1, serverCount)
 				// write only if the server count actually changed
 				if serverCount == prevServerCount {
 					continue


### PR DESCRIPTION
## Description

There may be circumstances in which none of the k0s controller leases are valid. In those cases, a konnectivity rollout is performed to account for that change, as usual. However, the agent itself treats a zero server count as one, so a rollout is futile.

Correct the server count from zero to one in both the server and agent components.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
