### PR TITLE
Prepare for label-based active controller counting

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -36,6 +36,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/component/controller/clusterconfig"
 	"github.com/k0sproject/k0s/pkg/component/controller/cplb"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
+	"github.com/k0sproject/k0s/pkg/component/controller/leasecounter"
 	"github.com/k0sproject/k0s/pkg/component/controller/workerconfig"
 	"github.com/k0sproject/k0s/pkg/component/iptables"
 	"github.com/k0sproject/k0s/pkg/component/manager"
@@ -345,7 +346,7 @@ func (c *command) start(ctx context.Context, runtimeConfig *config.RuntimeConfig
 	}
 
 	if !singleController {
-		nodeComponents.Add(ctx, &controller.K0sControllersLeaseCounter{
+		nodeComponents.Add(ctx, &leasecounter.K0sControllersLeaseCounter{
 			NodeName:              nodeName,
 			InvocationID:          c.K0sVars.InvocationID,
 			KubeClientFactory:     adminClientFactory,

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -346,7 +346,7 @@ func (c *command) start(ctx context.Context, runtimeConfig *config.RuntimeConfig
 	}
 
 	if !singleController {
-		nodeComponents.Add(ctx, &leasecounter.K0sControllersLeaseCounter{
+		nodeComponents.Add(ctx, &leasecounter.Component{
 			NodeName:              nodeName,
 			InvocationID:          c.K0sVars.InvocationID,
 			KubeClientFactory:     adminClientFactory,

--- a/pkg/autopilot/controller/updates/clusterinfo.go
+++ b/pkg/autopilot/controller/updates/clusterinfo.go
@@ -13,7 +13,8 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/build"
-	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/k0sproject/k0s/pkg/component/controller/leasecounter"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -120,7 +121,7 @@ func (c *ClusterInfoCollector) CollectData(ctx context.Context) (*ClusterInfo, e
 	}
 
 	// Collect control plane node count
-	ci.ControlPlaneNodesCount, err = kubeutil.CountActiveControllerLeases(ctx, c.client)
+	ci.ControlPlaneNodesCount, err = leasecounter.ActiveLeases(ctx, c.client)
 	if err != nil {
 		return ci, fmt.Errorf("can't collect control plane nodes count: %w", err)
 	}

--- a/pkg/component/controller/leasecounter/component.go
+++ b/pkg/component/controller/leasecounter/component.go
@@ -100,12 +100,12 @@ func (c *Component) runLeaseCounter(ctx context.Context, clients kubernetes.Inte
 		c.log.Debug("Counting active controller leases")
 		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-		count, err := kubeutil.CountActiveControllerLeases(ctx, clients)
+		numActiveLeases, err := ActiveLeases(ctx, clients)
 		if err != nil {
 			c.log.WithError(err).Error("Failed to count controller lease holders")
 			return
 		}
 
-		c.UpdateControllerCount(count)
+		c.UpdateControllerCount(numActiveLeases)
 	}, 10*time.Second)
 }

--- a/pkg/component/controller/leasecounter/component.go
+++ b/pkg/component/controller/leasecounter/component.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 k0s authors
 // SPDX-License-Identifier: Apache-2.0
 
-package controller
+package leasecounter
 
 import (
 	"context"

--- a/pkg/component/controller/leasecounter/component.go
+++ b/pkg/component/controller/leasecounter/component.go
@@ -21,6 +21,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	nodeNameLabel = "k0s.k0sproject.io/node-name"
+
+	leaseTypeLabel                = "k0s.k0sproject.io/lease-type"
+	leaseTypeLabelValueController = "controller"
+)
+
 // Implements a component that manages a lease per controller. The
 // per-controller leases are used to determine the amount of currently running
 // controllers
@@ -55,8 +62,12 @@ func (c *Component) Start(context.Context) error {
 	client, err := leaderelection.NewClient(&leaderelection.LeaseConfig{
 		Namespace: corev1.NamespaceNodeLease,
 		Name:      leaseName,
-		Identity:  c.InvocationID,
-		Client:    kubeClient.CoordinationV1(),
+		Labels: map[string]string{
+			nodeNameLabel:  string(c.NodeName),
+			leaseTypeLabel: leaseTypeLabelValueController,
+		},
+		Identity: c.InvocationID,
+		Client:   kubeClient.CoordinationV1(),
 	})
 	if err != nil {
 		return err

--- a/pkg/component/controller/leasecounter/component.go
+++ b/pkg/component/controller/leasecounter/component.go
@@ -21,9 +21,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// K0sControllersLeaseCounter implements a component that manages a lease per controller.
-// The per-controller leases are used to determine the amount of currently running controllers
-type K0sControllersLeaseCounter struct {
+// Implements a component that manages a lease per controller. The
+// per-controller leases are used to determine the amount of currently running
+// controllers
+type Component struct {
 	NodeName              apitypes.NodeName
 	InvocationID          string
 	KubeClientFactory     kubeutil.ClientFactoryInterface
@@ -33,28 +34,28 @@ type K0sControllersLeaseCounter struct {
 	stop func()
 }
 
-var _ manager.Component = (*K0sControllersLeaseCounter)(nil)
+var _ manager.Component = (*Component)(nil)
 
 // Init initializes the component needs
-func (l *K0sControllersLeaseCounter) Init(_ context.Context) error {
-	l.log = logrus.WithField("component", "controllerlease")
+func (c *Component) Init(context.Context) error {
+	c.log = logrus.WithField("component", "controllerlease")
 	return nil
 }
 
 // Run runs the leader elector to keep the lease object up-to-date.
-func (l *K0sControllersLeaseCounter) Start(context.Context) error {
-	kubeClient, err := l.KubeClientFactory.GetClient()
+func (c *Component) Start(context.Context) error {
+	kubeClient, err := c.KubeClientFactory.GetClient()
 	if err != nil {
 		return fmt.Errorf("can't create kubernetes rest client for lease pool: %w", err)
 	}
 
 	// Use the node name to make the lease names be clear to which controller they belong to
-	leaseName := "k0s-ctrl-" + string(l.NodeName)
+	leaseName := "k0s-ctrl-" + string(c.NodeName)
 
 	client, err := leaderelection.NewClient(&leaderelection.LeaseConfig{
 		Namespace: corev1.NamespaceNodeLease,
 		Name:      leaseName,
-		Identity:  l.InvocationID,
+		Identity:  c.InvocationID,
 		Client:    kubeClient.CoordinationV1(),
 	})
 	if err != nil {
@@ -65,46 +66,46 @@ func (l *K0sControllersLeaseCounter) Start(context.Context) error {
 	var wg sync.WaitGroup
 
 	wg.Add(2)
-	go func() { defer wg.Done(); l.runLeaderElection(ctx, client) }()
-	go func() { defer wg.Done(); l.runLeaseCounter(ctx, kubeClient) }()
-	l.stop = func() { cancel(); wg.Wait() }
+	go func() { defer wg.Done(); c.runLeaderElection(ctx, client) }()
+	go func() { defer wg.Done(); c.runLeaseCounter(ctx, kubeClient) }()
+	c.stop = func() { cancel(); wg.Wait() }
 
 	return nil
 }
 
 // Stop stops the component
-func (l *K0sControllersLeaseCounter) Stop() error {
-	if l.stop != nil {
-		l.stop()
+func (c *Component) Stop() error {
+	if c.stop != nil {
+		c.stop()
 	}
 	return nil
 }
 
-func (l *K0sControllersLeaseCounter) runLeaderElection(ctx context.Context, client *leaderelection.Client) {
-	l.log.Info("Trying to acquire the controller lease")
+func (c *Component) runLeaderElection(ctx context.Context, client *leaderelection.Client) {
+	c.log.Info("Trying to acquire the controller lease")
 	client.Run(ctx, func(status leaderelection.Status) {
 		if status == leaderelection.StatusLeading {
-			l.log.Info("Holding the controller lease")
+			c.log.Info("Holding the controller lease")
 		} else {
-			l.log.Error("Lost the controller lease")
+			c.log.Error("Lost the controller lease")
 		}
 	})
 }
 
 // Updates the number of active controller leases every 10 secs.
-func (l *K0sControllersLeaseCounter) runLeaseCounter(ctx context.Context, clients kubernetes.Interface) {
-	l.log.Debug("Starting controller lease counter every 10 secs")
+func (c *Component) runLeaseCounter(ctx context.Context, clients kubernetes.Interface) {
+	c.log.Debug("Starting controller lease counter every 10 secs")
 
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
-		l.log.Debug("Counting active controller leases")
+		c.log.Debug("Counting active controller leases")
 		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 		count, err := kubeutil.CountActiveControllerLeases(ctx, clients)
 		if err != nil {
-			l.log.WithError(err).Error("Failed to count controller lease holders")
+			c.log.WithError(err).Error("Failed to count controller lease holders")
 			return
 		}
 
-		l.UpdateControllerCount(count)
+		c.UpdateControllerCount(count)
 	}, 10*time.Second)
 }

--- a/pkg/component/controller/leasecounter/util.go
+++ b/pkg/component/controller/leasecounter/util.go
@@ -22,7 +22,8 @@ func ActiveLeases(ctx context.Context, kubeClient kubernetes.Interface) (count u
 	}
 	for _, l := range leases.Items {
 		switch {
-		case !strings.HasPrefix(l.Name, "k0s-ctrl-"):
+		// FIXME: Remove the name prefix check in k0s 1.38+.
+		case l.Labels[leaseTypeLabel] != leaseTypeLabelValueController && !strings.HasPrefix(l.Name, "k0s-ctrl-"):
 		case l.Spec.HolderIdentity == nil || *l.Spec.HolderIdentity == "":
 		case kubeutil.IsValidLease(l):
 			count++

--- a/pkg/component/controller/leasecounter/util.go
+++ b/pkg/component/controller/leasecounter/util.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package leasecounter
+
+import (
+	"context"
+	"strings"
+
+	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Counts the active controller leases.
+func ActiveLeases(ctx context.Context, kubeClient kubernetes.Interface) (count uint, _ error) {
+	leases, err := kubeClient.CoordinationV1().Leases(corev1.NamespaceNodeLease).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return 0, err
+	}
+	for _, l := range leases.Items {
+		switch {
+		case !strings.HasPrefix(l.Name, "k0s-ctrl-"):
+		case l.Spec.HolderIdentity == nil || *l.Spec.HolderIdentity == "":
+		case kubeutil.IsValidLease(l):
+			count++
+		}
+	}
+
+	return count, nil
+}

--- a/pkg/component/controller/leasecounter/util_test.go
+++ b/pkg/component/controller/leasecounter/util_test.go
@@ -26,16 +26,20 @@ func TestActiveLeases(t *testing.T) {
 		leases   []runtime.Object
 	}{
 		{
-			"counts a single active controller lease",
+			"counts a controller lease identified by label",
 			1, []runtime.Object{makeLease()},
+		},
+		{
+			"counts a legacy controller lease identified by name prefix",
+			1, []runtime.Object{makeLease(withoutControllerLabel, withName("k0s-ctrl-foo"))},
 		},
 		{
 			"returns zero when there are no leases",
 			0, nil,
 		},
 		{
-			"ignores leases without the controller prefix",
-			0, []runtime.Object{makeLease(withName("some-other-lease"))},
+			"ignores leases without the controller label or name prefix",
+			0, []runtime.Object{makeLease(withoutControllerLabel, withName("some-other-lease"))},
 		},
 		{
 			"ignores leases with no holder identity",
@@ -52,15 +56,18 @@ func TestActiveLeases(t *testing.T) {
 		{
 			"counts only the active controller leases among a mix",
 			3, []runtime.Object{
-				makeLease(withName("k0s-ctrl-0")),
-				makeLease(withName("k0s-ctrl-1")),
-				makeLease(withName("k0s-ctrl-2")),
-				// Not counted: doesn't have the controller prefix.
-				makeLease(withName("kube-node-lease-holder")),
+				// Counted: identified by label.
+				makeLease(withName("lease-0")),
+				makeLease(withName("lease-1")),
+				// FIXME: remove in k0s 1.38+
+				// Counted: legacy lease identified by name prefix.
+				makeLease(withoutControllerLabel, withName("k0s-ctrl-legacy")),
+				// Not counted: neither label nor prefix.
+				makeLease(withoutControllerLabel, withName("kube-node-lease-holder")),
 				// Not counted: no holder identity.
-				makeLease(withName("k0s-ctrl-no-holder"), noHolderIdentity),
+				makeLease(withName("lease-no-holder"), noHolderIdentity),
 				// Not counted: expired.
-				makeLease(withName("k0s-ctrl-expired"), expired),
+				makeLease(withName("lease-expired"), expired),
 			},
 		},
 	} {
@@ -77,8 +84,11 @@ func makeLease(funcs ...func(*coordinationv1.Lease)) *coordinationv1.Lease {
 	now := metav1.NowMicro()
 	lease := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "k0s-ctrl-foo",
+			Name:      "foo",
 			Namespace: corev1.NamespaceNodeLease,
+			Labels: map[string]string{
+				leaseTypeLabel: leaseTypeLabelValueController,
+			},
 		},
 		Spec: coordinationv1.LeaseSpec{
 			HolderIdentity:       new("foo"),
@@ -97,6 +107,12 @@ func withName(name string) func(*coordinationv1.Lease) {
 	return func(l *coordinationv1.Lease) {
 		l.Name = name
 	}
+}
+
+// Removes the controller lease type label, so the lease is only considered a
+// controller lease if its name carries the legacy prefix.
+func withoutControllerLabel(l *coordinationv1.Lease) {
+	delete(l.Labels, leaseTypeLabel)
 }
 
 // Pushes the lease's renew time far enough into the past that its duration has

--- a/pkg/component/controller/leasecounter/util_test.go
+++ b/pkg/component/controller/leasecounter/util_test.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package leasecounter
+
+import (
+	"testing"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActiveLeases(t *testing.T) {
+	noHolderIdentity := func(l *coordinationv1.Lease) { l.Spec.HolderIdentity = nil }
+	emptyHolderIdentity := func(l *coordinationv1.Lease) { l.Spec.HolderIdentity = new("") }
+
+	for _, tt := range []struct {
+		name     string
+		expected uint
+		leases   []runtime.Object
+	}{
+		{
+			"counts a single active controller lease",
+			1, []runtime.Object{makeLease()},
+		},
+		{
+			"returns zero when there are no leases",
+			0, nil,
+		},
+		{
+			"ignores leases without the controller prefix",
+			0, []runtime.Object{makeLease(withName("some-other-lease"))},
+		},
+		{
+			"ignores leases with no holder identity",
+			0, []runtime.Object{makeLease(noHolderIdentity)},
+		},
+		{
+			"ignores leases with an empty holder identity",
+			0, []runtime.Object{makeLease(emptyHolderIdentity)},
+		},
+		{
+			"ignores expired leases",
+			0, []runtime.Object{makeLease(expired)},
+		},
+		{
+			"counts only the active controller leases among a mix",
+			3, []runtime.Object{
+				makeLease(withName("k0s-ctrl-0")),
+				makeLease(withName("k0s-ctrl-1")),
+				makeLease(withName("k0s-ctrl-2")),
+				// Not counted: doesn't have the controller prefix.
+				makeLease(withName("kube-node-lease-holder")),
+				// Not counted: no holder identity.
+				makeLease(withName("k0s-ctrl-no-holder"), noHolderIdentity),
+				// Not counted: expired.
+				makeLease(withName("k0s-ctrl-expired"), expired),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewSimpleClientset(tt.leases...)
+			count, err := ActiveLeases(t.Context(), c)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, count)
+		})
+	}
+}
+
+func makeLease(funcs ...func(*coordinationv1.Lease)) *coordinationv1.Lease {
+	now := metav1.NowMicro()
+	lease := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "k0s-ctrl-foo",
+			Namespace: corev1.NamespaceNodeLease,
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity:       new("foo"),
+			LeaseDurationSeconds: new(int32(60)),
+			AcquireTime:          &now,
+			RenewTime:            &now,
+		},
+	}
+	for _, f := range funcs {
+		f(lease)
+	}
+	return lease
+}
+
+func withName(name string) func(*coordinationv1.Lease) {
+	return func(l *coordinationv1.Lease) {
+		l.Name = name
+	}
+}
+
+// Pushes the lease's renew time far enough into the past that its duration has
+// elapsed.
+func expired(l *coordinationv1.Lease) {
+	dur := time.Duration(*l.Spec.LeaseDurationSeconds) * time.Second
+	renewed := metav1.NewMicroTime(time.Now().Add(-dur - time.Second))
+	l.Spec.RenewTime = &renewed
+}

--- a/pkg/kubernetes/lease.go
+++ b/pkg/kubernetes/lease.go
@@ -4,14 +4,9 @@
 package kubernetes
 
 import (
-	"context"
-	"strings"
 	"time"
 
 	coordinationv1 "k8s.io/api/coordination/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 // IsValidLease check whether or not the lease is expired
@@ -21,21 +16,4 @@ func IsValidLease(lease coordinationv1.Lease) bool {
 	leaseExpiry := lease.Spec.RenewTime.Add(leaseDur * time.Second)
 
 	return leaseExpiry.After(time.Now())
-}
-
-func CountActiveControllerLeases(ctx context.Context, kubeClient kubernetes.Interface) (count uint, _ error) {
-	leases, err := kubeClient.CoordinationV1().Leases(corev1.NamespaceNodeLease).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return 0, err
-	}
-	for _, l := range leases.Items {
-		switch {
-		case !strings.HasPrefix(l.Name, "k0s-ctrl-"):
-		case l.Spec.HolderIdentity == nil || *l.Spec.HolderIdentity == "":
-		case IsValidLease(l):
-			count++
-		}
-	}
-
-	return count, nil
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/build"
-	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
+	"github.com/k0sproject/k0s/pkg/component/controller/leasecounter"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,7 +68,7 @@ func (c *Component) collectTelemetry(ctx context.Context, clients kubernetes.Int
 	data.WorkerData = wds
 	data.MEMTotal = sums.memTotal
 	data.CPUTotal = sums.cpuTotal
-	data.ControlPlaneNodesCount, err = kubeutil.CountActiveControllerLeases(ctx, clients)
+	data.ControlPlaneNodesCount, err = leasecounter.ActiveLeases(ctx, clients)
 	if err != nil {
 		return data, fmt.Errorf("can't collect control plane nodes count: %w", err)
 	}


### PR DESCRIPTION
## Description

The name prefix based approach is not really Kubernetes-style. Switch to a label-based approach instead. This will allow for switching to lease based server counting for konnectivity in k0s 1.38.

Move the controller lease counter to its own package, and also move the counting of the active controller leases there, bringing the lease counter component and the code that actually counts them closer together.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
