### PR TITLE
Allow set network for all bootloose machines

### DIFF
--- a/inttest/common/bootloosesuite.go
+++ b/inttest/common/bootloosesuite.go
@@ -1226,6 +1226,7 @@ func (s *BootlooseSuite) initializeBootlooseClusterInDir(dir string) error {
 					Privileged:   true,
 					Volumes:      volumes,
 					PortMappings: portMaps,
+					Networks:     s.Networks,
 				},
 			},
 		},
@@ -1239,6 +1240,7 @@ func (s *BootlooseSuite) initializeBootlooseClusterInDir(dir string) error {
 				Privileged:   true,
 				Volumes:      volumes,
 				PortMappings: portMaps,
+				Networks:     s.Networks,
 			},
 			Count: 1,
 		})
@@ -1251,6 +1253,7 @@ func (s *BootlooseSuite) initializeBootlooseClusterInDir(dir string) error {
 				Image:        defaultBootLooseImage,
 				Privileged:   true,
 				PortMappings: []config.PortMapping{{ContainerPort: 22}},
+				Networks:     s.Networks,
 			},
 			Count: 1,
 		})
@@ -1270,6 +1273,7 @@ func (s *BootlooseSuite) initializeBootlooseClusterInDir(dir string) error {
 						ContainerPort: 80,
 					},
 				},
+				Networks: s.Networks,
 			},
 			Count: 1,
 		})


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

We want to switch from footloose to bootloose in k0smtoron but in some tests when running containers as remotemachines, we need to put that remote machine in the same network as the management cluster, which seems to be a configuration lost in bootloose.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
