### PR TITLE
fix: reject non-semver versions for OCI charts

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/k0sproject/k0s/internal/pkg/dir"
 	internallog "github.com/k0sproject/k0s/internal/pkg/log"
 	"github.com/k0sproject/k0s/pkg/constant"
@@ -294,6 +295,7 @@ func (hc *Commands) downloadDependencies(chart *chart.Chart, chartPath string, r
 
 func (hc *Commands) locateChart(name string, version string, registryClient *registry.Client) (string, error) {
 	name = strings.TrimSpace(name)
+	version = strings.TrimSpace(version)
 
 	if _, err := os.Stat(name); err == nil {
 		abs, err := filepath.Abs(name)
@@ -304,6 +306,11 @@ func (hc *Commands) locateChart(name string, version string, registryClient *reg
 	}
 	if filepath.IsAbs(name) || strings.HasPrefix(name, ".") {
 		return name, fmt.Errorf("can't locate chart: path not found: %s", name)
+	}
+	if registry.IsOCI(name) {
+		if _, err := semver.NewVersion(version); err != nil {
+			return "", fmt.Errorf("can't locate chart `%s-%s`: OCI charts require a fixed SemVer version: %w", name, version, err)
+		}
 	}
 
 	dl := downloader.ChartDownloader{

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommands_locateChart_OCIRequiresFixedVersion(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	underTest := &Commands{
+		repoFile:     tempDir + "/repositories.yaml",
+		helmCacheDir: tempDir + "/cache",
+	}
+
+	for _, version := range []string{"", "latest"} {
+		_, err := underTest.locateChart("oci://ghcr.io/k0sproject/charts/test", version, nil)
+		require.ErrorContains(t, err, "OCI charts require a fixed SemVer version")
+	}
+}


### PR DESCRIPTION
## Description

Fixes #5156

OCI charts with an empty or non semver `version` could panic in Helm download code. This patch bails out early and returns a clean error instead. Small fix, but it kills a nasty footgun.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

Repro:

1. Use an OCI chart and leave `spec.version` empty, or set it to `latest`
2. Hit the Helm path that installs it
3. Before this patch, the path can panic with a nil pointer dereference in Helm
4. After this patch, it returns `OCI charts require a fixed SemVer version`

Checks I ran:

- `go test ./pkg/helm -run TestCommands_locateChart_OCIRequiresFixedVersion -count=1`
- `go test ./pkg/helm/...`

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
