### PR TITLE
Extend Renovate's OCI image versioning regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,9 +44,10 @@
     {
       "description": "Special version scheme for k0sproject OCI images",
       "matchPackageNames": [
-        "quay.io/k0sproject/*"
+        "quay.io/k0sproject/*",
+        "docker.io/sigwindowstools/kube-proxy"
       ],
-      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-(?:iptables\\d+\\.\\d+\\.\\d+-)?(?:k0s\\.)?(?<build>\\d+))?$"
+      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-(?<prerelease>(?:alpha|beta|rc)\\.\\d+))?(?:-(?<compatibility>.+?))??(?:-(?:iptables\\d+\\.\\d+\\.\\d+))?(?:-(?:k0s\\.)?(?<build>\\d+))?$"
     },
     {
       "description": "Ignore all Go dependencies by default",


### PR DESCRIPTION
## Description

Add pre-release and compatibility groups to the OCI image versioning regex, so that the pre-release bumps for Kubernetes work as expected. The compatibility matching group uses non-greedy quantifiers, so that they won't slurp any k0s suffixes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
