### PR TITLE
autopilot: don't wait before first kubelet cert check

### DIFF
--- a/pkg/component/worker/autopilot.go
+++ b/pkg/component/worker/autopilot.go
@@ -47,10 +47,10 @@ func (a *Autopilot) Start(ctx context.Context) error {
 	defer cancel()
 
 	var restConfig *rest.Config
-	// wait.PollUntilWithContext passes it is own ctx argument as a ctx to the given function
 	// Poll until the kubelet config can be loaded successfully, as this is the access to the kube api
-	// needed by autopilot.
-	if err := wait.PollUntilWithContext(timeout, defaultPollDuration, func(ctx context.Context) (done bool, err error) {
+	// needed by autopilot. immediate=true checks the condition before the first wait interval, so if
+	// the cert is already in place (the common case) there is no delay.
+	if err := wait.PollUntilContextCancel(timeout, defaultPollDuration, true, func(ctx context.Context) (done bool, err error) {
 		log.Debugf("Attempting to load autopilot client config")
 		if restConfig, err = a.CertManager.GetRestConfig(ctx); err != nil {
 			log.WithError(err).Warnf("Failed to load autopilot client config, retrying in %v", defaultPollDuration)


### PR DESCRIPTION
PollUntilWithContext (which is deprectaed) waits the full interval before the first condition check. Since the kubelet cert is already written by the time Start is called, the component blocked for 5 seconds on every worker startup for no reason. Switch to PollUntilContextCancel with immediate=true so the cert is checked on entry and the 5-second interval only applies when the cert is genuinely not ready yet.

<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
