### PR TITLE
Support K0S_JOIN_TOKEN and deprecate CLI token args

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -93,6 +93,7 @@ func NewControllerCmd() *cobra.Command {
 
 			if len(args) > 0 {
 				c.TokenArg = args[0]
+				logrus.Warn("Passing the join token as a positional CLI argument is deprecated and will be removed in a future release. Please use the --token-file flag or the K0S_JOIN_TOKEN environment variable instead.")
 			}
 			if err := internal.CheckSingleTokenSource(c.TokenArg, c.TokenFile); err != nil {
 				return err

--- a/cmd/internal/tokendata.go
+++ b/cmd/internal/tokendata.go
@@ -9,8 +9,11 @@ import (
 	"os"
 )
 
-// EnvVarToken is the environment variable name for the join token
+// EnvVarToken is the environment variable name for the join token (legacy/fallback)
 const EnvVarToken = "K0S_TOKEN"
+
+// EnvVarJoinToken is the preferred environment variable name for the join token
+const EnvVarJoinToken = "K0S_JOIN_TOKEN"
 
 // CheckSingleTokenSource verifies that at most one token source is provided.
 // Returns an error if multiple sources are specified.
@@ -22,22 +25,25 @@ func CheckSingleTokenSource(tokenArg, tokenFile string) error {
 	if tokenFile != "" {
 		tokenSources++
 	}
-	if os.Getenv(EnvVarToken) != "" {
+	if os.Getenv(EnvVarJoinToken) != "" || os.Getenv(EnvVarToken) != "" {
 		tokenSources++
 	}
 
 	if tokenSources > 1 {
-		return fmt.Errorf("you can only pass one token source: either as a CLI argument, via '--token-file [path]', or via the %s environment variable", EnvVarToken)
+		return fmt.Errorf("you can only pass one token source: either as a CLI argument, via '--token-file [path]', or via the %s / %s environment variables", EnvVarJoinToken, EnvVarToken)
 	}
 
 	return nil
 }
 
 // GetTokenData resolves the join token from multiple possible sources:
-// CLI argument, token file, or K0S_TOKEN environment variable.
+// CLI argument, token file, or K0S_JOIN_TOKEN/K0S_TOKEN environment variable.
 // Returns empty string if no token source is available.
 func GetTokenData(tokenArg, tokenFile string) (string, error) {
-	tokenEnvValue := os.Getenv(EnvVarToken)
+	tokenEnvValue := os.Getenv(EnvVarJoinToken)
+	if tokenEnvValue == "" {
+		tokenEnvValue = os.Getenv(EnvVarToken)
+	}
 
 	if tokenArg != "" {
 		return tokenArg, nil

--- a/cmd/internal/tokendata_test.go
+++ b/cmd/internal/tokendata_test.go
@@ -17,6 +17,7 @@ func TestCheckSingleTokenSource(t *testing.T) {
 
 	t.Run("returns nil when no token sources provided", func(t *testing.T) {
 		t.Setenv(EnvVarToken, "")
+		t.Setenv(EnvVarJoinToken, "")
 
 		err := CheckSingleTokenSource("", "")
 		require.NoError(t, err)
@@ -24,6 +25,7 @@ func TestCheckSingleTokenSource(t *testing.T) {
 
 	t.Run("returns nil when only arg provided", func(t *testing.T) {
 		t.Setenv(EnvVarToken, "")
+		t.Setenv(EnvVarJoinToken, "")
 
 		err := CheckSingleTokenSource(testToken, "")
 		require.NoError(t, err)
@@ -31,20 +33,31 @@ func TestCheckSingleTokenSource(t *testing.T) {
 
 	t.Run("returns nil when only file provided", func(t *testing.T) {
 		t.Setenv(EnvVarToken, "")
+		t.Setenv(EnvVarJoinToken, "")
 
 		err := CheckSingleTokenSource("", "/path/to/token")
 		require.NoError(t, err)
 	})
 
-	t.Run("returns nil when only env provided", func(t *testing.T) {
+	t.Run("returns nil when only env provided (K0S_TOKEN)", func(t *testing.T) {
 		t.Setenv(EnvVarToken, testToken)
+		t.Setenv(EnvVarJoinToken, "")
 
 		err := CheckSingleTokenSource("", "")
 		require.NoError(t, err)
 	})
 
-	t.Run("returns error when multiple token sources provided - env and arg", func(t *testing.T) {
+	t.Run("returns nil when only env provided (K0S_JOIN_TOKEN)", func(t *testing.T) {
+		t.Setenv(EnvVarToken, "")
+		t.Setenv(EnvVarJoinToken, testToken)
+
+		err := CheckSingleTokenSource("", "")
+		require.NoError(t, err)
+	})
+
+	t.Run("returns error when multiple token sources provided - env (K0S_TOKEN) and arg", func(t *testing.T) {
 		t.Setenv(EnvVarToken, testToken)
+		t.Setenv(EnvVarJoinToken, "")
 
 		err := CheckSingleTokenSource(testToken, "")
 		require.Error(t, err)
@@ -52,8 +65,28 @@ func TestCheckSingleTokenSource(t *testing.T) {
 		assert.Contains(t, err.Error(), EnvVarToken)
 	})
 
-	t.Run("returns error when multiple token sources provided - env and file", func(t *testing.T) {
+	t.Run("returns error when multiple token sources provided - env (K0S_JOIN_TOKEN) and arg", func(t *testing.T) {
+		t.Setenv(EnvVarToken, "")
+		t.Setenv(EnvVarJoinToken, testToken)
+
+		err := CheckSingleTokenSource(testToken, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "you can only pass one token source")
+		assert.Contains(t, err.Error(), EnvVarJoinToken)
+	})
+
+	t.Run("returns error when multiple token sources provided - env (K0S_TOKEN) and file", func(t *testing.T) {
 		t.Setenv(EnvVarToken, testToken)
+		t.Setenv(EnvVarJoinToken, "")
+
+		err := CheckSingleTokenSource("", "/path/to/token")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "you can only pass one token source")
+	})
+
+	t.Run("returns error when multiple token sources provided - env (K0S_JOIN_TOKEN) and file", func(t *testing.T) {
+		t.Setenv(EnvVarToken, "")
+		t.Setenv(EnvVarJoinToken, testToken)
 
 		err := CheckSingleTokenSource("", "/path/to/token")
 		require.Error(t, err)
@@ -62,6 +95,7 @@ func TestCheckSingleTokenSource(t *testing.T) {
 
 	t.Run("returns error when multiple token sources provided - arg and file", func(t *testing.T) {
 		t.Setenv(EnvVarToken, "")
+		t.Setenv(EnvVarJoinToken, "")
 
 		err := CheckSingleTokenSource(testToken, "/path/to/token")
 		require.Error(t, err)
@@ -70,6 +104,7 @@ func TestCheckSingleTokenSource(t *testing.T) {
 
 	t.Run("returns error when all three token sources provided", func(t *testing.T) {
 		t.Setenv(EnvVarToken, testToken)
+		t.Setenv(EnvVarJoinToken, testToken)
 
 		err := CheckSingleTokenSource(testToken, "/path/to/token")
 		require.Error(t, err)
@@ -79,17 +114,38 @@ func TestCheckSingleTokenSource(t *testing.T) {
 
 func TestGetTokenData_EnvVar(t *testing.T) {
 	testToken := "test-token-data"
+	legacyToken := "legacy-token-data"
 
-	t.Run("reads token from K0S_TOKEN env var", func(t *testing.T) {
-		t.Setenv(EnvVarToken, testToken)
+	t.Run("reads token from K0S_JOIN_TOKEN env var", func(t *testing.T) {
+		t.Setenv(EnvVarToken, "")
+		t.Setenv(EnvVarJoinToken, testToken)
 
 		token, err := GetTokenData("", "")
 		require.NoError(t, err)
 		assert.Equal(t, testToken, token)
 	})
 
-	t.Run("empty K0S_TOKEN returns empty string", func(t *testing.T) {
+	t.Run("reads token from K0S_TOKEN env var when K0S_JOIN_TOKEN is empty", func(t *testing.T) {
+		t.Setenv(EnvVarToken, legacyToken)
+		t.Setenv(EnvVarJoinToken, "")
+
+		token, err := GetTokenData("", "")
+		require.NoError(t, err)
+		assert.Equal(t, legacyToken, token)
+	})
+
+	t.Run("prioritizes K0S_JOIN_TOKEN over K0S_TOKEN", func(t *testing.T) {
+		t.Setenv(EnvVarToken, legacyToken)
+		t.Setenv(EnvVarJoinToken, testToken)
+
+		token, err := GetTokenData("", "")
+		require.NoError(t, err)
+		assert.Equal(t, testToken, token)
+	})
+
+	t.Run("empty environment variables returns empty string", func(t *testing.T) {
 		t.Setenv(EnvVarToken, "")
+		t.Setenv(EnvVarJoinToken, "")
 
 		token, err := GetTokenData("", "")
 		require.NoError(t, err)
@@ -102,6 +158,7 @@ func TestGetTokenData_TokenArg(t *testing.T) {
 
 	t.Run("reads token from argument", func(t *testing.T) {
 		t.Setenv(EnvVarToken, "")
+		t.Setenv(EnvVarJoinToken, "")
 
 		token, err := GetTokenData(testToken, "")
 		require.NoError(t, err)
@@ -114,6 +171,7 @@ func TestGetTokenData_TokenFile(t *testing.T) {
 
 	t.Run("reads token from file", func(t *testing.T) {
 		t.Setenv(EnvVarToken, "")
+		t.Setenv(EnvVarJoinToken, "")
 
 		tmpDir := t.TempDir()
 		tokenFile := filepath.Join(tmpDir, "token")
@@ -126,6 +184,7 @@ func TestGetTokenData_TokenFile(t *testing.T) {
 
 	t.Run("returns error for non-existent file", func(t *testing.T) {
 		t.Setenv(EnvVarToken, "")
+		t.Setenv(EnvVarJoinToken, "")
 
 		_, err := GetTokenData("", "/non/existent/path")
 		require.Error(t, err)
@@ -136,6 +195,7 @@ func TestGetTokenData_TokenFile(t *testing.T) {
 
 	t.Run("returns error for empty file", func(t *testing.T) {
 		t.Setenv(EnvVarToken, "")
+		t.Setenv(EnvVarJoinToken, "")
 
 		tmpDir := t.TempDir()
 		tokenFile := filepath.Join(tmpDir, "empty-token")
@@ -152,6 +212,7 @@ func TestGetTokenData_TokenFile(t *testing.T) {
 func TestGetTokenData_NoToken(t *testing.T) {
 	t.Run("returns empty string when no token provided", func(t *testing.T) {
 		t.Setenv(EnvVarToken, "")
+		t.Setenv(EnvVarJoinToken, "")
 
 		token, err := GetTokenData("", "")
 		require.NoError(t, err)

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -83,6 +83,7 @@ func NewWorkerCmd() *cobra.Command {
 			c := (*Command)(opts)
 			if len(args) > 0 {
 				c.TokenArg = args[0]
+				logrus.Warn("Passing the join token as a positional CLI argument is deprecated and will be removed in a future release. Please use the --token-file flag or the K0S_JOIN_TOKEN environment variable instead.")
 			}
 			if err := internal.CheckSingleTokenSource(c.TokenArg, c.TokenFile); err != nil {
 				return err
@@ -171,7 +172,11 @@ func kubeconfigGetterFromJoinToken(tokenFile, tokenArg string) clientcmd.Kubecon
 		}
 	}
 
-	if envToken := os.Getenv(internal.EnvVarToken); envToken != "" {
+	envToken := os.Getenv(internal.EnvVarJoinToken)
+	if envToken == "" {
+		envToken = os.Getenv(internal.EnvVarToken)
+	}
+	if envToken != "" {
 		return func() (*clientcmdapi.Config, error) {
 			return loadKubeconfigFromJoinToken(envToken)
 		}

--- a/cmd/worker/worker_test.go
+++ b/cmd/worker/worker_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestKubeconfigGetterFromJoinToken_NoSources(t *testing.T) {
 	t.Setenv(internal.EnvVarToken, "")
+	t.Setenv(internal.EnvVarJoinToken, "")
 
 	getter := kubeconfigGetterFromJoinToken("", "")
 	require.Nil(t, getter)
@@ -20,6 +21,7 @@ func TestKubeconfigGetterFromJoinToken_NoSources(t *testing.T) {
 
 func TestKubeconfigGetterFromJoinToken_TokenFileLazy(t *testing.T) {
 	t.Setenv(internal.EnvVarToken, "")
+	t.Setenv(internal.EnvVarJoinToken, "")
 	tokenFile := filepath.Join(t.TempDir(), "missing.token")
 
 	getter := kubeconfigGetterFromJoinToken(tokenFile, "")
@@ -32,6 +34,18 @@ func TestKubeconfigGetterFromJoinToken_TokenFileLazy(t *testing.T) {
 
 func TestKubeconfigGetterFromJoinToken_EnvVarDeferred(t *testing.T) {
 	t.Setenv(internal.EnvVarToken, "not-base64")
+	t.Setenv(internal.EnvVarJoinToken, "")
+
+	getter := kubeconfigGetterFromJoinToken("", "")
+	require.NotNil(t, getter)
+
+	_, err := getter()
+	require.ErrorContains(t, err, "failed to decode join token")
+}
+
+func TestKubeconfigGetterFromJoinToken_JoinEnvVarDeferred(t *testing.T) {
+	t.Setenv(internal.EnvVarToken, "")
+	t.Setenv(internal.EnvVarJoinToken, "not-base64")
 
 	getter := kubeconfigGetterFromJoinToken("", "")
 	require.NotNil(t, getter)
@@ -42,6 +56,7 @@ func TestKubeconfigGetterFromJoinToken_EnvVarDeferred(t *testing.T) {
 
 func TestKubeconfigGetterFromJoinToken_InvalidArgDeferred(t *testing.T) {
 	t.Setenv(internal.EnvVarToken, "")
+	t.Setenv(internal.EnvVarJoinToken, "")
 
 	getter := kubeconfigGetterFromJoinToken("", "invalid")
 	require.NotNil(t, getter)


### PR DESCRIPTION
### Description
This PR resolves #5253 by:
1. Adding support for the `K0S_JOIN_TOKEN` environment variable as the preferred source for join tokens.
2. Falling back to the legacy `K0S_TOKEN` environment variable for backwards compatibility.
3. Adding deprecation warnings to both `k0s controller` and `k0s worker` subcommands when a join token is passed as a positional command-line argument.

This ensures credentials are passed securely and gives users a clear deprecation warning timeline to transition off positional arguments.

### Testing
Ran unit tests for validation and retrieval:
- `go test -v ./cmd/internal/...`
- `go test -v ./cmd/worker/...`
All tests passed successfully.

### AI Assistance Note
This PR was written with AI assistance.