### PR TITLE
[Backport release-1.34] Bump docker.io/library/alpine Docker tag to v3.23.5

### DIFF
--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=docker.io/library/alpine versioning=docker
-alpine_patch_version = 3.23.0
+alpine_patch_version = 3.23.2
 alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 
 # renovate: datasource=golang-version depName=go

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=docker.io/library/alpine versioning=docker
-alpine_patch_version = 3.23.2
+alpine_patch_version = 3.23.3
 alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 
 # renovate: datasource=golang-version depName=go

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=docker.io/library/alpine versioning=docker
-alpine_patch_version = 3.23.3
+alpine_patch_version = 3.23.4
 alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 
 # renovate: datasource=golang-version depName=go

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=docker.io/library/alpine versioning=docker
-alpine_patch_version = 3.23.4
+alpine_patch_version = 3.23.5
 alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 
 # renovate: datasource=golang-version depName=go

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=docker.io/library/alpine versioning=docker
-alpine_patch_version = 3.22.5
+alpine_patch_version = 3.23.0
 alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 
 # renovate: datasource=golang-version depName=go


### PR DESCRIPTION
Backport to release-1.34:

* #6773
* #6873
* #7040
* #7481
* #7872

See:

* #7475
* #7860
