### PR TITLE
[Backport release-1.33] Bump Alpine to 3.22.5 and Python to 3.14.3

### DIFF
--- a/docs/Makefile.variables
+++ b/docs/Makefile.variables
@@ -1,2 +1,2 @@
 # renovate: datasource=python-version depName=python versioning=python
-python_version = 3.14.1
+python_version = 3.14.2

--- a/docs/Makefile.variables
+++ b/docs/Makefile.variables
@@ -1,2 +1,2 @@
 # renovate: datasource=python-version depName=python versioning=python
-python_version = 3.14.2
+python_version = 3.14.3

--- a/docs/Makefile.variables
+++ b/docs/Makefile.variables
@@ -1,2 +1,2 @@
 # renovate: datasource=python-version depName=python versioning=python
-python_version = 3.13.5
+python_version = 3.13.6

--- a/docs/Makefile.variables
+++ b/docs/Makefile.variables
@@ -1,2 +1,2 @@
 # renovate: datasource=python-version depName=python versioning=python
-python_version = 3.13.7
+python_version = 3.14.0

--- a/docs/Makefile.variables
+++ b/docs/Makefile.variables
@@ -1,2 +1,2 @@
 # renovate: datasource=python-version depName=python versioning=python
-python_version = 3.13.4
+python_version = 3.13.5

--- a/docs/Makefile.variables
+++ b/docs/Makefile.variables
@@ -1,2 +1,2 @@
 # renovate: datasource=python-version depName=python versioning=python
-python_version = 3.13.6
+python_version = 3.13.7

--- a/docs/Makefile.variables
+++ b/docs/Makefile.variables
@@ -1,2 +1,2 @@
 # renovate: datasource=python-version depName=python versioning=python
-python_version = 3.14.0
+python_version = 3.14.1

--- a/docs/Makefile.variables
+++ b/docs/Makefile.variables
@@ -1,2 +1,2 @@
 # renovate: datasource=python-version depName=python versioning=python
-python_version = 3.13.1
+python_version = 3.13.4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -31,7 +31,7 @@ pyparsing==3.2.3
 python-dateutil==2.9.0.post0
 PyYAML==6.0.2
 pyyaml_env_tag==1.1
-regex==2025.7.34
+regex==2025.8.29
 requests==2.32.3
 six==1.17.0
 termcolor==3.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -31,7 +31,7 @@ pyparsing==3.2.3
 python-dateutil==2.9.0.post0
 PyYAML==6.0.2
 pyyaml_env_tag==1.1
-regex==2024.11.6
+regex==2025.7.34
 requests==2.32.3
 six==1.17.0
 termcolor==3.1.0

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=docker.io/library/alpine versioning=docker
-alpine_patch_version = 3.22.2
+alpine_patch_version = 3.22.3
 alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 
 # renovate: datasource=golang-version depName=go

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=docker.io/library/alpine versioning=docker
-alpine_patch_version = 3.22.4
+alpine_patch_version = 3.22.5
 alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 
 # renovate: datasource=golang-version depName=go

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=docker.io/library/alpine versioning=docker
-alpine_patch_version = 3.21.6
+alpine_patch_version = 3.22.0
 alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 
 # renovate: datasource=golang-version depName=go

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=docker.io/library/alpine versioning=docker
-alpine_patch_version = 3.22.1
+alpine_patch_version = 3.22.2
 alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 
 # renovate: datasource=golang-version depName=go

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=docker.io/library/alpine versioning=docker
-alpine_patch_version = 3.22.0
+alpine_patch_version = 3.22.1
 alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 
 # renovate: datasource=golang-version depName=go

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=docker.io/library/alpine versioning=docker
-alpine_patch_version = 3.22.3
+alpine_patch_version = 3.22.4
 alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 
 # renovate: datasource=golang-version depName=go


### PR DESCRIPTION
Backport `release-1.33`:

* #5973
* #5981
* #5982
* #6143
* #6219
* #6242
* #6283
* #6344
* #6480
* #6489
* #7146
* #7488
* #7855
* #7970

See:

* #6760
* #6806
* #7072