### PR TITLE
Omit anonymous-auth default when authentication config has anonymous

### DIFF
--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -19,6 +20,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 
 	"github.com/k0sproject/k0s/internal/pkg/stringmap"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
@@ -142,7 +144,26 @@ func (a *APIServer) Start(ctx context.Context) error {
 		args[name] = value
 	}
 	args = a.NodeConfig.Spec.FeatureGates.BuildArgs(args, kubeAPIComponentName)
+
+	// kube-apiserver refuses to start if the --anonymous-auth flag is set
+	// while the file referenced by --authentication-config contains the
+	// anonymous field. Skip the anonymous-auth default in that case, so that
+	// anonymous authentication can be managed via the configuration file.
+	anonymousAuthManaged := false
+	if path := args["authentication-config"]; path != "" {
+		var err error
+		anonymousAuthManaged, err = authenticationConfigHasAnonymous(path)
+		if err != nil {
+			logrus.WithError(err).Warn("Failed to check the authentication configuration for the anonymous field, applying the anonymous-auth default")
+		} else if anonymousAuthManaged && args["anonymous-auth"] != "" {
+			logrus.Warn("The anonymous-auth flag is set while the authentication configuration contains the anonymous field, kube-apiserver will refuse to start")
+		}
+	}
+
 	for name, value := range apiDefaultArgs {
+		if name == "anonymous-auth" && anonymousAuthManaged {
+			continue
+		}
 		if args[name] == "" {
 			args[name] = value
 		}
@@ -283,6 +304,26 @@ func (a *APIServer) Ready() error {
 		return fmt.Errorf("expected 200 for api server ready check, got %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// authenticationConfigHasAnonymous reports whether the authentication
+// configuration file at path contains the anonymous field. If it does,
+// kube-apiserver manages anonymous authentication via the configuration file
+// and refuses to start when the --anonymous-auth flag is set as well.
+func authenticationConfigHasAnonymous(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	var authConfig struct {
+		Anonymous json.RawMessage `json:"anonymous"`
+	}
+	if err := yaml.Unmarshal(data, &authConfig); err != nil {
+		return false, fmt.Errorf("failed to parse %q: %w", path, err)
+	}
+
+	return len(authConfig.Anonymous) > 0 && string(authConfig.Anonymous) != "null", nil
 }
 
 func getEtcdArgs(storage *v1beta1.StorageSpec, k0sVars *config.CfgVars) ([]string, error) {

--- a/pkg/component/controller/apiserver_test.go
+++ b/pkg/component/controller/apiserver_test.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -21,6 +22,77 @@ func TestApiServerSuite(t *testing.T) {
 	apiServerSuite := &apiServerSuite{}
 
 	suite.Run(t, apiServerSuite)
+}
+
+func (a *apiServerSuite) TestAuthenticationConfigHasAnonymous() {
+	writeConfig := func(content string) string {
+		path := filepath.Join(a.T().TempDir(), "authentication-config.yaml")
+		a.Require().NoError(os.WriteFile(path, []byte(content), 0o600))
+		return path
+	}
+
+	a.Run("anonymous field present", func() {
+		path := writeConfig(`
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthenticationConfiguration
+anonymous:
+  enabled: true
+  conditions:
+    - path: /readyz
+`)
+		hasAnonymous, err := authenticationConfigHasAnonymous(path)
+		a.Require().NoError(err)
+		a.Require().True(hasAnonymous)
+	})
+
+	a.Run("anonymous field present but disabled", func() {
+		path := writeConfig(`
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthenticationConfiguration
+anonymous:
+  enabled: false
+`)
+		hasAnonymous, err := authenticationConfigHasAnonymous(path)
+		a.Require().NoError(err)
+		a.Require().True(hasAnonymous)
+	})
+
+	a.Run("anonymous field absent", func() {
+		path := writeConfig(`
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthenticationConfiguration
+jwt:
+  - issuer:
+      url: https://example.com/dex
+`)
+		hasAnonymous, err := authenticationConfigHasAnonymous(path)
+		a.Require().NoError(err)
+		a.Require().False(hasAnonymous)
+	})
+
+	a.Run("anonymous field null", func() {
+		path := writeConfig(`
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthenticationConfiguration
+anonymous: null
+`)
+		hasAnonymous, err := authenticationConfigHasAnonymous(path)
+		a.Require().NoError(err)
+		a.Require().False(hasAnonymous)
+	})
+
+	a.Run("file missing", func() {
+		hasAnonymous, err := authenticationConfigHasAnonymous(filepath.Join(a.T().TempDir(), "nonexistent.yaml"))
+		a.Require().Error(err)
+		a.Require().False(hasAnonymous)
+	})
+
+	a.Run("file malformed", func() {
+		path := writeConfig(`{unparseable`)
+		hasAnonymous, err := authenticationConfigHasAnonymous(path)
+		a.Require().Error(err)
+		a.Require().False(hasAnonymous)
+	})
 }
 
 func (a *apiServerSuite) TestGetEtcdArgs() {


### PR DESCRIPTION
## Description

k0s always passes `--anonymous-auth` to kube-apiserver. `anonymous-auth: "false"` is part of `apiDefaultArgs` and is backfilled whenever the arg is not set via `spec.api.extraArgs`. kube-apiserver refuses to start when that flag is set while the file referenced by `--authentication-config` contains the `anonymous` field (KEP-4633, stable since Kubernetes v1.34). As a result the `anonymous` field cannot be used with k0s at all.

With this change k0s inspects the file referenced by the `authentication-config` extra arg. When the file contains the `anonymous` field, the `anonymous-auth` default is omitted and the configuration file governs anonymous authentication. Behavior is unchanged in every other case:

| Configuration | Before | After |
|---|---|---|
| No `authentication-config` extra arg | `--anonymous-auth=false` | unchanged |
| `authentication-config` set, file without `anonymous` | `--anonymous-auth=false` | unchanged |
| `authentication-config` set, file with `anonymous` | kube-apiserver refuses to start | flag omitted, file governs |
| Explicit `anonymous-auth` extra arg | passed through | unchanged, warning logged if it conflicts with the file |

If the file cannot be read or parsed, k0s logs a warning and keeps the current behavior of passing the flag.

The main use case is letting load balancers health check `/readyz` without credentials while every other anonymous request is still rejected with 401, matching the intent of `--anonymous-auth=false`:

```yaml
anonymous:
  enabled: true
  conditions:
    - path: /readyz
```

RKE2 fixed the same limitation in rancher/rke2#8137.

Fixes #7961

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

Unit tests cover the new `authenticationConfigHasAnonymous` helper: field present, present but disabled, absent, null value, missing file, and malformed file. The full `pkg/component/controller` suite passes locally.

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
