### PR TITLE
Refactor feature gates

### DIFF
--- a/pkg/apis/k0s/v1beta1/feature_gates.go
+++ b/pkg/apis/k0s/v1beta1/feature_gates.go
@@ -5,19 +5,9 @@ package v1beta1
 
 import (
 	"errors"
-	"slices"
 )
 
 var _ Validateable = (*FeatureGates)(nil)
-
-// KubernetesComponents default components to use feature gates with
-var KubernetesComponents = []string{
-	"kube-apiserver",
-	"kube-controller-manager",
-	"kubelet",
-	"kube-scheduler",
-	"kube-proxy",
-}
 
 // FeatureGates collection of feature gate specs
 // +listType=map
@@ -48,15 +38,6 @@ type FeatureGate struct {
 	// +kubebuilder:default={kube-apiserver,kube-controller-manager,kubelet,kube-scheduler,kube-proxy}
 	// +listType=set
 	Components []string `json:"components,omitempty"`
-}
-
-// Checks if this feature gate applies to a given component or not.
-func (fg *FeatureGate) AppliesTo(component string) bool {
-	components := fg.Components
-	if len(components) == 0 {
-		components = KubernetesComponents
-	}
-	return slices.Contains(components, component)
 }
 
 // Validate given feature gate

--- a/pkg/apis/k0s/v1beta1/feature_gates.go
+++ b/pkg/apis/k0s/v1beta1/feature_gates.go
@@ -5,12 +5,7 @@ package v1beta1
 
 import (
 	"errors"
-	"maps"
 	"slices"
-	"strconv"
-	"strings"
-
-	"github.com/k0sproject/k0s/internal/pkg/stringmap"
 )
 
 var _ Validateable = (*FeatureGates)(nil)
@@ -38,46 +33,6 @@ func (fgs FeatureGates) Validate() []error {
 		}
 	}
 	return errors
-}
-
-// BuildArgs builds CLI args using the given args and component name.
-func (fgs FeatureGates) BuildArgs(args stringmap.StringMap, component string) stringmap.StringMap {
-	var newValue strings.Builder
-
-	oldValueLen, _ := newValue.WriteString(args["feature-gates"])
-	for _, feature := range fgs {
-		if feature.AppliesTo(component) {
-			if newValue.Len() > 0 {
-				newValue.WriteByte(',')
-			}
-			newValue.WriteString(feature.Name)
-			newValue.WriteByte('=')
-			newValue.WriteString(strconv.FormatBool(feature.Enabled))
-		}
-	}
-
-	args = maps.Clone(args)
-	if newValue.Len() == oldValueLen {
-		return args
-	}
-
-	if args == nil {
-		return stringmap.StringMap{"feature-gates": newValue.String()}
-	}
-
-	args["feature-gates"] = newValue.String()
-	return args
-}
-
-// AsMap returns feature gates as map[string]bool, used in kubelet
-func (fgs FeatureGates) AsMap(component string) map[string]bool {
-	componentFeatureGates := map[string]bool{}
-	for _, feature := range fgs {
-		if feature.AppliesTo(component) {
-			componentFeatureGates[feature.Name] = feature.Enabled
-		}
-	}
-	return componentFeatureGates
 }
 
 // FeatureGate specifies single feature gate

--- a/pkg/apis/k0s/v1beta1/feature_gates.go
+++ b/pkg/apis/k0s/v1beta1/feature_gates.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 
 	"github.com/k0sproject/k0s/internal/pkg/stringmap"
@@ -44,8 +45,8 @@ func (fgs FeatureGates) BuildArgs(args stringmap.StringMap, component string) st
 	args = maps.Clone(args)
 	componentFeatureGates := []string{}
 	for _, feature := range fgs {
-		if value, found := feature.EnabledFor(component); found {
-			componentFeatureGates = append(componentFeatureGates, fmt.Sprintf("%s=%t", feature.Name, value))
+		if feature.AppliesTo(component) {
+			componentFeatureGates = append(componentFeatureGates, fmt.Sprintf("%s=%t", feature.Name, feature.Enabled))
 		}
 	}
 	if len(componentFeatureGates) == 0 {
@@ -70,9 +71,8 @@ func (fgs FeatureGates) BuildArgs(args stringmap.StringMap, component string) st
 func (fgs FeatureGates) AsMap(component string) map[string]bool {
 	componentFeatureGates := map[string]bool{}
 	for _, feature := range fgs {
-		value, found := feature.EnabledFor(component)
-		if found {
-			componentFeatureGates[feature.Name] = value
+		if feature.AppliesTo(component) {
+			componentFeatureGates[feature.Name] = feature.Enabled
 		}
 	}
 	return componentFeatureGates
@@ -93,22 +93,13 @@ type FeatureGate struct {
 	Components []string `json:"components,omitempty"`
 }
 
-// EnabledFor checks if current feature gate is enabled for a given component
-func (fg *FeatureGate) EnabledFor(component string) (value bool, found bool) {
+// Checks if this feature gate applies to a given component or not.
+func (fg *FeatureGate) AppliesTo(component string) bool {
 	components := fg.Components
 	if len(components) == 0 {
 		components = KubernetesComponents
 	}
-
-	for _, c := range components {
-		if c == component {
-			found = true
-		}
-	}
-	if found {
-		value = fg.Enabled
-	}
-	return
+	return slices.Contains(components, component)
 }
 
 // Validate given feature gate

--- a/pkg/apis/k0s/v1beta1/feature_gates.go
+++ b/pkg/apis/k0s/v1beta1/feature_gates.go
@@ -77,8 +77,8 @@ func (fgs FeatureGates) AsMap(component string) map[string]bool {
 func (fgs FeatureGates) AsSliceOfStrings(component string) []string {
 	featureGates := []string{}
 	for _, feature := range fgs {
-		if flag := feature.String(component); flag != "" {
-			featureGates = append(featureGates, flag)
+		if value, found := feature.EnabledFor(component); found {
+			featureGates = append(featureGates, fmt.Sprintf("%s=%t", feature.Name, value))
 		}
 	}
 	return featureGates
@@ -123,13 +123,4 @@ func (fg *FeatureGate) Validate() error {
 		return errors.New("feature gate must have name")
 	}
 	return nil
-}
-
-// String represents feature gate as a string
-func (fg *FeatureGate) String(component string) string {
-	value, found := fg.EnabledFor(component)
-	if !found {
-		return ""
-	}
-	return fmt.Sprintf("%s=%t", fg.Name, value)
 }

--- a/pkg/apis/k0s/v1beta1/feature_gates.go
+++ b/pkg/apis/k0s/v1beta1/feature_gates.go
@@ -42,7 +42,12 @@ func (fgs FeatureGates) Validate() []error {
 // BuildArgs builds CLI args using the given args and component name.
 func (fgs FeatureGates) BuildArgs(args stringmap.StringMap, component string) stringmap.StringMap {
 	args = maps.Clone(args)
-	componentFeatureGates := fgs.AsSliceOfStrings(component)
+	componentFeatureGates := []string{}
+	for _, feature := range fgs {
+		if value, found := feature.EnabledFor(component); found {
+			componentFeatureGates = append(componentFeatureGates, fmt.Sprintf("%s=%t", feature.Name, value))
+		}
+	}
 	if len(componentFeatureGates) == 0 {
 		return args
 	}
@@ -71,17 +76,6 @@ func (fgs FeatureGates) AsMap(component string) map[string]bool {
 		}
 	}
 	return componentFeatureGates
-}
-
-// AsSliceOfStrings returns feature gates as slice of strings, used in arguments
-func (fgs FeatureGates) AsSliceOfStrings(component string) []string {
-	featureGates := []string{}
-	for _, feature := range fgs {
-		if value, found := feature.EnabledFor(component); found {
-			featureGates = append(featureGates, fmt.Sprintf("%s=%t", feature.Name, value))
-		}
-	}
-	return featureGates
 }
 
 // FeatureGate specifies single feature gate

--- a/pkg/apis/k0s/v1beta1/feature_gates.go
+++ b/pkg/apis/k0s/v1beta1/feature_gates.go
@@ -5,9 +5,9 @@ package v1beta1
 
 import (
 	"errors"
-	"fmt"
 	"maps"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/k0sproject/k0s/internal/pkg/stringmap"
@@ -42,28 +42,30 @@ func (fgs FeatureGates) Validate() []error {
 
 // BuildArgs builds CLI args using the given args and component name.
 func (fgs FeatureGates) BuildArgs(args stringmap.StringMap, component string) stringmap.StringMap {
-	args = maps.Clone(args)
-	componentFeatureGates := []string{}
+	var newValue strings.Builder
+
+	oldValueLen, _ := newValue.WriteString(args["feature-gates"])
 	for _, feature := range fgs {
 		if feature.AppliesTo(component) {
-			componentFeatureGates = append(componentFeatureGates, fmt.Sprintf("%s=%t", feature.Name, feature.Enabled))
+			if newValue.Len() > 0 {
+				newValue.WriteByte(',')
+			}
+			newValue.WriteString(feature.Name)
+			newValue.WriteByte('=')
+			newValue.WriteString(strconv.FormatBool(feature.Enabled))
 		}
 	}
-	if len(componentFeatureGates) == 0 {
+
+	args = maps.Clone(args)
+	if newValue.Len() == oldValueLen {
 		return args
 	}
 
-	fg := args["feature-gates"]
-	featureGatesString := strings.Join(componentFeatureGates, ",")
-	if fg != "" {
-		fg = fmt.Sprintf("%s,%s", fg, featureGatesString)
-	} else {
-		fg = featureGatesString
-	}
 	if args == nil {
-		return stringmap.StringMap{"feature-gates": fg}
+		return stringmap.StringMap{"feature-gates": newValue.String()}
 	}
-	args["feature-gates"] = fg
+
+	args["feature-gates"] = newValue.String()
 	return args
 }
 

--- a/pkg/apis/k0s/v1beta1/feature_gates_test.go
+++ b/pkg/apis/k0s/v1beta1/feature_gates_test.go
@@ -13,37 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFeatureGate_String(t *testing.T) {
-	for _, test := range []struct {
-		name      string
-		gate      FeatureGate
-		component string
-		expected  string
-	}{
-		{
-			name:      "enabled",
-			gate:      FeatureGate{Name: "Enabled", Enabled: true},
-			component: "kubelet",
-			expected:  "Enabled=true",
-		},
-		{
-			name:      "disabled",
-			gate:      FeatureGate{Name: "Disabled"},
-			component: "kubelet",
-			expected:  "Disabled=false",
-		},
-		{
-			name:      "different component",
-			gate:      FeatureGate{Name: "Other", Enabled: true, Components: []string{"component-b"}},
-			component: "component-a",
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, test.gate.String(test.component))
-		})
-	}
-}
-
 func TestFeatureGate_Validate(t *testing.T) {
 	for _, test := range []struct {
 		name string

--- a/pkg/apis/k0s/v1beta1/feature_gates_test.go
+++ b/pkg/apis/k0s/v1beta1/feature_gates_test.go
@@ -4,10 +4,7 @@
 package v1beta1
 
 import (
-	"maps"
 	"testing"
-
-	"github.com/k0sproject/k0s/internal/pkg/stringmap"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -114,166 +111,9 @@ spec:
 	}, c.Spec.FeatureGates)
 }
 
-func TestFeatureGates_BuildArgs(t *testing.T) {
-	someGates := FeatureGates{
-		{Name: "DefaultComponents", Enabled: true},
-		{Name: "APIServerOnly", Components: []string{"kube-apiserver"}},
-	}
-
-	for _, test := range []struct {
-		name                                                string
-		gates                                               FeatureGates
-		args                                                stringmap.StringMap
-		expectedDefault, expectedAPIServer, expectedUnknown stringmap.StringMap
-	}{
-		{
-			name:  "nil",
-			gates: nil,
-			args: stringmap.StringMap{
-				"unrelated": "value",
-			},
-			expectedDefault: stringmap.StringMap{
-				"unrelated": "value",
-			},
-			expectedAPIServer: stringmap.StringMap{
-				"unrelated": "value",
-			},
-			expectedUnknown: stringmap.StringMap{
-				"unrelated": "value",
-			},
-		},
-		{
-			name:  "empty",
-			gates: FeatureGates{},
-			args: stringmap.StringMap{
-				"unrelated": "value",
-			},
-			expectedDefault: stringmap.StringMap{
-				"unrelated": "value",
-			},
-			expectedAPIServer: stringmap.StringMap{
-				"unrelated": "value",
-			},
-			expectedUnknown: stringmap.StringMap{
-				"unrelated": "value",
-			},
-		},
-		{
-			name:  "without existing arguments",
-			gates: someGates,
-			args:  stringmap.StringMap{},
-			expectedDefault: stringmap.StringMap{
-				"feature-gates": "DefaultComponents=true",
-			},
-			expectedAPIServer: stringmap.StringMap{
-				"feature-gates": "DefaultComponents=true,APIServerOnly=false",
-			},
-			expectedUnknown: stringmap.StringMap{},
-		},
-		{
-			name:  "preserves unrelated arguments",
-			gates: someGates,
-			args:  stringmap.StringMap{"unrelated": "value"},
-			expectedDefault: stringmap.StringMap{
-				"feature-gates": "DefaultComponents=true",
-				"unrelated":     "value",
-			},
-			expectedAPIServer: stringmap.StringMap{
-				"feature-gates": "DefaultComponents=true,APIServerOnly=false",
-				"unrelated":     "value",
-			},
-			expectedUnknown: stringmap.StringMap{
-				"unrelated": "value",
-			},
-		},
-		{
-			name:  "appends to existing feature gates",
-			gates: someGates,
-			args: stringmap.StringMap{
-				"feature-gates": "Existing=true",
-			},
-			expectedDefault: stringmap.StringMap{
-				"feature-gates": "Existing=true,DefaultComponents=true",
-			},
-			expectedAPIServer: stringmap.StringMap{
-				"feature-gates": "Existing=true,DefaultComponents=true,APIServerOnly=false",
-			},
-			expectedUnknown: stringmap.StringMap{
-				"feature-gates": "Existing=true",
-			},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			for _, component := range KubernetesComponents {
-				expected := test.expectedDefault
-				if component == "kube-apiserver" {
-					expected = test.expectedAPIServer
-				}
-				args := maps.Clone(test.args)
-
-				actual := test.gates.BuildArgs(args, component)
-
-				assert.Equalf(t, test.args, args, "Arguments were modified in-place")
-				assert.Equalf(t, expected, actual, "For component %s", component)
-			}
-
-			args := maps.Clone(test.args)
-
-			actual := test.gates.BuildArgs(args, "some-unknown-component")
-
-			assert.Equalf(t, test.args, args, "Arguments were modified in-place")
-			assert.Equalf(t, test.expectedUnknown, actual, "For some unknown component")
-		})
-	}
-}
-
 func TestFeatureGates_Validate(t *testing.T) {
 	errs := (FeatureGates{{}, {Name: "Valid"}, {}}).Validate()
 	require.Len(t, errs, 2)
 	assert.EqualError(t, errs[0], "feature gate must have name")
 	assert.EqualError(t, errs[1], "feature gate must have name")
-}
-
-func TestFeatureGates_AsMap(t *testing.T) {
-	t.Run("empty", func(t *testing.T) {
-		actual := FeatureGates{}.AsMap("component")
-		assert.Empty(t, actual)
-	})
-
-	underTest := FeatureGates{
-		{Name: "DefaultComponentsEnabled", Enabled: true},
-		{Name: "DefaultComponentsDisabled"},
-		{Name: "APIEnabled", Enabled: true, Components: []string{"kube-apiserver"}},
-		{Name: "SchedulerEnabled", Enabled: true, Components: []string{"kube-scheduler"}},
-	}
-
-	for _, test := range []struct {
-		component string
-		expected  map[string]bool
-	}{
-		{
-			component: "kube-apiserver",
-			expected: map[string]bool{
-				"DefaultComponentsEnabled":  true,
-				"DefaultComponentsDisabled": false,
-				"APIEnabled":                true,
-			},
-		},
-		{
-			component: "kube-scheduler",
-			expected: map[string]bool{
-				"DefaultComponentsEnabled":  true,
-				"DefaultComponentsDisabled": false,
-				"SchedulerEnabled":          true,
-			},
-		},
-		{
-			component: "other",
-			expected:  map[string]bool{},
-		},
-	} {
-		t.Run(test.component, func(t *testing.T) {
-			assert.Equal(t, test.expected, underTest.AsMap(test.component))
-		})
-	}
 }

--- a/pkg/apis/k0s/v1beta1/feature_gates_test.go
+++ b/pkg/apis/k0s/v1beta1/feature_gates_test.go
@@ -30,63 +30,6 @@ func TestFeatureGate_Validate(t *testing.T) {
 	}
 }
 
-func TestFeatureGate_AppliesTo(t *testing.T) {
-	for _, test := range []struct {
-		name      string
-		gate      FeatureGate
-		component string
-		expected  bool
-	}{
-		{
-			name:      "explicit component enabled",
-			gate:      FeatureGate{Enabled: true, Components: []string{"component-a"}},
-			component: "component-a",
-			expected:  true,
-		},
-		{
-			name:      "explicit component disabled",
-			gate:      FeatureGate{Components: []string{"component-a"}},
-			component: "component-a",
-			expected:  true,
-		},
-		{
-			name:      "enabled gate does not match component",
-			gate:      FeatureGate{Enabled: true, Components: []string{"component-a"}},
-			component: "component-b",
-			expected:  false,
-		},
-		{
-			name:      "disabled gate does not match component",
-			gate:      FeatureGate{Components: []string{"component-a"}},
-			component: "component-b",
-			expected:  false,
-		},
-		{
-			name:      "enabled for a default component",
-			gate:      FeatureGate{Enabled: true},
-			component: "kubelet",
-			expected:  true,
-		},
-		{
-			name:      "disabled for a default component",
-			gate:      FeatureGate{},
-			component: "kubelet",
-			expected:  true,
-		},
-		{
-			name:      "not enabled for a non-default component",
-			gate:      FeatureGate{Enabled: true},
-			component: "other-component",
-			expected:  false,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			actual := test.gate.AppliesTo(test.component)
-			assert.Equal(t, test.expected, actual)
-		})
-	}
-}
-
 func TestFeatureGates_FromConfig(t *testing.T) {
 	c, err := ConfigFromBytes([]byte(`
 apiVersion: k0s.k0sproject.io/v1beta1

--- a/pkg/apis/k0s/v1beta1/feature_gates_test.go
+++ b/pkg/apis/k0s/v1beta1/feature_gates_test.go
@@ -235,36 +235,6 @@ func TestFeatureGates_Validate(t *testing.T) {
 	assert.EqualError(t, errs[1], "feature gate must have name")
 }
 
-func TestFeatureGates_AsSliceOfStrings(t *testing.T) {
-	underTest := FeatureGates{
-		{Name: "FeatureGate1", Enabled: true},
-		{Name: "FeatureGate2"},
-		{Name: "FeatureGate3", Enabled: true},
-		{Name: "SchedulerOnly", Enabled: true, Components: []string{"kube-scheduler"}},
-	}
-
-	t.Run("skips gates for other components", func(t *testing.T) {
-		assert.Equal(t, []string{
-			"FeatureGate1=true",
-			"FeatureGate2=false",
-			"FeatureGate3=true",
-		}, underTest.AsSliceOfStrings("kubelet"))
-	})
-
-	t.Run("includes gates for the given component", func(t *testing.T) {
-		assert.Equal(t, []string{
-			"FeatureGate1=true",
-			"FeatureGate2=false",
-			"FeatureGate3=true",
-			"SchedulerOnly=true",
-		}, underTest.AsSliceOfStrings("kube-scheduler"))
-	})
-
-	t.Run("no matching gates", func(t *testing.T) {
-		assert.Empty(t, underTest.AsSliceOfStrings("some-unknown-component"))
-	})
-}
-
 func TestFeatureGates_AsMap(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		actual := FeatureGates{}.AsMap("component")

--- a/pkg/apis/k0s/v1beta1/feature_gates_test.go
+++ b/pkg/apis/k0s/v1beta1/feature_gates_test.go
@@ -33,60 +33,59 @@ func TestFeatureGate_Validate(t *testing.T) {
 	}
 }
 
-func TestFeatureGate_EnabledFor(t *testing.T) {
+func TestFeatureGate_AppliesTo(t *testing.T) {
 	for _, test := range []struct {
-		name           string
-		gate           FeatureGate
-		component      string
-		enabled, found bool
+		name      string
+		gate      FeatureGate
+		component string
+		expected  bool
 	}{
 		{
 			name:      "explicit component enabled",
 			gate:      FeatureGate{Enabled: true, Components: []string{"component-a"}},
 			component: "component-a",
-			enabled:   true, found: true,
+			expected:  true,
 		},
 		{
 			name:      "explicit component disabled",
 			gate:      FeatureGate{Components: []string{"component-a"}},
 			component: "component-a",
-			enabled:   false, found: true,
+			expected:  true,
 		},
 		{
 			name:      "enabled gate does not match component",
 			gate:      FeatureGate{Enabled: true, Components: []string{"component-a"}},
 			component: "component-b",
-			enabled:   false, found: false,
+			expected:  false,
 		},
 		{
 			name:      "disabled gate does not match component",
 			gate:      FeatureGate{Components: []string{"component-a"}},
 			component: "component-b",
-			enabled:   false, found: false,
+			expected:  false,
 		},
 		{
 			name:      "enabled for a default component",
 			gate:      FeatureGate{Enabled: true},
 			component: "kubelet",
-			enabled:   true, found: true,
+			expected:  true,
 		},
 		{
 			name:      "disabled for a default component",
 			gate:      FeatureGate{},
 			component: "kubelet",
-			enabled:   false, found: true,
+			expected:  true,
 		},
 		{
 			name:      "not enabled for a non-default component",
 			gate:      FeatureGate{Enabled: true},
 			component: "other-component",
-			enabled:   false, found: false,
+			expected:  false,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			value, found := test.gate.EnabledFor(test.component)
-			assert.Equal(t, test.enabled, value)
-			assert.Equal(t, test.found, found)
+			actual := test.gate.AppliesTo(test.component)
+			assert.Equal(t, test.expected, actual)
 		})
 	}
 }

--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -27,6 +27,7 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/users"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/assets"
+	"github.com/k0sproject/k0s/pkg/component/featuregates"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
@@ -143,7 +144,7 @@ func (a *APIServer) Start(ctx context.Context) error {
 		}
 		args[name] = value
 	}
-	args = a.NodeConfig.Spec.FeatureGates.BuildArgs(args, kubeAPIComponentName)
+	args = featuregates.ToArgs(args, a.NodeConfig.Spec.FeatureGates, kubeAPIComponentName)
 
 	// kube-apiserver refuses to start if the --anonymous-auth flag is set
 	// while the file referenced by --authentication-config contains the

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/users"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/assets"
+	"github.com/k0sproject/k0s/pkg/component/featuregates"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
@@ -127,7 +128,7 @@ func (a *Manager) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterC
 		args["leader-elect"] = "false"
 	}
 
-	args = clusterConfig.Spec.FeatureGates.BuildArgs(args, kubeControllerManagerComponent)
+	args = featuregates.ToArgs(args, clusterConfig.Spec.FeatureGates, kubeControllerManagerComponent)
 
 	if args.Equals(a.previousConfig) && a.supervisor != nil {
 		// no changes and supervisor already running, do nothing

--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/k0sproject/k0s/internal/sync/value"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/applier"
+	"github.com/k0sproject/k0s/pkg/component/featuregates"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
@@ -283,7 +284,7 @@ func (k *KubeProxy) getConfig(clusterConfig *v1beta1.ClusterConfig) *proxyConfig
 					Kubeconfig: "/var/lib/kube-proxy/kubeconfig.conf",
 				},
 				ClusterCIDR:        clusterConfig.Spec.Network.BuildPodCIDR(k.nodeConfig.Spec.PrimaryAddressFamily()),
-				FeatureGates:       clusterConfig.Spec.FeatureGates.AsMap("kube-proxy"),
+				FeatureGates:       featuregates.ToMap(clusterConfig.Spec.FeatureGates, "kube-proxy"),
 				Mode:               kubeproxyv1alpha1.ProxyMode(kubeProxy.Mode),
 				MetricsBindAddress: kubeProxy.MetricsBindAddress,
 				HealthzBindAddress: kubeProxy.HealthzBindAddress,

--- a/pkg/component/controller/scheduler.go
+++ b/pkg/component/controller/scheduler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/k0sproject/k0s/internal/pkg/users"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/assets"
+	"github.com/k0sproject/k0s/pkg/component/featuregates"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
@@ -87,7 +88,7 @@ func (a *Scheduler) Reconcile(ctx context.Context, clusterConfig *v1beta1.Cluste
 	if a.DisableLeaderElection {
 		args["leader-elect"] = "false"
 	}
-	args = clusterConfig.Spec.FeatureGates.BuildArgs(args, kubeSchedulerComponentName)
+	args = featuregates.ToArgs(args, clusterConfig.Spec.FeatureGates, kubeSchedulerComponentName)
 
 	if args.Equals(a.previousConfig) && a.supervisor != nil {
 		// no changes and supervisor already running, do nothing

--- a/pkg/component/controller/workerconfig/reconciler.go
+++ b/pkg/component/controller/workerconfig/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/applier"
 	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
+	"github.com/k0sproject/k0s/pkg/component/featuregates"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	workerconfig "github.com/k0sproject/k0s/pkg/component/worker/config"
 	"github.com/k0sproject/k0s/pkg/config"
@@ -582,7 +583,7 @@ func (r *Reconciler) buildProfile(snapshot *snapshot) *workerconfig.Profile {
 	workerProfile := &workerconfig.Profile{
 		APIServerAddresses: slices.Clone(snapshot.apiServers),
 		KubeletConfiguration: kubeletv1beta1.KubeletConfiguration{
-			FeatureGates: snapshot.featureGates.AsMap("kubelet"),
+			FeatureGates: featuregates.ToMap(snapshot.featureGates, "kubelet"),
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: kubeletv1beta1.SchemeGroupVersion.String(),
 				Kind:       "KubeletConfiguration",

--- a/pkg/component/featuregates/featuregates.go
+++ b/pkg/component/featuregates/featuregates.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package featuregates converts the feature gates from the k0s cluster
+// configuration into the two forms consumed by Kubernetes components: the
+// --feature-gates CLI flag value ("Name=true,Name=false") and the
+// map[string]bool used in component configuration files. Both match what
+// k8s.io/component-base/featuregate parses via Set and SetFromMap.
+package featuregates
+
+import (
+	"maps"
+	"strconv"
+	"strings"
+
+	"github.com/k0sproject/k0s/internal/pkg/stringmap"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+)
+
+// Based on args, returns a new argument map in which the feature-gates flag
+// includes all the given gates that apply to the given component, formatted in
+// the way the component's --feature-gates CLI flag expects. Feature gates are
+// appended to any feature-gates value already present in args, so user-provided
+// extra arguments are preserved.
+func ToArgs(args stringmap.StringMap, gates k0sv1beta1.FeatureGates, component string) stringmap.StringMap {
+	var newValue strings.Builder
+
+	oldValueLen, _ := newValue.WriteString(args["feature-gates"])
+	for _, feature := range gates {
+		if feature.AppliesTo(component) {
+			if newValue.Len() > 0 {
+				newValue.WriteByte(',')
+			}
+			newValue.WriteString(feature.Name)
+			newValue.WriteByte('=')
+			newValue.WriteString(strconv.FormatBool(feature.Enabled))
+		}
+	}
+
+	args = maps.Clone(args)
+	if newValue.Len() == oldValueLen {
+		return args
+	}
+
+	if args == nil {
+		return stringmap.StringMap{"feature-gates": newValue.String()}
+	}
+
+	args["feature-gates"] = newValue.String()
+	return args
+}
+
+// Returns the feature gates that apply to the given component as a map, in the
+// form used by the FeatureGates field of component configuration files such as
+// KubeletConfiguration and KubeProxyConfiguration.
+func ToMap(gates k0sv1beta1.FeatureGates, component string) map[string]bool {
+	componentFeatureGates := map[string]bool{}
+	for _, feature := range gates {
+		if feature.AppliesTo(component) {
+			componentFeatureGates[feature.Name] = feature.Enabled
+		}
+	}
+	return componentFeatureGates
+}

--- a/pkg/component/featuregates/featuregates.go
+++ b/pkg/component/featuregates/featuregates.go
@@ -9,6 +9,7 @@
 package featuregates
 
 import (
+	"iter"
 	"maps"
 	"slices"
 	"strconv"
@@ -27,15 +28,13 @@ func ToArgs(args stringmap.StringMap, gates k0sv1beta1.FeatureGates, component s
 	var newValue strings.Builder
 
 	oldValueLen, _ := newValue.WriteString(args["feature-gates"])
-	for _, feature := range gates {
-		if isComponentSelected(feature.Components, component) {
-			if newValue.Len() > 0 {
-				newValue.WriteByte(',')
-			}
-			newValue.WriteString(feature.Name)
-			newValue.WriteByte('=')
-			newValue.WriteString(strconv.FormatBool(feature.Enabled))
+	for name, enabled := range forComponent(gates, component) {
+		if newValue.Len() > 0 {
+			newValue.WriteByte(',')
 		}
+		newValue.WriteString(name)
+		newValue.WriteByte('=')
+		newValue.WriteString(strconv.FormatBool(enabled))
 	}
 
 	args = maps.Clone(args)
@@ -55,13 +54,21 @@ func ToArgs(args stringmap.StringMap, gates k0sv1beta1.FeatureGates, component s
 // form used by the FeatureGates field of component configuration files such as
 // KubeletConfiguration and KubeProxyConfiguration.
 func ToMap(gates k0sv1beta1.FeatureGates, component string) map[string]bool {
-	componentFeatureGates := map[string]bool{}
-	for _, feature := range gates {
-		if isComponentSelected(feature.Components, component) {
-			componentFeatureGates[feature.Name] = feature.Enabled
+	return maps.Collect(forComponent(gates, component))
+}
+
+// Yields the names and enabled states of the feature gates that apply to the
+// given component.
+func forComponent(gates k0sv1beta1.FeatureGates, component string) iter.Seq2[string, bool] {
+	return func(yield func(string, bool) bool) {
+		for _, feature := range gates {
+			if isComponentSelected(feature.Components, component) {
+				if !yield(feature.Name, feature.Enabled) {
+					return
+				}
+			}
 		}
 	}
-	return componentFeatureGates
 }
 
 // Default components to use feature gates with.

--- a/pkg/component/featuregates/featuregates.go
+++ b/pkg/component/featuregates/featuregates.go
@@ -10,6 +10,7 @@ package featuregates
 
 import (
 	"maps"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -27,7 +28,7 @@ func ToArgs(args stringmap.StringMap, gates k0sv1beta1.FeatureGates, component s
 
 	oldValueLen, _ := newValue.WriteString(args["feature-gates"])
 	for _, feature := range gates {
-		if feature.AppliesTo(component) {
+		if isComponentSelected(feature.Components, component) {
 			if newValue.Len() > 0 {
 				newValue.WriteByte(',')
 			}
@@ -56,9 +57,26 @@ func ToArgs(args stringmap.StringMap, gates k0sv1beta1.FeatureGates, component s
 func ToMap(gates k0sv1beta1.FeatureGates, component string) map[string]bool {
 	componentFeatureGates := map[string]bool{}
 	for _, feature := range gates {
-		if feature.AppliesTo(component) {
+		if isComponentSelected(feature.Components, component) {
 			componentFeatureGates[feature.Name] = feature.Enabled
 		}
 	}
 	return componentFeatureGates
+}
+
+// Default components to use feature gates with.
+var defaultComponents = []string{
+	"kube-apiserver",
+	"kube-controller-manager",
+	"kubelet",
+	"kube-scheduler",
+	"kube-proxy",
+}
+
+func isComponentSelected(components []string, component string) bool {
+	if len(components) > 0 {
+		return slices.Contains(components, component)
+	}
+
+	return slices.Contains(defaultComponents, component)
 }

--- a/pkg/component/featuregates/featuregates_test.go
+++ b/pkg/component/featuregates/featuregates_test.go
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package featuregates
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/k0sproject/k0s/internal/pkg/stringmap"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToArgs(t *testing.T) {
+	someGates := k0sv1beta1.FeatureGates{
+		{Name: "DefaultComponents", Enabled: true},
+		{Name: "APIServerOnly", Components: []string{"kube-apiserver"}},
+	}
+
+	for _, test := range []struct {
+		name                                                string
+		gates                                               k0sv1beta1.FeatureGates
+		args                                                stringmap.StringMap
+		expectedDefault, expectedAPIServer, expectedUnknown stringmap.StringMap
+	}{
+		{
+			name:  "nil",
+			gates: nil,
+			args: stringmap.StringMap{
+				"unrelated": "value",
+			},
+			expectedDefault: stringmap.StringMap{
+				"unrelated": "value",
+			},
+			expectedAPIServer: stringmap.StringMap{
+				"unrelated": "value",
+			},
+			expectedUnknown: stringmap.StringMap{
+				"unrelated": "value",
+			},
+		},
+		{
+			name:  "empty",
+			gates: k0sv1beta1.FeatureGates{},
+			args: stringmap.StringMap{
+				"unrelated": "value",
+			},
+			expectedDefault: stringmap.StringMap{
+				"unrelated": "value",
+			},
+			expectedAPIServer: stringmap.StringMap{
+				"unrelated": "value",
+			},
+			expectedUnknown: stringmap.StringMap{
+				"unrelated": "value",
+			},
+		},
+		{
+			name:  "without existing arguments",
+			gates: someGates,
+			args:  stringmap.StringMap{},
+			expectedDefault: stringmap.StringMap{
+				"feature-gates": "DefaultComponents=true",
+			},
+			expectedAPIServer: stringmap.StringMap{
+				"feature-gates": "DefaultComponents=true,APIServerOnly=false",
+			},
+			expectedUnknown: stringmap.StringMap{},
+		},
+		{
+			name:  "preserves unrelated arguments",
+			gates: someGates,
+			args:  stringmap.StringMap{"unrelated": "value"},
+			expectedDefault: stringmap.StringMap{
+				"feature-gates": "DefaultComponents=true",
+				"unrelated":     "value",
+			},
+			expectedAPIServer: stringmap.StringMap{
+				"feature-gates": "DefaultComponents=true,APIServerOnly=false",
+				"unrelated":     "value",
+			},
+			expectedUnknown: stringmap.StringMap{
+				"unrelated": "value",
+			},
+		},
+		{
+			name:  "appends to existing feature gates",
+			gates: someGates,
+			args: stringmap.StringMap{
+				"feature-gates": "Existing=true",
+			},
+			expectedDefault: stringmap.StringMap{
+				"feature-gates": "Existing=true,DefaultComponents=true",
+			},
+			expectedAPIServer: stringmap.StringMap{
+				"feature-gates": "Existing=true,DefaultComponents=true,APIServerOnly=false",
+			},
+			expectedUnknown: stringmap.StringMap{
+				"feature-gates": "Existing=true",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for _, component := range k0sv1beta1.KubernetesComponents {
+				expected := test.expectedDefault
+				if component == "kube-apiserver" {
+					expected = test.expectedAPIServer
+				}
+				args := maps.Clone(test.args)
+
+				actual := ToArgs(args, test.gates, component)
+
+				assert.Equalf(t, test.args, args, "Arguments were modified in-place")
+				assert.Equalf(t, expected, actual, "For component %s", component)
+			}
+
+			args := maps.Clone(test.args)
+
+			actual := ToArgs(args, test.gates, "some-unknown-component")
+
+			assert.Equalf(t, test.args, args, "Arguments were modified in-place")
+			assert.Equalf(t, test.expectedUnknown, actual, "For some unknown component")
+		})
+	}
+}
+
+func TestToMap(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		underTest := ToMap(k0sv1beta1.FeatureGates{}, "component")
+		assert.Empty(t, underTest)
+	})
+
+	featureGates := k0sv1beta1.FeatureGates{
+		{Name: "DefaultComponentsEnabled", Enabled: true},
+		{Name: "DefaultComponentsDisabled"},
+		{Name: "APIEnabled", Enabled: true, Components: []string{"kube-apiserver"}},
+		{Name: "SchedulerEnabled", Enabled: true, Components: []string{"kube-scheduler"}},
+	}
+
+	for _, test := range []struct {
+		component string
+		expected  map[string]bool
+	}{
+		{
+			component: "kube-apiserver",
+			expected: map[string]bool{
+				"DefaultComponentsEnabled":  true,
+				"DefaultComponentsDisabled": false,
+				"APIEnabled":                true,
+			},
+		},
+		{
+			component: "kube-scheduler",
+			expected: map[string]bool{
+				"DefaultComponentsEnabled":  true,
+				"DefaultComponentsDisabled": false,
+				"SchedulerEnabled":          true,
+			},
+		},
+		{
+			component: "other",
+			expected:  map[string]bool{},
+		},
+	} {
+		t.Run(test.component, func(t *testing.T) {
+			assert.Equal(t, test.expected, ToMap(featureGates, test.component))
+		})
+	}
+}

--- a/pkg/component/featuregates/featuregates_test.go
+++ b/pkg/component/featuregates/featuregates_test.go
@@ -169,3 +169,18 @@ func TestToMap(t *testing.T) {
 		})
 	}
 }
+
+func TestForComponent_StopsEarly(t *testing.T) {
+	gates := k0sv1beta1.FeatureGates{
+		{Name: "First", Enabled: true},
+		{Name: "Second"},
+	}
+
+	collected := map[string]bool{}
+	for name, enabled := range forComponent(gates, "kubelet") {
+		collected[name] = enabled
+		break
+	}
+
+	assert.Equal(t, map[string]bool{"First": true}, collected)
+}

--- a/pkg/component/featuregates/featuregates_test.go
+++ b/pkg/component/featuregates/featuregates_test.go
@@ -103,7 +103,7 @@ func TestToArgs(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			for _, component := range k0sv1beta1.KubernetesComponents {
+			for _, component := range defaultComponents {
 				expected := test.expectedDefault
 				if component == "kube-apiserver" {
 					expected = test.expectedAPIServer


### PR DESCRIPTION
## Description

(Follow-up to #7990.)

Separate the concern of declaring feature gates (the API types) from the concern of feeding them to Kubernetes components (CLI flags, configuration files, basically stuff that's understood by `k8s.io/component-base/featuregate`).

The `FeatureGate` types in the API package are stripped down to the type definitions and their validation. Everything else got either inlined or moved into the new  `pkg/component/featuregates` package: `ToArgs` (formerly called `BuildArgs`) produces the `--feature-gates` CLI flag, while `ToMap` (formerly called `AsMap`) produces the map used in configuration files. Both are driven by a shared generator function that yields the feature gates selected for a component.

Along the way, the flag construction was reworked to format directly into a string builder instead of going through intermediate slices, and to return a new argument map instead of modifying its input.

The existing unit tests were migrated to the new package unchanged. A new test covers the generator's early termination.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commit messages are signed-off
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings