### PR TITLE
Avoid immortal Renovate PRs for grouped updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -139,7 +139,8 @@
         "projectcalico/calico"
       ],
       "groupName": "Calico",
-      "groupSlug": "calico"
+      "groupSlug": "calico",
+      "commitMessageExtra": "{{~#if (includes (lookupArray upgrades \"depName\") \"quay.io/k0sproject/calico-node\")}}{{~#each (distinct (lookupArray upgrades \"prettyNewVersion\"))}}{{~#if (containsString . \"-\")}} to {{{.}}}{{/if}}{{/each~}}{{~else}}{{~#each (distinct (lookupArray upgrades \"prettyNewVersion\"))}} to {{{.}}}{{/each~}}{{/if~}}"
     },
     {
       "description": "Group all etcd bumps",
@@ -212,7 +213,7 @@
       ],
       "groupName": "Traefik",
       "groupSlug": "traefik",
-      "commitMessageExtra": "{{~#if (includes (lookupArray upgrades \"depName\") \"quay.io/k0sproject/traefik\")}}{{~#each upgrades}}{{~#if (equals depName \"quay.io/k0sproject/traefik\")}} to {{{prettyNewVersion}}}{{/if}}{{/each~}}{{~else}}{{~#each (distinct (lookupArray upgrades \"prettyNewVersion\"))}} to {{{.}}}{{/each~}}{{/if~}}"
+      "commitMessageExtra": "{{~#if (includes (lookupArray upgrades \"depName\") \"quay.io/k0sproject/traefik\")}}{{~#each (distinct (lookupArray upgrades \"prettyNewVersion\"))}}{{~#if (containsString . \"-\")}} to {{{.}}}{{/if}}{{/each~}}{{~else}}{{~#each (distinct (lookupArray upgrades \"prettyNewVersion\"))}} to {{{.}}}{{/each~}}{{/if~}}"
     },
     {
       "description": "Run codegen if required",


### PR DESCRIPTION
## Description

Renovate deems a grouped PR immortal if the individual upgrades render to distinct version strings: The PR title then carries no version at all (see #7882), so closing the PR cannot be recorded as ignoring anything, and Renovate will simply recreate it (see #8006). The Calico group mixes plain upstream versions and those with a k0s suffix, so its PRs had both a title without a version number and were immortal and came back after being closed.

Give the Calico group the same `commitMessageExtra` treatment as the Traefik group, so that PR titles keep a version and closing a PR sticks.

Also rework the Traefik template to iterate over distinct version strings instead of the individual upgrades: The quay.io image is
tracked in two files, which duplicated the version in the PR title. Both templates now prefer the hyphenated k0s image versions, which embed the corresponding upstream version.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings