### PR TITLE
Use the direct kubelet kubeconfig consistently

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -401,21 +401,28 @@ func (c *command) start(ctx context.Context, runtimeConfig *config.RuntimeConfig
 			),
 		)
 	}
-	nodeComponents.Add(ctx, &status.Status{
+	statusComponent := status.Status{
 		Prober: prober.DefaultProber,
 		StatusInformation: status.K0sStatus{
 			Pid:           os.Getpid(),
 			Role:          "controller",
 			Args:          os.Args,
 			Version:       build.Version,
-			Workloads:     controllerMode.WorkloadsEnabled(),
 			SingleNode:    controllerMode == config.SingleNodeMode,
 			K0sVars:       c.K0sVars,
 			ClusterConfig: nodeConfig,
 		},
-		Socket:      c.K0sVars.StatusSocketPath,
-		CertManager: worker.NewCertificateManager(c.K0sVars.KubeletAuthConfigPath),
-	})
+		Socket: c.K0sVars.StatusSocketPath,
+	}
+	if controllerMode.WorkloadsEnabled() {
+		// The status component must use the same Kubernetes client configuration as
+		// the embedded kubelet, otherwise the API connectivity check would be
+		// inaccurate. For embedded workers, this is always the "direct"
+		// configuration.
+		statusComponent.StatusInformation.Workloads = true
+		statusComponent.CertManager = worker.NewCertificateManager(worker.DirectKubeletKubeconfigPath(c.K0sVars))
+	}
+	nodeComponents.Add(ctx, &statusComponent)
 
 	perfTimer.Checkpoint("starting-certificates-init")
 	certs := &Certificates{

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -216,17 +216,6 @@ func (c *Command) Start(ctx context.Context, nodeName apitypes.NodeName, kubelet
 	}
 
 	kubeletKubeconfigPath := c.K0sVars.KubeletAuthConfigPath
-	workerConfig, err := workerconfig.LoadProfile(
-		ctx,
-		kubernetes.KubeconfigFromFile(kubeletKubeconfigPath),
-		c.K0sVars.DataDir,
-		c.WorkerProfile,
-	)
-	if err != nil {
-		return err
-	}
-
-	componentManager := manager.New(prober.DefaultProber)
 
 	// When upgrading controller+worker nodes in a multi-node cluster with a load balancer, the API
 	// server address needs to be overridden to point to the local API server. This is needed so
@@ -239,6 +228,18 @@ func (c *Command) Start(ctx context.Context, nodeName apitypes.NodeName, kubelet
 		}
 		kubeletKubeconfigPath = directKubeconfigPath
 	}
+
+	workerConfig, err := workerconfig.LoadProfile(
+		ctx,
+		kubernetes.KubeconfigFromFile(kubeletKubeconfigPath),
+		c.K0sVars.DataDir,
+		c.WorkerProfile,
+	)
+	if err != nil {
+		return err
+	}
+
+	componentManager := manager.New(prober.DefaultProber)
 
 	var staticPods worker.StaticPods
 

--- a/pkg/component/worker/utils.go
+++ b/pkg/component/worker/utils.go
@@ -144,6 +144,12 @@ func writeKubeletBootstrapKubeconfig(kubeconfig clientcmdapi.Config) (string, er
 	return bootstrapFile.Name(), nil
 }
 
+// DirectKubeletKubeconfigPath returns the path to the kubeconfig written by
+// [CreateDirectKubeletKubeconfig].
+func DirectKubeletKubeconfigPath(k0sVars *config.CfgVars) string {
+	return filepath.Join(k0sVars.RunDir, "kubelet-direct.conf")
+}
+
 // CreateDirectKubeletKubeconfig creates a kubelet kubeconfig that points directly to the local API
 // server instead of using NLLB. This is used on controller+worker nodes where we want kubelet to
 // connect directly to the local API server.
@@ -180,7 +186,7 @@ func CreateDirectKubeletKubeconfig(ctx context.Context, k0sVars *config.CfgVars,
 		return "", fmt.Errorf("failed to read kubeconfig: %w", err)
 	}
 
-	directKubeconfigPath := filepath.Join(k0sVars.RunDir, "kubelet-direct.conf")
+	directKubeconfigPath := DirectKubeletKubeconfigPath(k0sVars)
 
 	if err := writePatchedKubeconfig(directKubeconfigPath, directKubeconfig, localAPIServer); err != nil {
 		return "", fmt.Errorf("failed to write load-balanced kubeconfig file: %w", err)


### PR DESCRIPTION
## Description

The kubelet's client configuration (`kubelet.conf`) is bootstrapped only once and isn't touched again afterwards, so it keeps pointing to whatever API server address was in use back then. On nodes that run workloads, k0s already maintains a patched copy of it (`kubelet-direct.conf`) that points to the local API server, but that copy is created too late and isn't used everywhere:

* The worker profile is loaded through the bootstrapped kubeconfig _before_ the patched copy is created. If the address recorded in there isn't reachable anymore, k0s refuses to start at all:

  ```
  Error: Get "https://localhost:6443/api/v1/namespaces/kube-system/configmaps/worker-config-default-1.36": dial tcp [::1]:6443: connect: connection refused
  ```

* The status component creates its own certificate manager straight from the bootstrapped kubeconfig, whereas the embedded worker uses the patched one. So `k0s status` keeps reporting failing kube-api probes, even though the cluster is perfectly healthy:

  ```
  Kube-api probing successful: false
  Kube-api probing last error:  Get "https://localhost:6443/version": dial tcp [::1]:6443: connect: connection refused
  ```

Both are triggered whenever the local API server address changes after the kubelet's client configuration has been bootstrapped, for instance when enabling `spec.api.onlyBindToAddress` on an already running cluster.

Create the patched kubeconfig before it's used for the first time, and use it for the status component's probes as well. The bootstrapped `kubelet.conf` itself is intentionally left untouched.

Fixes #6997

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

Single node (`k0s controller --single`), bootstrapped without `onlyBindToAddress`, then restarted with `spec.api.onlyBindToAddress: true` while `kubelet.conf` still recorded `https://localhost:6443`:

| | v1.36.2+k0s.0 | this branch |
| --- | --- | --- |
| k0s startup | fails with the `worker-config-default-1.36` error above | starts up |
| node status | `NotReady` | `Ready` |
| `k0s status` probe | `false`, connection refused for `localhost:6443` | `true` |

Added a unit test for `CreateDirectKubeletKubeconfig`, and ran `make lint`, `make check-unit` and `make build && git diff --exit-code`.

The existing `bind-address` smoke test covers the case where `onlyBindToAddress` is set from the very first boot, which is unaffected by this bug. Happy to add a smoke test that enables it on an already bootstrapped controller+worker node if you'd like that covered in CI.

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
