### PR TITLE
Distinguish pending from performed restarts in Autopilot

### DIFF
--- a/pkg/autopilot/controller/root_controller.go
+++ b/pkg/autopilot/controller/root_controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/autopilot/controller/plans"
 	aproot "github.com/k0sproject/k0s/pkg/autopilot/controller/root"
 	"github.com/k0sproject/k0s/pkg/autopilot/controller/signal"
+	apsigk0s "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/k0s"
 	"github.com/k0sproject/k0s/pkg/autopilot/controller/updates"
 	"github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/pkg/leaderelection"
@@ -40,7 +41,7 @@ type leaderElector interface {
 	Run(context.Context, func(leaderelection.Status))
 }
 
-type subControllerStartRoutineFunc func(ctx context.Context, logger *logrus.Entry, event leaderelection.Status) error
+type subControllerStartRoutineFunc func(ctx context.Context, logger *logrus.Entry, restartTracker *apsigk0s.RestartTracker, event leaderelection.Status) error
 type createLeaderElectorFunc func(leaderelection.Config) (leaderElector, error)
 
 type rootController struct {
@@ -118,9 +119,13 @@ func (c *rootController) Run(ctx context.Context) error {
 		le.Run(ctx, status.Set)
 	}()
 
+	// The restart tracker needs to outlive the individual controller managers,
+	// which get rebuilt whenever the lease status changes.
+	var restartTracker apsigk0s.RestartTracker
+
 	// Start controllers
 	leaseEventStatus, leaseEventStatusExpired := status.Peek()
-	subControllerCancel, errCh := c.startSubControllers(ctx, leaseEventStatus)
+	subControllerCancel, errCh := c.startSubControllers(ctx, &restartTracker, leaseEventStatus)
 
 	for {
 		select {
@@ -151,7 +156,7 @@ func (c *rootController) Run(ctx context.Context) error {
 			}
 
 			// Start controllers
-			subControllerCancel, errCh = c.startSubControllers(ctx, leaseEventStatus)
+			subControllerCancel, errCh = c.startSubControllers(ctx, &restartTracker, leaseEventStatus)
 		}
 	}
 }
@@ -159,7 +164,7 @@ func (c *rootController) Run(ctx context.Context) error {
 // startSubControllerRoutine is what is executed by default by `startSubControllers`.
 // This creates the controller-runtime manager, registers all required components,
 // and starts it in a goroutine.
-func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *logrus.Entry, event leaderelection.Status) error {
+func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *logrus.Entry, restartTracker *apsigk0s.RestartTracker, event leaderelection.Status) error {
 	managerOpts := crman.Options{
 		Scheme: scheme,
 		Controller: crconfig.Controller{
@@ -238,7 +243,7 @@ func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *
 	}
 	clusterID := string(ns.UID)
 
-	if err := signal.RegisterControllers(ctx, logger, mgr, delegateMap[apdel.ControllerDelegateController], c.cfg.K0sDataDir, c.enableWorker, clusterID, event); err != nil {
+	if err := signal.RegisterControllers(ctx, logger, mgr, delegateMap[apdel.ControllerDelegateController], restartTracker, c.cfg.K0sDataDir, c.enableWorker, clusterID, event); err != nil {
 		logger.WithError(err).Error("unable to register signal controllers")
 		return err
 	}
@@ -266,7 +271,7 @@ func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *
 }
 
 // startSubControllers starts all of the controllers specific to the leader mode.
-func (c *rootController) startSubControllers(ctx context.Context, event leaderelection.Status) (context.CancelCauseFunc, <-chan error) {
+func (c *rootController) startSubControllers(ctx context.Context, restartTracker *apsigk0s.RestartTracker, event leaderelection.Status) (context.CancelCauseFunc, <-chan error) {
 	logger := c.log.WithField("leadermode", event == leaderelection.StatusLeading)
 	logger.Info("Starting subcontrollers")
 
@@ -276,7 +281,7 @@ func (c *rootController) startSubControllers(ctx context.Context, event leaderel
 	go func() {
 		var err error
 		defer func() { close(errCh); cancel(err) }()
-		err = c.startSubHandlerRoutine(ctx, logger, event)
+		err = c.startSubHandlerRoutine(ctx, logger, restartTracker, event)
 		errCh <- err
 	}()
 

--- a/pkg/autopilot/controller/root_controller_test.go
+++ b/pkg/autopilot/controller/root_controller_test.go
@@ -16,6 +16,7 @@ import (
 	aptu "github.com/k0sproject/k0s/internal/autopilot/testutil"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	aproot "github.com/k0sproject/k0s/pkg/autopilot/controller/root"
+	apsigk0s "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/k0s"
 	"github.com/k0sproject/k0s/pkg/autopilot/controller/updates"
 	"github.com/k0sproject/k0s/pkg/leaderelection"
 	"github.com/k0sproject/k0s/static"
@@ -80,7 +81,7 @@ func TestModeSwitch(t *testing.T) {
 		rootController.newLeaderElector = func(c leaderelection.Config) (leaderElector, error) {
 			return &leaseEventStatusCh, nil
 		}
-		rootController.startSubHandlerRoutine = func(ctx context.Context, logger *logrus.Entry, event leaderelection.Status) error {
+		rootController.startSubHandlerRoutine = func(ctx context.Context, logger *logrus.Entry, restartTracker *apsigk0s.RestartTracker, event leaderelection.Status) error {
 			seenEvents = append(seenEvents, "start: "+event.String())
 			<-ctx.Done()
 			seenEvents = append(seenEvents, "stop: "+event.String())

--- a/pkg/autopilot/controller/root_worker.go
+++ b/pkg/autopilot/controller/root_worker.go
@@ -14,6 +14,7 @@ import (
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	aproot "github.com/k0sproject/k0s/pkg/autopilot/controller/root"
 	"github.com/k0sproject/k0s/pkg/autopilot/controller/signal"
+	apsigk0s "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/k0s"
 	"github.com/k0sproject/k0s/pkg/leaderelection"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,6 +74,10 @@ func (w *rootWorker) Run(ctx context.Context) error {
 		HealthProbeBindAddress: w.cfg.HealthProbeBindAddr,
 	}
 
+	// The restart tracker needs to outlive the individual controller managers,
+	// which get rebuilt on each retry attempt.
+	var restartTracker apsigk0s.RestartTracker
+
 	// In some cases, we need to wait on the worker side until controller deploys all autopilot CRDs
 	var attempt uint
 	return k8sretry.OnError(wait.Backoff{
@@ -110,7 +115,7 @@ func (w *rootWorker) Run(ctx context.Context) error {
 			return fmt.Errorf("unable to register indexers: %w", err)
 		}
 
-		if err := signal.RegisterControllers(ctx, logger, mgr, apdel.NodeControllerDelegate(), w.cfg.K0sDataDir, true, clusterID, leaderelection.StatusPending); err != nil {
+		if err := signal.RegisterControllers(ctx, logger, mgr, apdel.NodeControllerDelegate(), &restartTracker, w.cfg.K0sDataDir, true, clusterID, leaderelection.StatusPending); err != nil {
 			return fmt.Errorf("unable to register signal controllers: %w", err)
 		}
 

--- a/pkg/autopilot/controller/signal/init.go
+++ b/pkg/autopilot/controller/signal/init.go
@@ -19,10 +19,12 @@ import (
 	crman "sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-// RegisterControllers registers all of the autopilot controllers used by both controller
-// and worker modes.
-func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, k0sDataDir string, enableWorker bool, clusterID string, leaseStatus leaderelection.Status) error {
-	if err := k0s.RegisterControllers(ctx, logger, mgr, delegate, enableWorker, clusterID, leaseStatus); err != nil {
+// RegisterControllers registers all of the autopilot controllers used by both
+// controller and worker modes. The restart tracker's lifetime needs to be tied
+// to the process, i.e. it has to be shared by all the managers this function is
+// called with throughout the lifetime of the process.
+func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, restartTracker *k0s.RestartTracker, k0sDataDir string, enableWorker bool, clusterID string, leaseStatus leaderelection.Status) error {
+	if err := k0s.RegisterControllers(ctx, logger, mgr, delegate, restartTracker, enableWorker, clusterID, leaseStatus); err != nil {
 		return fmt.Errorf("unable to register k0s controllers: %w", err)
 	}
 

--- a/pkg/autopilot/controller/signal/k0s/apply.go
+++ b/pkg/autopilot/controller/signal/k0s/apply.go
@@ -51,10 +51,11 @@ func applyingUpdateEventFilter(hostname string, handler apsigpred.ErrorHandler) 
 }
 
 type applyingUpdate struct {
-	log          *logrus.Entry
-	client       crcli.Client
-	delegate     apdel.ControllerDelegate
-	k0sBinaryDir string
+	log              *logrus.Entry
+	client           crcli.Client
+	delegate         apdel.ControllerDelegate
+	k0sBinaryDir     string
+	restartInitiated RestartInitiatedFunc
 }
 
 // registeryApplyingUpdate registers the 'applying-update' controller to the
@@ -68,6 +69,7 @@ func registerApplyingUpdate(
 	eventFilter crpred.Predicate,
 	delegate apdel.ControllerDelegate,
 	k0sBinaryDir string,
+	restartInitiated RestartInitiatedFunc,
 ) error {
 	name := strings.ToLower(delegate.Name()) + "_k0s_applying_update"
 	logger.Info("Registering reconciler: ", name)
@@ -78,10 +80,11 @@ func registerApplyingUpdate(
 		WithEventFilter(eventFilter).
 		Complete(
 			&applyingUpdate{
-				log:          logger.WithFields(logrus.Fields{"reconciler": "k0s-applying-update", "object": delegate.Name()}),
-				client:       mgr.GetClient(),
-				delegate:     delegate,
-				k0sBinaryDir: k0sBinaryDir,
+				log:              logger.WithFields(logrus.Fields{"reconciler": "k0s-applying-update", "object": delegate.Name()}),
+				client:           mgr.GetClient(),
+				delegate:         delegate,
+				k0sBinaryDir:     k0sBinaryDir,
+				restartInitiated: restartInitiated,
 			},
 		)
 }
@@ -134,6 +137,12 @@ func (r *applyingUpdate) Reconcile(ctx context.Context, req cr.Request) (cr.Resu
 	}
 
 	logger.Infof("Updating signaling response to '%s'", signalData.Status.Status)
+
+	// Record the pending restart before making the 'Restart' status visible to
+	// the API. The restart controllers may never observe a 'Restart' status
+	// that has been written by this process without knowing that it's pending.
+	r.restartInitiated(signalData)
+
 	if err := r.client.Update(ctx, signalNodeCopy, &crcli.UpdateOptions{}); err != nil {
 		return cr.Result{Requeue: true}, fmt.Errorf("failed to update signal node to status '%s': %w", signalData.Status.Status, err)
 	}

--- a/pkg/autopilot/controller/signal/k0s/init.go
+++ b/pkg/autopilot/controller/signal/k0s/init.go
@@ -8,6 +8,7 @@ package k0s
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,9 +34,15 @@ import (
 	crpred "sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// RegisterControllers registers all of the autopilot controllers used for updating `k0s`
-// to the controller-runtime manager.
-func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, enableWorker bool, clusterID string, leaseStatus leaderelection.Status) error {
+// Registers all of the autopilot controllers used for updating k0s to the
+// controller-runtime manager. The restart tracker's lifetime needs to be tied
+// to the process, i.e. it has to be shared by all the managers this function is
+// called with throughout the lifetime of the process.
+func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, restartTracker *RestartTracker, enableWorker bool, clusterID string, leaseStatus leaderelection.Status) error {
+	if restartTracker == nil {
+		return errors.New("restart tracker is required")
+	}
+
 	logger = logger.WithField("controller", delegate.Name())
 
 	hostname, err := apcomm.FindEffectiveHostname()
@@ -139,15 +146,15 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 		}
 	}
 
-	if err := registerApplyingUpdate(logger, mgr, applyingUpdateEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s applying-update")), delegate, k0sBinaryDir); err != nil {
+	if err := registerApplyingUpdate(logger, mgr, applyingUpdateEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s applying-update")), delegate, k0sBinaryDir, restartTracker.RestartInitiated); err != nil {
 		return fmt.Errorf("unable to register applying-update controller: %w", err)
 	}
 
-	if err := registerRestart(logger, mgr, restartEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s restart")), delegate); err != nil {
+	if err := registerRestart(logger, mgr, restartEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s restart")), delegate, restartTracker.IsRestartPending); err != nil {
 		return fmt.Errorf("unable to register restart controller: %w", err)
 	}
 
-	if err := registerRestarted(logger, mgr, restartedEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s restarted")), delegate); err != nil {
+	if err := registerRestarted(logger, mgr, restartedEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s restarted")), delegate, restartTracker.IsRestartPending); err != nil {
 		return fmt.Errorf("unable to register restarted controller: %w", err)
 	}
 

--- a/pkg/autopilot/controller/signal/k0s/restart_unix.go
+++ b/pkg/autopilot/controller/signal/k0s/restart_unix.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -49,17 +50,49 @@ func restartEventFilter(hostname string, handler apsigpred.ErrorHandler) crpred.
 	)
 }
 
+// Records that this process is about to initiate a restart for the given signal data.
+type RestartInitiatedFunc = func(apsigv2.SignalData)
+
+// Indicates whether this process initiated a restart for the given signal data.
+// Since this process is still running, such a restart has yet to be performed.
+// Conversely, a 'Restart' status that this process didn't write itself predates
+// it, i.e. the restart has already taken place.
+type IsRestartPendingFunc = func(apsigv2.SignalData) bool
+
+// Keeps track of a k0s restart that has been initiated by the currently running
+// process. Its lifetime needs to be tied to the k0s process. Whether a restart
+// is still pending or has already been performed can only be decided by knowing
+// if the 'Restart' status has been written by this very process.
+type RestartTracker struct {
+	initiatedData atomic.Pointer[apsigv2.SignalData]
+}
+
+// See [RestartInitiatedFunc].
+func (t *RestartTracker) RestartInitiated(signalData apsigv2.SignalData) {
+	t.initiatedData.Store(&signalData)
+}
+
+// See [IsRestartPendingFunc].
+func (t *RestartTracker) IsRestartPending(pendingData apsigv2.SignalData) bool {
+	if initiatedData := t.initiatedData.Load(); initiatedData != nil {
+		return initiatedData.PlanID == pendingData.PlanID && initiatedData.Created == pendingData.Created &&
+			initiatedData.Status != nil && pendingData.Status != nil && *initiatedData.Status == *pendingData.Status
+	}
+	return false
+}
+
 type restart struct {
-	log      *logrus.Entry
-	client   crcli.Client
-	delegate apdel.ControllerDelegate
+	log              *logrus.Entry
+	client           crcli.Client
+	delegate         apdel.ControllerDelegate
+	isRestartPending IsRestartPendingFunc
 }
 
 // registerRestart registers the 'restart' controller to the controller-runtime manager.
 //
 // This controller is only interested in changes to signal nodes where its signaling
 // status is marked as `Restart`
-func registerRestart(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate) error {
+func registerRestart(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, isRestartPending IsRestartPendingFunc) error {
 	name := strings.ToLower(delegate.Name()) + "_k0s_restart"
 	logger.Info("Registering reconciler: ", name)
 
@@ -69,9 +102,10 @@ func registerRestart(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred
 		WithEventFilter(eventFilter).
 		Complete(
 			&restart{
-				log:      logger.WithFields(logrus.Fields{"reconciler": "k0s-restart", "object": delegate.Name()}),
-				client:   mgr.GetClient(),
-				delegate: delegate,
+				log:              logger.WithFields(logrus.Fields{"reconciler": "k0s-restart", "object": delegate.Name()}),
+				client:           mgr.GetClient(),
+				delegate:         delegate,
+				isRestartPending: isRestartPending,
 			},
 		)
 }
@@ -111,7 +145,13 @@ func (r *restart) Reconcile(ctx context.Context, req cr.Request) (cr.Result, err
 		return cr.Result{}, nil
 	}
 
-	if k0sVersion == signalData.Command.K0sUpdate.Version {
+	// Check if this very process wrote the 'Restart' status. Such a restart is
+	// still pending and needs to be performed by terminating k0s. Conversely, a
+	// 'Restart' status that hasn't been written by this process predates it,
+	// which means that the restart has already been performed.
+	restartPending := r.isRestartPending(signalData)
+
+	if k0sVersion == signalData.Command.K0sUpdate.Version || (!restartPending && signalData.Command.K0sUpdate.ForceUpdate) {
 		signalNodeCopy := r.delegate.DeepCopy(signalNode)
 		signalData.Status = apsigv2.NewStatus(UnCordoning)
 
@@ -124,6 +164,13 @@ func (r *restart) Reconcile(ctx context.Context, req cr.Request) (cr.Result, err
 			return cr.Result{}, fmt.Errorf("unable to update signal node with '%s' status: %w", signalData.Status.Status, err)
 		}
 
+		return cr.Result{}, nil
+	}
+
+	if !restartPending {
+		// The restart has already been performed, but the expected version of
+		// k0s still isn't running. Performing another restart won't help.
+		logger.Debug("Not restarting k0s: the restart has already been performed")
 		return cr.Result{}, nil
 	}
 

--- a/pkg/autopilot/controller/signal/k0s/restart_unix_test.go
+++ b/pkg/autopilot/controller/signal/k0s/restart_unix_test.go
@@ -1,0 +1,62 @@
+//go:build unix
+
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k0s
+
+import (
+	"testing"
+
+	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRestartTracker(t *testing.T) {
+	newSignalData := func(planID, statusTimestamp string) apsigv2.SignalData {
+		commandID := 123
+		return apsigv2.SignalData{
+			PlanID:  planID,
+			Created: "now",
+			Command: apsigv2.Command{
+				ID: &commandID,
+				K0sUpdate: &apsigv2.CommandK0sUpdate{
+					URL:         "https://updates.example.com/k0s",
+					Version:     "v99.99.99",
+					ForceUpdate: true,
+				},
+			},
+			Status: &apsigv2.Status{Status: Restart, Timestamp: statusTimestamp},
+		}
+	}
+
+	restartSignal := newSignalData("plan1", "2020-01-01T12:30:00Z")
+
+	renewedRestartSignal := restartSignal
+	renewedRestartSignal.Status = &apsigv2.Status{Status: Restart, Timestamp: "2020-01-01T12:31:00Z"}
+
+	// Some other plan's signal data that reached the Restart state.
+	otherPlanRestartSignal := newSignalData("plan2", "2020-01-01T12:32:00Z")
+
+	t.Run("nothing pending initially", func(t *testing.T) {
+		var underTest RestartTracker
+		assert.False(t, underTest.IsRestartPending(restartSignal))
+	})
+
+	t.Run("pending after initiation", func(t *testing.T) {
+		var underTest RestartTracker
+		underTest.RestartInitiated(restartSignal)
+		assert.True(t, underTest.IsRestartPending(restartSignal))
+		assert.False(t, underTest.IsRestartPending(renewedRestartSignal))
+		assert.False(t, underTest.IsRestartPending(otherPlanRestartSignal))
+	})
+
+	t.Run("latest initiation wins", func(t *testing.T) {
+		var underTest RestartTracker
+		underTest.RestartInitiated(restartSignal)
+		underTest.RestartInitiated(otherPlanRestartSignal)
+		assert.False(t, underTest.IsRestartPending(restartSignal))
+		assert.True(t, underTest.IsRestartPending(otherPlanRestartSignal))
+	})
+}

--- a/pkg/autopilot/controller/signal/k0s/restarted_unix.go
+++ b/pkg/autopilot/controller/signal/k0s/restarted_unix.go
@@ -25,9 +25,10 @@ import (
 )
 
 type restarted struct {
-	log      *logrus.Entry
-	client   crcli.Client
-	delegate apdel.ControllerDelegate
+	log              *logrus.Entry
+	client           crcli.Client
+	delegate         apdel.ControllerDelegate
+	isRestartPending IsRestartPendingFunc
 }
 
 // restartedEventFilter creates a controller-runtime predicate that governs which
@@ -51,7 +52,7 @@ func restartedEventFilter(hostname string, handler apsigpred.ErrorHandler) crpre
 //
 // This controller is only interested in changes to signal nodes where its signaling
 // status is marked as `Restart`
-func registerRestarted(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate) error {
+func registerRestarted(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, isRestartPending IsRestartPendingFunc) error {
 	name := strings.ToLower(delegate.Name()) + "_k0s_restarted"
 	logger.Info("Registering reconciler: ", name)
 
@@ -61,9 +62,10 @@ func registerRestarted(logger *logrus.Entry, mgr crman.Manager, eventFilter crpr
 		WithEventFilter(eventFilter).
 		Complete(
 			&restarted{
-				log:      logger.WithFields(logrus.Fields{"reconciler": "k0s-restarted", "object": delegate.Name()}),
-				client:   mgr.GetClient(),
-				delegate: delegate,
+				log:              logger.WithFields(logrus.Fields{"reconciler": "k0s-restarted", "object": delegate.Name()}),
+				client:           mgr.GetClient(),
+				delegate:         delegate,
+				isRestartPending: isRestartPending,
 			},
 		)
 }
@@ -102,6 +104,13 @@ func (r *restarted) Reconcile(ctx context.Context, req cr.Request) (cr.Result, e
 
 	if signalData.Status != nil && signalData.Status.Status != Restart {
 		logger.Debug("Ignoring signal status ", signalData.Status.Status)
+		return cr.Result{}, nil
+	}
+
+	if r.isRestartPending(signalData) {
+		// This process initiated the restart, and it hasn't been performed
+		// yet. Advancing the state now would skip the restart entirely.
+		logger.Info("Not advancing: the restart initiated by this process is still pending")
 		return cr.Result{}, nil
 	}
 


### PR DESCRIPTION
## Description

The k0s-restart reconciler determined whether to terminate k0s solely by comparing the version reported via the status socket to the version requested in the update plan. It couldn't tell whether a signaled restart was still pending or had already been performed. Once the restart brings up the new k0s process, node object updates (such as kubelet status heartbeats) retrigger the reconciler. For forced updates whose plan version doesn't match the version reported by the binary, the comparison never succeeds, and the reconciler terminated the freshly started process over and over again. The k0s-restarted reconciler, which honors forceupdate, then had to win a race against the next kill to move the signal to UnCordoning.

Break this cycle by tracking restart initiations in the process itself. The applying-update reconciler records the signal data right before making the Restart status visible to the API, and the restart reconciler only terminates k0s for restarts recorded by the running process. If the restart status was not written by the process itself, it has to predate the process, meaning a restart must have already occurred. For forced updates, move the signal to UnCordoning in that case instead. Conversely, the restarted reconciler no longer advances the signal while a restart initiated by the running process is pending. Previously, a restart could be skipped entirely if the controller managers happened to be rebuilt in the short window between the status update and the process's termination.

Create the tracker in the Autopilot roots and hand it down to the controllers. Its lifetime needs to be tied to the process, not to any particular controller manager, as the controller root rebuilds its managers whenever the lease status changes, and the worker root does so on every retry attempt.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
