### PR TITLE
Make cAdvisor metrics tests environment aware

### DIFF
--- a/inttest/basic/cadvisor.go
+++ b/inttest/basic/cadvisor.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"iter"
 	"maps"
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -309,6 +310,14 @@ func verifyCAdvisorMetrics(ctx context.Context, t *testing.T, client kubernetes.
 			_, found := slices.BinarySearchFunc(allMetrics, c, slices.Compare)
 			return found
 		})
+
+		// PSI metrics are only available on kernels that support it.
+		if _, err := os.Stat("/sys/fs/cgroup/cpu.pressure"); err != nil && assert.ErrorIs(&f, err, os.ErrNotExist) {
+			missingMetrics = slices.DeleteFunc(missingMetrics, func(c []string) bool {
+				return strings.HasPrefix(c[0], "container_pressure_")
+			})
+		}
+
 		assert.Empty(&f, missingMetrics, "Some expected cAdvisor metrics are missing")
 
 		verifyContainerMetricsImageLabels(&f, families)
@@ -331,9 +340,14 @@ func collectAllMetrics(families map[string]*clientmodel.MetricFamily) (all [][]s
 			labels[0] = name
 
 			for name, value := range nonNilLabels(metric.Label) {
-				if value != "" {
-					labels = append(labels, name)
+				if value == "" && // Skip labels with empty values...
+					// ...except if they are reporting the system UUID, which
+					// might or might not be there, depending on the test
+					// environment.
+					(name != "system_uuid" || !strings.HasPrefix(labels[0], "machine_")) {
+					continue
 				}
+				labels = append(labels, name)
 			}
 			slices.Sort(labels[1:])
 			if !slices.ContainsFunc(all[off:], func(c []string) bool {


### PR DESCRIPTION
## Description

The existence of some metrics is dependent on the test environment. For example, PSI metrics are only returned if the kernel exposes them. Same for the system UUID: If the hardware exposes it via SMBIOS/DMI, it's present, otherwise not.

See:

* #7984

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
