### PR TITLE
Retry conflicting signal node updates after downloads

### DIFF
--- a/pkg/autopilot/controller/signal/common/download.go
+++ b/pkg/autopilot/controller/signal/common/download.go
@@ -11,6 +11,9 @@ import (
 	apdl "github.com/k0sproject/k0s/pkg/autopilot/download"
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/util/retry"
+
 	"github.com/sirupsen/logrus"
 	cr "sigs.k8s.io/controller-runtime"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
@@ -89,12 +92,28 @@ func (r *downloadController) Reconcile(ctx context.Context, req cr.Request) (cr.
 		signalData.Status = apsigv2.NewStatus(manifest.SuccessState)
 	}
 
-	if err := signalData.Marshal(signalNodeCopy.GetAnnotations()); err != nil {
-		return cr.Result{}, fmt.Errorf("failed to marshal signal data: %w", err)
-	}
-
 	logger.Infof("Updating signaling response to '%s'", signalData.Status.Status)
-	if err := r.client.Update(ctx, signalNodeCopy, &crcli.UpdateOptions{}); err != nil {
+
+	// Conflicts are resolved by refreshing the signal node and re-applying the
+	// signal data on top of it. Simply returning the error would requeue the
+	// request, which would repeat the download that just succeeded. As long as
+	// the signal node is being updated by others more frequently than it takes
+	// to perform the download, the download would be repeated indefinitely.
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := signalData.Marshal(signalNodeCopy.GetAnnotations()); err != nil {
+			return fmt.Errorf("failed to marshal signal data: %w", err)
+		}
+
+		err := r.client.Update(ctx, signalNodeCopy, &crcli.UpdateOptions{})
+		if apierrors.IsConflict(err) {
+			logger.WithError(err).Debug("Conflict while updating signal node, refreshing it")
+			if getErr := r.client.Get(ctx, req.NamespacedName, signalNodeCopy); getErr != nil {
+				return fmt.Errorf("failed to refresh signal node: %w", getErr)
+			}
+		}
+
+		return err
+	}); err != nil {
 		return cr.Result{}, fmt.Errorf("failed to update signal node to status '%s': %w", signalData.Status.Status, err)
 	}
 

--- a/pkg/autopilot/controller/signal/common/download_test.go
+++ b/pkg/autopilot/controller/signal/common/download_test.go
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
+	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
+	apdl "github.com/k0sproject/k0s/pkg/autopilot/download"
+	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
+	apscheme "github.com/k0sproject/k0s/pkg/client/clientset/scheme"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cr "sigs.k8s.io/controller-runtime"
+	crcli "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+type testManifestBuilder struct {
+	downloadDir  string
+	url          string
+	successState string
+}
+
+func (b *testManifestBuilder) Build(_ crcli.Object, _ apsigv2.SignalData) (DownloadManifest, error) {
+	return DownloadManifest{
+		Config: apdl.Config{
+			URL:         b.url,
+			DownloadDir: b.downloadDir,
+			Filename:    "k0s.tmp",
+		},
+		SuccessState: b.successState,
+	}, nil
+}
+
+// TestDownloadControllerConflict ensures that a signal node that gets modified
+// while its update is being downloaded doesn't cause the download to be
+// repeated, and that the concurrent modification is retained.
+func TestDownloadControllerConflict(t *testing.T) {
+	var downloads atomic.Uint32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		downloads.Add(1)
+		_, _ = w.Write([]byte("some k0s binary"))
+	}))
+	t.Cleanup(server.Close)
+
+	scheme := apimruntime.NewScheme()
+	require.NoError(t, apscheme.AddToScheme(scheme))
+
+	signalData := apsigv2.SignalData{
+		PlanID:  "abc123",
+		Created: "now",
+		Command: apsigv2.Command{
+			ID: new(int),
+			K0sUpdate: &apsigv2.CommandK0sUpdate{
+				URL:     server.URL,
+				Version: "v1.2.3",
+			},
+		},
+		Status: apsigv2.NewStatus(Downloading),
+	}
+	annotations := map[string]string{}
+	require.NoError(t, signalData.Marshal(annotations))
+
+	signalNode := &apv1beta2.ControlNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "controller0", Annotations: annotations},
+	}
+
+	// Modify the signal node behind the reconciler's back while it's updating
+	// it, so that the first update attempt runs into a conflict.
+	var conflictInjected atomic.Bool
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(signalNode).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, client crcli.WithWatch, obj crcli.Object, opts ...crcli.UpdateOption) error {
+				if conflictInjected.Swap(true) {
+					return client.Update(ctx, obj, opts...)
+				}
+
+				var concurrent apv1beta2.ControlNode
+				if err := client.Get(ctx, crcli.ObjectKeyFromObject(obj), &concurrent); err != nil {
+					return err
+				}
+				concurrent.Annotations["test.k0sproject.io/touch"] = "touched"
+				if err := client.Update(ctx, &concurrent); err != nil {
+					return err
+				}
+
+				return apierrors.NewConflict(
+					schema.GroupResource{Group: "autopilot.k0sproject.io", Resource: "controlnodes"},
+					obj.GetName(), errors.New("injected conflict"),
+				)
+			},
+		}).
+		Build()
+
+	underTest := NewDownloadController(
+		logrus.NewEntry(logrus.StandardLogger()),
+		client,
+		apdel.ControlNodeControllerDelegate(),
+		&testManifestBuilder{
+			downloadDir:  t.TempDir(),
+			url:          server.URL,
+			successState: "Cordoning",
+		},
+	)
+
+	_, err := underTest.Reconcile(t.Context(), cr.Request{
+		NamespacedName: types.NamespacedName{Name: signalNode.Name},
+	})
+	require.NoError(t, err)
+	assert.True(t, conflictInjected.Load(), "Conflict hasn't been injected")
+	assert.Equal(t, uint32(1), downloads.Load(), "Download has been repeated")
+
+	var updated apv1beta2.ControlNode
+	require.NoError(t, client.Get(t.Context(), crcli.ObjectKeyFromObject(signalNode), &updated))
+
+	var updatedSignalData apsigv2.SignalData
+	require.NoError(t, updatedSignalData.Unmarshal(updated.Annotations))
+	if assert.NotNil(t, updatedSignalData.Status) {
+		assert.Equal(t, "Cordoning", updatedSignalData.Status.Status)
+	}
+	assert.Equal(t, "touched", updated.Annotations["test.k0sproject.io/touch"],
+		"Concurrent modification has been lost")
+}


### PR DESCRIPTION
## Description

The download reconciler stores its result by updating the signal node it just downloaded an update for. Whenever that update conflicts with a concurrent modification, the error is returned and the request is requeued, which repeats the whole download. If the signal node happens to be modified by others more frequently than the download takes, the reconciler keeps downloading the same file over and over again without ever storing its result, and the update never proceeds past the downloading phase:

```
Starting download of 'http://localhost/dist/k0s-new'
Download of 'http://localhost/dist/k0s-new' successful
Updating signaling response to 'Cordoning'
Reconciler error ... error="failed to update signal node to status 'Cordoning': Operation cannot be
fulfilled on controlnodes.autopilot.k0sproject.io \"controller1\": the object has been modified;
please apply your changes to the latest version and try again"
```

This is what makes the `check-ap-controllerworker` smoketest fail intermittently: the test modifies the ControlNodes once per second in order to stress Autopilot's reconcilers, and the last controller to be updated gets stuck in the downloading phase, repeating the above three lines until the suite times out after 5 minutes. Two examples on `main`:

* https://github.com/k0sproject/k0s/actions/runs/30094704281 (commit 5aee99a3)
* https://github.com/k0sproject/k0s/actions/runs/30238355160

Conflicts are now resolved by refreshing the signal node and re-applying the signal data on top of it, so the download result can be stored without repeating the download, and concurrent modifications are retained.

This is the same class of problem as #7703 / #7706, but in a different reconciler, and with a different failure mode: the download reconciler doesn't wedge permanently, it just live-locks for as long as the signal node keeps being modified. That PR is left untouched here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

`TestDownloadControllerConflict` injects a conflicting concurrent modification into the first update attempt and asserts that the download is performed exactly once, that the resulting status is stored, and that the concurrent modification isn't lost. It fails without the change in `download.go`:

```
--- FAIL: TestDownloadControllerConflict (0.09s)
    Error: Received unexpected error:
           failed to update signal node to status 'Cordoning': Operation cannot be fulfilled on
           controlnodes.autopilot.k0sproject.io "controller0": injected conflict
```

`make lint` and the unit tests in `pkg/autopilot/...` pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
