### PR TITLE
Stop and wait for svc deletion on Windows before re-install

### DIFF
--- a/.github/workflows/win-wsl.yaml
+++ b/.github/workflows/win-wsl.yaml
@@ -260,6 +260,10 @@ jobs:
           & kubectl get nodes,pods -A
           go test -v -count=1 ./inttest/windows
 
+      - name: Reinstall with force
+        run: |
+          & .\k0s.exe install worker --force --token-file=k0s-worker-token --debug --labels test.k0sproject.io/foo=bar --kubelet-extra-args="--hostname-override=windowsworker"
+          & .\k0s.exe start
       - name: Stop & reset k0s worker
         run: |
           & .\k0s.exe stop --debug

--- a/cmd/install/controller.go
+++ b/cmd/install/controller.go
@@ -66,7 +66,7 @@ With the controller subcommand you can setup a single node cluster by running:
 			}
 
 			args := append([]string{"controller"}, flagsAndVals...)
-			if err := install.InstallService(args, envVars, installFlags.force); err != nil {
+			if err := install.InstallService(cmd.Context(), args, envVars, installFlags.force); err != nil {
 				return fmt.Errorf("failed to install controller service: %w", err)
 			}
 

--- a/cmd/install/worker.go
+++ b/cmd/install/worker.go
@@ -38,7 +38,7 @@ All default values of worker command will be passed to the service stub unless o
 			}
 
 			args := append([]string{"worker"}, flagsAndVals...)
-			if err := install.InstallService(args, envVars, installFlags.force); err != nil {
+			if err := install.InstallService(cmd.Context(), args, envVars, installFlags.force); err != nil {
 				return fmt.Errorf("failed to install worker service: %w", err)
 			}
 

--- a/pkg/install/service.go
+++ b/pkg/install/service.go
@@ -4,12 +4,15 @@
 package install
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"runtime"
+	"time"
 
 	"github.com/kardianos/service"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var (
@@ -54,7 +57,7 @@ func InstalledService() (service.Service, error) {
 }
 
 // InstallService installs the k0s service, per the given arguments, and the detected platform
-func InstallService(args []string, envVars []string, force bool) error {
+func InstallService(ctx context.Context, args []string, envVars []string, force bool) error {
 	var svcConfig *service.Config
 
 	prg := &Program{}
@@ -83,10 +86,31 @@ func InstallService(args []string, envVars []string, force bool) error {
 	svcConfig.Arguments = args
 
 	if force {
+		if runtime.GOOS == "windows" {
+			// On Windows, the service must be stopped first
+			if err = s.Stop(); err != nil && !errors.Is(err, service.ErrNotInstalled) {
+				logrus.Warnf("failed to stop service before re-install: %v", err)
+			}
+		}
+
 		logrus.Infof("Uninstalling %s service", svcConfig.Name)
 		err = s.Uninstall()
 		if err != nil && !errors.Is(err, service.ErrNotInstalled) {
 			logrus.Warnf("failed to uninstall service: %v", err)
+		}
+		// On windows the service delete/uninstall is async, wait till it is done
+		if runtime.GOOS == "windows" {
+			if err = wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
+				_, err = s.Status()
+				if errors.Is(err, service.ErrNotInstalled) {
+					return true, nil
+				}
+				logrus.Info("waiting for the service to be actually deleted")
+				return false, nil
+			}); err != nil {
+				logrus.Errorf("failed to wait service to be deleted: %v", err)
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION

## Description

On Windows we cannot re-install a svc unless the svc is stopped. So stop the svc first on Windows and then proceed with the uninstall and reinstall steps. Uninstall is also async so we need to poll until the svc is actually gone.

Fixes #8029

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
