### PR TITLE
docs: use the version src_var for cali_ver in the image example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -565,7 +565,7 @@ If you want the list of default images and their versions to be included, use `k
 
 #### Image example
 
-{% set cali_ver = src_var('CalicoKubeControllersImage') -%}
+{% set cali_ver = src_var('CalicoKubeControllersImageVersion') -%}
 {% set metrics_ver = src_var('MetricsImageVersion') -%}
 
 ```yaml


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

The "Image example" in `docs/configuration.md` set `cali_ver` from `src_var('CalicoKubeControllersImage')` (the full image reference) while the parallel line correctly uses `src_var('MetricsImageVersion')`. Since `cali_ver` is meant to hold a version, use `src_var('CalicoKubeControllersImageVersion')` so the rendered example shows a version (`v3.32.1-0`) rather than an image name.

`CalicoKubeControllersImageVersion` is a string literal in `pkg/constant/constant.go` (alongside `MetricsImageVersion`), which is exactly the source `src_var` parses (`docs/mkdocs_modules/k0s_mkdocs_hacks/macros.py`), so the reference resolves.

Fixes #8038

## Type of change

- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test

Confirmed `CalicoKubeControllersImageVersion` is a literal const in `pkg/constant/constant.go` (`"v3.32.1-0"`) and is resolved by `src_var` the same way `MetricsImageVersion` is, so the docs still build and the example renders a version.

## Checklist

- [x] My commit messages are signed-off
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

---

Disclosure: prepared with AI assistance; I reviewed the change and verified the variable against the source cited above.
