### PR TITLE
Bump pushgateway-ttl image to 1.4.0-k0s.2

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -70,7 +70,7 @@ const (
 	KonnectivityImage                     = "quay.io/k0sproject/apiserver-network-proxy-agent"
 	KonnectivityImageVersion              = "v0.36.0-k0s.0"
 	PushGatewayImage                      = "quay.io/k0sproject/pushgateway-ttl"
-	PushGatewayImageVersion               = "1.4.0-k0s.1"
+	PushGatewayImageVersion               = "1.4.0-k0s.2"
 	MetricsImage                          = "quay.io/k0sproject/metrics-server"
 	MetricsImageVersion                   = "v0.9.0-k0s.0"
 	KubePauseContainerImage               = "quay.io/k0sproject/pause"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

Bump pushgateway image. New version fixes some CVEs