### PR TITLE
[release-1.36] Bump cni-node to v1.9.1-k0s.1

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -102,7 +102,7 @@ const (
 	KubeRouterCNIImage                    = "quay.io/k0sproject/kube-router"
 	KubeRouterCNIImageVersion             = "v2.10.0-iptables1.8.13-k0s.0"
 	KubeRouterCNIInstallerImage           = "quay.io/k0sproject/cni-node"
-	KubeRouterCNIInstallerImageVersion    = "1.8.0-k0s.0"
+	KubeRouterCNIInstallerImageVersion    = "v1.9.1-k0s.1"
 
 	/* Controller component names */
 


### PR DESCRIPTION
Bumping cni-node to v1.9.1-k0s.1. I hope it should be fine to backport it.