### PR TITLE
Fix: Don't add trailing-dot SAN to kube-apiserver certificate

### DIFF
--- a/cmd/controller/certificates.go
+++ b/cmd/controller/certificates.go
@@ -233,7 +233,6 @@ func (c *Certificates) generateSANList(ctx context.Context) ([]string, error) {
 		"kubernetes.default",
 		"kubernetes.default.svc",
 		"kubernetes.default.svc." + c.ClusterSpec.Network.ClusterDomain,
-		"kubernetes.default.svc." + c.ClusterSpec.Network.ClusterDomain + ".",
 		"localhost",
 		"127.0.0.1",
 	}

--- a/cmd/controller/certificates_test.go
+++ b/cmd/controller/certificates_test.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	"github.com/k0sproject/k0s/pkg/certificate"
+	"github.com/k0sproject/k0s/pkg/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The API server certificate needs to be accepted for the in-cluster service
+// name, no matter if clients spell it as a relative or as a fully qualified
+// (trailing dot) domain name. A separate SAN for the fully qualified spelling
+// isn't required for that: hostname verification strips the trailing dot from
+// the name that's being verified.
+func TestGenerateSANList_ClusterDomainNames(t *testing.T) {
+	clusterSpec := v1beta1.DefaultClusterSpec()
+	serverCert, verifyOpts := issueServerCert(t, clusterSpec)
+
+	for _, hostname := range []string{
+		"kubernetes",
+		"kubernetes.default",
+		"kubernetes.default.svc",
+		"kubernetes.default.svc." + clusterSpec.Network.ClusterDomain,
+		"kubernetes.default.svc." + clusterSpec.Network.ClusterDomain + ".",
+		"localhost",
+	} {
+		t.Run(hostname, func(t *testing.T) {
+			opts := verifyOpts
+			opts.DNSName = hostname
+			_, err := serverCert.Verify(opts)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// issueServerCert generates the API server's SAN list for the given cluster
+// spec and issues the server certificate for it, just as k0s does at runtime.
+// It returns the parsed certificate along with the verification options that
+// validate it against the CA that issued it.
+func issueServerCert(t *testing.T, clusterSpec *v1beta1.ClusterSpec) (*x509.Certificate, x509.VerifyOptions) {
+	k0sVars, err := config.NewCfgVars(nil, t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(k0sVars.CertRootDir, 0755))
+
+	certManager := certificate.Manager{K0sVars: k0sVars}
+	require.NoError(t, certManager.EnsureCA("ca", "kubernetes-ca", time.Hour))
+
+	underTest := Certificates{
+		CertManager: certManager,
+		ClusterSpec: clusterSpec,
+		K0sVars:     k0sVars,
+	}
+
+	hostnames, err := underTest.generateSANList(t.Context())
+	require.NoError(t, err)
+
+	serverCert, err := certManager.EnsureCertificate(certificate.Request{
+		Name:      "server",
+		CN:        "kubernetes",
+		O:         "kubernetes",
+		CACert:    filepath.Join(k0sVars.CertRootDir, "ca.crt"),
+		CAKey:     filepath.Join(k0sVars.CertRootDir, "ca.key"),
+		Hostnames: hostnames,
+	}, os.Getuid(), time.Hour)
+	require.NoError(t, err)
+
+	caCert, err := os.ReadFile(filepath.Join(k0sVars.CertRootDir, "ca.crt"))
+	require.NoError(t, err)
+	roots := x509.NewCertPool()
+	require.True(t, roots.AppendCertsFromPEM(caCert), "Failed to load CA certificate")
+
+	return parseCert(t, []byte(serverCert.Cert)), x509.VerifyOptions{
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+}
+
+func parseCert(t *testing.T, pemBytes []byte) *x509.Certificate {
+	block, _ := pem.Decode(pemBytes)
+	require.NotNil(t, block, "Failed to decode PEM data")
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	return cert
+}


### PR DESCRIPTION
## Description

`generateSANList` in `cmd/controller/certificates.go` puts the in-cluster API service name
into the kube-apiserver serving certificate twice — once as a relative name and once as a
fully qualified name with a trailing dot:

```go
"kubernetes.default.svc." + c.ClusterSpec.Network.ClusterDomain,
"kubernetes.default.svc." + c.ClusterSpec.Network.ClusterDomain + ".",
```

This PR drops the trailing-dot variant, i.e. it partially reverts
b2474004fc5d8d2b33fc5c4b718b2e8288a12277 (#7843, June 2026), which introduced it. k0s did
not have that SAN before, and clusters created before that commit have been serving the
dot-less name only.

**The trailing-dot entry is redundant.** Hostname verification strips a trailing dot from
the name being verified, so the dot-less SAN already covers both spellings:

* Go, `crypto/x509/verify.go` (go1.26.6):

  ```go
  func validHostname(host string, isPattern bool) bool {
      if !isPattern {
          host = strings.TrimSuffix(host, ".")
      }
      // ...

  func splitHostname(host string) []string {
      return strings.Split(toLowerCaseASCII(strings.TrimSuffix(host, ".")), ".")
  }
  ```

  Note the `isPattern` asymmetry: the trailing dot is stripped from the *input* name, but
  not from the SAN *pattern*. A trailing-dot SAN has an empty final label, so it is not a
  valid hostname pattern and can only ever be matched by exact string comparison — it can
  never match anything that the dot-less SAN doesn't already match.

* OpenSSL accepts both spellings against the k0s certificate even in strict mode
  ([verified by @jnummelin](https://github.com/k0sproject/k0s/pull/8068#issuecomment-5241074350)):

  ```console
  # openssl verify -CAfile ca.crt -purpose sslserver -x509_strict \
      -verify_hostname kubernetes.default.svc.cluster.local. server.crt
  server.crt: OK
  ```

**Upstream doesn't add it either.** kubeadm's `GetAPIServerAltNames`
([`cmd/kubeadm/app/util/pkiutil/pki_helpers.go`](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/util/pkiutil/pki_helpers.go))
stops at the relative name:

```go
dnsNames = append(dnsNames, "kubernetes", "kubernetes.default", "kubernetes.default.svc")
if len(cfg.Networking.DNSDomain) > 0 {
    dnsNames = append(dnsNames, fmt.Sprintf("kubernetes.default.svc.%s", cfg.Networking.DNSDomain))
}
```

So the SAN is a k0s-only deviation that buys nothing, while every extra name in a serving
certificate is one more thing to get wrong.

### What this PR is *not* about anymore

The original motivation was flux-operator failing against the k0s API with
`tls: failed to parse certificate from server: x509: SAN dNSName is malformed`. As
@makhov and @jnummelin found, that was **not** a problem with the certificate: it was a
regression in Go's x509 parser — [golang/go#75828](https://github.com/golang/go/issues/75828),
present in Go 1.25.2 and fixed in Go 1.25.3
([backport golang/go#75861](https://github.com/golang/go/issues/75861)) and Go 1.26.
Clients built with a fixed toolchain are fine either way.

I've also dropped the RFC 5280 / RFC 1034 "malformed name" argument from the original
description. Whether the preferred name syntax permits an empty final label is genuinely
arguable (see the [discussion in this PR](https://github.com/k0sproject/k0s/pull/8068)),
and this change doesn't rest on that reading — it rests on the SAN being redundant and on
parity with upstream.

Relates to #7843, golang/go#75828.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

None of the above fits exactly: this is a non-breaking cleanup / partial revert. It was
filed as a bug fix, but the breakage that triggered it turned out to be a Go regression,
not a k0s bug. Existing certificates are not reissued by this change; the SAN disappears
when a certificate is regenerated.

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

`TestGenerateSANList_ClusterDomainNames` in `cmd/controller/certificates_test.go` no longer
inspects SAN strings. Per @ncopa's review, it now goes through a real x509 validator: it
issues a CA and a server certificate with `pkg/certificate.Manager` from the SAN list that
`generateSANList` produces — the same code path k0s uses at runtime — and then validates
the certificate with `crypto/x509`:

```go
_, err := serverCert.Verify(x509.VerifyOptions{
    DNSName:   hostname, // incl. "kubernetes.default.svc.cluster.local."
    Roots:     roots,    // the CA that issued it
    KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
})
```

```console
$ go test ./cmd/controller/... -run TestGenerateSANList -v
--- PASS: TestGenerateSANList_ClusterDomainNames (0.14s)
    --- PASS: TestGenerateSANList_ClusterDomainNames/kubernetes (0.00s)
    --- PASS: TestGenerateSANList_ClusterDomainNames/kubernetes.default (0.00s)
    --- PASS: TestGenerateSANList_ClusterDomainNames/kubernetes.default.svc (0.00s)
    --- PASS: TestGenerateSANList_ClusterDomainNames/kubernetes.default.svc.cluster.local (0.00s)
    --- PASS: TestGenerateSANList_ClusterDomainNames/kubernetes.default.svc.cluster.local. (0.00s)
    --- PASS: TestGenerateSANList_ClusterDomainNames/localhost (0.00s)
PASS
```

To be explicit about what the test does and doesn't do: it is a contract test, not a
regression guard. It passes both before and after the removal, on purpose — the point is
to show that clients can still validate the fully qualified name once the SAN is gone. A
test that asserted the absence of a trailing dot in the SAN list would just restate the
diff.

Local verification (Go 1.26.6):

```sh
gofmt -l cmd/controller/     # no output
go vet ./cmd/controller/...  # clean
go test ./cmd/controller/... # ok
```

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings