### PR TITLE
Preserve legacy dual-stack pod CIDR order on upgrade

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -609,6 +609,7 @@ func (c *command) start(ctx context.Context, runtimeConfig *config.RuntimeConfig
 			ServiceClusterIPRange: nodeConfig.Spec.Network.BuildServiceCIDR(nodeConfig.Spec.PrimaryAddressFamily()),
 			PrimaryAddressFamily:  nodeConfig.Spec.PrimaryAddressFamily(),
 			ExtraArgs:             flags.KubeControllerManagerExtraArgs,
+			KubeClientFactory:     adminClientFactory,
 		})
 	}
 

--- a/pkg/component/controller/controllermanager.go
+++ b/pkg/component/controller/controllermanager.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,6 +21,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/config"
 	"github.com/k0sproject/k0s/pkg/constant"
+	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
 	"github.com/k0sproject/k0s/pkg/supervisor"
 )
 
@@ -31,6 +33,7 @@ type Manager struct {
 	ServiceClusterIPRange string
 	PrimaryAddressFamily  v1beta1.PrimaryAddressFamilyType
 	ExtraArgs             string
+	KubeClientFactory     kubeutil.ClientFactoryInterface
 
 	supervisor     *supervisor.Supervisor
 	executablePath string
@@ -79,6 +82,40 @@ func (a *Manager) Start(_ context.Context) error { return nil }
 func (a *Manager) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterConfig) error {
 	logger := logrus.WithField("component", kubeControllerManagerComponent)
 	logger.Info("Starting reconcile")
+
+	args, err := a.buildArgs(ctx, clusterConfig)
+	if err != nil {
+		return err
+	}
+
+	if args.Equals(a.previousConfig) && a.supervisor != nil {
+		// no changes and supervisor already running, do nothing
+		logger.Info("reconcile has nothing to do")
+		return nil
+	}
+	// Stop in case there's process running already and we need to change the config
+	if a.supervisor != nil {
+		logger.Info("reconcile has nothing to do")
+		if err := a.supervisor.Stop(); err != nil {
+			logger.WithError(err).Error("Failed to stop executable")
+		}
+		a.supervisor = nil
+	}
+
+	a.supervisor = &supervisor.Supervisor{
+		Name:    kubeControllerManagerComponent,
+		BinPath: a.executablePath,
+		RunDir:  a.K0sVars.RunDir,
+		DataDir: a.K0sVars.DataDir,
+		Args:    append(args.ToDashedArgs(), clusterConfig.Spec.ControllerManager.RawArgs...),
+		UID:     a.uid,
+	}
+	a.previousConfig = args
+	return a.supervisor.Supervise(ctx)
+}
+
+func (a *Manager) buildArgs(ctx context.Context, clusterConfig *v1beta1.ClusterConfig) (stringmap.StringMap, error) {
+	logger := logrus.WithField("component", kubeControllerManagerComponent)
 	ccmAuthConf := filepath.Join(a.K0sVars.CertRootDir, "ccm.conf")
 	args := stringmap.StringMap{
 		"authentication-kubeconfig":        ccmAuthConf,
@@ -90,12 +127,32 @@ func (a *Manager) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterC
 		"requestheader-client-ca-file":     filepath.Join(a.K0sVars.CertRootDir, "front-proxy-ca.crt"),
 		"root-ca-file":                     filepath.Join(a.K0sVars.CertRootDir, "ca.crt"),
 		"service-account-private-key-file": filepath.Join(a.K0sVars.CertRootDir, "sa.key"),
-		"cluster-cidr":                     clusterConfig.Spec.Network.BuildPodCIDR(a.PrimaryAddressFamily),
 		"service-cluster-ip-range":         a.ServiceClusterIPRange,
 		"profiling":                        "false",
 		"terminated-pod-gc-threshold":      "12500",
 		"v":                                a.LogLevel,
 	}
+
+	// For dual-stack clusters, k0s < 1.36 used to allocate IPv6-first pod CIDRs
+	// unconditionally, whereas newer versions follow the primary address family
+	// (see https://github.com/k0sproject/k0s/issues/7927). Since
+	// kube-controller-manager expects the --cluster-cidr order to match the
+	// order persisted in the nodes' spec.podCIDRs, derive the order from the
+	// existing nodes to stay compatible with pre-1.36 clusters.
+	podCIDRs := clusterConfig.Spec.Network.BuildPodCIDR(a.PrimaryAddressFamily)
+	if a.KubeClientFactory != nil {
+		detected, err := podCIDRForCluster(ctx, a.KubeClientFactory, clusterConfig.Spec.Network, a.PrimaryAddressFamily)
+		if err != nil {
+			var inconsistent *inconsistentPodCIDROrderError
+			if errors.As(err, &inconsistent) {
+				return nil, fmt.Errorf("refusing to start kube-controller-manager: %w; set controllerManager.extraArgs.cluster-cidr explicitly to fix the pod CIDR order", err)
+			}
+			logger.WithError(err).Warn("Failed to detect pod CIDR order from existing nodes, using primary address family order")
+		} else {
+			podCIDRs = detected
+		}
+	}
+	args["cluster-cidr"] = podCIDRs
 
 	// Handle the extra args as last so they can be used to override some k0s "hardcodings"
 	if a.ExtraArgs != "" {
@@ -129,30 +186,7 @@ func (a *Manager) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterC
 
 	args = clusterConfig.Spec.FeatureGates.BuildArgs(args, kubeControllerManagerComponent)
 
-	if args.Equals(a.previousConfig) && a.supervisor != nil {
-		// no changes and supervisor already running, do nothing
-		logger.Info("reconcile has nothing to do")
-		return nil
-	}
-	// Stop in case there's process running already and we need to change the config
-	if a.supervisor != nil {
-		logger.Info("reconcile has nothing to do")
-		if err := a.supervisor.Stop(); err != nil {
-			logger.WithError(err).Error("Failed to stop executable")
-		}
-		a.supervisor = nil
-	}
-
-	a.supervisor = &supervisor.Supervisor{
-		Name:    kubeControllerManagerComponent,
-		BinPath: a.executablePath,
-		RunDir:  a.K0sVars.RunDir,
-		DataDir: a.K0sVars.DataDir,
-		Args:    append(args.ToDashedArgs(), clusterConfig.Spec.ControllerManager.RawArgs...),
-		UID:     a.uid,
-	}
-	a.previousConfig = args
-	return a.supervisor.Supervise(ctx)
+	return args, nil
 }
 
 // Stop stops Manager

--- a/pkg/component/controller/controllermanager_test.go
+++ b/pkg/component/controller/controllermanager_test.go
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/k0sproject/k0s/internal/testutil"
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	"github.com/k0sproject/k0s/pkg/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func dualStackClusterConfig() *v1beta1.ClusterConfig {
+	network := &v1beta1.Network{
+		PodCIDR:              "172.16.0.0/16",
+		ServiceCIDR:          "172.31.0.0/16",
+		DualStack:            v1beta1.DualStack{Enabled: true, IPv6PodCIDR: "fd00:172:16::/108", IPv6ServiceCIDR: "fd00:172:31::/108"},
+		Provider:             "kuberouter",
+		KubeRouter:           v1beta1.DefaultKubeRouter(),
+		KubeProxy:            v1beta1.DefaultKubeProxy(),
+		PrimaryAddressFamily: v1beta1.PrimaryFamilyUnknown,
+	}
+	return &v1beta1.ClusterConfig{
+		Spec: &v1beta1.ClusterSpec{
+			ControllerManager: &v1beta1.ControllerManagerSpec{},
+			Network:           network,
+		},
+	}
+}
+
+func newManagerForTest() *Manager {
+	return &Manager{
+		K0sVars: &config.CfgVars{
+			CertRootDir: "/var/lib/k0s/pki",
+		},
+		ServiceClusterIPRange: "172.31.0.0/16,fd00:172:31::/108",
+		PrimaryAddressFamily:  v1beta1.PrimaryFamilyIPv4,
+	}
+}
+
+func TestManagerBuildArgs(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("single-stack cluster", func(t *testing.T) {
+		clusterConfig := dualStackClusterConfig()
+		clusterConfig.Spec.Network.DualStack.Enabled = false
+		manager := newManagerForTest()
+
+		args, err := manager.buildArgs(ctx, clusterConfig)
+		require.NoError(t, err)
+		assert.Equal(t, "172.16.0.0/16", args["cluster-cidr"])
+	})
+
+	t.Run("dual-stack new cluster uses primary family", func(t *testing.T) {
+		clusterConfig := dualStackClusterConfig()
+		manager := newManagerForTest()
+		manager.KubeClientFactory = testutil.NewFakeClientFactory()
+
+		args, err := manager.buildArgs(ctx, clusterConfig)
+		require.NoError(t, err)
+		assert.Equal(t, "172.16.0.0/16,fd00:172:16::/108", args["cluster-cidr"])
+	})
+
+	t.Run("dual-stack legacy IPv6-first nodes are preserved", func(t *testing.T) {
+		clusterConfig := dualStackClusterConfig()
+		manager := newManagerForTest()
+		manager.KubeClientFactory = testutil.NewFakeClientFactory(
+			&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}, Spec: corev1.NodeSpec{PodCIDRs: []string{"fd00:172:16::1000/117", "172.16.0.0/24"}}},
+		)
+
+		args, err := manager.buildArgs(ctx, clusterConfig)
+		require.NoError(t, err)
+		assert.Equal(t, "fd00:172:16::/108,172.16.0.0/16", args["cluster-cidr"])
+	})
+
+	t.Run("explicit cluster-cidr extra arg always wins", func(t *testing.T) {
+		clusterConfig := dualStackClusterConfig()
+		clusterConfig.Spec.ControllerManager.ExtraArgs = map[string]string{
+			"cluster-cidr": "fd00:172:16::/108,172.16.0.0/16",
+		}
+		manager := newManagerForTest()
+		manager.KubeClientFactory = testutil.NewFakeClientFactory(
+			&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}, Spec: corev1.NodeSpec{PodCIDRs: []string{"172.16.0.0/24", "fd00:172:16::1000/117"}}},
+		)
+
+		args, err := manager.buildArgs(ctx, clusterConfig)
+		require.NoError(t, err)
+		assert.Equal(t, "fd00:172:16::/108,172.16.0.0/16", args["cluster-cidr"])
+	})
+
+	t.Run("inconsistent node order fails reconciliation", func(t *testing.T) {
+		clusterConfig := dualStackClusterConfig()
+		manager := newManagerForTest()
+		manager.KubeClientFactory = testutil.NewFakeClientFactory(
+			&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}, Spec: corev1.NodeSpec{PodCIDRs: []string{"fd00:172:16::1000/117", "172.16.0.0/24"}}},
+			&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}, Spec: corev1.NodeSpec{PodCIDRs: []string{"172.16.1.0/24", "fd00:172:16::2000/117"}}},
+		)
+
+		_, err := manager.buildArgs(ctx, clusterConfig)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "refusing to start kube-controller-manager")
+	})
+}

--- a/pkg/component/controller/podcidr.go
+++ b/pkg/component/controller/podcidr.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// inconsistentPodCIDROrderError is returned when the existing nodes' dual-stack
+// pod CIDRs don't share a common family order. Starting kube-controller-manager
+// in that state would crash it with confusing "out the range of cluster cidr"
+// errors, so we refuse to start it instead.
+type inconsistentPodCIDROrderError struct {
+	node     string
+	expected v1beta1.PrimaryAddressFamilyType
+	actual   v1beta1.PrimaryAddressFamilyType
+}
+
+func (e *inconsistentPodCIDROrderError) Error() string {
+	return fmt.Sprintf("node %q has %s-first pod CIDRs, but other nodes have %s-first pod CIDRs", e.node, e.actual, e.expected)
+}
+
+// podCIDRForCluster returns the value to pass to kube-controller-manager's
+// --cluster-cidr flag. For dual-stack clusters it derives the pod CIDR family
+// order from the existing nodes, so that clusters bootstrapped before k0s 1.36
+// (which unconditionally allocated IPv6-first pod CIDRs, see
+// https://github.com/k0sproject/k0s/issues/7927) keep working after an upgrade.
+// New clusters without any dual-stack nodes yet fall back to the configured
+// primary address family.
+//
+// A returned error is either a transient failure while talking to the API
+// server, or an [*inconsistentPodCIDROrderError] in case the nodes disagree on
+// the pod CIDR family order.
+func podCIDRForCluster(ctx context.Context, factory kubeutil.ClientFactoryInterface, network *v1beta1.Network, primaryFamily v1beta1.PrimaryAddressFamilyType) (string, error) {
+	if !network.DualStack.Enabled {
+		return network.BuildPodCIDR(primaryFamily), nil
+	}
+
+	client, err := factory.GetClient()
+	if err != nil {
+		return "", fmt.Errorf("failed to get kube client: %w", err)
+	}
+
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	effectiveFamily, found, err := detectLegacyPodCIDROrder(nodes.Items)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		effectiveFamily = primaryFamily
+	}
+
+	return network.BuildPodCIDR(effectiveFamily), nil
+}
+
+// detectLegacyPodCIDROrder inspects the existing nodes' allocated pod CIDRs
+// and reports their family order. Only dual-stack nodes with two pod CIDRs are
+// taken into account; single-stack nodes are ignored, as they don't carry any
+// ordering information.
+//
+// The first return value is the family of the first pod CIDR, which determines
+// the order in which kube-controller-manager must be started. found is false
+// when there is no dual-stack node to derive an order from. An error is
+// returned when the nodes disagree on the order.
+func detectLegacyPodCIDROrder(nodes []corev1.Node) (v1beta1.PrimaryAddressFamilyType, bool, error) {
+	var effectiveFamily v1beta1.PrimaryAddressFamilyType
+	found := false
+
+	for i := range nodes {
+		node := &nodes[i]
+		if len(node.Spec.PodCIDRs) != 2 {
+			continue
+		}
+
+		_, firstCIDR, err := net.ParseCIDR(node.Spec.PodCIDRs[0])
+		if err != nil {
+			return "", false, fmt.Errorf("failed to parse pod CIDR %q of node %q: %w", node.Spec.PodCIDRs[0], node.Name, err)
+		}
+
+		var family v1beta1.PrimaryAddressFamilyType
+		if firstCIDR.IP.To4() != nil {
+			family = v1beta1.PrimaryFamilyIPv4
+		} else {
+			family = v1beta1.PrimaryFamilyIPv6
+		}
+
+		if !found {
+			effectiveFamily = family
+			found = true
+			continue
+		}
+		if family != effectiveFamily {
+			return "", false, &inconsistentPodCIDROrderError{node: node.Name, expected: effectiveFamily, actual: family}
+		}
+	}
+
+	return effectiveFamily, found, nil
+}

--- a/pkg/component/controller/podcidr_test.go
+++ b/pkg/component/controller/podcidr_test.go
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/k0sproject/k0s/internal/testutil"
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func dualStackNode(name string, podCIDRs ...string) corev1.Node {
+	return corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.NodeSpec{
+			PodCIDRs: podCIDRs,
+		},
+	}
+}
+
+func TestDetectLegacyPodCIDROrder(t *testing.T) {
+	t.Run("no nodes", func(t *testing.T) {
+		_, found, err := detectLegacyPodCIDROrder(nil)
+		require.NoError(t, err)
+		assert.False(t, found)
+	})
+
+	t.Run("single-stack nodes only", func(t *testing.T) {
+		nodes := []corev1.Node{
+			dualStackNode("node-1", "10.233.0.0/24"),
+			dualStackNode("node-2", "fd00::/108"),
+		}
+		_, found, err := detectLegacyPodCIDROrder(nodes)
+		require.NoError(t, err)
+		assert.False(t, found)
+	})
+
+	t.Run("IPv6-first dual-stack nodes", func(t *testing.T) {
+		nodes := []corev1.Node{
+			dualStackNode("node-1", "fd00:172:16::1000/117", "172.16.0.0/24"),
+			dualStackNode("node-2", "fd00:172:16::2000/117", "172.16.1.0/24"),
+		}
+		family, found, err := detectLegacyPodCIDROrder(nodes)
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, v1beta1.PrimaryFamilyIPv6, family)
+	})
+
+	t.Run("IPv4-first dual-stack nodes", func(t *testing.T) {
+		nodes := []corev1.Node{
+			dualStackNode("node-1", "172.16.0.0/24", "fd00:172:16::1000/117"),
+			dualStackNode("node-2", "172.16.1.0/24", "fd00:172:16::2000/117"),
+		}
+		family, found, err := detectLegacyPodCIDROrder(nodes)
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, v1beta1.PrimaryFamilyIPv4, family)
+	})
+
+	t.Run("mixed order", func(t *testing.T) {
+		nodes := []corev1.Node{
+			dualStackNode("node-1", "fd00:172:16::1000/117", "172.16.0.0/24"),
+			dualStackNode("node-2", "172.16.1.0/24", "fd00:172:16::2000/117"),
+		}
+		_, found, err := detectLegacyPodCIDROrder(nodes)
+		assert.False(t, found)
+		var inconsistent *inconsistentPodCIDROrderError
+		require.ErrorAs(t, err, &inconsistent)
+		assert.Equal(t, "node-2", inconsistent.node)
+	})
+
+	t.Run("single-stack nodes are ignored", func(t *testing.T) {
+		nodes := []corev1.Node{
+			dualStackNode("node-1", "10.233.0.0/24"),
+			dualStackNode("node-2", "fd00:172:16::2000/117", "172.16.1.0/24"),
+		}
+		family, found, err := detectLegacyPodCIDROrder(nodes)
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, v1beta1.PrimaryFamilyIPv6, family)
+	})
+
+	t.Run("invalid pod CIDR", func(t *testing.T) {
+		nodes := []corev1.Node{dualStackNode("node-1", "not-a-cidr", "172.16.0.0/24")}
+		_, found, err := detectLegacyPodCIDROrder(nodes)
+		assert.False(t, found)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse pod CIDR")
+	})
+}
+
+func TestPodCIDRForCluster(t *testing.T) {
+	newDualStackNetwork := func() *v1beta1.Network {
+		return &v1beta1.Network{
+			PodCIDR:              "172.16.0.0/16",
+			ServiceCIDR:          "172.31.0.0/16",
+			DualStack:            v1beta1.DualStack{Enabled: true, IPv6PodCIDR: "fd00:172:16::/108", IPv6ServiceCIDR: "fd00:172:31::/108"},
+			Provider:             "kuberouter",
+			KubeRouter:           v1beta1.DefaultKubeRouter(),
+			KubeProxy:            v1beta1.DefaultKubeProxy(),
+			PrimaryAddressFamily: v1beta1.PrimaryFamilyUnknown,
+		}
+	}
+
+	ctx := context.Background()
+
+	t.Run("single-stack ignores nodes", func(t *testing.T) {
+		network := newDualStackNetwork()
+		network.DualStack.Enabled = false
+		factory := testutil.NewFakeClientFactory(
+			&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}, Spec: corev1.NodeSpec{PodCIDRs: []string{"172.16.0.0/24"}}},
+		)
+		cidr, err := podCIDRForCluster(ctx, factory, network, v1beta1.PrimaryFamilyIPv4)
+		require.NoError(t, err)
+		assert.Equal(t, "172.16.0.0/16", cidr)
+	})
+
+	t.Run("new cluster without nodes uses primary family", func(t *testing.T) {
+		network := newDualStackNetwork()
+		factory := testutil.NewFakeClientFactory()
+		cidr, err := podCIDRForCluster(ctx, factory, network, v1beta1.PrimaryFamilyIPv4)
+		require.NoError(t, err)
+		assert.Equal(t, "172.16.0.0/16,fd00:172:16::/108", cidr)
+	})
+
+	t.Run("legacy IPv6-first nodes are preserved", func(t *testing.T) {
+		network := newDualStackNetwork()
+		factory := testutil.NewFakeClientFactory(
+			&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}, Spec: corev1.NodeSpec{PodCIDRs: []string{"fd00:172:16::1000/117", "172.16.0.0/24"}}},
+		)
+		cidr, err := podCIDRForCluster(ctx, factory, network, v1beta1.PrimaryFamilyIPv4)
+		require.NoError(t, err)
+		assert.Equal(t, "fd00:172:16::/108,172.16.0.0/16", cidr)
+	})
+
+	t.Run("IPv4-first nodes stay IPv4-first", func(t *testing.T) {
+		network := newDualStackNetwork()
+		factory := testutil.NewFakeClientFactory(
+			&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}, Spec: corev1.NodeSpec{PodCIDRs: []string{"172.16.0.0/24", "fd00:172:16::1000/117"}}},
+		)
+		cidr, err := podCIDRForCluster(ctx, factory, network, v1beta1.PrimaryFamilyIPv4)
+		require.NoError(t, err)
+		assert.Equal(t, "172.16.0.0/16,fd00:172:16::/108", cidr)
+	})
+
+	t.Run("inconsistent node order is an error", func(t *testing.T) {
+		network := newDualStackNetwork()
+		factory := testutil.NewFakeClientFactory(
+			&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}, Spec: corev1.NodeSpec{PodCIDRs: []string{"fd00:172:16::1000/117", "172.16.0.0/24"}}},
+			&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}, Spec: corev1.NodeSpec{PodCIDRs: []string{"172.16.1.0/24", "fd00:172:16::2000/117"}}},
+		)
+		_, err := podCIDRForCluster(ctx, factory, network, v1beta1.PrimaryFamilyIPv4)
+		var inconsistent *inconsistentPodCIDROrderError
+		require.ErrorAs(t, err, &inconsistent)
+	})
+
+	t.Run("IPv6 primary family", func(t *testing.T) {
+		network := newDualStackNetwork()
+		factory := testutil.NewFakeClientFactory()
+		cidr, err := podCIDRForCluster(ctx, factory, network, v1beta1.PrimaryFamilyIPv6)
+		require.NoError(t, err)
+		assert.Equal(t, "fd00:172:16::/108,172.16.0.0/16", cidr)
+	})
+}


### PR DESCRIPTION
Fixes #7927

## Problem

Since k0s 1.36 (#7684), the pod CIDR order for dual-stack clusters follows the primary address family. Before that, k0s unconditionally allocated IPv6-first pod CIDRs. `kube-controller-manager` (via the node IPAM controller) expects the `--cluster-cidr` order to match the order persisted in the nodes' `spec.podCIDRs` — it matches them index by index. After upgrading a pre-1.36 dual-stack cluster with IPv4 as primary family, kube-controller-manager starts with `172.16.0.0/16,fd00:...` while the existing nodes carry `[fd00:..., 172.16.0.0/...]`, crashing with:

```
failed to mark cidr[fd00:172:16::1000/117] at idx [0] as occupied for node: k8sw-1: cidr fd00:172:16::1000/117 is out the range of cluster cidr 172.16.0.0/16
```

## Fix

Derive the pod CIDR family order from the existing nodes before starting `kube-controller-manager`, instead of unconditionally following the primary address family:

- Single-stack clusters are unaffected.
- Explicit `controllerManager.extraArgs.cluster-cidr` (or `--kube-controller-manager-extra-args`) overrides still win, since the override is applied after the default is computed.
- New clusters without dual-stack nodes fall back to the current `BuildPodCIDR(primaryAddressFamily)` behavior.
- If existing nodes disagree on the family order, reconciliation fails with an actionable error suggesting an explicit `cluster-cidr` override, instead of letting kube-controller-manager crash with a confusing "out the range of cluster cidr" message.
- Transient API errors during detection degrade gracefully (warning + primary-family order) rather than preventing kube-controller-manager from ever starting.
- Service CIDR ordering is untouched, so legacy clusters that have IPv4-first service CIDRs but IPv6-first pod CIDRs keep working.

## Implementation

- `pkg/component/controller/podcidr.go` (new): `detectLegacyPodCIDROrder` inspects the existing nodes' `spec.podCIDRs` (only dual-stack nodes with two CIDRs) and reports the family order; `podCIDRForCluster` builds the effective `--cluster-cidr` value.
- `pkg/component/controller/controllermanager.go`: `Manager` gained a `KubeClientFactory`; args building was extracted into `buildArgs` for testability and now applies the detected order.
- `cmd/controller/controller.go`: injects the admin client factory into the controller manager component.

## Tests

- `podcidr_test.go`: no nodes, single-stack-only nodes, IPv6-first and IPv4-first dual-stack nodes, mixed ordering (actionable error), invalid CIDR, single-stack nodes ignored.
- `controllermanager_test.go`: single-stack cluster, new dual-stack cluster (primary family), legacy IPv6-first nodes preserved, explicit `cluster-cidr` override wins, inconsistent ordering fails reconciliation.

An integration test covering a real 1.35 → patched upgrade is not included yet, as the bootloose-based test infrastructure would require running two different k0s binary versions; unit tests cover the detection logic.
