### PR TITLE
Pass kine endpoint via env var instead of arg to hide secrets

### DIFF
--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -106,7 +106,6 @@ func (k *Kine) Start(ctx context.Context) error {
 	logrus.Info("Starting kine")
 
 	args := stringmap.StringMap{
-		"--endpoint": k.Config.DataSource,
 		// NB: kine doesn't parse URLs properly, so construct potentially
 		// invalid URLs that are understood by kine.
 		// https://github.com/k3s-io/kine/blob/v0.16.3/pkg/util/network.go#L5-L13
@@ -132,7 +131,7 @@ func (k *Kine) Start(ctx context.Context) error {
 		UID:     k.uid,
 		GID:     kineGID,
 	}
-
+	os.Setenv("KINE_ENDPOINT", k.Config.DataSource)
 	return k.supervisor.Supervise(ctx)
 }
 

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -130,8 +130,10 @@ func (k *Kine) Start(ctx context.Context) error {
 		Args:    append(args.ToArgs(), k.Config.RawArgs...),
 		UID:     k.uid,
 		GID:     kineGID,
+
+		AdditionalEnv: []string{"KINE_ENDPOINT=" + k.Config.DataSource},
+		KeepEnvPrefix: true,
 	}
-	os.Setenv("KINE_ENDPOINT", k.Config.DataSource)
 	return k.supervisor.Supervise(ctx)
 }
 

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -46,6 +46,7 @@ type Supervisor struct {
 	GID            int
 	TimeoutStop    time.Duration
 	TimeoutRespawn time.Duration
+	AdditionalEnv  []string
 	// For those components having env prefix convention such as ETCD_xxx, we should keep the prefix.
 	KeepEnvPrefix bool
 	// A function to clean some leftovers before starting or restarting the supervised process
@@ -245,7 +246,7 @@ func (s *Supervisor) Supervise(ctx context.Context) error {
 			} else {
 				s.cmd = exec.Command(s.BinPath, s.Args...)
 				s.cmd.Dir = s.DataDir
-				s.cmd.Env = getEnv(s.DataDir, s.Name, s.KeepEnvPrefix)
+				s.cmd.Env = getEnv(s.DataDir, s.Name, s.KeepEnvPrefix, s.AdditionalEnv)
 				if s.Stdin != nil {
 					s.cmd.Stdin = s.Stdin()
 				}
@@ -351,8 +352,8 @@ func (s *Supervisor) maybeCleanupPIDFile(ctx context.Context) error {
 // Prepare the env for exec:
 // - handle component specific env
 // - inject k0s embedded bins into path
-func getEnv(dataDir, component string, keepEnvPrefix bool) []string {
-	env := os.Environ()
+func getEnv(dataDir, component string, keepEnvPrefix bool, env []string) []string {
+	env = append(env, os.Environ()...)
 	componentPrefix := strings.ToUpper(component) + "_"
 
 	// put the component specific env vars in the front.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Since a kine endpoint can contain secrets like DB passwords, it should not be passed as an argument visible to any OS process and user. Instead using an environment variable which is supported since https://github.com/k3s-io/kine/commit/992a97f2e45812ea12350d803ed7efa1800aaddd (shipped since https://github.com/k3s-io/kine/releases/tag/v0.14.1) can avoid leaking such secrets.

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
