### PR TITLE
Add hack/list-images tool and make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,6 +231,10 @@ endif
 .PHONY: codegen
 codegen: $(codegen_targets)
 
+.PHONY: list-images
+list-images:
+	@$(GO) run ./hack/list-images
+
 .PHONY: lint-copyright
 lint-copyright:
 	hack/copyright.sh

--- a/hack/list-images/main.go
+++ b/hack/list-images/main.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+// list-images prints every container image (and its version) that k0s may
+// pull, across all platforms and configurations. Unlike `k0s airgap
+// list-images`, it doesn't need a running node or a linux host to build/run,
+// since it only touches pkg/airgap and pkg/apis/k0s/v1beta1 directly.
+package main
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/k0sproject/k0s/pkg/airgap"
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+
+	imagespecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func main() {
+	spec := v1beta1.DefaultClusterSpec()
+
+	// Mirrors the platforms built by the airgap-image-bundle-*.tar Makefile
+	// targets.
+	seen := make(map[string]struct{})
+	var uris []string
+	for _, platform := range []imagespecv1.Platform{
+		{OS: "linux", Architecture: "amd64"},
+		{OS: "linux", Architecture: "arm64"},
+		{OS: "linux", Architecture: "arm"},
+		{OS: "linux", Architecture: "riscv64"},
+		{OS: "windows", Architecture: "amd64"},
+	} {
+		for _, uri := range airgap.GetImageURIs(airgap.TargetEnv{Platform: platform, Spec: spec}, true) {
+			if _, ok := seen[uri]; !ok {
+				seen[uri] = struct{}{}
+				uris = append(uris, uri)
+			}
+		}
+	}
+
+	slices.Sort(uris)
+	for _, uri := range uris {
+		fmt.Println(uri)
+	}
+}


### PR DESCRIPTION
Prints every image (with version) that k0s may pull, across all platforms and configurations. Unlike `k0s airgap list-images`, it only touches pkg/airgap and pkg/apis/k0s/v1beta1, so it builds and runs on any host OS without needing a running node or a linux build of k0s.

<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
