### PR TITLE
Track registry.k8s.io images with Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -474,7 +474,7 @@
         "**/Makefile*"
       ],
       "matchStrings": [
-        "\\b(?<depName>(docker|k8s\\.gcr|quay)\\.io/(?:[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*)(:|.*\\n.*= \")v?(?<currentValue>[0-9_][\\w.-]{0,127})(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
+        "\\b(?<depName>(docker|k8s\\.gcr|quay|registry\\.k8s)\\.io/(?:[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*)(:|.*\\n.*= \")v?(?<currentValue>[0-9_][\\w.-]{0,127})(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
       ],
       "datasourceTemplate": "docker",
       "extractVersionTemplate": "^v?(?<version>[\\w][\\w.-]{0,127})"


### PR DESCRIPTION
The container-image regex manager only matched docker.io, k8s.gcr.io, and quay.io prefixes, so KubePauseWindowsContainerImageVersion (registry.k8s.io/pause) never got bumped automatically.

<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
