### PR TITLE
Import images from embedded zip payload

### DIFF
--- a/docs/airgap-install.md
+++ b/docs/airgap-install.md
@@ -10,8 +10,10 @@ installations require an image bundle that contains all the container images
 that would normally be pulled over the network. K0s uses so-called OCI archives
 for this: Tarball representations of an [OCI Image Layout]. They allow for
 multiple images to be packed into a single file. K0s will watch for image
-bundles in the `<data-dir>/images` folder will automatically import them into
-the container runtime.
+bundles in the `<data-dir>/images` folder and will automatically import them
+into the container runtime. Bundles may also be
+[embedded into the k0s executable](#by-embedding-them-into-the-k0s-executable)
+itself.
 
 There are several ways to obtain an image bundle:
 
@@ -157,6 +159,58 @@ spec:
           dstDir: /var/lib/k0s/images
           perm: 0755
 ```
+
+### By embedding them into the k0s executable
+
+Image bundles can also be embedded into the k0s executable itself, so that a
+single file carries both k0s and the images it needs. This is an alternative to
+placing bundles into the `images` directory on each worker node, and can be
+useful if you're distributing your own k0s executable anyways.
+
+K0s executables have a ZIP archive appended to them, which k0s reads at runtime.
+It holds the embedded binaries, such as containerd and kubelet, in a `bin`
+directory. Image bundles go into an `images` directory. Everything else is
+reserved for k0s.
+
+The archive can be modified with any ZIP tool. Using [Info-ZIP]'s `zip`:
+
+```console
+$ cp k0s k0s.zip
+$ zip -A k0s.zip
+Zip entry offsets appear off by 102564002 bytes - correcting...
+$ mkdir images && cp image-bundle.tar images/
+$ zip -0 k0s.zip images/image-bundle.tar
+  adding: images/image-bundle.tar (stored 0%)
+$ mv k0s.zip k0s && chmod +x k0s
+$ unzip -l k0s
+```
+
+Some things to be aware of:
+
+- The intermediate `.zip` file name is not optional. When adding files, `zip`
+  appends `.zip` to archive names that have no extension, so `zip k0s ...` would
+  silently create a new `k0s.zip` archive instead of modifying the executable.
+- Don't use `zip`'s `-j` flag. Bundles have to end up in the `images` directory,
+  and `-j` would store them in the archive's root, where k0s won't look for
+  them.
+- The `-0` flag stores the bundle without compressing it. Image layers are
+  already compressed, so compressing them again mainly costs CPU time when
+  building and when importing.
+- Bundles have to be uncompressed tarballs, just like the ones in the `images`
+  directory: k0s won't decompress them before importing. Note that this doesn't
+  apply to the ZIP compression itself, which is transparent to k0s. So storing
+  an uncompressed tarball with compression is a way to get smaller executables.
+- Bundles in a node's `images` directory are imported after the embedded ones, so
+  they can be used to override images that are embedded in the executable.
+- Modifying the executable invalidates any checksums and signatures that have
+  been published for it. Remember to distribute your own, if you rely on them.
+  This is also relevant when using [Autopilot](autopilot.md), which distributes
+  k0s executables to nodes.
+- Downgrading to a k0s version that doesn't support embedded image bundles will
+  unpin the images that have been imported from them, making them eligible for
+  garbage collection by the kubelet.
+
+[Info-ZIP]: https://infozip.sourceforge.net/
 
 ## Disable image pulling (optional)
 

--- a/hack/zip-files/main.go
+++ b/hack/zip-files/main.go
@@ -127,7 +127,9 @@ func compressFile(ctx context.Context, filePath string) (*compressedFile, error)
 		return nil, err
 	}
 
-	f.header.Name = filepath.Base(filePath)
+	// Embedded executables live in the payload's bin directory. Keep this in
+	// sync with EmbeddedBinDir in pkg/assets.
+	f.header.Name = "bin/" + filepath.Base(filePath)
 	f.header.UncompressedSize64 = uint64(bytesWritten)
 	f.header.CompressedSize64 = uint64(f.buf.Len())
 	f.header.Method = zip.Deflate

--- a/inttest/.gitignore
+++ b/inttest/.gitignore
@@ -2,3 +2,5 @@
 bin/
 .*.stamp
 **/*.tfvars
+/embedded-test-images.tar
+/k0s-embedded-images

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -51,6 +51,33 @@ check-bootloose-alpine-buildx:
 	$(DOCKER) build --progress=plain -t update-server --build-arg BASE=bootloose-alpine -f update-server/Dockerfile update-server
 	touch $@
 
+# An image that's not part of the k0s image bundle, so that it can only have been
+# imported from the k0s executable's ZIP payload. Kept small, as it's embedded
+# into a k0s executable that gets distributed to all the test's nodes.
+embedded_test_image = docker.io/library/alpine:$(alpine_patch_version)
+
+embedded-test-images.tar: ../embedded-bins/Makefile.variables Makefile
+	$(DOCKER) pull --platform=linux/$(ARCH) '$(embedded_test_image)'
+	$(DOCKER) image save -o '$@' '$(embedded_test_image)'
+
+# A k0s executable with an image bundle embedded in its ZIP payload. Built using
+# the procedure that's documented in docs/airgap-install.md, so that the docs get
+# tested along with the import itself.
+#
+# Note that ../k0s is used instead of K0S_PATH: target specific variables are
+# inherited by prerequisites, and check-embedded-images points K0S_PATH at this
+# very executable.
+k0s-embedded-images: embedded-test-images.tar
+	rm -rf -- '$@' '$@.zip' '$@.tmp'
+	mkdir -p '$@.tmp/images'
+	cp -- '$<' '$@.tmp/images/test-images.tar'
+	cp -- ../k0s '$@.zip'
+	zip -A '$@.zip'
+	cd '$@.tmp' && zip -0 '$(CURDIR)/$@.zip' images/test-images.tar
+	rm -rf -- '$@.tmp'
+	chmod +x '$@.zip'
+	mv -- '$@.zip' '$@'
+
 check-network: bin/sonobuoy
 	$(realpath bin/sonobuoy) run --wait=1200 --plugin=e2e --plugin-env=e2e.E2E_USE_GO_RUNNER=true \
 		--e2e-focus='\[sig-network\].*\[Conformance\]' \
@@ -84,6 +111,11 @@ check-ap-updater-periodic: TIMEOUT=10m
 check-configchange: TIMEOUT=8m
 
 check-ctr: TIMEOUT=10m
+
+# Run this test with a k0s executable that has an image bundle embedded in it.
+check-embedded-images: export K0S_PATH = $(CURDIR)/k0s-embedded-images
+check-embedded-images: export K0S_EMBEDDED_TEST_IMAGE = $(embedded_test_image)
+check-embedded-images: k0s-embedded-images
 
 check-kubeletcertrotate: TIMEOUT=15m
 
@@ -123,3 +155,4 @@ $(smoketests): .bootloose-alpine.stamp
 clean:
 	-[ -x bin/sonobuoy ] && bin/sonobuoy delete
 	rm -rf bin sonobuoy/*_sonobuoy_*.tar.gz .*.stamp
+	rm -rf embedded-test-images.tar k0s-embedded-images k0s-embedded-images.zip k0s-embedded-images.tmp

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -50,6 +50,7 @@ smoketests := \
 	check-dualstack-kuberouter \
 	check-dualstack-kuberouter-dynamicconfig \
 	check-embedded-binaries \
+	check-embedded-images \
 	check-etcdlearner \
 	check-etcdmember \
 	check-externaletcd \

--- a/inttest/embedded-images/embedded_images_test.go
+++ b/inttest/embedded-images/embedded_images_test.go
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package embeddedimages
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/k0s/inttest/common"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type EmbeddedImagesSuite struct {
+	common.BootlooseSuite
+
+	// image is the container image that's embedded into the k0s executable that's
+	// being tested.
+	image string
+}
+
+func (s *EmbeddedImagesSuite) TestEmbeddedImagesAreImported() {
+	ctx := s.Context()
+
+	s.Require().NoError(s.InitController(0))
+	s.Require().NoError(s.RunWorkers())
+
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	s.Require().NoError(s.WaitForNodeReady(s.WorkerNode(0), kc))
+
+	ssh, err := s.SSH(ctx, s.WorkerNode(0))
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+
+	// Check this before anything refers to the image, so that it cannot have been
+	// pulled by the kubelet.
+	s.T().Log("Verifying that the embedded image has been imported")
+	s.assertImageIsPinnedToPayload(ctx, ssh)
+
+	// Embedded bundles are streamed straight out of the k0s executable. Nothing
+	// should have been extracted into the OCI bundle directory.
+	s.T().Log("Verifying that no bundles have been extracted to disk")
+	out, err := ssh.ExecWithOutput(ctx, "ls -A /var/lib/k0s/images")
+	s.Require().NoError(err)
+	s.Empty(strings.TrimSpace(out), "Expected the OCI bundle directory to be empty")
+
+	// The embedded executables live in the same payload as the image bundles.
+	s.T().Log("Verifying that the embedded executables are still staged")
+	_, err = ssh.ExecWithOutput(ctx, "/var/lib/k0s/bin/kubelet --version")
+	s.Require().NoError(err)
+
+	// An imported image is only useful if it can actually be run. Never pulling it
+	// ensures that it's the imported one that's being used.
+	s.T().Log("Creating a Pod that must not pull its image")
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "embedded"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:            "embedded",
+				Image:           s.image,
+				ImagePullPolicy: corev1.PullNever,
+				Command:         []string{"sleep", "3600"},
+			}},
+		},
+	}
+	_, err = kc.CoreV1().Pods(metav1.NamespaceDefault).Create(ctx, &pod, metav1.CreateOptions{})
+	s.Require().NoError(err)
+	s.Require().NoError(common.WaitForPod(ctx, kc, "embedded", metav1.NamespaceDefault))
+
+	// Restarting k0s reconciles the embedded bundles once more. The image has to
+	// remain pinned: unpinning it would make it eligible for garbage collection,
+	// even though the bundle it came from is still embedded.
+	s.T().Log("Restarting k0s")
+	s.Require().NoError(s.StopWorker(s.WorkerNode(0)))
+	// Wait for the node to actually drop out before waiting for it to come back.
+	// Its readiness is reported by the kubelet that's just been stopped, so it
+	// remains stale for a while, and waiting for it to be ready would return
+	// before k0s has been restarted at all.
+	s.Require().NoError(
+		common.WaitForNodeReadyStatus(ctx, kc, s.WorkerNode(0), corev1.ConditionUnknown),
+		"Didn't observe node %s to become non-ready", s.WorkerNode(0),
+	)
+	s.Require().NoError(s.StartWorker(s.WorkerNode(0)))
+	// The kubelet is started after the OCI bundles have been imported, so the
+	// node being ready again means that the bundles have been reconciled anew.
+	s.Require().NoError(s.WaitForNodeReady(s.WorkerNode(0), kc))
+
+	s.T().Log("Verifying that the embedded image is still pinned")
+	s.assertImageIsPinnedToPayload(ctx, ssh)
+}
+
+// assertImageIsPinnedToPayload checks that the embedded image is present in
+// containerd, that it's pinned, and that it's been imported from the k0s
+// executable's ZIP payload rather than from the OCI bundle directory.
+func (s *EmbeddedImagesSuite) assertImageIsPinnedToPayload(ctx context.Context, ssh *common.SSHConnection) {
+	s.T().Helper()
+
+	out, err := ssh.ExecWithOutput(ctx, fmt.Sprintf(`k0s ctr images ls "name==%s"`, s.image))
+	s.Require().NoError(err)
+	s.Contains(out, s.image, "Expected the embedded image to be present in containerd")
+	s.Contains(out, "io.cri-containerd.pinned=pinned", "Expected the embedded image to be pinned")
+	s.Contains(out, "k0s-embedded://images/test-images.tar",
+		"Expected the embedded image to be sourced from the k0s executable's payload")
+}
+
+func TestEmbeddedImagesSuite(t *testing.T) {
+	// Provided by the Makefile, which embeds this image into the k0s executable
+	// that's being tested.
+	image := os.Getenv("K0S_EMBEDDED_TEST_IMAGE")
+	require.NotEmpty(t, image, "K0S_EMBEDDED_TEST_IMAGE is not set")
+
+	suite.Run(t, &EmbeddedImagesSuite{
+		BootlooseSuite: common.BootlooseSuite{
+			// So that k0s can be restarted.
+			LaunchMode:      common.LaunchModeOpenRC,
+			ControllerCount: 1,
+			WorkerCount:     1,
+		},
+		image: image,
+	})
+}

--- a/pkg/assets/payload.go
+++ b/pkg/assets/payload.go
@@ -13,6 +13,10 @@ import (
 	"time"
 )
 
+// ErrNoPayload indicates that an executable has no ZIP payload appended to it.
+// This is the case for k0s executables built with EMBEDDED_BINS_BUILDMODE=none.
+var ErrNoPayload = errors.New("no payload attached")
+
 // Payload provides read-only access to the ZIP archive that is appended to a
 // k0s executable.
 //
@@ -31,7 +35,7 @@ type Payload struct {
 var _ fs.FS = (*Payload)(nil)
 
 // OpenSelfPayload opens the ZIP payload that is appended to the currently
-// running executable. Returns errNoPayloadAttached if there's no ZIP archive
+// running executable. Returns ErrNoPayload if there's no ZIP archive
 // appended to it.
 func OpenSelfPayload() (*Payload, error) {
 	path, err := os.Executable()
@@ -43,7 +47,7 @@ func OpenSelfPayload() (*Payload, error) {
 }
 
 // openPayload opens the ZIP payload that is appended to the executable at path.
-// Returns errNoPayloadAttached if there's no ZIP archive appended to it.
+// Returns ErrNoPayload if there's no ZIP archive appended to it.
 func openPayload(path string) (*Payload, error) {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -64,7 +68,7 @@ func openPayload(path string) (*Payload, error) {
 		// An invalid ZIP file means that this is a bare executable, without any
 		// ZIP payload appended to it.
 		if errors.Is(err, zip.ErrFormat) {
-			return nil, errNoPayloadAttached
+			return nil, ErrNoPayload
 		}
 
 		return nil, fmt.Errorf("while opening the payload of %s: %w", path, err)
@@ -88,4 +92,27 @@ func (p *Payload) ModTime() time.Time {
 // Close closes the payload.
 func (p *Payload) Close() error {
 	return p.zip.Close()
+}
+
+// ContentID returns an opaque identifier for the contents of the payload entry
+// described by info, which is expected to have been obtained from a [Payload].
+// The identifier changes whenever the entry's contents change, and is stable
+// across rebuilds, copies and reinstallations of the executable. Returns false
+// if info doesn't describe a payload entry whose contents can be identified.
+//
+// Note that the identifier is not a cryptographic checksum. It is only intended
+// to detect changed contents, not to protect against tampering.
+func ContentID(info fs.FileInfo) (string, bool) {
+	header, ok := info.Sys().(*zip.FileHeader)
+	if !ok || info.IsDir() {
+		return "", false
+	}
+
+	// Empty entries have no CRC32 checksum recorded, but there's nothing to
+	// distinguish them by, either.
+	if header.CRC32 == 0 && header.UncompressedSize64 == 0 {
+		return "", false
+	}
+
+	return fmt.Sprintf("crc32:%08x/%d", header.CRC32, header.UncompressedSize64), true
 }

--- a/pkg/assets/payload.go
+++ b/pkg/assets/payload.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package assets
+
+import (
+	"archive/zip"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"syscall"
+	"time"
+)
+
+// Payload provides read-only access to the ZIP archive that is appended to a
+// k0s executable.
+//
+// Payload implements [fs.FS]. Entry names are slash-separated and don't have a
+// leading slash. Embedded executables live in [EmbeddedBinDir]; the archive's
+// root is reserved. Directories may be opened and read, even if the archive
+// doesn't contain any explicit entries for them.
+//
+// Payloads must be closed after use. Files obtained from Open must be closed
+// before closing the payload itself.
+type Payload struct {
+	zip     *zip.ReadCloser
+	modTime time.Time
+}
+
+var _ fs.FS = (*Payload)(nil)
+
+// OpenSelfPayload opens the ZIP payload that is appended to the currently
+// running executable. Returns errNoPayloadAttached if there's no ZIP archive
+// appended to it.
+func OpenSelfPayload() (*Payload, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine current executable: %w", err)
+	}
+
+	return openPayload(path)
+}
+
+// openPayload opens the ZIP payload that is appended to the executable at path.
+// Returns errNoPayloadAttached if there's no ZIP archive appended to it.
+func openPayload(path string) (*Payload, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("%w: %s", syscall.EISDIR, path)
+	}
+
+	// Note that OpenReader may return a usable reader alongside an error, e.g.
+	// for ErrInsecurePath, in which case closing it is up to the caller.
+	zipFile, err := zip.OpenReader(path)
+	if err != nil {
+		if zipFile != nil {
+			err = errors.Join(err, zipFile.Close())
+		}
+
+		// An invalid ZIP file means that this is a bare executable, without any
+		// ZIP payload appended to it.
+		if errors.Is(err, zip.ErrFormat) {
+			return nil, errNoPayloadAttached
+		}
+
+		return nil, fmt.Errorf("while opening the payload of %s: %w", path, err)
+	}
+
+	return &Payload{zipFile, info.ModTime()}, nil
+}
+
+// Open opens the named payload entry, using the semantics of [fs.FS.Open].
+func (p *Payload) Open(name string) (fs.File, error) {
+	return p.zip.Open(name)
+}
+
+// ModTime returns the modification time of the executable that this payload is
+// appended to. The modification times recorded inside the archive itself are not
+// meaningful, since the k0s build doesn't set them.
+func (p *Payload) ModTime() time.Time {
+	return p.modTime
+}
+
+// Close closes the payload.
+func (p *Payload) Close() error {
+	return p.zip.Close()
+}

--- a/pkg/assets/payload_test.go
+++ b/pkg/assets/payload_test.go
@@ -56,7 +56,7 @@ func TestOpenPayload_NoPayload(t *testing.T) {
 		require.NoError(t, err)
 
 		payload, err := openPayload(file)
-		assert.ErrorIs(t, err, errNoPayloadAttached)
+		assert.ErrorIs(t, err, ErrNoPayload)
 		assert.Nil(t, payload)
 	})
 
@@ -76,14 +76,14 @@ func TestOpenPayload_InaccessibleExecutable(t *testing.T) {
 	t.Run("nonExistent", func(t *testing.T) {
 		payload, err := openPayload(filepath.Join(t.TempDir(), "enoent"))
 		assert.ErrorIs(t, err, fs.ErrNotExist)
-		assert.NotErrorIs(t, err, errNoPayloadAttached)
+		assert.NotErrorIs(t, err, ErrNoPayload)
 		assert.Nil(t, payload)
 	})
 
 	t.Run("directory", func(t *testing.T) {
 		payload, err := openPayload(t.TempDir())
 		assert.ErrorIs(t, err, syscall.EISDIR)
-		assert.NotErrorIs(t, err, errNoPayloadAttached)
+		assert.NotErrorIs(t, err, ErrNoPayload)
 		assert.Nil(t, payload)
 	})
 }
@@ -136,6 +136,78 @@ func TestPayload_SynthesizedDirectories(t *testing.T) {
 			names[i] = entry.Name()
 		}
 		assert.Equal(t, []string{"containerd", "etcd"}, names)
+	})
+}
+
+func TestContentID(t *testing.T) {
+	contentID := func(t *testing.T, payload *Payload, name string) (string, bool) {
+		info, err := fs.Stat(payload, name)
+		require.NoError(t, err)
+		return ContentID(info)
+	}
+
+	openPayloadWith := func(t *testing.T, entries map[string][]byte) *Payload {
+		payload, err := openPayload(writeExecutableWithPayload(t, entries))
+		require.NoError(t, err)
+		t.Cleanup(func() { assert.NoError(t, payload.Close()) })
+		return payload
+	}
+
+	t.Run("identifiesContents", func(t *testing.T) {
+		payload := openPayloadWith(t, map[string][]byte{
+			"images/foo.tar": []byte("some bundle"),
+			"images/bar.tar": []byte("another bundle"),
+		})
+
+		foo, ok := contentID(t, payload, "images/foo.tar")
+		require.True(t, ok)
+		assert.NotEmpty(t, foo)
+		bar, ok := contentID(t, payload, "images/bar.tar")
+		require.True(t, ok)
+		assert.NotEqual(t, foo, bar, "Entries with differing contents should be distinguishable")
+	})
+
+	// Identifiers have to survive rebuilds of the executable, so that unchanged
+	// bundles won't be imported again after an upgrade.
+	t.Run("stableAcrossExecutables", func(t *testing.T) {
+		entries := map[string][]byte{"images/foo.tar": []byte("some bundle")}
+		first := openPayloadWith(t, entries)
+		second := openPayloadWith(t, entries)
+
+		firstID, ok := contentID(t, first, "images/foo.tar")
+		require.True(t, ok)
+		secondID, ok := contentID(t, second, "images/foo.tar")
+		require.True(t, ok)
+		assert.Equal(t, firstID, secondID)
+	})
+
+	t.Run("unidentifiable", func(t *testing.T) {
+		payload := openPayloadWith(t, map[string][]byte{
+			"bin/containerd":   []byte("containerd"),
+			"images/empty.tar": nil,
+		})
+
+		// Directories are synthesized, so they have no recorded contents.
+		t.Run("directory", func(t *testing.T) {
+			id, ok := contentID(t, payload, EmbeddedBinDir)
+			assert.False(t, ok)
+			assert.Empty(t, id)
+		})
+
+		t.Run("emptyEntry", func(t *testing.T) {
+			id, ok := contentID(t, payload, "images/empty.tar")
+			assert.False(t, ok)
+			assert.Empty(t, id)
+		})
+
+		// FileInfos that don't originate from a payload can't be identified.
+		t.Run("foreignFileInfo", func(t *testing.T) {
+			info, err := os.Stat(t.TempDir())
+			require.NoError(t, err)
+			id, ok := ContentID(info)
+			assert.False(t, ok)
+			assert.Empty(t, id)
+		})
 	})
 }
 

--- a/pkg/assets/payload_test.go
+++ b/pkg/assets/payload_test.go
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package assets
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"io/fs"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeExecutableWithPayload writes a file that mimics a k0s executable with a
+// ZIP payload appended to it: some opaque prefix bytes standing in for the
+// executable image, followed by a ZIP archive containing entries.
+func writeExecutableWithPayload(t *testing.T, entries map[string][]byte) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	exec, err := os.Executable()
+	require.NoError(t, err)
+	prefix, err := os.ReadFile(exec)
+	require.NoError(t, err)
+	_, err = buf.Write(prefix)
+	require.NoError(t, err)
+
+	archive := zip.NewWriter(&buf)
+	for _, name := range slices.Sorted(maps.Keys(entries)) {
+		// Use CreateHeader instead of Create, so that the modification times
+		// stay zero, just like in the payloads produced by hack/zip-files.
+		entry, err := archive.CreateHeader(&zip.FileHeader{Name: name, Method: zip.Deflate})
+		require.NoError(t, err)
+		_, err = entry.Write(entries[name])
+		require.NoError(t, err)
+	}
+	require.NoError(t, archive.Close())
+
+	path := filepath.Join(t.TempDir(), "k0s-withpayload")
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0755))
+	return path
+}
+
+func TestOpenPayload_NoPayload(t *testing.T) {
+	t.Run("bareExecutable", func(t *testing.T) {
+		file, err := os.Executable()
+		require.NoError(t, err)
+
+		payload, err := openPayload(file)
+		assert.ErrorIs(t, err, errNoPayloadAttached)
+		assert.Nil(t, payload)
+	})
+
+	t.Run("emptyFile", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "k0s")
+		require.NoError(t, os.WriteFile(path, nil, 0755))
+
+		payload, err := openPayload(path)
+		assert.Error(t, err)
+		assert.Nil(t, payload)
+	})
+}
+
+// Failing to inspect an executable must be distinguishable from it not having
+// any payload attached, so that such errors don't get mistaken for a bare k0s.
+func TestOpenPayload_InaccessibleExecutable(t *testing.T) {
+	t.Run("nonExistent", func(t *testing.T) {
+		payload, err := openPayload(filepath.Join(t.TempDir(), "enoent"))
+		assert.ErrorIs(t, err, fs.ErrNotExist)
+		assert.NotErrorIs(t, err, errNoPayloadAttached)
+		assert.Nil(t, payload)
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		payload, err := openPayload(t.TempDir())
+		assert.ErrorIs(t, err, syscall.EISDIR)
+		assert.NotErrorIs(t, err, errNoPayloadAttached)
+		assert.Nil(t, payload)
+	})
+}
+
+func TestPayload_ModTime(t *testing.T) {
+	path := writeExecutableWithPayload(t, map[string][]byte{"bin/etcd": []byte("etcd")})
+	modTime := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(path, time.Time{}, modTime))
+
+	payload, err := openPayload(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, payload.Close()) })
+
+	assert.True(t, modTime.Equal(payload.ModTime()),
+		"Expected the payload to report the executable's modification time %s, got %s",
+		modTime, payload.ModTime())
+}
+
+// Payloads don't contain any explicit directory entries. The fs.FS
+// implementation of archive/zip synthesizes them, which is what allows the
+// payload's directories to be enumerated.
+func TestPayload_SynthesizedDirectories(t *testing.T) {
+	path := writeExecutableWithPayload(t, map[string][]byte{
+		"bin/containerd":  []byte("containerd"),
+		"bin/etcd":        []byte("etcd"),
+		"images/some.tar": []byte("some bundle"),
+	})
+
+	payload, err := openPayload(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, payload.Close()) })
+
+	t.Run("root", func(t *testing.T) {
+		entries, err := fs.ReadDir(payload, ".")
+		require.NoError(t, err)
+		names := make([]string, len(entries))
+		for i, entry := range entries {
+			assert.True(t, entry.IsDir(), "Expected %s to be a directory", entry.Name())
+			names[i] = entry.Name()
+		}
+		assert.Equal(t, []string{"bin", "images"}, names)
+	})
+
+	t.Run("bin", func(t *testing.T) {
+		entries, err := fs.ReadDir(payload, EmbeddedBinDir)
+		require.NoError(t, err)
+		names := make([]string, len(entries))
+		for i, entry := range entries {
+			assert.False(t, entry.IsDir(), "Expected %s to be a file", entry.Name())
+			names[i] = entry.Name()
+		}
+		assert.Equal(t, []string{"containerd", "etcd"}, names)
+	})
+}
+
+func TestPayload_Open(t *testing.T) {
+	path := writeExecutableWithPayload(t, map[string][]byte{
+		"bin/containerd": []byte("containerd"),
+		"bin/etcd":       []byte("etcd"),
+	})
+
+	payload, err := openPayload(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, payload.Close()) })
+
+	t.Run("notExist", func(t *testing.T) {
+		file, err := payload.Open("bin/nonexistent")
+		assert.ErrorIs(t, err, fs.ErrNotExist)
+		assert.Nil(t, file)
+	})
+
+	// Executables are looked up by their exact names. Payload entries are not
+	// reachable by any other name, in particular not without their directory.
+	t.Run("noLookupByBaseName", func(t *testing.T) {
+		file, err := payload.Open("containerd")
+		assert.ErrorIs(t, err, fs.ErrNotExist)
+		assert.Nil(t, file)
+	})
+
+	t.Run("multipleOpenEntriesConcurrently", func(t *testing.T) {
+		containerd, err := payload.Open("bin/containerd")
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, containerd.Close()) }()
+		etcd, err := payload.Open("bin/etcd")
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, etcd.Close()) }()
+
+		etcdContents, err := io.ReadAll(etcd)
+		require.NoError(t, err)
+		assert.Equal(t, "etcd", string(etcdContents))
+		containerdContents, err := io.ReadAll(containerd)
+		require.NoError(t, err)
+		assert.Equal(t, "containerd", string(containerdContents))
+	})
+}

--- a/pkg/assets/payload_test.go
+++ b/pkg/assets/payload_test.go
@@ -137,6 +137,12 @@ func TestPayload_SynthesizedDirectories(t *testing.T) {
 		}
 		assert.Equal(t, []string{"containerd", "etcd"}, names)
 	})
+
+	t.Run("absolute path not accepted", func(t *testing.T) {
+		data, err := fs.ReadFile(payload, "/images/some.tar")
+		require.ErrorIs(t, err, fs.ErrInvalid)
+		assert.Empty(t, data)
+	})
 }
 
 func TestContentID(t *testing.T) {

--- a/pkg/assets/stage.go
+++ b/pkg/assets/stage.go
@@ -4,10 +4,10 @@
 package assets
 
 import (
-	"archive/zip"
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -91,54 +91,37 @@ func StageExecutable(dir, name string, opts ...StageOpt) (string, error) {
 	return path, fmt.Errorf("%w, %w, %w", err, statErr, lookErr)
 }
 
-func stage(name, path string, perm os.FileMode, opts ...StageOpt) error {
+func stage(name, path string, perm os.FileMode, opts ...StageOpt) (err error) {
+	payload, err := OpenSelfPayload()
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, payload.Close()) }()
+
+	return stageFrom(payload, name, path, perm, opts...)
+}
+
+func stageFrom(payload *Payload, name, path string, perm os.FileMode, opts ...StageOpt) (err error) {
 	log := logrus.WithField("path", path)
 	log.Infof("Staging")
-
-	selfexe, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("unable to determine current executable: %w", err)
-	}
-
-	exinfo, err := os.Stat(selfexe)
-	if err != nil {
-		return fmt.Errorf("unable to stat current executable: %w", err)
-	}
-
-	// Note that OpenReader may return a usable reader alongside an error, e.g.
-	// for ErrInsecurePath, in which case closing it is up to the caller.
-	zipFile, err := zip.OpenReader(selfexe)
-	defer func() {
-		if zipFile != nil {
-			err = errors.Join(err, zipFile.Close())
-		}
-	}()
-	if err != nil {
-		// If the error indicates an invalid ZIP file, we assume that this is a
-		// bare k0s executable, without any ZIP payload appended.
-		if errors.Is(err, zip.ErrFormat) {
-			return errNoPayloadAttached
-		}
-		return fmt.Errorf("while staging %q: %w", name, err)
-	}
 
 	// ZIP entry names are always slash-separated, on all platforms, so this
 	// must not use filepath.Join. (Which it couldn't anyways, since the path
 	// parameter shadows the path package.)
-	entryName := EmbeddedBinDir + "/" + name
-
-	var (
-		fileToExtract *zip.File
-		fileInfo      os.FileInfo
-	)
-	for _, archivedFile := range zipFile.File {
-		if archivedFile.Name == entryName {
-			fileToExtract = archivedFile
-			fileInfo = fileToExtract.FileInfo()
-			break
+	contents, err := payload.Open(EmbeddedBinDir + "/" + name)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return errNotEmbedded
 		}
+		return fmt.Errorf("while extracting %q: %w", name, err)
 	}
-	if fileToExtract == nil || fileInfo.IsDir() {
+	defer func() { err = errors.Join(err, contents.Close()) }()
+
+	fileInfo, err := contents.Stat()
+	if err != nil {
+		return fmt.Errorf("while extracting %q: %w", name, err)
+	}
+	if fileInfo.IsDir() {
 		return errNotEmbedded
 	}
 
@@ -146,7 +129,7 @@ func stage(name, path string, perm os.FileMode, opts ...StageOpt) error {
 	// matches the one of the k0s executable and its file size matches the one
 	// of the to-be-staged file.
 	if info, err := os.Stat(path); err == nil {
-		if !exinfo.IsDir() && exinfo.ModTime().Equal(info.ModTime()) && info.Size() == fileInfo.Size() {
+		if payload.ModTime().Equal(info.ModTime()) && info.Size() == fileInfo.Size() {
 			log.Debug("Re-use existing file")
 			return nil
 		}
@@ -156,16 +139,6 @@ func stage(name, path string, perm os.FileMode, opts ...StageOpt) error {
 		return err
 	}
 
-	// Get a reader for the uncompressed file contents
-	contents, err := fileToExtract.Open()
-	if err != nil {
-		if errors.Is(err, zip.ErrAlgorithm) {
-			err = fmt.Errorf("%w (compression method %d)", err, fileToExtract.Method)
-		}
-		return fmt.Errorf("while extracting %q: %w", name, err)
-	}
-	defer func() { err = errors.Join(err, contents.Close()) }()
-
 	log.Debug("Writing static file")
 
 	opener := file.AtomicWithTarget(path).
@@ -173,7 +146,7 @@ func stage(name, path string, perm os.FileMode, opts ...StageOpt) error {
 		// In order to properly determine if an update of an embedded binary
 		// file is needed, the staged embedded binary needs to have the same
 		// modification time as the `k0s` executable.
-		WithModificationTime(exinfo.ModTime())
+		WithModificationTime(payload.ModTime())
 
 	// Apply any additional options
 	for _, opt := range opts {

--- a/pkg/assets/stage.go
+++ b/pkg/assets/stage.go
@@ -19,6 +19,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// EmbeddedBinDir is the directory inside the ZIP payload that holds the
+// embedded executables. The payload's root is reserved. Keep this in sync with
+// hack/zip-files, which produces the payload.
+const EmbeddedBinDir = "bin"
+
 var errNoPayloadAttached = errors.New("no payload attached")
 var errNotEmbedded = errors.New("not an embedded asset")
 
@@ -117,12 +122,17 @@ func stage(name, path string, perm os.FileMode, opts ...StageOpt) error {
 		return fmt.Errorf("while staging %q: %w", name, err)
 	}
 
+	// ZIP entry names are always slash-separated, on all platforms, so this
+	// must not use filepath.Join. (Which it couldn't anyways, since the path
+	// parameter shadows the path package.)
+	entryName := EmbeddedBinDir + "/" + name
+
 	var (
 		fileToExtract *zip.File
 		fileInfo      os.FileInfo
 	)
 	for _, archivedFile := range zipFile.File {
-		if archivedFile.Name == name {
+		if archivedFile.Name == entryName {
 			fileToExtract = archivedFile
 			fileInfo = fileToExtract.FileInfo()
 			break

--- a/pkg/assets/stage.go
+++ b/pkg/assets/stage.go
@@ -100,7 +100,14 @@ func stage(name, path string, perm os.FileMode, opts ...StageOpt) error {
 		return fmt.Errorf("unable to stat current executable: %w", err)
 	}
 
+	// Note that OpenReader may return a usable reader alongside an error, e.g.
+	// for ErrInsecurePath, in which case closing it is up to the caller.
 	zipFile, err := zip.OpenReader(selfexe)
+	defer func() {
+		if zipFile != nil {
+			err = errors.Join(err, zipFile.Close())
+		}
+	}()
 	if err != nil {
 		// If the error indicates an invalid ZIP file, we assume that this is a
 		// bare k0s executable, without any ZIP payload appended.
@@ -109,7 +116,6 @@ func stage(name, path string, perm os.FileMode, opts ...StageOpt) error {
 		}
 		return fmt.Errorf("while staging %q: %w", name, err)
 	}
-	defer func() { err = errors.Join(err, zipFile.Close()) }()
 
 	var (
 		fileToExtract *zip.File

--- a/pkg/assets/stage.go
+++ b/pkg/assets/stage.go
@@ -24,7 +24,6 @@ import (
 // hack/zip-files, which produces the payload.
 const EmbeddedBinDir = "bin"
 
-var errNoPayloadAttached = errors.New("no payload attached")
 var errNotEmbedded = errors.New("not an embedded asset")
 
 // StageOpt configures how an executable is staged.
@@ -64,7 +63,7 @@ func StageExecutable(dir, name string, opts ...StageOpt) (string, error) {
 	}
 
 	// If the executable is not embedded, try to find an existing one.
-	if !errors.Is(err, errNoPayloadAttached) && !errors.Is(err, errNotEmbedded) {
+	if !errors.Is(err, ErrNoPayload) && !errors.Is(err, errNotEmbedded) {
 		return path, err
 	}
 

--- a/pkg/assets/stage_test.go
+++ b/pkg/assets/stage_test.go
@@ -4,9 +4,12 @@
 package assets
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/stretchr/testify/assert"
@@ -39,6 +42,113 @@ func TestStageExecutable_Fallbacks(t *testing.T) {
 		stagedPath, err := StageExecutable(stageDir, exeName)
 		if assert.NoError(t, err) {
 			assert.Equal(t, exePath, stagedPath, "Executable should have been found on disk")
+		}
+	})
+}
+
+func TestStageFrom(t *testing.T) {
+	openTestPayload := func(t *testing.T) *Payload {
+		path := writeExecutableWithPayload(t, map[string][]byte{
+			"bin/containerd":   []byte("containerd"),
+			"bin/nested/thing": []byte("nested thing"),
+			"images/foo.tar":   []byte("some bundle"),
+		})
+		payload, err := openPayload(path)
+		require.NoError(t, err)
+		t.Cleanup(func() { assert.NoError(t, payload.Close()) })
+		return payload
+	}
+
+	t.Run("extracts", func(t *testing.T) {
+		payload := openTestPayload(t)
+		path := filepath.Join(t.TempDir(), "containerd")
+
+		require.NoError(t, stageFrom(payload, "containerd", path, 0750))
+
+		contents, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, "containerd", string(contents))
+
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		if runtime.GOOS != "windows" {
+			assert.Equal(t, os.FileMode(0750), info.Mode().Perm())
+		}
+		// Staged files inherit the executable's modification time, so that
+		// stageFrom can tell if they are up to date.
+		assert.True(t, payload.ModTime().Equal(info.ModTime()),
+			"Expected modification time %s, got %s", payload.ModTime(), info.ModTime())
+	})
+
+	t.Run("notEmbedded", func(t *testing.T) {
+		payload := openTestPayload(t)
+		dir := t.TempDir()
+
+		t.Run("noSuchEntry", func(t *testing.T) {
+			err := stageFrom(payload, "kubelet", filepath.Join(dir, "kubelet"), 0750)
+			assert.ErrorIs(t, err, errNotEmbedded)
+		})
+
+		t.Run("directoryEntry", func(t *testing.T) {
+			err := stageFrom(payload, "nested", filepath.Join(dir, "nested"), 0750)
+			assert.ErrorIs(t, err, errNotEmbedded)
+		})
+
+		// Asset names are not supposed to be paths. Names that would escape the
+		// payload's bin directory are rejected outright, instead of being
+		// reported as not embedded, which would trigger a fallback to an
+		// executable of that name on disk or in the PATH.
+		t.Run("nameEscapingBinDir", func(t *testing.T) {
+			err := stageFrom(payload, "../images/foo.tar", filepath.Join(dir, "foo.tar"), 0750)
+			assert.ErrorIs(t, err, fs.ErrInvalid)
+			assert.NotErrorIs(t, err, errNotEmbedded)
+		})
+
+		for _, name := range []string{"kubelet", "nested", "foo.tar"} {
+			assert.NoFileExists(t, filepath.Join(dir, name))
+		}
+	})
+
+	// Staging is skipped if the file on disk has both the executable's
+	// modification time and the size of the embedded file.
+	t.Run("reusesUpToDateFile", func(t *testing.T) {
+		payload := openTestPayload(t)
+		path := filepath.Join(t.TempDir(), "containerd")
+		require.NoError(t, os.WriteFile(path, []byte("kept as-is"), 0750))
+		require.NoError(t, os.Chtimes(path, time.Time{}, payload.ModTime()))
+
+		require.NoError(t, stageFrom(payload, "containerd", path, 0750))
+
+		contents, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, "kept as-is", string(contents), "Existing file should not have been overwritten")
+	})
+
+	t.Run("reStages", func(t *testing.T) {
+		for _, test := range []struct {
+			name     string
+			contents string
+			modTime  func(*Payload) time.Time
+		}{
+			// Same size, but a different modification time.
+			{"onModTimeMismatch", "CONTAINERD", func(p *Payload) time.Time {
+				return p.ModTime().Add(-time.Hour)
+			}},
+			// Same modification time, but a different size.
+			{"onSizeMismatch", "containerd, but longer", (*Payload).ModTime},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				payload := openTestPayload(t)
+				path := filepath.Join(t.TempDir(), "containerd")
+				require.NoError(t, os.WriteFile(path, []byte(test.contents), 0750))
+				require.NoError(t, os.Chtimes(path, time.Time{}, test.modTime(payload)))
+
+				require.NoError(t, stageFrom(payload, "containerd", path, 0750))
+
+				contents, err := os.ReadFile(path)
+				require.NoError(t, err)
+				assert.Equal(t, "containerd", string(contents), "Existing file should have been overwritten")
+			})
 		}
 	})
 }

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -522,6 +522,9 @@ type ImageSources map[string]time.Time
 // the ZIP payload of the k0s executable.
 func bundleSourceExists(payloadFS fs.FS, path string, modtime time.Time) (bool, error) {
 	if name, embedded := strings.CutPrefix(path, embeddedSourcePrefix); embedded {
+		if payloadFS == nil {
+			return false, fmt.Errorf("can't tell if embedded bundle %s exists: the embedded payload couldn't be opened", name)
+		}
 		// Embedded bundles are identified by their contents, which are already
 		// known to be unchanged if the payload still contains them. Comparing
 		// modification times here would unpin images whenever the k0s

--- a/pkg/component/worker/ocibundle.go
+++ b/pkg/component/worker/ocibundle.go
@@ -8,8 +8,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -21,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
+	"github.com/k0sproject/k0s/pkg/assets"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/component/prober"
 	workercontainerd "github.com/k0sproject/k0s/pkg/component/worker/containerd"
@@ -33,6 +37,19 @@ const (
 	// Follows a list of labels we use to control imported images.
 	ImagePinnedLabel      = "io.cri-containerd.pinned"
 	ImageSourcePathsLabel = "io.k0sproject.ocibundle-paths"
+
+	// embeddedBundleDir is the directory inside the k0s executable's ZIP payload
+	// that holds the embedded OCI bundles.
+	embeddedBundleDir = "images"
+
+	// embeddedSourcePrefix marks image source paths that refer to an OCI bundle
+	// embedded in the k0s executable's ZIP payload, rather than to a file in the
+	// OCI bundle directory. The remainder of such a path is the payload entry
+	// name, e.g. "images/bundle.tar".
+	//
+	// Note that the k0s executable's path is deliberately not part of this, so
+	// that images stay pinned when k0s is moved or reinstalled.
+	embeddedSourcePrefix = "k0s-embedded://"
 )
 
 // OCIBundleReconciler tries to import OCI bundle into the running containerd instance
@@ -40,10 +57,14 @@ type OCIBundleReconciler struct {
 	ociBundleDir      string
 	containerdAddress string
 	log               *logrus.Entry
-	alreadyImported   map[string]time.Time
-	mtx               sync.Mutex
-	cancel            context.CancelFunc
-	end               chan struct{}
+	// openPayload opens the ZIP payload appended to the k0s executable.
+	openPayload func() (*assets.Payload, error)
+	// alreadyImported maps the names of the bundles that have been imported by
+	// this reconciler to the version of their contents at the time.
+	alreadyImported map[string]string
+	mtx             sync.Mutex
+	cancel          context.CancelFunc
+	end             chan struct{}
 	*prober.EventEmitter
 }
 
@@ -55,10 +76,118 @@ func NewOCIBundleReconciler(vars *config.CfgVars) *OCIBundleReconciler {
 		ociBundleDir:      vars.OCIBundleDir,
 		containerdAddress: workercontainerd.Address(vars.RunDir),
 		log:               logrus.WithField("component", "OCIBundleReconciler"),
+		openPayload:       assets.OpenSelfPayload,
 		EventEmitter:      prober.NewEventEmitter(),
-		alreadyImported:   map[string]time.Time{},
+		alreadyImported:   map[string]string{},
 		end:               make(chan struct{}),
 	}
+}
+
+// bundleSource is an OCI image bundle that can be imported into containerd.
+type bundleSource struct {
+	// name identifies this bundle in the import bookkeeping and in the image
+	// source label. Bundles in the OCI bundle directory use their path, embedded
+	// bundles their payload entry name, prefixed with embeddedSourcePrefix.
+	name string
+
+	// version changes whenever the bundle's contents change. Only used to decide
+	// if a bundle needs to be imported again.
+	version string
+
+	// modTime is the modification time recorded in the image source label.
+	modTime time.Time
+
+	// open returns a reader for the bundle's uncompressed tar stream. It is only
+	// valid as long as the store backing this bundle is, i.e. as long as the
+	// payload that an embedded bundle belongs to remains open.
+	open func() (io.ReadCloser, error)
+}
+
+// bundleSourcesFromDir returns the OCI bundles in dir, which is expected to be
+// the OCI bundle directory.
+func bundleSourcesFromDir(dir string) ([]bundleSource, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	sources := make([]bundleSource, 0, len(entries))
+	for _, entry := range entries {
+		path := filepath.Join(dir, entry.Name())
+		info, err := os.Stat(path)
+		if err != nil {
+			return sources, fmt.Errorf("failed to stat %s: %w", path, err)
+		}
+		if info.IsDir() {
+			continue
+		}
+
+		modTime := info.ModTime()
+		sources = append(sources, bundleSource{
+			name: path,
+			// Bundles in the OCI bundle directory are expected to be replaced
+			// rather than modified in place, so their modification time is a
+			// good enough indication of their contents.
+			version: modTime.String(),
+			modTime: modTime,
+			open:    func() (io.ReadCloser, error) { return os.Open(path) },
+		})
+	}
+
+	return sources, nil
+}
+
+// bundleSourcesFromPayload returns the OCI bundles that are embedded in
+// payloadFS, the ZIP payload of the k0s executable. The modTime is the one
+// recorded for those bundles in the image source label. The returned sources are
+// only valid as long as the payload remains open.
+func bundleSourcesFromPayload(payloadFS fs.FS, modTime time.Time) ([]bundleSource, error) {
+	entries, err := fs.ReadDir(payloadFS, embeddedBundleDir)
+	if err != nil {
+		// Executables without any embedded bundles have no such directory. This
+		// is the case for all the k0s executables that are shipped by the k0s
+		// project, so it's not an error.
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	sources := make([]bundleSource, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		// ZIP entry names are always slash-separated, on all platforms.
+		entryName := embeddedBundleDir + "/" + entry.Name()
+		info, err := entry.Info()
+		if err != nil {
+			return sources, fmt.Errorf("failed to inspect %s: %w", entryName, err)
+		}
+
+		version, ok := assets.ContentID(info)
+		if !ok {
+			// Without a way to tell if the contents changed, the bundle has to
+			// be imported on every start. Importing is idempotent, so the only
+			// cost is the time it takes.
+			version = ""
+		}
+
+		sources = append(sources, bundleSource{
+			name:    embeddedSourcePrefix + entryName,
+			version: version,
+			// Embedded bundles are identified by their contents. Their recorded
+			// modification time is irrelevant, but has to be stored, since it's
+			// part of the image source label's format.
+			modTime: modTime,
+			open: func() (io.ReadCloser, error) {
+				return payloadFS.Open(entryName)
+			},
+		})
+	}
+
+	return sources, nil
 }
 
 func (a *OCIBundleReconciler) Init(_ context.Context) error {
@@ -91,70 +220,123 @@ func (a *OCIBundleReconciler) containerdClient(ctx context.Context) (*containerd
 }
 
 // loadOne connects to containerd and imports the provided OCI bundle.
-func (a *OCIBundleReconciler) loadOne(ctx context.Context, fpath string, modtime time.Time) error {
+func (a *OCIBundleReconciler) loadOne(ctx context.Context, payloadFS fs.FS, src bundleSource) error {
 	client, err := a.containerdClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create containerd client: %w", err)
 	}
 	defer client.Close()
-	if err := a.unpackBundle(ctx, client, fpath, modtime); err != nil {
+	if err := a.unpackBundle(ctx, client, payloadFS, src); err != nil {
 		return fmt.Errorf("failed to process OCI bundle: %w", err)
 	}
 	return nil
 }
 
-// loadAll loads all OCI bundle files into containerd. Read all files from the OCI bundle
-// directory and loads them one by one. Errors are logged but not returned, upon failure
-// in one file this function logs the error and moves to the next file. Files are indexed
-// by name and imported only once (if the file has not been modified).
+// loadAll loads all the OCI bundles that are embedded in the k0s executable, as
+// well as all the ones in the OCI bundle directory, into containerd. Errors are
+// logged but not returned, upon failure in one bundle this function logs the
+// error and moves to the next one. Bundles are indexed by name and imported only
+// once, as long as their contents don't change.
 func (a *OCIBundleReconciler) loadAll(ctx context.Context) {
-	// We are going to consume everything in the directory so we block. This keeps
-	// things simple and avoid the need to handle two imports of the same file at the
-	// same time without requiring locks based on file path.
+	// We are going to consume every bundle, so we block. This keeps things simple
+	// and avoids the need to handle two imports of the same bundle at the same
+	// time without requiring locks based on bundle names.
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 
-	a.log.Info("Loading OCI bundles directory")
-	files, err := os.ReadDir(a.ociBundleDir)
-	if err != nil {
-		a.log.WithError(err).Errorf("Failed to read bundles directory")
-		return
-	}
-	a.EmitWithPayload("importing OCI bundles", files)
-	for _, file := range files {
-		fpath := filepath.Join(a.ociBundleDir, file.Name())
-		finfo, err := os.Stat(fpath)
+	a.log.Info("Loading OCI bundles")
+
+	var sources []bundleSource
+
+	// The payload has to stay open for as long as its bundles may be read, i.e.
+	// for the whole duration of this call, including the unpinning below, which
+	// needs to inspect the same set of embedded bundles.
+	var payloadFS fs.FS
+	payload, err := a.openPayload()
+	switch {
+	case err == nil:
+		defer func() {
+			if err := payload.Close(); err != nil {
+				a.log.WithError(err).Warn("Failed to close payload")
+			}
+		}()
+		payloadFS = payload
+
+		embeddedSources, err := bundleSourcesFromPayload(payload, payload.ModTime())
 		if err != nil {
-			a.log.WithError(err).Errorf("failed to stat %s", fpath)
-			continue
+			a.log.WithError(err).Error("Failed to collect the embedded OCI bundles")
 		}
+		sources = append(sources, embeddedSources...)
 
-		modtime := finfo.ModTime()
-		if when, ok := a.alreadyImported[fpath]; ok && when.Equal(modtime) {
-			continue
-		}
+	case errors.Is(err, assets.ErrNoPayload):
+		// A bare k0s executable has no embedded bundles. Images that claim to
+		// originate from one are stale and may be unpinned.
+		payloadFS = emptyFS{}
 
-		a.log.Infof("Loading OCI bundle %s", fpath)
-		if err := a.loadOne(ctx, fpath, modtime); err != nil {
-			a.log.WithError(err).Errorf("Failed to load OCI bundle %s", fpath)
-			continue
-		}
-
-		a.alreadyImported[fpath] = modtime
-		a.log.Infof("OCI bundle %s loaded", fpath)
+	default:
+		// It's unknown if there are any embedded bundles. Leave payloadFS unset,
+		// so that the unpinning below is skipped, instead of unpinning images
+		// whose embedded bundles may well still be there.
+		a.log.WithError(err).Error("Failed to open the k0s executable's payload")
 	}
 
-	if err := a.unpinAll(ctx); err != nil {
+	// Collect the bundles from the OCI bundle directory after the embedded ones,
+	// so that a bundle that's placed there takes precedence over an embedded one.
+	dirSources, err := bundleSourcesFromDir(a.ociBundleDir)
+	if err != nil {
+		a.log.WithError(err).Error("Failed to collect the OCI bundles in the bundle directory")
+	}
+	sources = append(sources, dirSources...)
+
+	names := make([]string, len(sources))
+	for i, src := range sources {
+		names[i] = src.name
+	}
+	a.EmitWithPayload("importing OCI bundles", names)
+
+	for _, src := range sources {
+		// Bundles whose contents cannot be identified have an empty version and
+		// are imported again on every run.
+		if version, ok := a.alreadyImported[src.name]; ok && src.version != "" && version == src.version {
+			continue
+		}
+
+		log := a.log.WithField("bundle", src.name)
+		log.Info("Loading OCI bundle")
+		if err := a.loadOne(ctx, payloadFS, src); err != nil {
+			log.WithError(err).Error("Failed to load OCI bundle")
+			continue
+		}
+
+		a.alreadyImported[src.name] = src.version
+		log.Info("OCI bundle loaded")
+	}
+
+	if payloadFS == nil {
+		a.log.Warn("Not unpinning images: it's unknown which OCI bundles are embedded")
+		a.Emit("skipped unpinning images")
+	} else if err := a.unpinAll(ctx, payloadFS); err != nil {
 		a.log.WithError(err).Errorf("Failed to unpin images")
 	}
 
 	a.Emit("finished importing OCI bundles")
 }
 
+// emptyFS is an fs.FS without any files in it.
+type emptyFS struct{}
+
+func (emptyFS) Open(name string) (fs.File, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+	return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+}
+
 // unpin unpins containerd images from the image store. we unpin an image if
-// the file from where it was imported no longer exists or the file content
-// has been changed.
-func (a *OCIBundleReconciler) unpinAll(ctx context.Context) error {
+// the bundle from where it was imported no longer exists or its content has
+// been changed. Bundles are looked up in the local file system, or, for embedded
+// bundles, in payloadFS, the ZIP payload of the k0s executable.
+func (a *OCIBundleReconciler) unpinAll(ctx context.Context, payloadFS fs.FS) error {
 	client, err := a.containerdClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create containerd client: %w", err)
@@ -168,7 +350,7 @@ func (a *OCIBundleReconciler) unpinAll(ctx context.Context) error {
 	}
 
 	for _, image := range images {
-		if err := a.unpinOne(ctx, image, isvc); err != nil {
+		if err := a.unpinOne(ctx, image, isvc, payloadFS); err != nil {
 			a.log.WithError(err).Errorf("Failed to unpin image %s", image.Name)
 		}
 	}
@@ -176,7 +358,7 @@ func (a *OCIBundleReconciler) unpinAll(ctx context.Context) error {
 }
 
 // unpinOne checks if we can unpin the provided image and if so unpins it.
-func (a *OCIBundleReconciler) unpinOne(ctx context.Context, image images.Image, isvc images.Store) error {
+func (a *OCIBundleReconciler) unpinOne(ctx context.Context, image images.Image, isvc images.Store, payloadFS fs.FS) error {
 	// if this image isn't pinned, return immediately.
 	if v, pin := image.Labels[ImagePinnedLabel]; !pin || v != "pinned" {
 		return nil
@@ -194,10 +376,10 @@ func (a *OCIBundleReconciler) unpinOne(ctx context.Context, image images.Image, 
 	// if any of the registered sources is still present, we can't unpin the image.
 	// we just update the image label to remove references to the bundles that no
 	// longer exist.
-	if exists, err := sources.Exist(); err != nil {
+	if exists, err := sources.Exist(payloadFS); err != nil {
 		return fmt.Errorf("failed to check if sources exist: %w", err)
 	} else if exists {
-		if err := sources.Refresh(); err != nil {
+		if err := sources.Refresh(payloadFS); err != nil {
 			return fmt.Errorf("failed to refresh image sources: %w", err)
 		}
 		if err := SetImageSources(&image, sources); err != nil {
@@ -275,10 +457,12 @@ func (a *OCIBundleReconciler) Start(ctx context.Context) error {
 
 // unpackBundle imports the bundle into the containerd storage. imported images are
 // pinned and labeled so we can control them later.
-func (a *OCIBundleReconciler) unpackBundle(ctx context.Context, client *containerd.Client, bundlePath string, modtime time.Time) error {
-	r, err := os.Open(bundlePath)
+func (a *OCIBundleReconciler) unpackBundle(ctx context.Context, client *containerd.Client, payloadFS fs.FS, src bundleSource) error {
+	// Embedded bundles are streamed straight out of the k0s executable's ZIP
+	// payload, i.e. they are never extracted to disk.
+	r, err := src.open()
 	if err != nil {
-		return fmt.Errorf("can't open bundle file %s: %w", bundlePath, err)
+		return fmt.Errorf("can't open bundle %s: %w", src.name, err)
 	}
 	defer r.Close()
 	// WithSkipMissing allows us to skip missing blobs
@@ -306,7 +490,7 @@ func (a *OCIBundleReconciler) unpackBundle(ctx context.Context, client *containe
 		}
 
 		i.Labels[ImagePinnedLabel] = "pinned"
-		if err := AddToImageSources(&i, bundlePath, modtime); err != nil {
+		if err := AddToImageSources(&i, payloadFS, src.name, src.modTime); err != nil {
 			return fmt.Errorf("failed to add image source: %w", err)
 		}
 
@@ -327,21 +511,58 @@ func (a *OCIBundleReconciler) Stop() error {
 
 // ImageSources holds a map of bundle paths with their respective modification times.
 // this is used to track from which bundles a given image was imported.
+//
+// Paths prefixed with embeddedSourcePrefix refer to bundles embedded in the k0s
+// executable's ZIP payload, all the other paths to files in the node's file
+// system.
 type ImageSources map[string]time.Time
+
+// exists checks if the bundle identified by path is still available, and still
+// has the given modification time. Embedded bundles are looked up in payloadFS,
+// the ZIP payload of the k0s executable.
+func bundleSourceExists(payloadFS fs.FS, path string, modtime time.Time) (bool, error) {
+	if name, embedded := strings.CutPrefix(path, embeddedSourcePrefix); embedded {
+		// Embedded bundles are identified by their contents, which are already
+		// known to be unchanged if the payload still contains them. Comparing
+		// modification times here would unpin images whenever the k0s
+		// executable's modification time changes, which happens for reasons that
+		// have nothing to do with its contents, such as being reinstalled.
+		// Unusable names are reported as an error, not as non-existing. The
+		// latter would unpin the image, whereas an error leaves it pinned until
+		// this is sorted out. Check this explicitly, since file systems differ in
+		// how they report invalid names.
+		if !fs.ValidPath(name) {
+			return false, fmt.Errorf("%w: invalid embedded bundle name %q", fs.ErrInvalid, name)
+		}
+		if _, err := fs.Stat(payloadFS, name); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to stat embedded bundle %s: %w", name, err)
+		}
+		return true, nil
+	}
+
+	finfo, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to stat %s: %w", path, err)
+	}
+	return finfo.ModTime().Equal(modtime), nil
+}
 
 // Refresh removes from the list of source paths all the paths that no longer exists
 // or have been modified.
-func (i *ImageSources) Refresh() error {
+func (i *ImageSources) Refresh(payloadFS fs.FS) error {
 	newmap := map[string]time.Time{}
 	for path, modtime := range *i {
-		finfo, err := os.Stat(path)
+		exists, err := bundleSourceExists(payloadFS, path, modtime)
 		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				continue
-			}
-			return fmt.Errorf("failed to stat %s: %w", path, err)
+			return err
 		}
-		if finfo.ModTime().Equal(modtime) {
+		if exists {
 			newmap[path] = modtime
 		}
 	}
@@ -349,17 +570,15 @@ func (i *ImageSources) Refresh() error {
 	return nil
 }
 
-// Exist returns true if a given bundle source file still exists in the node fs.
-func (i *ImageSources) Exist() (bool, error) {
+// Exist returns true if a given bundle source is still available, either in the
+// node's file system or in the k0s executable's ZIP payload.
+func (i *ImageSources) Exist(payloadFS fs.FS) (bool, error) {
 	for path, modtime := range *i {
-		finfo, err := os.Stat(path)
+		exists, err := bundleSourceExists(payloadFS, path, modtime)
 		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				continue
-			}
-			return false, fmt.Errorf("failed to stat %s: %w", path, err)
+			return false, err
 		}
-		if finfo.ModTime().Equal(modtime) {
+		if exists {
 			return true, nil
 		}
 	}
@@ -399,12 +618,12 @@ func SetImageSources(image *images.Image, sources ImageSources) error {
 
 // AddToImageSources adds a new source path to the image sources. this function
 // will trim out of the sources the ones that no longer exists in the node fs.
-func AddToImageSources(image *images.Image, path string, modtime time.Time) error {
+func AddToImageSources(image *images.Image, payloadFS fs.FS, path string, modtime time.Time) error {
 	paths, err := GetImageSources(*image)
 	if err != nil {
 		return fmt.Errorf("failed to get image sources: %w", err)
 	}
-	if err := paths.Refresh(); err != nil {
+	if err := paths.Refresh(payloadFS); err != nil {
 		return fmt.Errorf("failed to refresh image sources: %w", err)
 	}
 	paths[path] = modtime

--- a/pkg/component/worker/ocibundle_embedded_test.go
+++ b/pkg/component/worker/ocibundle_embedded_test.go
@@ -1,0 +1,301 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package worker
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/json"
+	"hash/crc32"
+	"io"
+	"io/fs"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/k0sproject/k0s/pkg/component/prober"
+
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// payloadEntry builds an fstest.MapFile that carries the same ZIP metadata that
+// assets.ContentID relies on, so that embedded bundles can be identified by
+// their contents in tests.
+func payloadEntry(contents string) *fstest.MapFile {
+	data := []byte(contents)
+	return &fstest.MapFile{
+		Data: data,
+		Sys: &zip.FileHeader{
+			CRC32:              crc32.ChecksumIEEE(data),
+			UncompressedSize64: uint64(len(data)),
+		},
+	}
+}
+
+func TestBundleSourcesFromPayload(t *testing.T) {
+	modTime := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+
+	// The k0s executables shipped by the k0s project have no embedded bundles at
+	// all. That's not an error, there's simply nothing to import.
+	t.Run("noEmbeddedBundles", func(t *testing.T) {
+		sources, err := bundleSourcesFromPayload(fstest.MapFS{
+			"bin/containerd": payloadEntry("containerd"),
+		}, modTime)
+		assert.NoError(t, err)
+		assert.Empty(t, sources)
+	})
+
+	t.Run("collectsBundles", func(t *testing.T) {
+		sources, err := bundleSourcesFromPayload(fstest.MapFS{
+			"bin/containerd":    payloadEntry("containerd"),
+			"images/first.tar":  payloadEntry("first bundle"),
+			"images/second.tar": payloadEntry("second bundle"),
+			// Bundles are collected non-recursively, mirroring the behavior for
+			// the OCI bundle directory.
+			"images/nested/third.tar": payloadEntry("third bundle"),
+		}, modTime)
+		require.NoError(t, err)
+
+		names := make([]string, len(sources))
+		for i, src := range sources {
+			names[i] = src.name
+			assert.True(t, modTime.Equal(src.modTime), "Unexpected modification time for %s", src.name)
+			assert.NotEmpty(t, src.version, "Expected %s to be identifiable by its contents", src.name)
+		}
+		assert.Equal(t, []string{
+			"k0s-embedded://images/first.tar",
+			"k0s-embedded://images/second.tar",
+		}, names)
+	})
+
+	// Bundles are streamed out of the payload, they are never extracted to disk.
+	t.Run("opensBundleContents", func(t *testing.T) {
+		sources, err := bundleSourcesFromPayload(fstest.MapFS{
+			"images/some.tar": payloadEntry("some bundle"),
+		}, modTime)
+		require.NoError(t, err)
+		require.Len(t, sources, 1)
+
+		reader, err := sources[0].open()
+		require.NoError(t, err)
+		t.Cleanup(func() { assert.NoError(t, reader.Close()) })
+		contents, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		assert.Equal(t, "some bundle", string(contents))
+	})
+
+	// Bundles whose contents can't be identified have to be imported again on
+	// every run, which is indicated by an empty version.
+	t.Run("unidentifiableContents", func(t *testing.T) {
+		sources, err := bundleSourcesFromPayload(fstest.MapFS{
+			"images/some.tar": {Data: []byte("some bundle")},
+		}, modTime)
+		require.NoError(t, err)
+		require.Len(t, sources, 1)
+		assert.Empty(t, sources[0].version)
+	})
+}
+
+func TestBundleSourcesFromDir(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "some.tar"), []byte("some bundle"), 0644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "nested"), 0755))
+
+	sources, err := bundleSourcesFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, sources, 1, "Directories should be skipped")
+
+	assert.Equal(t, filepath.Join(dir, "some.tar"), sources[0].name)
+	assert.NotEmpty(t, sources[0].version)
+	reader, err := sources[0].open()
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, reader.Close()) })
+	contents, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, "some bundle", string(contents))
+}
+
+func TestImageSources_EmbeddedBundles(t *testing.T) {
+	payloadFS := fstest.MapFS{"images/some.tar": payloadEntry("some bundle")}
+
+	// Embedded bundles are identified by their contents, so the recorded
+	// modification time must not be taken into account. Otherwise images would
+	// get unpinned whenever the k0s executable's modification time changes, e.g.
+	// when it gets reinstalled.
+	t.Run("ignoresRecordedModTime", func(t *testing.T) {
+		for _, modTime := range []time.Time{{}, time.Now().Add(-time.Hour), time.Now().Add(time.Hour)} {
+			sources := ImageSources{"k0s-embedded://images/some.tar": modTime}
+			exists, err := sources.Exist(payloadFS)
+			require.NoError(t, err)
+			assert.True(t, exists, "Expected the embedded bundle to exist for modification time %s", modTime)
+
+			require.NoError(t, sources.Refresh(payloadFS))
+			assert.Len(t, sources, 1, "Expected the embedded bundle to be retained")
+		}
+	})
+
+	t.Run("goneFromPayload", func(t *testing.T) {
+		sources := ImageSources{"k0s-embedded://images/other.tar": time.Now()}
+		exists, err := sources.Exist(payloadFS)
+		require.NoError(t, err)
+		assert.False(t, exists)
+
+		require.NoError(t, sources.Refresh(payloadFS))
+		assert.Empty(t, sources)
+	})
+
+	// Bare k0s executables have no payload at all, so any embedded bundle that an
+	// image refers to is gone.
+	t.Run("noPayload", func(t *testing.T) {
+		sources := ImageSources{"k0s-embedded://images/some.tar": time.Now()}
+		exists, err := sources.Exist(emptyFS{})
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	// Embedded bundle names are not paths in the node's file system. They must
+	// never be resolved as such, no matter how they look. Names that aren't valid
+	// payload entry names are reported as an error rather than as non-existing,
+	// since the latter would unpin the image.
+	t.Run("notResolvedInFileSystem", func(t *testing.T) {
+		dir := t.TempDir()
+		decoy := filepath.Join(dir, "decoy.tar")
+		require.NoError(t, os.WriteFile(decoy, []byte("decoy"), 0644))
+		info, err := os.Stat(decoy)
+		require.NoError(t, err)
+
+		sources := ImageSources{embeddedSourcePrefix + decoy: info.ModTime()}
+		exists, err := sources.Exist(payloadFS)
+		assert.ErrorIs(t, err, fs.ErrInvalid)
+		assert.False(t, exists, "An embedded bundle must not be resolved in the file system")
+	})
+
+	// Sources of both kinds may be recorded for the same image.
+	t.Run("mixedWithFileSystemSources", func(t *testing.T) {
+		dir := t.TempDir()
+		onDisk := filepath.Join(dir, "on-disk.tar")
+		require.NoError(t, os.WriteFile(onDisk, []byte("on disk"), 0644))
+		info, err := os.Stat(onDisk)
+		require.NoError(t, err)
+
+		sources := ImageSources{
+			onDisk:                            info.ModTime(),
+			"k0s-embedded://images/some.tar":  time.Time{},
+			"k0s-embedded://images/other.tar": time.Time{},
+		}
+
+		require.NoError(t, sources.Refresh(payloadFS))
+		assert.Equal(t, []string{onDisk, "k0s-embedded://images/some.tar"}, sortedKeys(sources),
+			"Expected only the vanished embedded bundle to be dropped")
+
+		// Removing the file on disk leaves the embedded bundle as the only source.
+		require.NoError(t, os.Remove(onDisk))
+		require.NoError(t, sources.Refresh(payloadFS))
+		assert.Equal(t, []string{"k0s-embedded://images/some.tar"}, sortedKeys(sources))
+
+		exists, err := sources.Exist(payloadFS)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+}
+
+// fakeImageStore is an in-memory images.Store that records the updates made to
+// it.
+type fakeImageStore struct {
+	images.Store
+	updates []images.Image
+	fields  [][]string
+}
+
+func (s *fakeImageStore) Update(_ context.Context, image images.Image, fieldpaths ...string) (images.Image, error) {
+	s.updates = append(s.updates, image)
+	s.fields = append(s.fields, fieldpaths)
+	return image, nil
+}
+
+func TestUnpinOne(t *testing.T) {
+	payloadFS := fstest.MapFS{"images/some.tar": payloadEntry("some bundle")}
+
+	pinnedImage := func(t *testing.T, sources ImageSources) images.Image {
+		image := images.Image{
+			Name:   "example.com/some/image:latest",
+			Labels: map[string]string{ImagePinnedLabel: "pinned"},
+		}
+		if len(sources) > 0 {
+			data, err := json.Marshal(sources)
+			require.NoError(t, err)
+			image.Labels[ImageSourcePathsLabel] = string(data)
+		}
+		return image
+	}
+
+	unpinOne := func(t *testing.T, image images.Image, payloadFS fs.FS) *fakeImageStore {
+		reconciler := &OCIBundleReconciler{
+			log:          logrus.WithField("test", t.Name()),
+			EventEmitter: prober.NewEventEmitter(),
+		}
+		store := new(fakeImageStore)
+		require.NoError(t, reconciler.unpinOne(context.TODO(), image, store, payloadFS))
+		return store
+	}
+
+	// As long as the embedded bundle is still there, the image stays pinned.
+	// Unpinning it would allow the kubelet to garbage collect an image that
+	// cannot be pulled again on an air-gapped node.
+	t.Run("keepsPinWhileEmbeddedBundleExists", func(t *testing.T) {
+		image := pinnedImage(t, ImageSources{"k0s-embedded://images/some.tar": time.Time{}})
+		store := unpinOne(t, image, payloadFS)
+
+		require.Len(t, store.updates, 1)
+		assert.Equal(t, "pinned", store.updates[0].Labels[ImagePinnedLabel])
+		assert.Equal(t, [][]string{{"labels." + ImageSourcePathsLabel}}, store.fields,
+			"Only the image sources should have been updated")
+	})
+
+	t.Run("unpinsWhenEmbeddedBundleIsGone", func(t *testing.T) {
+		image := pinnedImage(t, ImageSources{"k0s-embedded://images/other.tar": time.Time{}})
+		store := unpinOne(t, image, payloadFS)
+
+		require.Len(t, store.updates, 1)
+		assert.NotContains(t, store.updates[0].Labels, ImagePinnedLabel)
+		assert.NotContains(t, store.updates[0].Labels, ImageSourcePathsLabel)
+	})
+
+	// Images that k0s didn't import have no image sources recorded. They may be
+	// pinned by someone else, e.g. containerd pins its own sandbox image.
+	t.Run("ignoresForeignImages", func(t *testing.T) {
+		store := unpinOne(t, pinnedImage(t, nil), payloadFS)
+		assert.Empty(t, store.updates, "Foreign images should be left alone")
+	})
+
+	t.Run("ignoresUnpinnedImages", func(t *testing.T) {
+		image := pinnedImage(t, ImageSources{"k0s-embedded://images/other.tar": time.Time{}})
+		delete(image.Labels, ImagePinnedLabel)
+		store := unpinOne(t, image, payloadFS)
+		assert.Empty(t, store.updates)
+	})
+}
+
+func TestEmptyFS(t *testing.T) {
+	_, err := fs.Stat(emptyFS{}, "images/some.tar")
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+
+	_, err = fs.ReadDir(emptyFS{}, embeddedBundleDir)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+
+	_, err = emptyFS{}.Open("../escaping")
+	assert.ErrorIs(t, err, fs.ErrInvalid)
+}
+
+// sortedKeys returns the keys of sources in ascending order.
+func sortedKeys(sources ImageSources) []string {
+	return slices.Sorted(maps.Keys(sources))
+}

--- a/pkg/component/worker/ocibundle_embedded_test.go
+++ b/pkg/component/worker/ocibundle_embedded_test.go
@@ -123,6 +123,14 @@ func TestBundleSourcesFromDir(t *testing.T) {
 	assert.Equal(t, "some bundle", string(contents))
 }
 
+type erroringFS struct {
+	err error
+}
+
+func (e erroringFS) Open(name string) (fs.File, error) {
+	return nil, e.err
+}
+
 func TestImageSources_EmbeddedBundles(t *testing.T) {
 	payloadFS := fstest.MapFS{"images/some.tar": payloadEntry("some bundle")}
 
@@ -161,21 +169,21 @@ func TestImageSources_EmbeddedBundles(t *testing.T) {
 		assert.False(t, exists)
 	})
 
-	// Embedded bundle names are not paths in the node's file system. They must
-	// never be resolved as such, no matter how they look. Names that aren't valid
-	// payload entry names are reported as an error rather than as non-existing,
-	// since the latter would unpin the image.
-	t.Run("notResolvedInFileSystem", func(t *testing.T) {
-		dir := t.TempDir()
-		decoy := filepath.Join(dir, "decoy.tar")
-		require.NoError(t, os.WriteFile(decoy, []byte("decoy"), 0644))
-		info, err := os.Stat(decoy)
-		require.NoError(t, err)
-
-		sources := ImageSources{embeddedSourcePrefix + decoy: info.ModTime()}
+	// Names that aren't valid payload entry names are reported as an error rather
+	// than as non-existing, since the latter would unpin the image.
+	t.Run("invalid path", func(t *testing.T) {
+		sources := ImageSources{embeddedSourcePrefix + "../../decoy.tar": time.Now()}
 		exists, err := sources.Exist(payloadFS)
 		assert.ErrorIs(t, err, fs.ErrInvalid)
 		assert.False(t, exists, "An embedded bundle must not be resolved in the file system")
+	})
+
+	// We must treat error from stat as a failure rather than as non-existing plus error
+	t.Run("embedded stat fails", func(t *testing.T) {
+		sources := ImageSources{"k0s-embedded://images/some.tar": time.Now()}
+		exists, err := sources.Exist(erroringFS{err: fs.ErrInvalid})
+		assert.ErrorIs(t, err, fs.ErrInvalid)
+		assert.False(t, exists)
 	})
 
 	// Sources of both kinds may be recorded for the same image.

--- a/pkg/component/worker/ocibundle_test.go
+++ b/pkg/component/worker/ocibundle_test.go
@@ -112,7 +112,7 @@ func TestAddToImageSources(t *testing.T) {
 	info1, err := os.Stat(img0)
 	require.NoError(t, err)
 
-	err = AddToImageSources(&image, img1, info1.ModTime())
+	err = AddToImageSources(&image, emptyFS{}, img1, info1.ModTime())
 	require.NoError(t, err)
 
 	expected := ImageSources{
@@ -128,7 +128,7 @@ func TestAddToImageSources(t *testing.T) {
 	err = os.Remove(img0)
 	require.NoError(t, err)
 
-	err = AddToImageSources(&image, img1, info1.ModTime())
+	err = AddToImageSources(&image, emptyFS{}, img1, info1.ModTime())
 	require.NoError(t, err)
 
 	expected = ImageSources{img1: info1.ModTime()}


### PR DESCRIPTION

## Description

Lets OCI image bundles be embedded into the k0s executable itself, so a single
file can carry both k0s, embedded bins and the container images it needs. On worker startup, k0s
imports the bundles found in its own ZIP payload into containerd.

Nothing changes for the executables shipped by default, they contain no
bundles, and the import is a no-op. Users add bundles with ordinary ZIP tooling,
as described in `docs/airgap-install.md`. The embedded executables move from the
archive's root into `bin`, bundles live in `images`, and the root is reserved —
purely an internal detail, since the payload never travels separately from the
executable that reads it.


## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
