### PR TITLE
Use patched CNI bins

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -100,7 +100,7 @@ const (
 	KubeRouterCNIImage                    = "quay.io/k0sproject/kube-router"
 	KubeRouterCNIImageVersion             = "v2.10.0-iptables1.8.13-k0s.1"
 	KubeRouterCNIInstallerImage           = "quay.io/k0sproject/cni-node"
-	KubeRouterCNIInstallerImageVersion    = "v1.9.1-k0s.1"
+	KubeRouterCNIInstallerImageVersion    = "v1.9.1-k0s.1-mac-pinning"
 
 	/* Controller component names */
 


### PR DESCRIPTION
Built from https://github.com/k0sproject/cni-node/pull/19

  Upstream is stalled with https://github.com/containernetworking/plugins/pull/1265
    so let's use a patched CNI bins in k0s side to see how well they fix
    some of the CI flakes.


## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
