### PR TITLE
Improve docs: enable "content.code.copy" feature

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,6 +120,7 @@ theme:
     - toc.autohide
     - search.suggest
     - search.highlight
+    - content.code.copy
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
<img width="871" height="238" alt="image" src="https://github.com/user-attachments/assets/038fb4ff-122b-46ee-92b2-e3933e5fdf32" />

## Description

Enables the [built-in "copy to clipboard"](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#code-copy-button) button for code blocks in the k0s documentation.

The docs are built with Material for MkDocs (`mkdocs-material==9.7.7`), which ships this
functionality as the `content.code.copy` theme feature, but it was never enabled. As a result,
readers had to select and copy the contents of every code snippet by hand — which is error prone
for the many multi-line install, config and `k0s` CLI commands throughout the docs.

The change is a single line in `mkdocs.yml`:

```yaml
theme:
  features:
    - toc.autohide
    - search.suggest
    - search.highlight
    - content.code.copy  # <-- added
```

No custom CSS/JS is needed: the theme injects the copy button into every fenced code block.
There are no new dependencies; the feature is provided by the already pinned version of
`mkdocs-material`.

<!-- No tracking issue; reported as a papercut in the docs. -->

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

Built and served the documentation locally:

```shell
python3 -m venv venv && ./venv/bin/pip install -r docs/requirements.txt
make -C docs cli                       # generates docs/cli from the k0s binary
PYTHONPATH="$PWD/docs/mkdocs_modules" K0S_VERSION="$(./k0s version)" mkdocs build --strict
python3 -m http.server 8890 -d site
```

Results:

- `mkdocs build --strict` completes without warnings or errors.
- The generated `site/**/index.html` contains `content.code.copy` in the theme feature list, and
  the Material JS bundle mounts a `md-code__button` with `data-clipboard-target` on each code
  block at runtime.
- Verified in the browser on pages with different snippet types (`install.md`,
  `k0s-in-docker.md`, `configuration.md`, generated `cli/*`): the copy icon appears in the top
  right corner of every code block, in both the light and the dark palette, and copies the
  snippet contents.

Tested with the versions pinned in `docs/requirements.txt` (mkdocs 1.6.1, mkdocs-material 9.7.7).

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
