### PR TITLE
Fix NewCRDStack silently discarding an explicit stack name

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/k0sproject/k0s/cmd/internal"
@@ -366,6 +367,19 @@ func (c *command) start(ctx context.Context, runtimeConfig *config.RuntimeConfig
 		leaderElector = leaderelector.NewLeasePool(c.K0sVars.InvocationID, adminClientFactory, "k0s-endpoint-reconciler")
 	}
 	nodeComponents.Add(ctx, leaderElector)
+
+	// TODO: Remove in v1.38+. Clean up the bogus on-disk etcd CRD manifest
+	// left behind by affected versions of k0s, so it doesn't fight the
+	// in-memory etcd-member stack over the CRD's stack-name label.
+	{
+		bogusEtcdDir := filepath.Join(c.K0sVars.ManifestsDir, "etcd")
+		bogusEtcdManifest := filepath.Join(bogusEtcdDir, "etcd-crd-etcd.k0sproject.io_etcdmembers.yaml")
+		if err := os.Remove(bogusEtcdManifest); err != nil && !os.IsNotExist(err) {
+			logrus.WithError(err).Warn("Failed to remove bogus etcd CRD manifest")
+		} else if err := os.Remove(bogusEtcdDir); err != nil && !os.IsNotExist(err) && !errors.Is(err, syscall.ENOTEMPTY) {
+			logrus.WithError(err).Warn("Failed to remove bogus etcd CRD manifest directory")
+		}
+	}
 
 	if !slices.Contains(flags.DisableComponents, constant.ApplierManagerComponentName) {
 		nodeComponents.Add(ctx, &applier.Manager{

--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -132,8 +132,10 @@ func (s *Stack) Apply(ctx context.Context, prune bool) error {
 			continue
 		} else { // The resource already exists, we need to update/patch it
 			localChecksum := resource.GetAnnotations()[ChecksumAnnotation]
-			if serverResource.GetAnnotations()[ChecksumAnnotation] == localChecksum {
-				s.log.Debug("resource checksums match, no need to update")
+			checksumMatches := serverResource.GetAnnotations()[ChecksumAnnotation] == localChecksum
+			stackNameMatches := serverResource.GetLabels()[NameLabel] == s.Name
+			if checksumMatches && stackNameMatches {
+				s.log.Debug("resource checksum and stack name match, no need to update")
 				s.keepResource(resource)
 				continue
 			}

--- a/pkg/applier/stack_test.go
+++ b/pkg/applier/stack_test.go
@@ -50,3 +50,42 @@ func TestStack_StripsNamespaceFromClusterScopedResource(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, appliedNs.Namespace)
 }
+
+func TestStack_StackNameChangeTriggersUpdateWithoutChecksumChange(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns-relabel-test",
+		},
+	}
+	resources, err := applier.ToUnstructured(nil, ns)
+	require.NoError(t, err)
+
+	fakes := testutil.NewFakeClientFactory()
+
+	oldStack := applier.Stack{
+		Name:      "old",
+		Resources: []*unstructured.Unstructured{resources},
+		Clients:   fakes,
+	}
+	require.NoError(t, oldStack.Apply(t.Context(), true))
+
+	applied, err := fakes.Client.CoreV1().Namespaces().Get(t.Context(), "ns-relabel-test", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "old", applied.Labels[applier.NameLabel])
+	checksumBefore := applied.Annotations[applier.ChecksumAnnotation]
+	require.NotEmpty(t, checksumBefore)
+
+	resources, err = applier.ToUnstructured(nil, ns)
+	require.NoError(t, err)
+	newStack := applier.Stack{
+		Name:      "new",
+		Resources: []*unstructured.Unstructured{resources},
+		Clients:   fakes,
+	}
+	require.NoError(t, newStack.Apply(t.Context(), false))
+
+	applied, err = fakes.Client.CoreV1().Namespaces().Get(t.Context(), "ns-relabel-test", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "new", applied.Labels[applier.NameLabel])
+	assert.Equal(t, checksumBefore, applied.Annotations[applier.ChecksumAnnotation])
+}

--- a/pkg/component/controller/crd.go
+++ b/pkg/component/controller/crd.go
@@ -28,7 +28,7 @@ type CRDStack struct {
 }
 
 type crdOpts struct {
-	stackName, assetsDir string
+	stackName string
 }
 
 type CRDOption func(*crdOpts)
@@ -42,9 +42,8 @@ func NewCRDStack(clients kubernetes.ClientFactoryInterface, leaderElector leader
 		opt(&options)
 	}
 
-	if options.assetsDir == "" {
+	if options.stackName == "" {
 		options.stackName = bundle
-		options.assetsDir = bundle
 	}
 
 	return &CRDStack{
@@ -57,10 +56,6 @@ func NewCRDStack(clients kubernetes.ClientFactoryInterface, leaderElector leader
 
 func WithStackName(stackName string) CRDOption {
 	return func(opts *crdOpts) { opts.stackName = stackName }
-}
-
-func WithCRDAssetsDir(assetsDir string) CRDOption {
-	return func(opts *crdOpts) { opts.assetsDir = assetsDir }
 }
 
 // Init implements [manager.Component]. It does nothing.
@@ -76,7 +71,7 @@ func (c *CRDStack) Start(context.Context) error {
 	go func() {
 		defer close(done)
 		leaderelection.RunLeaderTasks(ctx, c.leaderElector.CurrentStatus, func(ctx context.Context) {
-			resources, err := applier.ReadUnstructuredDir(static.CRDs, c.assetsDir)
+			resources, err := applier.ReadUnstructuredDir(static.CRDs, c.bundle)
 			if err != nil {
 				logrus.WithError(err).Errorf("Failed to read %s CRD stack", c.bundle)
 				return

--- a/pkg/component/controller/crd_test.go
+++ b/pkg/component/controller/crd_test.go
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCRDStack_WithStackName(t *testing.T) {
+	stack := NewCRDStack(nil, nil, "the-bundle-name", WithStackName("the-stack-name"))
+
+	assert.Equal(t, "the-stack-name", stack.stackName, "stack name should be taken from WithStackName")
+}
+
+func TestNewCRDStack_Defaults(t *testing.T) {
+	stack := NewCRDStack(nil, nil, "the-bundle-name")
+
+	assert.Equal(t, "the-bundle-name", stack.stackName, "stack name should default to bundle name")
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

While investigating the `CRD.Start()` code path named in issue #8103, I found that
`NewCRDStack` only defaulted the stack name when `assetsDir` was also empty. Any
caller that supplies `WithStackName` but not `WithCRDAssetsDir` has its explicit
stack name silently overwritten back to the bundle name. The etcd-member CRD stack
hits exactly this case: it's constructed with `WithStackName(EtcdMemberStackName)`
but no `WithCRDAssetsDir`, so it ends up applied and labeled
`k0s.k0sproject.io/stack=etcd` instead of the intended `etcd-member`.

This PR defaults the stack name on its own, independent of `assetsDir`.
`WithCRDAssetsDir`/`assetsDir` has had no callers for a while now; its removal here
is dead-code cleanup, not a consequence of the fix.

Resources already applied under the old, wrong stack name kept their stale label,
since a checksum match alone used to be enough to skip an update. The stack now
compares the stack name too, so a stale label gets corrected through the normal
update/patch path.

The same defaulting bug (introduced in v1.34, before the in-memory CRD stack
landed in v1.35) previously made the filesystem-based CRD component write the
etcd CRD manifest on disk under the wrong, bundle-derived stack name (`etcd`)
instead of `etcd-member`. Clusters that ran one of those versions may still have
that leftover manifest and directory around, which would otherwise compete with
the in-memory etcd-member stack over the same CRD's stack-name label. This PR
also removes that leftover manifest/directory on controller start, before the
applier manager gets a chance to scan the manifests directory.

**This fix is not confirmed to resolve the CRD-wipe symptom reported in #8103.**
The reporter's cluster runs v1.33.13, which predates the defaulting bug itself
(introduced in v1.34) as well as the in-memory CRD-stack mechanism (introduced in
v1.35) — so none of the code paths described above apply to their version, and I
could not reproduce the reported wipe there. This is a genuine, independently
provable bug found while reading the code the issue points at, fixed on its own
merits. Given that, this PR does not close #8103; see #8103 for the original report.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

Updated `TestNewCRDStack_WithStackName` and `TestNewCRDStack_Defaults` in
`pkg/component/controller/crd_test.go` to use testify assertions. Added
`TestStack_StackNameChangeTriggersUpdateWithoutChecksumChange` in
`pkg/applier/stack_test.go`, which verifies a resource whose stack-name label
doesn't match the current stack gets updated even when its checksum is unchanged.

The leftover-manifest cleanup is inlined directly at its call site in
`cmd/controller/controller.go` rather than living in its own function, so it isn't
covered by a dedicated unit test; I verified locally that `os.Remove` on a
non-empty directory returns an error matching `syscall.ENOTEMPTY` via `errors.Is`,
which the non-empty-directory branch relies on.

Also ran:

- `go build ./cmd/controller/... ./pkg/component/controller/... ./pkg/applier/...`
- `go vet ./cmd/controller/... ./pkg/component/controller/... ./pkg/applier/...`
- `go test ./cmd/controller/... ./pkg/component/controller/... ./pkg/applier/...` (no regressions)
- `golangci-lint run ./cmd/controller/... ./pkg/component/controller/... ./pkg/applier/...` (0 issues)
- `gofmt -l` on changed files (clean)

Not run: `make codegen` (no generated files touched by this change) and no live
cluster / e2e reproduction (this is a pure unit-level fix plus a small filesystem
cleanup, not something that requires a live cluster to validate).

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

Relates to #8103
