### PR TITLE
Pin Go minor per release branch in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -239,6 +239,17 @@
       "respectLatest": true
     },
     {
+      "description": "Bump Go for release-1.36",
+      "enabled": true,
+      "matchBaseBranches": [
+        "release-1.36"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "allowedVersions": "<=1.26"
+    },
+    {
       "description": "Bump Kubernetes for release-1.36",
       "enabled": true,
       "matchBaseBranches": [
@@ -305,7 +316,7 @@
       "matchDepNames": [
         "go"
       ],
-      "allowedVersions": "<=1.25"
+      "allowedVersions": "<=1.26"
     },
     {
       "description": "Bump containerd for release-1.35",
@@ -331,6 +342,17 @@
         "**/kube-proxy"
       ],
       "allowedVersions": "/^v?[01]\\.35\\./"
+    },
+    {
+      "description": "Bump Go for release-1.34",
+      "enabled": true,
+      "matchBaseBranches": [
+        "release-1.34"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "allowedVersions": "<=1.26"
     },
     {
       "description": "Bump Alpine for release-1.34",


### PR DESCRIPTION
Renovate only bumped Go on main and release-1.35, so release-1.36, release-1.34 and release-1.33 never got Go PRs and had to be served by manual backports. Add a per-branch rule for each, and align the Go minor with the one upstream Kubernetes builds the matching release with:

 - release-1.36 -> <=1.26
 - release-1.35 -> <=1.26 (was <=1.25)
 - release-1.34 -> <=1.26
 - release-1.33 -> <=1.25

main stays uncapped so it tracks the latest stable Go (1.27 as of now)
