### PR TITLE
Docs: add kernel inotify instance limit guidance

### DIFF
--- a/docs/external-runtime-deps.md
+++ b/docs/external-runtime-deps.md
@@ -179,6 +179,40 @@ to manually add `localhost` entries to the `/etc/hosts` file as shown below:
 [glibc's NSS APIs]: https://www.gnu.org/software/libc/manual/html_node/Name-Service-Switch.html
 [nss-myhostname]: https://www.freedesktop.org/software/systemd/man/latest/nss-myhostname.html
 
+### Kernel Parameters
+
+#### Inotify Instance Limit
+
+[Inotify API](https://www.man7.org/linux/man-pages/man7/inotify.7.html) allows
+applications to monitor filesystem changes.
+
+Workloads that run many pods or watch large numbers of files can exhaust the
+node's default inotify limits, particularly `fs.inotify.max_user_instances`,
+which limits how many inotify instances one user (UID) can have.
+
+A value of at least 1024 is recommended; 8192 is commonly used in Kubernetes
+environments:
+
+```text
+fs.inotify.max_user_instances = 8192
+```
+
+1. Check the current value:
+
+   ```bash
+   cat /proc/sys/fs/inotify/max_user_instances
+   ```
+
+2. To apply the new value persistently, create a `sysctl` configuration file,
+   for example, `/etc/sysctl.d/99-inotify.conf`, and place the parameter
+   setting from above in it.
+
+3. Load the new kernel values:
+
+   ```bash
+   sudo sysctl --system
+   ```
+
 ### External hard dependencies
 
 There are very few external tools that are needed or used.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

Add a section covering fs.inotify.max_user_instances kernel parameter tuning. The default value of 128 on many Linux distributions can be exhausted on nodes running a large number of pods, causing pods to fail with errors.

Fixes #8113

## Type of change
<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x] Documentation update

## How Has This Been Tested?

- [ x] Manual test
- [ ] Auto test added

Applied the new kernel parameter value as documented.  System on ubuntu 26.04.

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
