### PR TITLE
Fix lint findings surfaced by golangci-lint v2.13.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,6 +107,15 @@ linters:
       - linters:
           - staticcheck
         text: '^SA1019:'
+      # Platform stubs, such as users.LookupUID or cleanup.buildSteps, return an
+      # unconditional error on the platforms they don't support. Portable
+      # callers still have to check that error, which trips SA4023 on those
+      # platforms only. Per-site nolint directives aren't an option: they'd be
+      # reported as unused by nolintlint on the platforms where the stub isn't
+      # in use.
+      - linters:
+          - staticcheck
+        text: '^SA4023[:(]'
     paths:
       - zz_*
       - build

--- a/internal/testutil/kube_client.go
+++ b/internal/testutil/kube_client.go
@@ -120,7 +120,7 @@ func makeAPIResourceLists(scheme *runtime.Scheme) (allResources []*metav1.APIRes
 		var resources []metav1.APIResource
 		for kind, ty := range scheme.KnownTypes(gv) {
 			// Skip list kinds themselves.
-			if o, ok := reflect.New(ty).Interface().(runtime.Object); ok && meta.IsListType(o) {
+			if o, ok := reflect.TypeAssert[runtime.Object](reflect.New(ty)); ok && meta.IsListType(o) {
 				continue
 			}
 

--- a/pkg/autopilot/signaling/v2/marshal.go
+++ b/pkg/autopilot/signaling/v2/marshal.go
@@ -25,7 +25,7 @@ func Marshal(m map[string]string, value any) {
 		if value.Kind() == reflect.Struct {
 			Marshal(m, value.Interface())
 		} else {
-			if val, ok := value.Interface().(string); ok {
+			if val, ok := reflect.TypeAssert[string](value); ok {
 				if fieldName, ok := field.Tag.Lookup(TagAutopilot); ok {
 					m[fieldName] = val
 				}

--- a/pkg/kubernetes/watch/watcher_test.go
+++ b/pkg/kubernetes/watch/watcher_test.go
@@ -148,6 +148,7 @@ func TestWatcher(t *testing.T) {
 		t.Parallel()
 		provider, underTest := newTestWatcher()
 		provider.nextList.ResourceVersion = t.Name()
+		//nolint:unparam // signature is dictated by mockProvider.watch
 		provider.watch = func(metav1.ListOptions) error {
 			provider.ch = closedEventChanWith()
 			provider.watch = forbiddenWatch(t)


### PR DESCRIPTION
Preparation for #8144. golangci-lint v2.13.1 pulls in Staticcheck 2026.2 and a newer modernize, which report three things on the current tree. None of them are new bugs, but all three fail the lint job.

modernize/reflecttypeassert flags two reflect type assertions that reflect.TypeAssert expresses directly. That function is available in Go 1.26, so this does not depend on the pending Go 1.27 bump.

unparam flags a func literal in watcher_test.go whose error result is always nil. Its signature is dictated by the mockProvider.watch field rather than chosen, so silence it in place.

SA4023 requires exclusion in linter config. Platform stubs such as `users.LookupUID` and `cleanup.buildSteps` return an unconditional error on the platforms they don't support, and Staticcheck 2026.2 now infers that, so every portable caller checking that error is reported as an always-true comparison: 10 sites on windows, 2 on darwin, none on linux. Per-site nolint directives cannot work here, because on the platforms where the stub is actually implemented the directive is unused and nolintlint fails the build instead. Exclude the check repository-wide instead, alongside the existing SA1019 rule. Note the pattern has to match "SA4023(related information):" as well as "SA4023:", as golangci-lint reports those as separate issues.

Verified with golangci-lint v2.13.1: 0 issues for GOOS=linux, darwin and windows.

