### PR TITLE
[Backport release-1.35] Bump quay.io/k0sproject/pushgateway-ttl Docker tag to v1.4.0-k0s.3

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -72,7 +72,7 @@ const (
 	KonnectivityImage                     = "quay.io/k0sproject/apiserver-network-proxy-agent"
 	KonnectivityImageVersion              = "v0.34.0-k0s.2"
 	PushGatewayImage                      = "quay.io/k0sproject/pushgateway-ttl"
-	PushGatewayImageVersion               = "1.4.0-k0s.0"
+	PushGatewayImageVersion               = "1.4.0-k0s.3"
 	MetricsImage                          = "quay.io/k0sproject/metrics-server"
 	MetricsImageVersion                   = "v0.8.1-0"
 	KubePauseContainerImage               = "quay.io/k0sproject/pause"


### PR DESCRIPTION
Manual backport of #8142  to release-1.36.