### PR TITLE
[Backport release-1.35] Bump quay.io/k0sproject/metrics-server Docker tag to v0.9.0-k0s.1

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -74,7 +74,7 @@ const (
 	PushGatewayImage                      = "quay.io/k0sproject/pushgateway-ttl"
 	PushGatewayImageVersion               = "1.4.0-k0s.0"
 	MetricsImage                          = "quay.io/k0sproject/metrics-server"
-	MetricsImageVersion                   = "v0.8.1-0"
+	MetricsImageVersion                   = "v0.9.0-k0s.1"
 	KubePauseContainerImage               = "quay.io/k0sproject/pause"
 	KubePauseContainerImageVersion        = "3.10.1"
 	KubePauseWindowsContainerImage        = "registry.k8s.io/pause"


### PR DESCRIPTION
Backport #8139 to release 1.35