### PR TITLE
Increase timeout for check-ap-controllerworker to mitigate flakiness

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -73,6 +73,9 @@ check-addons: TIMEOUT=10m
 # Autopilot 3x3 HA test can take a while to run
 check-ap-ha3x3: export K0S_UPDATE_TO_VERSION ?= $(shell ../k0s version)
 
+# check-ap-controllerworker might need to re-download the new bin few times, so give it a bit more time to complete
+check-ap-controllerworker: TIMEOUT=10m
+
 check-ap-updater: .update-server.stamp
 check-ap-updater-periodic: .update-server.stamp
 check-ap-updater-periodic: TIMEOUT=10m


### PR DESCRIPTION

## Description

`check-ap-controllerworker` is quite flaky since couple weeks. There  seems to be several factors contributing to it.

If we look at the logs from failed runs, we see in some cases the download phase is super slow. E.g. in job 96434532650:
```
13:09:38  PDB deleted                  ← PDB already gone
13:09:59  controller0  Downloading
13:11:18  controller0  Cordoning       ← 79 seconds later (no PDB to blame)
13:11:21  controller0  ApplyingUpdate
13:11:37  controller0  Completed
13:11:40  controller1  Downloading
  ↑ deadline fires 21s later at 13:12:01
```

Earlier in #6982 we added a test harness that hammers the plan labels triggering conflicting updates, which we've fixed of course. In turn that means that the AP reconciler might need to re-reconcile, in this case re-download, several times. This explain why in some cases the download phase takes quite a bit of time, even when the download is always from `localhost`.

Based on Copilot looking into several success and failure cases, it _seems_ this started flaking much more around Aug 19th when GH runners was updated to never image ubuntu `20260816.277.1`.  Maybe there's some updates on Docker and other tools that are bit slower on IO. 🤷 

So this PR bumps up the timeout a bit in the hopes de-flaking this test.

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
