### PR TITLE
Remove Go version bump configs for release branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -308,17 +308,6 @@
       "allowedVersions": "<=1.4"
     },
     {
-      "description": "Bump Go for release-1.35",
-      "enabled": true,
-      "matchBaseBranches": [
-        "release-1.35"
-      ],
-      "matchDepNames": [
-        "go"
-      ],
-      "allowedVersions": "<=1.25"
-    },
-    {
       "description": "Bump containerd for release-1.35",
       "enabled": true,
       "matchBaseBranches": [

--- a/renovate.json
+++ b/renovate.json
@@ -316,7 +316,7 @@
       "matchDepNames": [
         "go"
       ],
-      "allowedVersions": "<=1.26"
+      "allowedVersions": "<=1.25"
     },
     {
       "description": "Bump containerd for release-1.35",
@@ -342,17 +342,6 @@
         "**/kube-proxy"
       ],
       "allowedVersions": "/^v?[01]\\.35\\./"
-    },
-    {
-      "description": "Bump Go for release-1.34",
-      "enabled": true,
-      "matchBaseBranches": [
-        "release-1.34"
-      ],
-      "matchDepNames": [
-        "go"
-      ],
-      "allowedVersions": "<=1.26"
     },
     {
       "description": "Bump Alpine for release-1.34",

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
   ],
   "baseBranchPatterns": [
     "main",
-    "/^release-1\\.3[3-6]$/"
+    "/^release-1\\.3[4-6]$/"
   ],
   "prTitleStrict": true,
   "commitMessageAction": "Bump",
@@ -400,42 +400,6 @@
         "opencontainers/runc"
       ],
       "allowedVersions": "<=1.3"
-    },
-    {
-      "description": "Bump etcd for release-1.33",
-      "enabled": true,
-      "matchBaseBranches": [
-        "release-1.33"
-      ],
-      "matchPackageNames": [
-        "go.etcd.io/etcd/**/v3",
-        "etcd-io/etcd"
-      ],
-      "allowedVersions": "<=3.5"
-    },
-    {
-      "description": "Bump Envoy for release-1.33",
-      "enabled": true,
-      "matchBaseBranches": [
-        "release-1.33"
-      ],
-      "matchDepNames": [
-        "quay.io/k0sproject/envoy-distroless"
-      ],
-      "allowedVersions": "<=1.32"
-    },
-    {
-      "description": "Bump Kubernetes for release-1.33",
-      "enabled": true,
-      "matchBaseBranches": [
-        "release-1.33"
-      ],
-      "matchPackageNames": [
-        "k8s.io/**",
-        "**/kubernetes",
-        "**/kube-proxy"
-      ],
-      "allowedVersions": "/^v?[01]\\.33\\./"
     },
     {
       "description": "Disallow Kubernetes digest bumps for release branches",


### PR DESCRIPTION
## Description

This partially reverts #8130 and only keeps the pinned Go version for the release-1.36 branch. All older supported release branches are at the same Go minor version, hence the Go version bumps can be backported. Also remove the settings for the no-longer-supported 1.33 release branch.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
