### PR TITLE
[Backport release-1.35] Remove gold linker for ARM architectures

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,18 +1,11 @@
 ARG BUILDIMAGE
 FROM $BUILDIMAGE
 
-ARG TARGETARCH
 RUN set -ex; \
-# Need to use the gold linker on ARM, Go really wants to have it.
-# https://github.com/golang/go/blob/go1.26.7/src/cmd/link/internal/ld/lib.go#L1678-L1697
-  case "$TARGETARCH" in \
-  arm*) binutils=binutils-gold ;; \
-    *)    binutils=binutils ;; \
-  esac; \
   if [ ! -z "$(which apt)" ]; then \
      apt update && apt install -y make gcc; \
   elif [ ! -z "$(which apk)" ]; then \
-     apk add --no-cache make gcc musl-dev "$binutils"; \
+     apk add --no-cache make gcc musl-dev binutils; \
   else \
      echo "unsupported package manager"; \
      exit 1; \


### PR DESCRIPTION
Backport to `release-1.35`:

* #7734