### PR TITLE
Bump golangci/golangci-lint to v2.13.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,6 +98,9 @@ linters:
         # them as warnings without having a non-zero exit code.
         # https://github.com/golangci/golangci-lint/pull/3184#issuecomment-1235438429
         - '-SA1019'
+        # Re-enable when golangci-lint includes https://github.com/dominikh/go-tools/commit/6cb65e58a558452b52f57cb43267ff9df669a77a.
+        # See https://github.com/dominikh/go-tools/issues/1738 for details.
+        - '-SA4023'
     testifylint:
       enable-all: true
       disable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,6 +91,13 @@ linters:
         # This forbids to name variables "close", which seems natural for "close" functions.
         - name: redefines-builtin-id
           disabled: true
+    staticcheck:
+      checks:
+        # Ignore deprecations: They shouldn't break the CI. If this were the
+        # case, it would be pointless to have them. There's no way in reporting
+        # them as warnings without having a non-zero exit code.
+        # https://github.com/golangci/golangci-lint/pull/3184#issuecomment-1235438429
+        - '-SA1019'
     testifylint:
       enable-all: true
       disable:
@@ -103,10 +110,6 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
-    rules:
-      - linters:
-          - staticcheck
-        text: '^SA1019:'
     paths:
       - zz_*
       - build

--- a/hack/tools/Makefile.variables
+++ b/hack/tools/Makefile.variables
@@ -1,4 +1,4 @@
 # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
 controller-tools_version = 0.21.0
 # renovate: datasource=github-releases depName=golangci/golangci-lint
-golangci-lint_version = 2.12.2
+golangci-lint_version = 2.13.1

--- a/internal/testutil/kube_client.go
+++ b/internal/testutil/kube_client.go
@@ -120,7 +120,7 @@ func makeAPIResourceLists(scheme *runtime.Scheme) (allResources []*metav1.APIRes
 		var resources []metav1.APIResource
 		for kind, ty := range scheme.KnownTypes(gv) {
 			// Skip list kinds themselves.
-			if o, ok := reflect.New(ty).Interface().(runtime.Object); ok && meta.IsListType(o) {
+			if o, ok := reflect.TypeAssert[runtime.Object](reflect.New(ty)); ok && meta.IsListType(o) {
 				continue
 			}
 

--- a/pkg/autopilot/signaling/v2/marshal.go
+++ b/pkg/autopilot/signaling/v2/marshal.go
@@ -25,7 +25,7 @@ func Marshal(m map[string]string, value any) {
 		if value.Kind() == reflect.Struct {
 			Marshal(m, value.Interface())
 		} else {
-			if val, ok := value.Interface().(string); ok {
+			if val, ok := reflect.TypeAssert[string](value); ok {
 				if fieldName, ok := field.Tag.Lookup(TagAutopilot); ok {
 					m[fieldName] = val
 				}

--- a/pkg/kubernetes/watch/watcher_test.go
+++ b/pkg/kubernetes/watch/watcher_test.go
@@ -148,6 +148,7 @@ func TestWatcher(t *testing.T) {
 		t.Parallel()
 		provider, underTest := newTestWatcher()
 		provider.nextList.ResourceVersion = t.Name()
+		//nolint:unparam // signature is dictated by mockProvider.watch
 		provider.watch = func(metav1.ListOptions) error {
 			provider.ch = closedEventChanWith()
 			provider.watch = forbiddenWatch(t)


### PR DESCRIPTION
## Description

Use `reflect.TypeAssert` instead of `v.Interface().(T)`. This is the now-preferred way of doing it and newer modernize linters will warn about this.  Also silence new false positives on the way.

Ignore deprecations directly via staticcheck config instead of matching on the error messages afterwards. Also bring back the comment about the reasoning behind ignoring them which was accidentally removed in #5721.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
