### PR TITLE
Don't use renovate.json as Renovate's global config

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -22,7 +22,6 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@83ec54fee49ab67d9cd201084c1ff325b4b462e4 # v46.1.10
         with:
-          configurationFile: renovate.json
           # Use the same token as the backport workflow. If this token is
           # unavailable, i.e. if the workflow is triggered on a fork, use the
           # stock GitHub Actions token instead ("Allow GitHub Actions to create

--- a/renovate.json
+++ b/renovate.json
@@ -184,7 +184,7 @@
       ],
       "groupName": "konnectivity",
       "groupSlug": "konnectivity",
-      "commitMessageExtra": "{{~#if (includes (lookupArray upgrades \"depName\") \"quay.io/k0sproject/apiserver-network-proxy-agent\")}}{{~#each upgrades}}{{~#if (equals depName \"quay.io/k0sproject/apiserver-network-proxy-agent\")}} to {{{prettyNewVersion}}}{{/if}}{{/each~}}{{~else}}{{~#each (distinct (lookupArray upgrades \"prettyNewVersion\"))}} to {{{.}}}{{/each~}}{{/if~}}"
+      "commitMessageExtra": "{{~#if (includes (lookupArray upgrades \"depName\") \"quay.io/k0sproject/apiserver-network-proxy-agent\")}}{{~#each (distinct (lookupArray upgrades \"prettyNewVersion\"))}}{{~#if (containsString . \"-\")}} to {{{.}}}{{/if}}{{/each~}}{{~else}}{{~#each (distinct (lookupArray upgrades \"prettyNewVersion\"))}} to {{{.}}}{{/each~}}{{/if~}}"
     },
     {
       "description": "Group all Helm bumps",


### PR DESCRIPTION
## Description

The Renovate workflow used the repository's `renovate.json` file as the self-hosted global configuration file. Renovate also reads this file as a repository configuration and merges it into the global configuration, which caused the file to be merged with itself, i.e. mergeable lists were concatenated with themselves. This resulted in some strange, subtle behavior, like duplicated Signed-off-by trailers, amongst others.

Nothing in `renovate.json` is a global-only option, so stop passing it as the global config and let Renovate pick it up as repository config only. The repository list and allowed commands are already provided via the environment.


The konnectivity group iterated over the individual upgrades to render the k0sproject image's version. Whenever the branch carried the same upgrade twice (e.g. because of the duplicated processing of `renovate.json`), the version got duplicated.

Iterate over the distinct version strings and prefer the hyphenated k0s image version. That's basically the same approach taken with the Calico and Traefik groups in #8008.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
