### PR TITLE
[Backport release-1.34] Bump go to v1.26.7

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM $BUILDIMAGE
 ARG TARGETARCH
 RUN set -ex; \
 # Need to use the gold linker on ARM, Go really wants to have it.
-# https://github.com/golang/go/blob/go1.25.12/src/cmd/link/internal/ld/lib.go#L1678-L1697
+# https://github.com/golang/go/blob/go1.26.7/src/cmd/link/internal/ld/lib.go#L1678-L1697
   case "$TARGETARCH" in \
   arm*) binutils=binutils-gold ;; \
     *)    binutils=binutils ;; \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,18 +1,11 @@
 ARG BUILDIMAGE
 FROM $BUILDIMAGE
 
-ARG TARGETARCH
 RUN set -ex; \
-# Need to use the gold linker on ARM, Go really wants to have it.
-# https://github.com/golang/go/blob/go1.26.7/src/cmd/link/internal/ld/lib.go#L1678-L1697
-  case "$TARGETARCH" in \
-  arm*) binutils=binutils-gold ;; \
-    *)    binutils=binutils ;; \
-  esac; \
   if [ ! -z "$(which apt)" ]; then \
      apt update && apt install -y make gcc; \
   elif [ ! -z "$(which apk)" ]; then \
-     apk add --no-cache make gcc musl-dev "$binutils"; \
+     apk add --no-cache make gcc musl-dev binutils; \
   else \
      echo "unsupported package manager"; \
      exit 1; \

--- a/embedded-bins/Makefile.variables
+++ b/embedded-bins/Makefile.variables
@@ -3,7 +3,7 @@ alpine_patch_version = 3.23.5
 alpine_version = $(word 1,$(subst ., ,$(alpine_patch_version))).$(word 2,$(subst ., ,$(alpine_patch_version)))
 
 # renovate: datasource=golang-version depName=go
-go_version = 1.25.12
+go_version = 1.26.7
 golang_buildimage=docker.io/library/golang:$(go_version)-alpine$(alpine_version)
 
 # renovate: datasource=github-releases depName=opencontainers/runc

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k0sproject/k0s
 
-go 1.25.0
+go 1.26.0
 
 // k0s
 require (

--- a/internal/pkg/file/atomic_test.go
+++ b/internal/pkg/file/atomic_test.go
@@ -215,7 +215,7 @@ func TestWriteAtomically(t *testing.T) {
 			)
 			assert.Equal(t, file, linkErr.New)
 			if runtime.GOOS == "windows" {
-				// https://github.com/golang/go/blob/go1.25.12/src/syscall/types_windows.go#L13
+				// https://github.com/golang/go/blob/go1.26.7/src/syscall/types_windows.go#L13
 				//revive:disable-next-line:var-naming
 				const ERROR_ACCESS_DENIED syscall.Errno = 5
 				var errno syscall.Errno


### PR DESCRIPTION
Backport to `release-1.34`:

* #8124
* #8165

See:

* #7734