### PR TITLE
[Backport release-1.35] Bump quay.io/k0sproject/coredns Docker tag to v1.14.7-k0s.0

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -84,7 +84,7 @@ const (
 	KubeProxyWindowsImage                 = "docker.io/sigwindowstools/kube-proxy"
 	KubeProxyWindowsImageVersion          = "v1.35.8-calico-hostprocess"
 	CoreDNSImage                          = "quay.io/k0sproject/coredns"
-	CoreDNSImageVersion                   = "1.14.2-0"
+	CoreDNSImageVersion                   = "1.14.7-k0s.0"
 	EnvoyProxyImage                       = "quay.io/k0sproject/envoy-distroless"
 	EnvoyProxyImageVersion                = "v1.37.2"
 	CalicoCNIImage                        = "quay.io/k0sproject/calico-cni"


### PR DESCRIPTION
backport of #8174 to release-1.35.