### PR TITLE
Include patch version in minor Go bumps by Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,13 @@
       ]
     },
     {
+      "description": "Include patch version in minor Go bumps",
+      "matchDepNames": [
+        "go"
+      ],
+      "commitMessageExtra": "{{~#if (containsString (replace '\\d+\\.\\d+\\.\\d+' 'x.y.z' (toJSON (distinct (lookupArray upgrades 'prettyNewVersion')))) 'x.y.z')}}{{~#each (distinct (lookupArray upgrades 'prettyNewVersion'))}}{{~#if (containsString (replace '\\d+\\.\\d+\\.\\d+' 'x.y.z' .) 'x.y.z')}} to {{{.}}}{{/if}}{{/each~}}{{~else}}{{~#each (distinct (lookupArray upgrades 'prettyNewVersion'))}} to {{{.}}}{{/each~}}{{/if~}}"
+    },
+    {
       "description": "Special version scheme for k0sproject OCI images",
       "matchPackageNames": [
         "quay.io/k0sproject/*",


### PR DESCRIPTION
## Description

A minor Go bump touches the toolchain version and the go.mod minimum version, which is tracked as major.minor only. As the two update versions differ, Renovate drops the version from bump messages altogether.

Add a bespoke commitMessageExtra that lists the distinct new versions, but only selects those with a patch component, i.e. the toolchain version. If none of them has a patch component, list them all instead, so that the message never ends up without a version.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
