### PR TITLE
Disable go modernize's embedlit lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,6 +86,11 @@ linters:
         SPDX-License-Identifier: Apache-2.0
     misspell:
       locale: US
+    modernize:
+      disable:
+        # A Go 1.27 feature that affects the whole codebase.
+        # Unclear whether it's a good idea for k0s to enforce this.
+        - embedlit
     revive:
       rules:
         # This forbids to name variables "close", which seems natural for "close" functions.


### PR DESCRIPTION
## Description

It's a Go 1.27 feature that affects the whole codebase, and it's really unclear whether it's a good idea for k0s to enforce this. It will make struct literals look very different, especially Kubernetes resources.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
