### PR TITLE
Merge the k0s and Kubernetes sections in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/k0sproject/k0s
 
 go 1.26.3
 
-// k0s
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/Masterminds/semver/v3 v3.5.0
@@ -62,14 +61,6 @@ require (
 	golang.org/x/tools v0.49.0
 	google.golang.org/grpc v1.83.1
 	helm.sh/helm/v3 v3.21.3
-	modernc.org/sqlite v1.57.0
-	oras.land/oras-go/v2 v2.6.2
-	sigs.k8s.io/controller-runtime v0.24.1
-	sigs.k8s.io/yaml v1.6.0
-)
-
-// Kubernetes
-require (
 	k8s.io/api v0.37.0-alpha.3
 	k8s.io/apiextensions-apiserver v0.37.0-alpha.3
 	k8s.io/apimachinery v0.37.0-alpha.3
@@ -88,6 +79,10 @@ require (
 	k8s.io/kubernetes v1.37.0-alpha.3
 	k8s.io/mount-utils v0.37.0-alpha.3
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd
+	modernc.org/sqlite v1.57.0
+	oras.land/oras-go/v2 v2.6.2
+	sigs.k8s.io/controller-runtime v0.24.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (


### PR DESCRIPTION
## Description

Go 1.27 no longer likes having more than one block for direct and one for indirect dependencies anymore, because Go always knows what's best for all the Go projects ¯\\\_(ツ)_/¯

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
