### PR TITLE
[release-1.36] Bump Traefik to v3.7.12-k0s.0

### DIFF
--- a/docs/compose-cluster.yaml
+++ b/docs/compose-cluster.yaml
@@ -61,7 +61,7 @@ networks:
 
 services:
   k0s-lb:
-    image: docker.io/library/traefik:v3.7.7
+    image: docker.io/library/traefik:v3.7.12
     container_name: k0s-lb
     hostname: k0s-lb
     networks:

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -88,7 +88,7 @@ const (
 	EnvoyProxyImage                       = "quay.io/k0sproject/envoy-distroless"
 	EnvoyProxyImageVersion                = "v1.39.0"
 	TraefikImage                          = "quay.io/k0sproject/traefik"
-	TraefikImageVersion                   = "v3.7.11-k0s.0"
+	TraefikImageVersion                   = "v3.7.12-k0s.0"
 	CalicoCNIImage                        = "quay.io/k0sproject/calico-cni"
 	CalicoCNIImageVersion                 = "v3.32.1-3"
 	CalicoCNIWindowsImage                 = "docker.io/calico/cni-windows"


### PR DESCRIPTION
Backport to `release-1.36`:

* #8184