### PR TITLE
Correct the supported version skew

### DIFF
--- a/docs/version-skew-policy.md
+++ b/docs/version-skew-policy.md
@@ -17,19 +17,24 @@ upgrade.
 
 ## Supported skew
 
-k0s follows the upstream Kubernetes
-[version skew policy](https://kubernetes.io/releases/version-skew-policy/).
-In practice, that means:
+k0s is designed and tested for clusters in which all nodes run either the same
+minor version or two adjacent ones, as happens during a rolling upgrade. In
+practice, that means:
 
-- **Control plane components** (kube-apiserver, kube-controller-manager,
-  kube-scheduler) must all be within **one minor** of each other in a
-  multi-controller cluster.
-- **kubelet** on a worker may be **up to three minors older** than the
-  oldest kube-apiserver in the cluster, but **must never be newer**.
-- **kube-proxy** on a worker must match the kubelet's minor version.
+- **Controllers** must all be within **one minor** of each other.
+- **Workers** may be **one minor older** than the controllers, but **must never
+  be newer**. This only applies to cluster upgrades. When **bootstrapping a new
+  cluster**, workers must run the **same minor** as the controllers.
 
-Patch-version differences inside the same minor are always supported and
-are the expected state during a phased upgrade.
+Patch-version differences inside the same minor are always supported and are the
+expected state during a phased upgrade.
+
+Note that the upstream Kubernetes [version skew policy] permits wider skews,
+such as kubelets up to three minors older than the API server. k0s doesn't
+support those. Each k0s version is only expected to interoperate with the
+previous one, and upgrades proceed one minor at a time.
+
+[version skew policy]: https://kubernetes.io/releases/version-skew-policy/
 
 ## Upgrades
 
@@ -38,12 +43,16 @@ When upgrading k0s in place:
 1. Upgrade controllers first, **one minor at a time** (e.g. v1.30 → v1.31,
    not v1.30 → v1.32).
 2. Upgrade workers after the control plane is fully on the new minor.
-3. Stay on the latest patch release of the old minor before stepping up to
-   the next minor.
+3. Consider moving to the latest patch release of the old minor first. This
+   isn't required, but it takes the old minor's latest fixes along into the
+   upgrade.
 
-[Autopilot](autopilot.md) automates this with multi-step plans; if you
-upgrade manually or via [k0sctl](k0sctl-install.md), make the same staging
-explicit in your plan.
+[Autopilot], [k0sctl], and [k0smotron] all upgrade controllers before workers.
+When upgrading manually, keep to the same order.
+
+[Autopilot]: autopilot.md
+[k0sctl]: k0sctl-install.md
+[k0smotron]: https://github.com/k0sproject/k0smotron
 
 ## Downgrades
 


### PR DESCRIPTION
## Description

The version skew policy simply stated that k0s follows the upstream Kubernetes policy. That's not how k0s is designed: each k0s version is only expected to interoperate with the previous one. Controllers must be within one minor of each other, and workers may be at most one minor older than the controllers.

State that rule directly and point out that the wider skews permitted by upstream aren't supported. Also, updating to the latest patch release is considered best practice, but not necessarily a requirement.

Fixes:
* #7540

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
