### PR TITLE
fix(calico): add missing CRDs, RBAC rules and fix controller config for v3.29/v3.32 mismatch

### DIFF
--- a/static/manifests/calico/ClusterRole/calico-kube-controllers.yaml
+++ b/static/manifests/calico/ClusterRole/calico-kube-controllers.yaml
@@ -41,6 +41,23 @@ rules:
       - list
       - update
       - watch
+  # ServiceAccounts are listed by the namespace controller for
+  # serviceaccount-based namespace isolation.
+  - apiGroups: [""]
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+  # Kubernetes NetworkPolicies are watched by the policy controller.
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
   # IPAM resources are manipulated in response to node and block updates, as well as periodic triggers.
   - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
     resources:

--- a/static/manifests/calico/ClusterRole/calico-node.yaml
+++ b/static/manifests/calico/ClusterRole/calico-node.yaml
@@ -62,10 +62,13 @@ rules:
     verbs:
       - watch
       - list
-  # Watch for changes to Kubernetes ClusterNetworkPolicies.
+  # Watch for changes to Kubernetes ClusterNetworkPolicies,
+  # AdminNetworkPolicies and BaselineAdminNetworkPolicies.
   - apiGroups: ["policy.networking.k8s.io"]
     resources:
       - clusternetworkpolicies
+      - adminnetworkpolicies
+      - baselineadminnetworkpolicies
     verbs:
       - watch
       - list

--- a/static/manifests/calico/CustomResourceDefinition/adminnetworkpolicies.policy.networking.k8s.io.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/adminnetworkpolicies.policy.networking.k8s.io.yaml
@@ -1,0 +1,34 @@
+---
+# AdminNetworkPolicy CRD required by Calico v3.29+ felix.
+# The bundled chart template (v3.32.1) configures felix to watch these
+# resources, but the CRDs were not included in the k0s static manifests.
+# See: https://github.com/kubernetes/enhancements/pull/2096
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: adminnetworkpolicies.policy.networking.k8s.io
+  annotations:
+    api-approved.kubernetes.io: "https://github.com/kubernetes/enhancements/pull/2096"
+spec:
+  group: policy.networking.k8s.io
+  scope: Cluster
+  names:
+    kind: AdminNetworkPolicy
+    plural: adminnetworkpolicies
+    singular: adminnetworkpolicy
+    shortNames:
+      - anp
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/static/manifests/calico/CustomResourceDefinition/baselineadminnetworkpolicies.policy.networking.k8s.io.yaml
+++ b/static/manifests/calico/CustomResourceDefinition/baselineadminnetworkpolicies.policy.networking.k8s.io.yaml
@@ -1,0 +1,34 @@
+---
+# BaselineAdminNetworkPolicy CRD required by Calico v3.29+ felix.
+# The bundled chart template (v3.32.1) configures felix to watch these
+# resources, but the CRDs were not included in the k0s static manifests.
+# See: https://github.com/kubernetes/enhancements/pull/2096
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: baselineadminnetworkpolicies.policy.networking.k8s.io
+  annotations:
+    api-approved.kubernetes.io: "https://github.com/kubernetes/enhancements/pull/2096"
+spec:
+  group: policy.networking.k8s.io
+  scope: Cluster
+  names:
+    kind: BaselineAdminNetworkPolicy
+    plural: baselineadminnetworkpolicies
+    singular: baselineadminnetworkpolicy
+    shortNames:
+      - banp
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/static/manifests/calico/Deployment/calico-kube-controllers.yaml
+++ b/static/manifests/calico/Deployment/calico-kube-controllers.yaml
@@ -41,8 +41,11 @@ spec:
           imagePullPolicy: {{ .PullPolicy }}
           env:
             # Choose which controllers to run.
+            # "loadbalancer" is not supported by the v3.29.x kube-controllers
+            # image. Only enable controllers that are supported by the
+            # deployed image version.
             - name: ENABLED_CONTROLLERS
-              value: node,loadbalancer
+              value: node,policy,profile,workloadendpoint
             - name: DATASTORE_TYPE
               value: kubernetes
           livenessProbe:


### PR DESCRIPTION
## Problem

k0s v1.36.3 bundles a **Calico chart template from v3.32.1** but deploys **Calico v3.29.3 images**. This version mismatch causes three issues:

### 1. Missing adminnetworkpolicies CRDs
The v3.32.1 felix configuration watches `adminnetworkpolicies` and `baselineadminnetworkpolicies` resources (API group `policy.networking.k8s.io`), but these CRDs are not included in the k0s static manifests (`static/manifests/calico/CustomResourceDefinition/`). Felix repeatedly fails to list these resources and never becomes ready.

**Error in calico-node logs:**
```
error=resource does not exist: KubernetesAdminNetworkPolicy with error: the server could not find the requested resource (get adminnetworkpolicies.policy.networking.k8s.io)
```

### 2. Missing RBAC for calico-kube-controllers
The `calico-kube-controllers` ClusterRole (from the v3.32.1 template) is missing permissions that the controller code requires:
- `serviceaccounts` (core API group) — needed by the namespace controller
- `networkpolicies` (`networking.k8s.io` API group) — needed by the policy controller

**Errors in calico-kube-controllers logs:**
```
serviceaccounts is forbidden: User "system:serviceaccount:kube-system:calico-kube-controllers" cannot list resource "serviceaccounts" in API group "" at the cluster scope
networkpolicies.networking.k8s.io is forbidden: User "system:serviceaccount:kube-system:calico-kube-controllers" cannot list resource "networkpolicies" in API group "networking.k8s.io" at the cluster scope
```

### 3. Invalid loadbalancer controller
The deployment sets `ENABLED_CONTROLLERS=node,loadbalancer` (from v3.32.1 template), but the v3.29.3 `kube-controllers` binary does not support the `loadbalancer` controller, causing a FATAL crash.

**Error:**
```
FATAL: Invalid controller 'loadbalancer' provided.
```

## Fix

This PR addresses all three issues in the static manifest files:

1. **Add CRD manifests** for `adminnetworkpolicies` and `baselineadminnetworkpolicies` in `static/manifests/calico/CustomResourceDefinition/`

2. **Add missing RBAC rules** to `calico-kube-controllers` ClusterRole:
   - `serviceaccounts` (get, list, watch)
   - `networkpolicies` in `networking.k8s.io` (get, list, watch)

3. **Add missing RBAC rules** to `calico-node` ClusterRole:
   - `adminnetworkpolicies` and `baselineadminnetworkpolicies` in `policy.networking.k8s.io` (watch, list)

4. **Fix ENABLED_CONTROLLERS** from `node,loadbalancer` to `node,policy,profile,workloadendpoint` (only enable controllers supported by v3.29.x)

## Testing

Verified on a 2-node k0s v1.36.3+k0s.2 cluster with Calico VXLAN CNI:
- All calico-node pods become 1/1 Ready (felix ready)
- calico-kube-controllers runs without RBAC errors
- No FATAL crashes from invalid controller

Closes #8199