### PR TITLE
Thread a real context through component readiness checks

### DIFF
--- a/pkg/component/controller/apiserver.go
+++ b/pkg/component/controller/apiserver.go
@@ -286,7 +286,7 @@ func (a *APIServer) Stop() error {
 }
 
 // Health-check interface
-func (a *APIServer) Ready() error {
+func (a *APIServer) Ready(ctx context.Context) error {
 	// Load client cert so the api can authenticate the request.
 	certFile := filepath.Join(a.K0sVars.CertRootDir, "admin.crt")
 	keyFile := filepath.Join(a.K0sVars.CertRootDir, "admin.key")
@@ -311,7 +311,11 @@ func (a *APIServer) Ready() error {
 	}
 	client := &http.Client{Transport: tr}
 	apiAddress := net.JoinHostPort(a.NodeConfig.Spec.API.Address, strconv.Itoa(a.NodeConfig.Spec.API.Port))
-	resp, err := client.Get(fmt.Sprintf("https://%s/readyz?verbose", apiAddress))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://%s/readyz?verbose", apiAddress), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/pkg/component/controller/etcd.go
+++ b/pkg/component/controller/etcd.go
@@ -512,9 +512,9 @@ func (e *Etcd) setupCerts(ctx context.Context) error {
 }
 
 // Health-check interface
-func (e *Etcd) Ready() error {
+func (e *Etcd) Ready(ctx context.Context) error {
 	logrus.WithField("component", "etcd").Debug("checking etcd endpoint for health")
-	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 	err := etcd.CheckEtcdReady(ctx, e.K0sVars.CertRootDir, e.K0sVars.EtcdCertDir, e.Config)
 	return err

--- a/pkg/component/controller/kine.go
+++ b/pkg/component/controller/kine.go
@@ -147,8 +147,8 @@ func (k *Kine) Stop() error {
 const hcKey = "/k0s-health-check"
 const hcValue = "value"
 
-func (k *Kine) Ready() error {
-	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+func (k *Kine) Ready(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 
 	ok, err := k.bypassClient.Write(ctx, hcKey, hcValue, 64*time.Second)

--- a/pkg/component/controller/konnectivity.go
+++ b/pkg/component/controller/konnectivity.go
@@ -194,8 +194,8 @@ func (k *Konnectivity) runServer(ctx context.Context, count uint) error {
 }
 
 // Ready implements manager.Ready.
-func (k *Konnectivity) Ready() error {
-	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
+func (k *Konnectivity) Ready(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	// This is somehow flipped: Check healthz instead of readyz.
 	return k.health(ctx, "/healthz")

--- a/pkg/component/manager/component.go
+++ b/pkg/component/manager/component.go
@@ -41,7 +41,9 @@ type Component interface {
 
 type Ready interface {
 	// Ready performs a ready check and indicates that a component is ready to run.
-	Ready() error
+	// The given context may be used to bound and cancel the readiness check; it is
+	// derived from the context passed to the manager's Start method.
+	Ready(context.Context) error
 }
 
 // Reconciler defines the component interface that is reconciled based

--- a/pkg/component/manager/manager.go
+++ b/pkg/component/manager/manager.go
@@ -186,10 +186,11 @@ func waitForReady(ctx context.Context, comp Component, name string, timeout time
 
 	// loop forever, until the context is canceled or until etcd is healthy
 	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
 	l := logrus.WithField("component", name)
 	for {
 		l.Debugf("waiting for component readiness")
-		if err := compWithReady.Ready(); err != nil {
+		if err := compWithReady.Ready(ctx); err != nil {
 			l.WithError(err).Debugf("component not ready yet")
 		} else {
 			return nil

--- a/pkg/component/manager/manager_test.go
+++ b/pkg/component/manager/manager_test.go
@@ -39,7 +39,7 @@ func (f *Fake) Stop() error {
 	f.StopCalled = true
 	return f.StopErr
 }
-func (f *Fake) Ready() error {
+func (f *Fake) Ready(_ context.Context) error {
 	f.HealthyCalled = true
 	return f.HealthyErr
 }

--- a/pkg/component/worker/nllb/reconciler.go
+++ b/pkg/component/worker/nllb/reconciler.go
@@ -229,7 +229,7 @@ func (r *Reconciler) Start(ctx context.Context) error {
 	return nil
 }
 
-func (r *Reconciler) Ready() error {
+func (r *Reconciler) Ready(_ context.Context) error {
 	if err := func() error {
 		r.mu.Lock()
 		defer r.mu.Unlock()

--- a/pkg/component/worker/nllb/reconciler_test.go
+++ b/pkg/component/worker/nllb/reconciler_test.go
@@ -94,7 +94,7 @@ func TestReconciler_Lifecycle(t *testing.T) {
 		t.Run("ready_fails", func(t *testing.T) {
 			underTest := createdReconciler(t)
 
-			err := underTest.Ready()
+			err := underTest.Ready(t.Context())
 
 			require.Error(t, err)
 			assert.Equal(t, "cannot check for readiness, not started: created", err.Error())
@@ -164,7 +164,7 @@ func TestReconciler_Lifecycle(t *testing.T) {
 		t.Run("ready_fails", func(t *testing.T) {
 			underTest := initializedReconciler(t)
 
-			err := underTest.Ready()
+			err := underTest.Ready(t.Context())
 
 			require.Error(t, err)
 			assert.Equal(t, "cannot check for readiness, not started: initialized", err.Error())
@@ -233,7 +233,7 @@ func TestReconciler_Lifecycle(t *testing.T) {
 		t.Run("ready_succeeds", func(t *testing.T) {
 			underTest, _ := startedReconciler(t)
 
-			err := underTest.Ready()
+			err := underTest.Ready(t.Context())
 
 			assert.NoError(t, err)
 		})

--- a/pkg/component/worker/static_pods.go
+++ b/pkg/component/worker/static_pods.go
@@ -480,7 +480,7 @@ func (s *staticPods) Stop() error {
 }
 
 // Health-check interface
-func (s *staticPods) Ready() error {
+func (s *staticPods) Ready(ctx context.Context) error {
 	url, err := s.ManifestURL()
 	if err != nil {
 		return err
@@ -490,7 +490,7 @@ func (s *staticPods) Ready() error {
 	client := http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
 	defer client.CloseIdleConnections()
 
-	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.JoinPath("_healthz").String(), nil)

--- a/pkg/component/worker/static_pods_test.go
+++ b/pkg/component/worker/static_pods_test.go
@@ -182,7 +182,7 @@ func TestStaticPods_Lifecycle(t *testing.T) {
 	})
 
 	t.Run("health_check_fails_without_init", func(t *testing.T) {
-		err := underTest.Ready()
+		err := underTest.Ready(t.Context())
 		require.Error(t, err)
 		require.Equal(t, "static_pods component is not yet running", err.Error())
 	})
@@ -211,7 +211,7 @@ func TestStaticPods_Lifecycle(t *testing.T) {
 	})
 
 	t.Run("health_check_fails_before_run", func(t *testing.T) {
-		err := underTest.Ready()
+		err := underTest.Ready(t.Context())
 		require.Error(t, err)
 		require.Equal(t, "static_pods component is not yet running", err.Error())
 	})
@@ -247,7 +247,7 @@ func TestStaticPods_Lifecycle(t *testing.T) {
 	})
 
 	t.Run("health_check_works", func(t *testing.T) {
-		err := underTest.Ready()
+		err := underTest.Ready(t.Context())
 		assert.NoError(t, err)
 		lastLog := logs.LastEntry()
 		require.Equal(t, "Answering health check", lastLog.Message)
@@ -298,7 +298,7 @@ func TestStaticPods_Lifecycle(t *testing.T) {
 			expectedErrMsg = "No connection could be made because the target machine actively refused it."
 		}
 
-		err := underTest.Ready()
+		err := underTest.Ready(t.Context())
 		require.ErrorContains(t, err, expectedErrMsg)
 	})
 


### PR DESCRIPTION
The `Ready` interface's `Ready()` method used `context.TODO()` internally in each implementation, so per-attempt timeouts and manager cancellation never reached an in-flight readiness probe. `Ready` now takes a `context.Context`, matching `Init`/`Start`/`Reconcile`, and every implementation (etcd, kine, apiserver, konnectivity, static_pods, nllb reconciler) threads the context the manager already has through to its probe.