### PR TITLE
Do not prune a stack when its manifest directory is empty

### DIFF
--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -62,6 +62,7 @@ smoketests := \
 	check-kubeletcertrotate \
 	check-kuberouter \
 	check-kuberouter-ipv6 \
+	check-manifestrestart \
 	check-metrics \
 	check-metricsscraper \
 	check-metricsscraper-singlenode \

--- a/inttest/manifestrestart/manifestrestart_test.go
+++ b/inttest/manifestrestart/manifestrestart_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package manifestrestart
+
+import (
+	"context"
+	"testing"
+
+	"github.com/k0sproject/k0s/inttest/common"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ManifestRestartSuite struct {
+	common.BootlooseSuite
+}
+
+// TestManifestDirNotPruned verifies that losing the local manifest directory
+// does not cause previously applied resources to be pruned.
+func (s *ManifestRestartSuite) TestManifestDirNotPruned() {
+	ctx := s.Context()
+
+	s.Require().NoError(s.InitController(0, "--enable-dynamic-config"))
+	s.Require().NoError(s.RunWorkers())
+
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+
+	for i := range s.WorkerCount {
+		s.Require().NoError(s.WaitForNodeReady(s.WorkerNode(i), kc))
+	}
+
+	s.Require().NoError(common.WaitForCoreDNSReady(ctx, kc))
+	s.Require().NoError(common.WaitForDeployment(ctx, kc, "metrics-server", metav1.NamespaceSystem))
+
+	coreDNSUID := s.deploymentUID(ctx, kc, "coredns")
+	metricsServerUID := s.deploymentUID(ctx, kc, "metrics-server")
+
+	s.Require().NoError(s.StopController(s.ControllerNode(0)))
+
+	ssh, err := s.SSH(ctx, s.ControllerNode(0))
+	s.Require().NoError(err)
+	defer ssh.Disconnect()
+	_, err = ssh.ExecWithOutput(ctx, "rm -rf /var/lib/k0s/manifests")
+	s.Require().NoError(err)
+
+	s.Require().NoError(s.StartController(s.ControllerNode(0)))
+	s.Require().NoError(s.WaitForKubeAPI(s.ControllerNode(0)))
+
+	s.Require().NoError(common.WaitForCoreDNSReady(ctx, kc))
+	s.Require().NoError(common.WaitForDeployment(ctx, kc, "metrics-server", metav1.NamespaceSystem))
+
+	s.Equal(coreDNSUID, s.deploymentUID(ctx, kc, "coredns"), "coredns Deployment must not have been deleted and re-created")
+	s.Equal(metricsServerUID, s.deploymentUID(ctx, kc, "metrics-server"), "metrics-server Deployment must not have been deleted and re-created")
+}
+
+func (s *ManifestRestartSuite) deploymentUID(ctx context.Context, kc kubernetes.Interface, name string) types.UID {
+	d, err := kc.AppsV1().Deployments(metav1.NamespaceSystem).Get(ctx, name, metav1.GetOptions{})
+	s.Require().NoError(err)
+	return d.UID
+}
+
+func TestManifestRestartSuite(t *testing.T) {
+	s := ManifestRestartSuite{
+		common.BootlooseSuite{
+			ControllerCount: 1,
+			WorkerCount:     1,
+		},
+	}
+	suite.Run(t, &s)
+}

--- a/pkg/component/controller/calico.go
+++ b/pkg/component/controller/calico.go
@@ -6,7 +6,6 @@ package controller
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
 	"path"
@@ -127,10 +126,7 @@ func NewCalico(nodeConfig *v1beta1.ClusterConfig, manifestsDir string, hasWindow
 
 // Init implements [manager.Component].
 func (c *Calico) Init(context.Context) error {
-	return errors.Join(
-		dir.Init(filepath.Join(c.manifestsDir, "calico_init"), constant.ManifestsDirMode),
-		dir.Init(filepath.Join(c.manifestsDir, "calico"), constant.ManifestsDirMode),
-	)
+	return nil
 }
 
 // Start implements [manager.Component].
@@ -207,6 +203,10 @@ func (c *Calico) Start(context.Context) error {
 func (c *Calico) dumpCRDs(patches v1beta1.Patches) error {
 	var emptyStruct struct{}
 
+	if err := dir.Init(filepath.Join(c.manifestsDir, "calico_init"), constant.ManifestsDirMode); err != nil {
+		return err
+	}
+
 	// Write the CRD definitions only at "boot", they do not change during runtime
 	crds, err := fs.ReadDir(static.CalicoManifests, "CustomResourceDefinition")
 	if err != nil {
@@ -245,6 +245,10 @@ func (c *Calico) dumpCRDs(patches v1beta1.Patches) error {
 }
 
 func (c *Calico) processConfigChanges(newConfig *calicoConfig, patches v1beta1.Patches) error {
+	if err := dir.Init(filepath.Join(c.manifestsDir, "calico"), constant.ManifestsDirMode); err != nil {
+		return err
+	}
+
 	manifestDirectories, err := fs.ReadDir(static.CalicoManifests, ".")
 	if err != nil {
 		return fmt.Errorf("error retrieving calico manifests: %w, will retry", err)

--- a/pkg/component/controller/calico_test.go
+++ b/pkg/component/controller/calico_test.go
@@ -44,9 +44,10 @@ func TestCalicoManifests(t *testing.T) {
 				assert.NotContains(t, entry.Name(), "calico-crd")
 			}
 		}
-		if entries, err := os.ReadDir(filepath.Join(calico.manifestsDir, "calico_init")); assert.NoError(t, err) {
-			assert.Empty(t, entries)
-		}
+		// calico_init is only created lazily, right before the CRDs are
+		// dumped into it, so it must not exist yet.
+		_, err := os.Stat(filepath.Join(calico.manifestsDir, "calico_init"))
+		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
 
 	t.Run("must_have_wireguard_enabled_if_config_has", func(t *testing.T) {

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -21,6 +22,7 @@ import (
 	"k8s.io/client-go/metadata"
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
+	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
@@ -319,7 +321,7 @@ func NewCoreDNS(k0sVars *config.CfgVars, clientFactory k8sutil.ClientFactoryInte
 
 // Init does nothing
 func (c *CoreDNS) Init(_ context.Context) error {
-	return dir.Init(c.manifestDir, constant.ManifestsDirMode)
+	return nil
 }
 
 // Run runs the CoreDNS reconciler component
@@ -438,11 +440,16 @@ func (c *CoreDNS) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterC
 		Name:     "coredns",
 		Template: coreDNSTemplate,
 		Data:     cfg,
-		Path:     filepath.Join(c.manifestDir, "coredns.yaml"),
 		Patches:  patches,
 	}
-	err = tw.Write()
-	if err != nil {
+	var manifest bytes.Buffer
+	if err := tw.WriteToBuffer(&manifest); err != nil {
+		return fmt.Errorf("error rendering coredns manifests: %w, will retry", err)
+	}
+	if err := dir.Init(c.manifestDir, constant.ManifestsDirMode); err != nil {
+		return err
+	}
+	if err := file.WriteContentAtomically(filepath.Join(c.manifestDir, "coredns.yaml"), manifest.Bytes(), constant.CertMode); err != nil {
 		return fmt.Errorf("error writing coredns manifests: %w, will retry", err)
 	}
 	c.previousConfig = cfg

--- a/pkg/component/controller/kubeproxy.go
+++ b/pkg/component/controller/kubeproxy.go
@@ -4,7 +4,7 @@
 package controller
 
 import (
-	"bufio"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
@@ -69,7 +69,7 @@ func NewKubeProxy(k0sVars *config.CfgVars, nodeConfig *v1beta1.ClusterConfig, ha
 }
 
 func (k *KubeProxy) Init(context.Context) error {
-	return dir.Init(k.manifestDir, constant.ManifestsDirMode)
+	return nil
 }
 
 func (k *KubeProxy) Start(context.Context) error {
@@ -161,56 +161,57 @@ func (k *KubeProxy) Stop() error {
 }
 
 func (k *KubeProxy) updateManifests(cfg *proxyConfig, includeWindows bool) error {
-	return file.AtomicWithTarget(filepath.Join(k.manifestDir, "kube-proxy.yaml")).
-		Do(func(unbuffered file.AtomicWriter) error {
-			buf := bufio.NewWriter(unbuffered)
+	var buf bytes.Buffer
 
-			templateData := struct {
-				*kubeProxyTemplateData
-				ConfigHash string
-			}{
-				kubeProxyTemplateData: &cfg.TemplateData,
-			}
+	templateData := struct {
+		*kubeProxyTemplateData
+		ConfigHash string
+	}{
+		kubeProxyTemplateData: &cfg.TemplateData,
+	}
 
-			if configMap, err := cfg.ConfigMapData.toConfigMap(); err != nil {
-				return err
-			} else {
-				hasher := sha256.New()
-				buf := io.MultiWriter(hasher, buf)
-				codec := applier.CodecFor(kubernetesscheme.Scheme)
-				if err := codec.Encode(configMap, buf); err != nil {
-					return err
-				}
-				templateData.ConfigHash = base64.RawURLEncoding.EncodeToString(hasher.Sum(nil))
-			}
+	if configMap, err := cfg.ConfigMapData.toConfigMap(); err != nil {
+		return err
+	} else {
+		hasher := sha256.New()
+		w := io.MultiWriter(hasher, &buf)
+		codec := applier.CodecFor(kubernetesscheme.Scheme)
+		if err := codec.Encode(configMap, w); err != nil {
+			return err
+		}
+		templateData.ConfigHash = base64.RawURLEncoding.EncodeToString(hasher.Sum(nil))
+	}
 
-			if err := (&templatewriter.TemplateWriter{
-				Name:     "kube-proxy",
-				Template: proxyTemplate,
-				Data:     &templateData,
-				Patches:  cfg.Patches,
-			}).WriteToBuffer(buf); err != nil {
-				return err
-			}
+	if err := (&templatewriter.TemplateWriter{
+		Name:     "kube-proxy",
+		Template: proxyTemplate,
+		Data:     &templateData,
+		Patches:  cfg.Patches,
+	}).WriteToBuffer(&buf); err != nil {
+		return err
+	}
 
-			if includeWindows {
-				proxyWindowsTemplate, err := fs.ReadFile(static.WindowsManifests, "DaemonSet/kube-proxy-windows.yaml")
-				if err != nil {
-					return err
-				}
+	if includeWindows {
+		proxyWindowsTemplate, err := fs.ReadFile(static.WindowsManifests, "DaemonSet/kube-proxy-windows.yaml")
+		if err != nil {
+			return err
+		}
 
-				if err := (&templatewriter.TemplateWriter{
-					Name:     "kube-proxy-windows",
-					Template: string(proxyWindowsTemplate),
-					Data:     &templateData,
-					Patches:  cfg.Patches,
-				}).WriteToBuffer(buf); err != nil {
-					return err
-				}
-			}
+		if err := (&templatewriter.TemplateWriter{
+			Name:     "kube-proxy-windows",
+			Template: string(proxyWindowsTemplate),
+			Data:     &templateData,
+			Patches:  cfg.Patches,
+		}).WriteToBuffer(&buf); err != nil {
+			return err
+		}
+	}
 
-			return buf.Flush()
-		})
+	if err := dir.Init(k.manifestDir, constant.ManifestsDirMode); err != nil {
+		return err
+	}
+
+	return file.AtomicWithTarget(filepath.Join(k.manifestDir, "kube-proxy.yaml")).Write(buf.Bytes())
 }
 
 func (k *KubeProxy) getConfig(clusterConfig *v1beta1.ClusterConfig) *proxyConfig {

--- a/pkg/component/controller/kuberouter.go
+++ b/pkg/component/controller/kuberouter.go
@@ -65,7 +65,7 @@ func NewKubeRouter(k0sVars *config.CfgVars, primaryAddressFamily v1beta1.Primary
 
 // Init implements [manager.Component].
 func (k *KubeRouter) Init(context.Context) error {
-	return dir.Init(filepath.Join(k.k0sVars.ManifestsDir, "kuberouter"), constant.ManifestsDirMode)
+	return nil
 }
 
 // Stop no-op as nothing running
@@ -169,6 +169,10 @@ func (k *KubeRouter) Reconcile(_ context.Context, clusterConfig *v1beta1.Cluster
 	err := tw.WriteToBuffer(output)
 	if err != nil {
 		return fmt.Errorf("error writing kube-router manifests, will NOT retry: %w", err)
+	}
+
+	if err := dir.Init(filepath.Join(k.k0sVars.ManifestsDir, "kuberouter"), constant.ManifestsDirMode); err != nil {
+		return err
 	}
 
 	if err := file.AtomicWithTarget(filepath.Join(k.k0sVars.ManifestsDir, "kuberouter", "kube-router.yaml")).

--- a/pkg/component/controller/metrics.go
+++ b/pkg/component/controller/metrics.go
@@ -77,10 +77,6 @@ func NewMetrics(k0sVars *config.CfgVars, clientCF kubeutil.ClientFactoryInterfac
 
 // Init implements [manager.Component].
 func (m *Metrics) Init(context.Context) error {
-	if err := dir.Init(filepath.Join(m.K0sVars.ManifestsDir, "metrics"), constant.ManifestsDirMode); err != nil {
-		return err
-	}
-
 	var j *job
 	j, err := m.newJob("kube-scheduler", "https://localhost:10259/metrics")
 	if err != nil {
@@ -149,14 +145,15 @@ func (m *Metrics) Reconcile(_ context.Context, clusterConfig *v1beta1.ClusterCon
 			},
 		}
 		output := bytes.NewBuffer([]byte{})
-		err := tw.WriteToBuffer(output)
-		if err != nil {
+		if err := tw.WriteToBuffer(output); err != nil {
 			return err
 		}
-		err = file.AtomicWithTarget(filepath.Join(m.K0sVars.ManifestsDir, "metrics", "pushgateway.yaml")).
+		if err := dir.Init(filepath.Join(m.K0sVars.ManifestsDir, "metrics"), constant.ManifestsDirMode); err != nil {
+			return err
+		}
+		if err := file.AtomicWithTarget(filepath.Join(m.K0sVars.ManifestsDir, "metrics", "pushgateway.yaml")).
 			WithPermissions(constant.CertMode).
-			Write(output.Bytes())
-		if err != nil {
+			Write(output.Bytes()); err != nil {
 			return err
 		}
 	}

--- a/pkg/component/controller/metricserver.go
+++ b/pkg/component/controller/metricserver.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -19,6 +20,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/k0sproject/k0s/internal/pkg/dir"
+	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/k0sproject/k0s/pkg/constant"
@@ -272,10 +274,6 @@ func (m *MetricServer) Start(ctx context.Context) error {
 	ctx, m.tickerDone = context.WithCancel(ctx)
 
 	msDir := filepath.Join(m.K0sVars.ManifestsDir, "metricserver")
-	err := dir.Init(msDir, constant.ManifestsDirMode)
-	if err != nil {
-		return err
-	}
 
 	go func() {
 		ticker := time.NewTicker(10 * time.Second)
@@ -301,11 +299,18 @@ func (m *MetricServer) Start(ctx context.Context) error {
 					Name:     "metricServer",
 					Template: metricServerTemplate,
 					Data:     newConfig,
-					Path:     filepath.Join(msDir, "metric_server.yaml"),
 					Patches:  patches,
 				}
-				err = tw.Write()
-				if err != nil {
+				var manifest bytes.Buffer
+				if err := tw.WriteToBuffer(&manifest); err != nil {
+					m.log.Errorf("error rendering metric server manifests: %s. will retry", err.Error())
+					continue
+				}
+				if err := dir.Init(msDir, constant.ManifestsDirMode); err != nil {
+					m.log.WithError(err).Error("Failed to create metrics-server manifest dir, will retry")
+					continue
+				}
+				if err := file.WriteContentAtomically(filepath.Join(msDir, "metric_server.yaml"), manifest.Bytes(), constant.CertMode); err != nil {
 					m.log.Errorf("error writing metric server manifests: %s. will retry", err.Error())
 					continue
 				}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

CoreDNS, metrics-server, Metrics, Calico, KubeRouter and KubeProxy used to
create their manifest subdirectory in `Init()`/`Start()`, before they had
anything to write into it. The applier-manager picks up a newly created stack
directory via fsnotify and fires an unconditional apply about a second after
it starts watching it. If that lands while the directory exists but is still
empty (e.g. right after a controller pod restart with fresh ephemeral
`/var/lib/k0s` storage, while the underlying Kubernetes objects from the
previous process instance still exist), `Applier.Apply` treats the empty
directory like an explicit `Applier.Delete` and prunes every object already
carrying that stack's label. Nothing recreates them afterwards, since the
applier is purely watch-based with no periodic resync.

We discussed a couple of alternatives before landing on this approach:
changing `Applier.Apply` so an empty directory is not treated as a delete
request was rejected as too big a behavioral change; moving these components
to in-memory applies (as done for some other stacks, e.g. #6739) would remove
the filesystem hand-off entirely but is a much larger, likely non-backportable
change.

Instead, each of the six components now creates its manifest subdirectory
immediately before writing its first manifest file, the same way
`konnectivityagent.go` already did. This doesn't eliminate the race — there's
still an async hop between creating the directory and writing into it — but it
shrinks the window from however long it takes for cluster config to become
available down to the gap between two statements in the same function, making
the wipe far less likely to hit in practice, and is simple enough to backport.
`Applier.Apply`'s prune-on-empty-directory behavior is unchanged.

Each manifest is now also rendered into an in-memory buffer before its
directory is created, rather than the directory being created ahead of a
straight write into a file within it. That way a template error leaves
neither a half-written file nor an empty, race-prone directory behind.
KubeRouter already worked this way; CoreDNS, metrics-server, Metrics and
KubeProxy now follow the same order.

Fixes #8214

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

Added `inttest/manifestrestart`: starts a controller with dynamic config
enabled and a worker, waits for CoreDNS and metrics-server to come up, records
their Deployment UIDs, stops the controller, wipes `/var/lib/k0s/manifests`,
restarts the controller, and asserts the UIDs are unchanged (i.e. the
Deployments were not deleted and re-created). Dynamic config is needed to
reproduce the race reliably: it depends on the apiserver being up and the
ClusterConfig CR round-tripping, which is what opens a gap wide enough to hit
in practice, whereas static config hands configuration to components over a
synchronous in-memory channel, so the manifest directory tends to get its
first write well within the applier's debounce window regardless of when the
directory was created.

`check-manifestrestart` passed in CI against an earlier commit on this branch,
before the commits were folded into one; it has not re-run against the current
commit yet. I have not bisected this locally (reverting the directory-creation
change and confirming the test then fails) to hard-prove it catches the
regression, since this environment has no Docker/privileged-container access
to run the inttest suite.

`go build`, `go vet` and `go test` on the affected packages
(`pkg/applier/...`, `pkg/component/controller/...`), `golangci-lint`, and
`gofmt` all passed against this diff.

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
