### PR TITLE
[Backport release-1.34] Stop and wait for svc deletion on Windows before re-install

### DIFF
--- a/cmd/install/controller.go
+++ b/cmd/install/controller.go
@@ -61,7 +61,7 @@ With the controller subcommand you can setup a single node cluster by running:
 			}
 
 			args := append([]string{"controller"}, flagsAndVals...)
-			if err := install.InstallService(args, installFlags.envVars, installFlags.force); err != nil {
+			if err := install.InstallService(cmd.Context(), args, installFlags.envVars, installFlags.force); err != nil {
 				return fmt.Errorf("failed to install controller service: %w", err)
 			}
 

--- a/cmd/install/worker.go
+++ b/cmd/install/worker.go
@@ -33,7 +33,7 @@ All default values of worker command will be passed to the service stub unless o
 			}
 
 			args := append([]string{"worker"}, flagsAndVals...)
-			if err := install.InstallService(args, installFlags.envVars, installFlags.force); err != nil {
+			if err := install.InstallService(cmd.Context(), args, installFlags.envVars, installFlags.force); err != nil {
 				return fmt.Errorf("failed to install worker service: %w", err)
 			}
 

--- a/pkg/install/service.go
+++ b/pkg/install/service.go
@@ -4,11 +4,14 @@
 package install
 
 import (
+	"context"
 	"errors"
 	"runtime"
+	"time"
 
 	"github.com/kardianos/service"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var (
@@ -53,7 +56,7 @@ func InstalledService() (service.Service, error) {
 }
 
 // InstallService installs the k0s service, per the given arguments, and the detected platform
-func InstallService(args []string, envVars []string, force bool) error {
+func InstallService(ctx context.Context, args []string, envVars []string, force bool) error {
 	var svcConfig *service.Config
 
 	prg := &Program{}
@@ -82,10 +85,31 @@ func InstallService(args []string, envVars []string, force bool) error {
 	svcConfig.Arguments = args
 
 	if force {
+		if runtime.GOOS == "windows" {
+			// On Windows, the service must be stopped first
+			if err = s.Stop(); err != nil && !errors.Is(err, service.ErrNotInstalled) {
+				logrus.Warnf("failed to stop service before re-install: %v", err)
+			}
+		}
+
 		logrus.Infof("Uninstalling %s service", svcConfig.Name)
 		err = s.Uninstall()
 		if err != nil && !errors.Is(err, service.ErrNotInstalled) {
 			logrus.Warnf("failed to uninstall service: %v", err)
+		}
+		// On windows the service delete/uninstall is async, wait till it is done
+		if runtime.GOOS == "windows" {
+			if err = wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
+				_, err = s.Status()
+				if errors.Is(err, service.ErrNotInstalled) {
+					return true, nil
+				}
+				logrus.Info("waiting for the service to be actually deleted")
+				return false, nil
+			}); err != nil {
+				logrus.Errorf("failed to wait service to be deleted: %v", err)
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Backport to `release-1.34`:

* #8202

See:

* #8033
* #8029