### PR TITLE
Verify k0s binary and airgap bundle checksums during autopilot updates

### DIFF
--- a/inttest/update-server/html/stable/index.yaml
+++ b/inttest/update-server/html/stable/index.yaml
@@ -1,11 +1,15 @@
 name: stable
 version: v0.0.0
 downloadURLs:
-  k0s:
-    linux-amd64: http://localhost/dist/k0s
-    linux-arm64: http://localhost/dist/k0s
-    linux-arm: http://localhost/dist/k0s
-  airgap:
-    linux-amd64: ..../k0s-images-amd64
-    linux-arm64: ..../k0s-images-arm64
-    linux-arm: ..../k0s-images-arm
+  - arch: amd64
+    os: linux
+    k0s: http://localhost/dist/k0s
+    airgapBundle: ..../k0s-images-amd64
+  - arch: arm64
+    os: linux
+    k0s: http://localhost/dist/k0s
+    airgapBundle: ..../k0s-images-arm64
+  - arch: arm
+    os: linux
+    k0s: http://localhost/dist/k0s
+    airgapBundle: ..../k0s-images-arm

--- a/inttest/update-server/html/unstable/index.yaml
+++ b/inttest/update-server/html/unstable/index.yaml
@@ -1,11 +1,15 @@
 name: unstable
 version: v99.99.99+k0s.0
 downloadURLs:
-  k0s:
-    linux-amd64: ..../k0s-amd64
-    linux-arm64: ..../k0s-arm64
-    linux-arm: ..../k0s-arm
-  airgap:
-    linux-amd64: ..../k0s-images-amd64
-    linux-arm64: ..../k0s-images-arm64
-    linux-arm: ..../k0s-images-arm
+  - arch: amd64
+    os: linux
+    k0s: ..../k0s-amd64
+    airgapBundle: ..../k0s-images-amd64
+  - arch: arm64
+    os: linux
+    k0s: ..../k0s-arm64
+    airgapBundle: ..../k0s-images-arm64
+  - arch: arm
+    os: linux
+    k0s: ..../k0s-arm
+    airgapBundle: ..../k0s-images-arm

--- a/pkg/autopilot/controller/updates/updater.go
+++ b/pkg/autopilot/controller/updates/updater.go
@@ -174,18 +174,11 @@ func (u *cronUpdater) toPlan(nextVersion *uc.Update) apv1beta2.Plan {
 	}
 
 	platforms := make(apv1beta2.PlanPlatformResourceURLMap)
-	for osArch, url := range nextVersion.DownloadURLs["k0s"] {
-		platforms[osArch] = apv1beta2.PlanResourceURL{
-			URL: url,
-			// TODO: Sha256 of file
-		}
-	}
 	airgapPlatforms := make(apv1beta2.PlanPlatformResourceURLMap)
-	for osArch, url := range nextVersion.DownloadURLs["airgap"] {
-		airgapPlatforms[osArch] = apv1beta2.PlanResourceURL{
-			URL: url,
-			// TODO: Sha256 of file
-		}
+	for _, dl := range nextVersion.DownloadURLs {
+		osArch := dl.OS + "-" + dl.Arch
+		platforms[osArch] = apv1beta2.PlanResourceURL{URL: dl.K0S, Sha256: dl.K0SSha256}
+		airgapPlatforms[osArch] = apv1beta2.PlanResourceURL{URL: dl.AirgapBundle, Sha256: dl.AirgapSha256}
 	}
 
 	p.Spec.ID = strconv.FormatInt(time.Now().Unix(), 10)

--- a/pkg/autopilot/controller/updates/updater_test.go
+++ b/pkg/autopilot/controller/updates/updater_test.go
@@ -1,0 +1,33 @@
+//go:build unix
+
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package updates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/k0sproject/k0s/pkg/autopilot/channels"
+	uc "github.com/k0sproject/k0s/pkg/autopilot/updater"
+)
+
+func TestToPlan_Sha256(t *testing.T) {
+	u := &cronUpdater{}
+
+	nextVersion := &uc.Update{
+		Version: "v1.2.3+k0s.0",
+		DownloadURLs: []channels.DownloadURL{
+			{Arch: "amd64", OS: "linux", K0S: "http://example.com/k0s", K0SSha256: "deadbeef"},
+			{Arch: "arm64", OS: "linux", K0S: "http://example.com/k0s-arm64"},
+		},
+	}
+
+	plan := u.toPlan(nextVersion)
+	platforms := plan.Spec.Commands[0].K0sUpdate.Platforms
+
+	assert.Equal(t, "deadbeef", platforms["linux-amd64"].Sha256)
+	assert.Empty(t, platforms["linux-arm64"].Sha256)
+}

--- a/pkg/autopilot/updater/api.go
+++ b/pkg/autopilot/updater/api.go
@@ -8,15 +8,14 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+
+	"github.com/k0sproject/k0s/pkg/autopilot/channels"
 )
 
 type Update struct {
-	Version      Version      `yaml:"version"`
-	DownloadURLs DownloadURLs `yaml:"downloadURLs"`
+	Version      Version                `yaml:"version"`
+	DownloadURLs []channels.DownloadURL `yaml:"downloadURLs"`
 }
-
-// DownloadURLs is a mapping from os-arch to download URLs
-type DownloadURLs map[string]map[string]string
 
 type Version string
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

`cronUpdater.toPlan()` always left `PlanResourceURL.Sha256` blank, so autopilot's downloader silently skipped hash verification for the k0s binary and airgap bundle it fetches. The update-server's `downloadURLs` entries can carry `k0sSha256`/`airgapSha256` per arch/os; when present, these should be copied into the Plan.

`updater.Update.DownloadURLs` was a `map[string]map[string]string` (artifact type -> os-arch -> URL), which has no room for a hash at all and doesn't match the update-server protocol documented at https://github.com/k0sproject/update (a list of per-arch/os entries with `k0s`/`k0sSha256`/`airgapBundle`/`airgapSha256` as sibling fields). I switched `DownloadURLs` to reuse `channels.DownloadURL` (the same type already used elsewhere in this codebase for that protocol), and updated `toPlan()` to read the hash fields directly. The two update-server test fixtures still using the old map shape (`stable`, `unstable`) were updated to the list shape so the existing `ap-updater` integration test keeps working; no hashes were added to those fixtures since verifying against a fake hash would break the download step.

When a server doesn't send a hash, the field is simply empty on the entry, so `Sha256` stays blank, same as before.

Fixes #8206

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Added `TestToPlan_Sha256` in `pkg/autopilot/controller/updates/updater_test.go`, covering one entry with a hash present (`Sha256` populated) and one without (`Sha256` stays blank). Ran `go build ./...`, `go vet ./pkg/autopilot/...`, and `go test ./pkg/autopilot/...`, all passing. Also manually verified the new `Update` type correctly parses a real response fetched from the k0sproject/update reference server.

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
