### PR TITLE
Disallow cfssl log usage outside the logging package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,15 @@ linters:
   settings:
     depguard:
       rules:
+        logging:
+          list-mode: lax
+          files:
+            - '!**/internal/pkg/log/*.go'
+          deny:
+            - pkg: github.com/cloudflare/cfssl/log
+              desc: >-
+                Use logrus instead. The cfssl logging is routed there. Probably
+                imported by accident when referring to a bare "log" identifier.
         cloud-provider:
           list-mode: lax
           files:


### PR DESCRIPTION
## Description

Whenever adding a bare log identifier to the codebase, goimports is "helpful" in adding the cfssl log import. The evidence that this isn't what you want is about as strong as the evidence that protons don't decay.

Stumbling over this far too often. It's time to catch this with the linter.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
