### PR TITLE
Log swallowed errors during resource pruning

### DIFF
--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -375,8 +375,10 @@ func (s *Stack) clientForResource(mapper meta.ResettableRESTMapper, resource uns
 }
 
 func (s *Stack) findPruneableResourceForGroupVersionKind(ctx context.Context, mapper meta.ResettableRESTMapper, groupVersionKind *schema.GroupVersionKind) []unstructured.Unstructured {
-	mapping, _ := getRESTMapping(mapper, groupVersionKind)
-	// FIXME error handling...
+	mapping, err := getRESTMapping(mapper, groupVersionKind)
+	if err != nil {
+		s.log.Debugf("error getting REST mapping for pruning: %s", err.Error())
+	}
 	if mapping != nil {
 		client, err := s.Clients.GetDynamicClient()
 		if err != nil {
@@ -397,7 +399,7 @@ func (s *Stack) getPruneableResources(ctx context.Context, drClient dynamic.Reso
 	}
 	resourceList, err := drClient.List(ctx, listOpts)
 	if err != nil {
-		// FIXME why no error propagation !??!
+		s.log.Debugf("error listing resources for pruning: %s", err.Error())
 		return nil
 	}
 	for _, resource := range resourceList.Items {

--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -377,11 +377,12 @@ func (s *Stack) clientForResource(mapper meta.ResettableRESTMapper, resource uns
 func (s *Stack) findPruneableResourceForGroupVersionKind(ctx context.Context, mapper meta.ResettableRESTMapper, groupVersionKind *schema.GroupVersionKind) []unstructured.Unstructured {
 	mapping, err := getRESTMapping(mapper, groupVersionKind)
 	if err != nil {
-		s.log.Debugf("error getting REST mapping for pruning: %s", err.Error())
+		s.log.Warnf("error getting REST mapping for pruning: %s", err.Error())
 	}
 	if mapping != nil {
 		client, err := s.Clients.GetDynamicClient()
 		if err != nil {
+			s.log.Warnf("error getting dynamic client for pruning: %s", err.Error())
 			return nil
 		}
 		// We're running this with full admin rights, we should have capability to get stuff with single call
@@ -399,7 +400,7 @@ func (s *Stack) getPruneableResources(ctx context.Context, drClient dynamic.Reso
 	}
 	resourceList, err := drClient.List(ctx, listOpts)
 	if err != nil {
-		s.log.Debugf("error listing resources for pruning: %s", err.Error())
+		s.log.Warnf("error listing resources for pruning: %s", err.Error())
 		return nil
 	}
 	for _, resource := range resourceList.Items {

--- a/pkg/applier/stack.go
+++ b/pkg/applier/stack.go
@@ -376,13 +376,14 @@ func (s *Stack) clientForResource(mapper meta.ResettableRESTMapper, resource uns
 
 func (s *Stack) findPruneableResourceForGroupVersionKind(ctx context.Context, mapper meta.ResettableRESTMapper, groupVersionKind *schema.GroupVersionKind) []unstructured.Unstructured {
 	mapping, err := getRESTMapping(mapper, groupVersionKind)
+	// FIXME error handling...
 	if err != nil {
-		s.log.Warnf("error getting REST mapping for pruning: %s", err.Error())
+		s.log.WithError(err).Warn("failed to get REST mapping while finding prunable resources")
 	}
 	if mapping != nil {
 		client, err := s.Clients.GetDynamicClient()
 		if err != nil {
-			s.log.Warnf("error getting dynamic client for pruning: %s", err.Error())
+			s.log.WithError(err).Warn("failed to get dynamic client while finding prunable resources")
 			return nil
 		}
 		// We're running this with full admin rights, we should have capability to get stuff with single call
@@ -400,7 +401,8 @@ func (s *Stack) getPruneableResources(ctx context.Context, drClient dynamic.Reso
 	}
 	resourceList, err := drClient.List(ctx, listOpts)
 	if err != nil {
-		s.log.Warnf("error listing resources for pruning: %s", err.Error())
+		// FIXME why no error propagation !??!
+		s.log.WithError(err).Warn("failed to list resources while finding prunable resources")
 		return nil
 	}
 	for _, resource := range resourceList.Items {


### PR DESCRIPTION
## Description
findPruneableResourceForGroupVersionKind and getPruneableResources both discarded errors outright instead of at least logging them, unlike the discovery error handling a few lines above in the same file. This logs them the same way instead of dropping them silently.

Fixes # (issue)
N/A, no existing issue, found while reading the pruning code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

Ran the existing pkg/applier unit tests plus go vet, gofmt, and golangci-lint (v2.13.2, the version this repo pins) locally, all clean. No new test added since this only adds logging to two already-existing error paths.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commit messages are signed-off
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings