### PR TITLE
Add test for ToConfigMapData with a nil profile

### DIFF
--- a/pkg/component/worker/config/config_test.go
+++ b/pkg/component/worker/config/config_test.go
@@ -26,6 +26,12 @@ func TestToConfigMapData(t *testing.T) {
 			assert.Equal(t, test.data, data)
 		})
 	}
+
+	t.Run("nil_profile", func(t *testing.T) {
+		data, err := ToConfigMapData(nil)
+		assert.Nil(t, data)
+		assert.EqualError(t, err, "cannot marshal nil profile")
+	})
 }
 
 func TestFromConfigMapData(t *testing.T) {


### PR DESCRIPTION
## Description
ToConfigMapData's nil profile guard (return an error rather than panic or marshal garbage) had no test exercising it, unlike every other branch in this function. This adds one.

Fixes # (issue)
N/A, no existing issue, found while looking for untested error paths.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

This is a test only change, none of the above categories quite fit; no production code is touched.

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commit messages are signed-off
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings