### PR TITLE
autopilot: don't write back stale signal nodes

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -73,7 +73,8 @@ check-addons: TIMEOUT=10m
 # Autopilot 3x3 HA test can take a while to run
 check-ap-ha3x3: export K0S_UPDATE_TO_VERSION ?= $(shell ../k0s version)
 
-# check-ap-controllerworker might need to re-download the new bin few times, so give it a bit more time to complete
+# check-ap-controllerworker updates three controller+worker nodes one by one,
+# which takes longer than the default timeout allows
 check-ap-controllerworker: TIMEOUT=10m
 
 check-ap-updater: .update-server.stamp

--- a/pkg/autopilot/controller/signal/airgap/signal.go
+++ b/pkg/autopilot/controller/signal/airgap/signal.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	cr "sigs.k8s.io/controller-runtime"
-	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crev "sigs.k8s.io/controller-runtime/pkg/event"
 	crman "sigs.k8s.io/controller-runtime/pkg/manager"
 	crpred "sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -91,17 +90,14 @@ func (h *signalControllerHandler) Handle(ctx context.Context, sctx apsigcomm.Sig
 	// We have no way at the moment to identify what version an airgap bundle is, or what version is
 	// installed, so always download.
 
-	signalNodeCopy := sctx.Delegate.DeepCopy(sctx.SignalNode)
 	status := Downloading
 
-	sctx.SignalData.Status = apsigv2.NewStatus(status)
-	if err := sctx.SignalData.Marshal(signalNodeCopy.GetAnnotations()); err != nil {
-		return cr.Result{}, fmt.Errorf("unable to marshal airgap signal data for node='%s': %w", signalNodeCopy.GetName(), err)
-	}
-
-	sctx.Log.Infof("Updating signaling response to '%s'", status)
-	if err := sctx.Client.Update(ctx, signalNodeCopy, &crcli.UpdateOptions{}); err != nil {
-		return cr.Result{}, fmt.Errorf("unable to update airgap signal node='%s' with status='%s': %w", signalNodeCopy.GetName(), status, err)
+	// Record the status on the signal node as it is now, not as it was read at
+	// the start of this reconcile. See [apsigcomm.UpdateSignalStatus].
+	nodeName := sctx.SignalNode.GetName()
+	key := sctx.Delegate.CreateNamespacedName(nodeName)
+	if _, err := apsigcomm.UpdateSignalStatus(ctx, sctx.Log, sctx.Client, sctx.Delegate, key, *sctx.SignalData, []string{""}, apsigv2.NewStatus(status)); err != nil {
+		return cr.Result{}, fmt.Errorf("unable to update airgap signal node='%s' with status='%s': %w", nodeName, status, err)
 	}
 
 	return cr.Result{}, nil

--- a/pkg/autopilot/controller/signal/common/download.go
+++ b/pkg/autopilot/controller/signal/common/download.go
@@ -76,26 +76,24 @@ func (r *downloadController) Reconcile(ctx context.Context, req cr.Request) (cr.
 
 	logger.Infof("Starting download of '%s'", manifest.URL)
 
+	var newStatus *apsigv2.Status
 	httpdl := apdl.NewDownloader(manifest.Config)
 	if err := httpdl.Download(ctx); err != nil {
 		logger.Errorf("Unable to download '%s': %v", manifest.URL, err)
 
 		// When the download is complete move the status to `FailedDownload`
-		signalData.Status = apsigv2.NewStatus(FailedDownload)
+		newStatus = apsigv2.NewStatus(FailedDownload)
 
 	} else {
 		logger.Infof("Download of '%s' successful", manifest.URL)
 		// When the download is complete move the status to the success state
-		signalData.Status = apsigv2.NewStatus(manifest.SuccessState)
+		newStatus = apsigv2.NewStatus(manifest.SuccessState)
 	}
 
-	if err := signalData.Marshal(signalNodeCopy.GetAnnotations()); err != nil {
-		return cr.Result{}, fmt.Errorf("failed to marshal signal data: %w", err)
-	}
-
-	logger.Infof("Updating signaling response to '%s'", signalData.Status.Status)
-	if err := r.client.Update(ctx, signalNodeCopy, &crcli.UpdateOptions{}); err != nil {
-		return cr.Result{}, fmt.Errorf("failed to update signal node to status '%s': %w", signalData.Status.Status, err)
+	// The download above may have taken a while, so don't write back the
+	// signal node as it was read before it started. See [UpdateSignalStatus].
+	if _, err := UpdateSignalStatus(ctx, logger, r.client, r.delegate, req.NamespacedName, signalData, []string{"", Downloading}, newStatus); err != nil {
+		return cr.Result{}, fmt.Errorf("failed to update signal node to status '%s': %w", newStatus.Status, err)
 	}
 
 	return cr.Result{}, nil

--- a/pkg/autopilot/controller/signal/common/signalstatus.go
+++ b/pkg/autopilot/controller/signal/common/signalstatus.go
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"slices"
+	"time"
+
+	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
+	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	crcli "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// How long to keep retrying a conflicting signaling status update. Six attempts
+// spread over about 0.8 seconds, which gives a lagging cache time to catch up
+// with whatever caused the conflict. Note that the sleeps happen between the
+// attempts, so there are five of them, 25ms doubling up to 400ms.
+//
+// Deliberately no Cap: [wait.Backoff] stops stepping once the next interval
+// would exceed it, which would cost an attempt without saving any time.
+var updateStatusBackoff = wait.Backoff{
+	Steps:    6,
+	Duration: 25 * time.Millisecond,
+	Factor:   2.0,
+	Jitter:   0.1,
+}
+
+// UpdateSignalStatus records newStatus, which must not be nil, as the signaling
+// status of the signal node identified by key. It reports whether the status
+// was actually recorded, which is false when the transition turned out to no
+// longer be applicable. Callers with a side effect to match against the write,
+// such as reporting an event, need to check it.
+//
+// Reconcilers download, drain or replace binaries before recording the
+// resulting status, based on a snapshot of the signal node taken when the
+// reconcile started. That snapshot is likely stale by the time the work is
+// done, so it must not be written back wholesale. Writing it as-is would
+// overwrite signaling that arrived while the work was running, such as a newer
+// plan for the same node. Writing it with optimistic concurrency instead fails
+// whenever something else modified the object meanwhile, and since a failed
+// write makes the reconciler redo the work, every retry loses the same race
+// again.
+//
+// So re-read the node and record the status on the fresh object, but only if
+// that is still applicable: the node has to carry the same signaling request,
+// and be in one of the validFrom statuses, where the empty string stands for a
+// node without a status yet. This is the precondition the reconciler checked
+// before it started, re-evaluated against the current state.
+//
+// validFrom is a set rather than an exact match because the status can move on
+// without invalidating the work. For airgap updates the download and signal
+// reconcilers are triggered by the same status-less event, so the signal
+// reconciler moves the node to Downloading while the download is already
+// running.
+//
+// Reads may be served from a cache that lags behind the API, so a write can
+// still conflict. That is what the retries are for, and the optimistic
+// concurrency keeps a lagging read from overwriting anything. The retries are
+// more patient than [retry.DefaultRetry] because a conflict means the cache has
+// yet to observe the write that caused it, and giving up after a few
+// milliseconds would only make the reconciler redo all of its work.
+func UpdateSignalStatus(
+	ctx context.Context,
+	logger *logrus.Entry,
+	client crcli.Client,
+	delegate apdel.ControllerDelegate,
+	key types.NamespacedName,
+	actedUpon apsigv2.SignalData,
+	validFrom []string,
+	newStatus *apsigv2.Status,
+) (recorded bool, _ error) {
+	err := retry.RetryOnConflict(updateStatusBackoff, func() error {
+		recorded = false // this attempt may follow one that got as far as the write
+
+		signalNode := delegate.CreateObject()
+		if err := client.Get(ctx, key, signalNode); err != nil {
+			return fmt.Errorf("unable to get signal node: %w", err)
+		}
+
+		var current apsigv2.SignalData
+		if err := current.Unmarshal(signalNode.GetAnnotations()); err != nil {
+			return fmt.Errorf("unable to unmarshal signal data: %w", err)
+		}
+
+		// A different request altogether: recording the status now would undo
+		// whatever superseded the one that was acted upon. That change will
+		// have triggered a reconcile of its own, so there's nothing to do here.
+		if !isSameRequest(current, actedUpon) {
+			logger.Infof("Not recording status '%s': the signaling request changed while it was being processed", newStatus.Status)
+			return nil
+		}
+
+		// The same request, but no longer in a state this transition applies
+		// to, i.e. it has already moved past it. Recording the status now would
+		// take the state machine backwards.
+		var currentStatus string
+		if current.Status != nil {
+			currentStatus = current.Status.Status
+		}
+		if !slices.Contains(validFrom, currentStatus) {
+			logger.Infof("Not recording status '%s': the signal node has moved on to '%s'", newStatus.Status, currentStatus)
+			return nil
+		}
+
+		current.Status = newStatus
+		if err := current.Marshal(signalNode.GetAnnotations()); err != nil {
+			return fmt.Errorf("unable to marshal signal data: %w", err)
+		}
+
+		logger.Infof("Updating signaling response to '%s'", newStatus.Status)
+		if err := client.Update(ctx, signalNode, &crcli.UpdateOptions{}); err != nil {
+			return err
+		}
+
+		recorded = true
+		return nil
+	})
+
+	return recorded, err
+}
+
+// isSameRequest reports whether both describe the same signaling request,
+// disregarding the status, which is what the transitions in here change.
+func isSameRequest(a, b apsigv2.SignalData) bool {
+	a.Status, b.Status = nil, nil
+	return reflect.DeepEqual(a, b)
+}

--- a/pkg/autopilot/controller/signal/common/signalstatus_test.go
+++ b/pkg/autopilot/controller/signal/common/signalstatus_test.go
@@ -1,0 +1,357 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
+	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
+	apdl "github.com/k0sproject/k0s/pkg/autopilot/download"
+	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
+	apscheme "github.com/k0sproject/k0s/pkg/client/clientset/scheme"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	crcli "sigs.k8s.io/controller-runtime/pkg/client"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	crrec "sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// The signal node that the tests in here operate on.
+const testNodeName = "controller0"
+
+// The state a successful download transitions to. The real one is the k0s
+// package's Cordoning, which can't be imported here.
+const testSuccessState = "Cordoning"
+
+// newSignalData builds a k0s update request in the given status, where the empty
+// string means a request that has no status yet.
+func newSignalData(planID, url, status string) apsigv2.SignalData {
+	commandID := 123
+	data := apsigv2.SignalData{
+		PlanID:  planID,
+		Created: "now",
+		Command: apsigv2.Command{
+			ID:        &commandID,
+			K0sUpdate: &apsigv2.CommandK0sUpdate{URL: url, Version: "v0.0.0"},
+		},
+	}
+	if status != "" {
+		data.Status = apsigv2.NewStatus(status)
+	}
+	return data
+}
+
+func newSignalNode(t *testing.T, data apsigv2.SignalData) *apv1beta2.ControlNode {
+	t.Helper()
+	node := &apv1beta2.ControlNode{
+		ObjectMeta: metav1.ObjectMeta{Name: testNodeName, Annotations: map[string]string{}},
+	}
+	require.NoError(t, data.Marshal(node.Annotations))
+	return node
+}
+
+func newFakeClient(t *testing.T, objects ...crcli.Object) crcli.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, apscheme.AddToScheme(scheme))
+	return crfake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func readSignalData(t *testing.T, client crcli.Client, key crcli.ObjectKey) apsigv2.SignalData {
+	t.Helper()
+	var node apv1beta2.ControlNode
+	require.NoError(t, client.Get(t.Context(), key, &node))
+	var data apsigv2.SignalData
+	require.NoError(t, data.Unmarshal(node.GetAnnotations()))
+	return data
+}
+
+// TestUpdateSignalStatus runs through a table of states a signal node can be in
+// by the time a reconciler is done with its work, ensuring the resulting status
+// is only recorded when that is still applicable, and that the log says what
+// actually happened.
+func TestUpdateSignalStatus(t *testing.T) {
+	var tests = []struct {
+		name         string
+		stored       apsigv2.SignalData
+		actedUpon    apsigv2.SignalData
+		validFrom    []string
+		newStatus    string
+		wantPlanID   string
+		wantStatus   string
+		wantRecorded bool
+	}{
+		// The ordinary case: nothing happened to the node meanwhile.
+		{
+			"Unchanged",
+			newSignalData("plan-1", "http://localhost/k0s", Downloading),
+			newSignalData("plan-1", "http://localhost/k0s", Downloading),
+			[]string{"", Downloading},
+			testSuccessState,
+			"plan-1", testSuccessState, true,
+		},
+
+		// A request that has no status yet, as seen by the signal handlers.
+		{
+			"NoStatusYet",
+			newSignalData("plan-1", "http://localhost/k0s", ""),
+			newSignalData("plan-1", "http://localhost/k0s", ""),
+			[]string{""},
+			Downloading,
+			"plan-1", Downloading, true,
+		},
+
+		// Another reconciler advanced the status without invalidating the work.
+		// This is what airgap updates do, where the download and signal
+		// reconcilers are triggered by the same status-less event.
+		{
+			"StatusAdvancedMeanwhile",
+			newSignalData("plan-1", "http://localhost/k0s", Downloading),
+			newSignalData("plan-1", "http://localhost/k0s", ""),
+			[]string{"", Downloading},
+			testSuccessState,
+			"plan-1", testSuccessState, true,
+		},
+
+		// A newer plan superseded the request that was acted upon. Recording
+		// the status now would drop that newer request on the floor.
+		{
+			"SupersededByNewerPlan",
+			newSignalData("plan-2", "http://localhost/new", Downloading),
+			newSignalData("plan-1", "http://localhost/k0s", Downloading),
+			[]string{"", Downloading},
+			testSuccessState,
+			"plan-2", Downloading, false,
+		},
+
+		// The same request, but already past this transition. Recording the
+		// status now would take the state machine backwards.
+		{
+			"MovedPastTransition",
+			newSignalData("plan-1", "http://localhost/k0s", Completed),
+			newSignalData("plan-1", "http://localhost/k0s", Downloading),
+			[]string{"", Downloading},
+			testSuccessState,
+			"plan-1", Completed, false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger, logged := logrus.New(), new(bytes.Buffer)
+			logger.SetOutput(logged)
+
+			node := newSignalNode(t, test.stored)
+			client := newFakeClient(t, node)
+			delegate := apdel.ControlNodeControllerDelegate()
+			key := delegate.CreateNamespacedName(node.Name)
+
+			recorded, err := UpdateSignalStatus(t.Context(), logrus.NewEntry(logger), client, delegate,
+				key, test.actedUpon, test.validFrom, apsigv2.NewStatus(test.newStatus))
+			assert.NoError(t, err, "a status that isn't applicable anymore is not an error")
+			assert.Equal(t, test.wantRecorded, recorded, "should report whether it recorded the status")
+
+			stored := readSignalData(t, client, key)
+			assert.Equal(t, test.wantPlanID, stored.PlanID)
+			if assert.NotNil(t, stored.Status) {
+				assert.Equal(t, test.wantStatus, stored.Status.Status)
+			}
+
+			// The log has to be tied to the write, so that a status which was
+			// never recorded doesn't leave a log claiming that it was.
+			update := "Updating signaling response to '" + test.newStatus + "'"
+			if test.wantRecorded {
+				assert.Contains(t, logged.String(), update)
+			} else {
+				assert.NotContains(t, logged.String(), update)
+				assert.Contains(t, logged.String(), "Not recording status '"+test.newStatus+"'")
+			}
+		})
+	}
+}
+
+// staleReadClient serves the first staleReads reads from a snapshot taken up
+// front, standing in for a cache that has yet to observe a write.
+type staleReadClient struct {
+	crcli.Client
+	stale      crcli.Object
+	staleReads int
+}
+
+func (c *staleReadClient) Get(ctx context.Context, key crcli.ObjectKey, obj crcli.Object, opts ...crcli.GetOption) error {
+	if c.staleReads > 0 {
+		c.staleReads--
+		stale := c.stale.DeepCopyObject()
+		reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(stale).Elem())
+		return nil
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+// TestUpdateSignalStatusRetriesStaleReads ensures a conflict caused by a
+// lagging read is retried until the read catches up. Propagating it instead
+// would make the reconciler redo all of its work.
+func TestUpdateSignalStatusRetriesStaleReads(t *testing.T) {
+	data := newSignalData("plan-1", "http://localhost/k0s", Downloading)
+	node := newSignalNode(t, data)
+	base := newFakeClient(t, node)
+	delegate := apdel.ControlNodeControllerDelegate()
+	key := delegate.CreateNamespacedName(node.Name)
+
+	// Snapshot the node, then bump it, so that the snapshot's resourceVersion
+	// is outdated in exactly the way a lagging cache would serve it.
+	var snapshot apv1beta2.ControlNode
+	require.NoError(t, base.Get(t.Context(), key, &snapshot))
+	bumped := snapshot.DeepCopy()
+	bumped.Annotations["unrelated.k0sproject.io/churn"] = "1"
+	require.NoError(t, base.Update(t.Context(), bumped))
+
+	client := &staleReadClient{Client: base, stale: &snapshot, staleReads: 2}
+	newStatus := apsigv2.NewStatus(testSuccessState)
+
+	recorded, err := UpdateSignalStatus(t.Context(), logrus.NewEntry(logrus.StandardLogger()),
+		client, delegate, key, data, []string{"", Downloading}, newStatus)
+	require.NoError(t, err)
+	assert.True(t, recorded, "the status is recorded once the read catches up")
+
+	assert.Zero(t, client.staleReads, "the stale reads should have been consumed by retries")
+	if stored := readSignalData(t, base, key); assert.NotNil(t, stored.Status) {
+		assert.Equal(t, *newStatus, *stored.Status)
+	}
+}
+
+// downloadManifestBuilder points the download reconciler at the given HTTP test
+// server, mirroring the real manifest builders in the k0s and airgap packages.
+type downloadManifestBuilder struct {
+	url string
+	dir string
+}
+
+func (b downloadManifestBuilder) Build(crcli.Object, apsigv2.SignalData) (DownloadManifest, error) {
+	return DownloadManifest{
+		Config:       apdl.Config{URL: b.url, DownloadDir: b.dir, Filename: "downloaded"},
+		SuccessState: testSuccessState,
+	}, nil
+}
+
+// TestDownloadControllerAgainstAnnotationChurn is a regression test for a
+// livelock seen in CI for check-ap-controllerworker, where a node stayed stuck
+// reporting Downloading until the whole suite timed out.
+//
+// That suite writes an unrelated annotation to every ControlNode about once a
+// second, on purpose, to generate reconcile churn. The download reconciler used
+// to write back the signal node as it had read it before the download, which
+// failed whenever one of those writes landed in between. Every failure made it
+// redo the download and race again, and since a download took about as long as
+// the interval between those writes, it kept losing: the CI failure showed 118
+// consecutive attempts over three minutes.
+//
+// The churn here is much faster than the download, so that a regression fails
+// immediately instead of depending on timing luck.
+func TestDownloadControllerAgainstAnnotationChurn(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(150 * time.Millisecond)
+		_, _ = w.Write([]byte("binary-content"))
+	}))
+	defer srv.Close()
+
+	node := newSignalNode(t, newSignalData("plan-1", srv.URL, Downloading))
+	client := newFakeClient(t, node)
+	delegate := apdel.ControlNodeControllerDelegate()
+	reconciler := NewDownloadController(logrus.NewEntry(logrus.StandardLogger()), client, delegate,
+		downloadManifestBuilder{url: srv.URL, dir: t.TempDir()})
+	req := crrec.Request{NamespacedName: delegate.CreateNamespacedName(node.Name)}
+
+	// Stand in for the inttest suite's load generator.
+	ctx, stopChurn := context.WithCancel(t.Context())
+	churnStopped := make(chan struct{})
+	go func() {
+		defer close(churnStopped)
+		for ctx.Err() == nil {
+			var cn apv1beta2.ControlNode
+			if err := client.Get(ctx, req.NamespacedName, &cn); err == nil {
+				cn.Annotations["test.k0sproject.io/touch"] = time.Now().Format(time.RFC3339Nano)
+				_ = client.Update(ctx, &cn)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	t.Cleanup(func() { stopChurn(); <-churnStopped })
+
+	var attempts, failures int
+	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); {
+		attempts++
+		if _, err := reconciler.Reconcile(t.Context(), req); err != nil {
+			failures++
+			continue
+		}
+		if status := readSignalData(t, client, req.NamespacedName).Status; status != nil && status.Status == testSuccessState {
+			t.Logf("reached %s after %d attempt(s), %d failure(s)", testSuccessState, attempts, failures)
+			return
+		}
+	}
+
+	t.Fatalf("the download reconciler never recorded %s within 5s: %d attempt(s), %d of which failed to write back the signal node",
+		testSuccessState, attempts, failures)
+}
+
+// TestDownloadControllerConcurrentStatusUpdate is a regression test for
+// check-ap-airgap. The airgap download and signal reconcilers are triggered by
+// the same status-less event, so the download reconciler starts out from a node
+// without a status while the signal reconciler moves that very node to
+// Downloading. Discarding the download result in that case leaves the update
+// stuck for good, because the airgap download reconciler is only ever triggered
+// by status-less events and would never be asked again.
+func TestDownloadControllerConcurrentStatusUpdate(t *testing.T) {
+	downloadStarted, releaseDownload := make(chan struct{}), make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(downloadStarted)
+		<-releaseDownload
+		_, _ = w.Write([]byte("bundle-content"))
+	}))
+	defer srv.Close()
+
+	data := newSignalData("plan-1", srv.URL, "")
+	node := newSignalNode(t, data)
+	client := newFakeClient(t, node)
+	delegate := apdel.ControlNodeControllerDelegate()
+	reconciler := NewDownloadController(logrus.NewEntry(logrus.StandardLogger()), client, delegate,
+		downloadManifestBuilder{url: srv.URL, dir: t.TempDir()})
+	key := delegate.CreateNamespacedName(node.Name)
+
+	reconciled := make(chan error, 1)
+	go func() {
+		_, err := reconciler.Reconcile(t.Context(), crrec.Request{NamespacedName: key})
+		reconciled <- err
+	}()
+
+	// While the download is in flight, the signal reconciler moves the node to
+	// Downloading, exactly as it does for airgap updates.
+	<-downloadStarted
+	var cn apv1beta2.ControlNode
+	require.NoError(t, client.Get(t.Context(), key, &cn))
+	downloading := data
+	downloading.Status = apsigv2.NewStatus(Downloading)
+	require.NoError(t, downloading.Marshal(cn.Annotations))
+	require.NoError(t, client.Update(t.Context(), &cn))
+	close(releaseDownload)
+
+	require.NoError(t, <-reconciled)
+
+	if stored := readSignalData(t, client, key); assert.NotNil(t, stored.Status) {
+		assert.Equal(t, testSuccessState, stored.Status.Status,
+			"the download result must be recorded even though the status moved to %s meanwhile", Downloading)
+	}
+}

--- a/pkg/autopilot/controller/signal/k0s/apply.go
+++ b/pkg/autopilot/controller/signal/k0s/apply.go
@@ -16,6 +16,7 @@ import (
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
+	apsigcomm "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common"
 	apsigpred "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common/predicate"
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
 
@@ -151,22 +152,28 @@ func (r *applyingUpdate) Reconcile(ctx context.Context, req cr.Request) (cr.Resu
 	}
 
 	// When the k0s process has been terminated, move to 'Restart'
-	signalNodeCopy := r.delegate.DeepCopy(signalNode)
-
-	signalData.Status = apsigv2.NewStatus(Restart)
-	if err := signalData.Marshal(signalNodeCopy.GetAnnotations()); err != nil {
-		return cr.Result{}, fmt.Errorf("unable to marshal signal data for node='%s': %w", req.Name, err)
-	}
-
-	logger.Infof("Updating signaling response to '%s'", signalData.Status.Status)
+	newStatus := apsigv2.NewStatus(Restart)
 
 	// Record the pending restart before making the 'Restart' status visible to
 	// the API. The restart controllers may never observe a 'Restart' status
 	// that has been written by this process without knowing that it's pending.
-	r.restartInitiated(signalData)
+	// This has to be the very same status that gets recorded below, timestamp
+	// included, as that's what identifies the restart as pending.
+	//
+	// Recording it up front means it's also recorded in case the status below
+	// turns out to be superseded and isn't written at all. That's harmless:
+	// a pending restart is only ever matched against the exact same request
+	// and status, timestamp included, so an entry for a request that no longer
+	// exists can't match anything anymore.
+	restartInitiatedData := signalData
+	restartInitiatedData.Status = newStatus
+	r.restartInitiated(restartInitiatedData)
 
-	if err := r.client.Update(ctx, signalNodeCopy, &crcli.UpdateOptions{}); err != nil {
-		return cr.Result{Requeue: true}, fmt.Errorf("failed to update signal node to status '%s': %w", signalData.Status.Status, err)
+	// The file operations above can take a while, so don't write back the
+	// signal node as it was read before they started. See
+	// [apsigcomm.UpdateSignalStatus].
+	if _, err := apsigcomm.UpdateSignalStatus(ctx, logger, r.client, r.delegate, req.NamespacedName, signalData, []string{"", ApplyingUpdate}, newStatus); err != nil {
+		return cr.Result{Requeue: true}, fmt.Errorf("failed to update signal node to status '%s': %w", newStatus.Status, err)
 	}
 
 	// Clean up k0s.tmp after a successful apply. If the file does not exist

--- a/pkg/autopilot/controller/signal/k0s/apply_test.go
+++ b/pkg/autopilot/controller/signal/k0s/apply_test.go
@@ -21,8 +21,10 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -38,7 +40,7 @@ type failFirstUpdateClient struct {
 func (c *failFirstUpdateClient) Update(ctx context.Context, obj crcli.Object, opts ...crcli.UpdateOption) error {
 	c.updateAttempts++
 	if c.updateAttempts == 1 {
-		return errors.New("simulated update conflict")
+		return errors.New("simulated update failure")
 	}
 	return c.Client.Update(ctx, obj, opts...)
 }
@@ -324,4 +326,103 @@ func TestApplyingUpdateReconcileRetryAfterUpdateFailure(t *testing.T) {
 
 	_, err = os.Stat(updateFilenamePath)
 	assert.True(t, os.IsNotExist(err))
+}
+
+// conflictOnFirstUpdateClient rejects the first update with a genuine API
+// conflict, the way a concurrent writer to the same signal node would.
+type conflictOnFirstUpdateClient struct {
+	crcli.Client
+	updates int
+}
+
+func (c *conflictOnFirstUpdateClient) Update(ctx context.Context, obj crcli.Object, opts ...crcli.UpdateOption) error {
+	c.updates++
+	if c.updates == 1 {
+		return apierrors.NewConflict(
+			schema.GroupResource{Group: "autopilot.k0sproject.io", Resource: "controlnodes"},
+			obj.GetName(), errors.New("the object has been modified"))
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+// TestApplyingUpdateAbsorbsWriteConflict ensures that losing the race to record
+// the resulting status does not make the reconciler apply the update again.
+//
+// The binary has already been replaced by the time the status is recorded, so a
+// conflict used to surface as a reconcile error and the whole sequence ran again
+// on the requeue. Against something that keeps writing to the signal node, that
+// is a race the reconciler can keep losing. The write is retried on its own now,
+// so one reconcile is enough and the apply happens once.
+func TestApplyingUpdateAbsorbsWriteConflict(t *testing.T) {
+	commandID := 123
+	signalData := apsigv2.SignalData{
+		PlanID:  "plan-1",
+		Created: "2026-01-01T00:00:00Z",
+		Command: apsigv2.Command{
+			ID: &commandID,
+			K0sUpdate: &apsigv2.CommandK0sUpdate{
+				URL:     "https://updates.example.com/k0s",
+				Version: "v1.2.3",
+			},
+		},
+		Status: &apsigv2.Status{Status: ApplyingUpdate, Timestamp: "2026-01-01T00:00:00Z"},
+	}
+
+	annotations := map[string]string{}
+	require.NoError(t, signalData.Marshal(annotations))
+
+	signalNode := &apv1beta2.ControlNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node0", Annotations: annotations},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, apscheme.AddToScheme(scheme))
+	baseClient := crfake.NewClientBuilder().WithObjects(signalNode).WithScheme(scheme).Build()
+
+	delegate := apdel.ControlNodeControllerDelegate()
+	client := &conflictOnFirstUpdateClient{Client: baseClient}
+
+	// The apply sequence records a pending restart exactly once per pass, so
+	// this counts how often the update was applied.
+	applies := 0
+	reconciler := &applyingUpdate{
+		log:              logrus.NewEntry(logrus.StandardLogger()),
+		client:           client,
+		delegate:         delegate,
+		k0sBinaryDir:     t.TempDir(),
+		restartInitiated: func(apsigv2.SignalData) { applies++ },
+	}
+
+	updateFilenamePath := filepath.Join(reconciler.k0sBinaryDir, apconst.K0sTempFilename)
+	k0sBinaryFilenamePath := filepath.Join(reconciler.k0sBinaryDir, "k0s")
+	updateLinkFilenamePath := filepath.Join(reconciler.k0sBinaryDir, apconst.K0sTempLinkFilename)
+
+	require.NoError(t, os.WriteFile(updateFilenamePath, []byte("new k0s binary"), 0755))
+	require.NoError(t, os.WriteFile(k0sBinaryFilenamePath, []byte("old k0s binary"), 0755))
+
+	req := crrec.Request{NamespacedName: types.NamespacedName{Name: "node0"}}
+
+	_, err := reconciler.Reconcile(t.Context(), req)
+	require.NoError(t, err, "a conflicting write is retried rather than surfaced for a requeue")
+
+	assert.Equal(t, 2, client.updates, "the conflict should have been retried within the same reconcile")
+	assert.Equal(t, 1, applies, "the update must not be applied a second time")
+
+	// The status made it, so the plan can move on.
+	updatedNode := delegate.CreateObject()
+	require.NoError(t, baseClient.Get(t.Context(), req.NamespacedName, updatedNode))
+	var updatedData apsigv2.SignalData
+	require.NoError(t, updatedData.Unmarshal(updatedNode.GetAnnotations()))
+	if assert.NotNil(t, updatedData.Status) {
+		assert.Equal(t, Restart, updatedData.Status.Status)
+	}
+
+	// And the apply itself completed: binary replaced, scratch files cleaned up.
+	replacedBinary, err := os.ReadFile(k0sBinaryFilenamePath)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("new k0s binary"), replacedBinary)
+	_, err = os.Stat(updateFilenamePath)
+	assert.True(t, os.IsNotExist(err), "k0s.tmp should be cleaned up after a successful apply")
+	_, err = os.Stat(updateLinkFilenamePath)
+	assert.True(t, os.IsNotExist(err), "the hard link should not be left behind")
 }

--- a/pkg/autopilot/controller/signal/k0s/cordon.go
+++ b/pkg/autopilot/controller/signal/k0s/cordon.go
@@ -16,6 +16,7 @@ import (
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
+	apsigcomm "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common"
 	apsigpred "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common/predicate"
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
 	kubeutil "github.com/k0sproject/k0s/pkg/kubernetes"
@@ -207,16 +208,12 @@ func (r *cordonUncordon) moveToNextState(ctx context.Context, signalNode crcli.O
 		return fmt.Errorf("unable to unmarshal signal data: %w", err)
 	}
 
-	signalData.Status = apsigv2.NewStatus(r.nextState)
-	signalNodeCopy := r.delegate.DeepCopy(signalNode)
-
-	if err := signalData.Marshal(signalNodeCopy.GetAnnotations()); err != nil {
-		return fmt.Errorf("unable to marshal signal data: %w", err)
-	}
-
-	logger.Infof("Updating signaling response to '%s'", signalData.Status.Status)
-	if err := r.client.Update(ctx, signalNodeCopy, &crcli.UpdateOptions{}); err != nil {
-		logger.Errorf("Failed to update signal node to status '%s': %v", signalData.Status.Status, err)
+	// Cordoning and draining can take a while, so don't write back the signal
+	// node as it was read before that started. See [apsigcomm.UpdateSignalStatus].
+	newStatus := apsigv2.NewStatus(r.nextState)
+	key := r.delegate.CreateNamespacedName(signalNode.GetName())
+	if _, err := apsigcomm.UpdateSignalStatus(ctx, logger, r.client, r.delegate, key, signalData, []string{"", r.currentState}, newStatus); err != nil {
+		logger.Errorf("Failed to update signal node to status '%s': %v", newStatus.Status, err)
 		return err
 	}
 	return nil

--- a/pkg/autopilot/controller/signal/k0s/restart_unix.go
+++ b/pkg/autopilot/controller/signal/k0s/restart_unix.go
@@ -15,6 +15,7 @@ import (
 
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
+	apsigcomm "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common"
 	apsigpred "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common/predicate"
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
 	"github.com/k0sproject/k0s/pkg/component/status"
@@ -152,16 +153,9 @@ func (r *restart) Reconcile(ctx context.Context, req cr.Request) (cr.Result, err
 	restartPending := r.isRestartPending(signalData)
 
 	if k0sVersion == signalData.Command.K0sUpdate.Version || (!restartPending && signalData.Command.K0sUpdate.ForceUpdate) {
-		signalNodeCopy := r.delegate.DeepCopy(signalNode)
-		signalData.Status = apsigv2.NewStatus(UnCordoning)
-
-		if err := signalData.Marshal(signalNodeCopy.GetAnnotations()); err != nil {
-			return cr.Result{}, fmt.Errorf("unable to marshal signal data for node='%s': %w", req.Name, err)
-		}
-
-		logger.Infof("Updating signaling response to '%s'", signalData.Status.Status)
-		if err := r.client.Update(ctx, signalNodeCopy, &crcli.UpdateOptions{}); err != nil {
-			return cr.Result{}, fmt.Errorf("unable to update signal node with '%s' status: %w", signalData.Status.Status, err)
+		newStatus := apsigv2.NewStatus(UnCordoning)
+		if _, err := apsigcomm.UpdateSignalStatus(ctx, logger, r.client, r.delegate, req.NamespacedName, signalData, []string{"", Restart}, newStatus); err != nil {
+			return cr.Result{}, fmt.Errorf("unable to update signal node with '%s' status: %w", newStatus.Status, err)
 		}
 
 		return cr.Result{}, nil

--- a/pkg/autopilot/controller/signal/k0s/restarted_unix.go
+++ b/pkg/autopilot/controller/signal/k0s/restarted_unix.go
@@ -12,6 +12,7 @@ import (
 
 	apcomm "github.com/k0sproject/k0s/pkg/autopilot/common"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
+	apsigcomm "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common"
 	apsigpred "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common/predicate"
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
 	"github.com/k0sproject/k0s/pkg/component/status"
@@ -117,16 +118,9 @@ func (r *restarted) Reconcile(ctx context.Context, req cr.Request) (cr.Result, e
 	// Move to the next successful state 'UnCordoning' if our versions match
 
 	if k0sVersion == signalData.Command.K0sUpdate.Version || signalData.Command.K0sUpdate.ForceUpdate {
-		signalNodeCopy := r.delegate.DeepCopy(signalNode)
-		signalData.Status = apsigv2.NewStatus(UnCordoning)
-
-		if err := signalData.Marshal(signalNodeCopy.GetAnnotations()); err != nil {
-			return cr.Result{}, fmt.Errorf("unable to marshal signal data for node='%s': %w", req.Name, err)
-		}
-
-		logger.Infof("Updating signaling response to '%s'", signalData.Status.Status)
-		if err := r.client.Update(ctx, signalNodeCopy, &crcli.UpdateOptions{}); err != nil {
-			return cr.Result{}, fmt.Errorf("unable to update signal node with '%s' status: %w", signalData.Status.Status, err)
+		newStatus := apsigv2.NewStatus(UnCordoning)
+		if _, err := apsigcomm.UpdateSignalStatus(ctx, logger, r.client, r.delegate, req.NamespacedName, signalData, []string{"", Restart}, newStatus); err != nil {
+			return cr.Result{}, fmt.Errorf("unable to update signal node with '%s' status: %w", newStatus.Status, err)
 		}
 
 		return cr.Result{}, nil

--- a/pkg/autopilot/controller/signal/k0s/signal.go
+++ b/pkg/autopilot/controller/signal/k0s/signal.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	cr "sigs.k8s.io/controller-runtime"
-	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crev "sigs.k8s.io/controller-runtime/pkg/event"
 	crman "sigs.k8s.io/controller-runtime/pkg/manager"
 	crpred "sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -124,28 +123,30 @@ func (h *signalControllerHandler) Handle(ctx context.Context, sctx apsigcomm.Sig
 		status = apsigcomm.Completed
 	}
 
-	// Populate the response into the annotations
-	signalNodeCopy := sctx.Delegate.DeepCopy(sctx.SignalNode)
-
 	var oldStatus string
 	if sctx.SignalData.Status != nil {
 		oldStatus = sctx.SignalData.Status.Status
 	}
-	sctx.SignalData.Status = apsigv2.NewStatus(status)
-	if err := sctx.SignalData.Marshal(signalNodeCopy.GetAnnotations()); err != nil {
-		return cr.Result{}, fmt.Errorf("unable to marshal k0s signal data for node='%s': %w", signalNodeCopy.GetName(), err)
+
+	// Determining the k0s version above talks to the status socket, so don't
+	// write back the signal node as it was read before that.
+	// See [apsigcomm.UpdateSignalStatus].
+	nodeName := sctx.SignalNode.GetName()
+	key := sctx.Delegate.CreateNamespacedName(nodeName)
+	recorded, err := apsigcomm.UpdateSignalStatus(ctx, sctx.Log, sctx.Client, sctx.Delegate, key, *sctx.SignalData, []string{""}, apsigv2.NewStatus(status))
+	if err != nil {
+		return cr.Result{}, fmt.Errorf("unable to update k0s signal node='%s' with status='%s': %w", nodeName, status, err)
 	}
 
-	sctx.Log.Infof("Updating signaling response to '%s'", status)
-	if err := sctx.Client.Update(ctx, signalNodeCopy, &crcli.UpdateOptions{}); err != nil {
-		return cr.Result{}, fmt.Errorf("unable to update k0s signal node='%s' with status='%s': %w", signalNodeCopy.GetName(), status, err)
+	// Only report a transition that actually happened. The status is not
+	// recorded if the request was superseded while the version was determined.
+	if recorded {
+		_ = apcomm.ReportEvent(&apcomm.Event{
+			ClusterID: h.clusterID,
+			OldStatus: oldStatus,
+			NewStatus: status,
+		})
 	}
-
-	_ = apcomm.ReportEvent(&apcomm.Event{
-		ClusterID: h.clusterID,
-		OldStatus: oldStatus,
-		NewStatus: status,
-	})
 
 	return cr.Result{}, nil
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

The signal reconcilers download, drain or replace binaries and then write the status back to the signal node as it was read before that work started. The write fails if anything else touched the object meanwhile, and since a failed write makes the reconciler redo the work, every retry loses the same race again. In check-ap-controllerworker a node sat in 'Downloading' for 3 minutes and 118 attempts before the suite timed out.

Add UpdateSignalStatus, which re-reads the node and records the status on the fresh object, retrying conflicts. Retrying is cheap now that no work happens inside the read-modify-write window. Patching just the status would avoid the conflicts too, but would silently overwrite signaling that arrived while the work was running, such as a newer plan for the same node.

Only record the status if the node still carries the same request and is in one of the statuses the transition is valid from. This is the same precondition the reconcilers already check before they start, just re-evaluated against the current state. It has to be a set: for airgap updates the download and signal reconcilers trigger on the same status-less event, so the signal reconciler moves the node to 'Downloading' while the download is already running.

Converted all seven transitions: the shared download reconciler, the k0s cordon/uncordon, apply, restart and restarted reconcilers, and the k0s and airgap signal handlers. Only the download reconciler was seen failing, so that one is fixed in the first commit. The other six have the same race but no reported flakiness and follow in a second commit. A third commit corrects the timeout comment left behind by #8151.

This is the root cause behind the flakiness that #8151 worked around by raising the timeout. 

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

`TestUpdateSignalStatus` covers the states a signal node can be in when a reconciler is done with its work, and asserts that the status is recorded only when that is still applicable. `TestDownloadControllerAgainstAnnotationChurn` reproduces the livelock by writing an unrelated annotation faster than the download takes, and `TestDownloadControllerConcurrentStatusUpdate` covers the airgap case where the signal reconciler advances the status while the download is running. Both fail against the old code.

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
