### PR TITLE
Use in-memory stack apply in coredns component

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -388,6 +388,7 @@ func (c *command) start(ctx context.Context, runtimeConfig *config.RuntimeConfig
 			IgnoredStacks: []string{
 				controller.AutopilotStackName,
 				controller.ClusterConfigStackName,
+				controller.CoreDNSStackName,
 				controller.EtcdMemberStackName,
 				controller.HelmExtensionStackName,
 				controller.SystemRBACStackName,
@@ -539,7 +540,7 @@ func (c *command) start(ctx context.Context, runtimeConfig *config.RuntimeConfig
 	}
 
 	if !slices.Contains(flags.DisableComponents, constant.CoreDNSComponentname) {
-		coreDNS, err := controller.NewCoreDNS(c.K0sVars, adminClientFactory, nodeConfig)
+		coreDNS, err := controller.NewCoreDNS(adminClientFactory, leaderElector, nodeConfig)
 		if err != nil {
 			return fmt.Errorf("failed to create CoreDNS reconciler: %w", err)
 		}

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -540,7 +540,7 @@ func (c *command) start(ctx context.Context, runtimeConfig *config.RuntimeConfig
 	}
 
 	if !slices.Contains(flags.DisableComponents, constant.CoreDNSComponentname) {
-		coreDNS, err := controller.NewCoreDNS(adminClientFactory, leaderElector, nodeConfig)
+		coreDNS, err := controller.NewCoreDNS(adminClientFactory, leaderElector.CurrentStatus, nodeConfig)
 		if err != nil {
 			return fmt.Errorf("failed to create CoreDNS reconciler: %w", err)
 		}

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -4,15 +4,18 @@
 package controller
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
-	"path/filepath"
 	"reflect"
 	"time"
 
+	"github.com/k0sproject/k0s/internal/sync/value"
+	"github.com/k0sproject/k0s/pkg/applier"
+	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/manager"
-	"github.com/k0sproject/k0s/pkg/config"
+	"github.com/k0sproject/k0s/pkg/leaderelection"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -20,10 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/metadata"
 
-	"github.com/k0sproject/k0s/internal/pkg/dir"
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
-	"github.com/k0sproject/k0s/pkg/constant"
 	k8sutil "github.com/k0sproject/k0s/pkg/kubernetes"
 )
 
@@ -262,6 +263,9 @@ spec:
     protocol: TCP
 `
 
+// CoreDNSStackName is the name of the in-memory applier stack managing the CoreDNS resources.
+const CoreDNSStackName = "coredns"
+
 const HostsPerExtraReplica = 10.0
 
 var _ manager.Component = (*CoreDNS)(nil)
@@ -272,12 +276,13 @@ type CoreDNS struct {
 	dnsAddress             string
 	clusterDomain          string
 	client                 metadata.Interface
+	clientFactory          k8sutil.ClientFactoryInterface
+	leaderElector          leaderelector.Interface
 	log                    *logrus.Entry
-	manifestDir            string
 	previousConfig         coreDNSConfig
 	previousPatches        v1beta1.Patches
 	stopFunc               context.CancelFunc
-	lastKnownClusterConfig *v1beta1.ClusterConfig
+	lastKnownClusterConfig value.Latest[*v1beta1.ClusterConfig]
 }
 
 type coreDNSConfig struct {
@@ -292,7 +297,7 @@ type coreDNSConfig struct {
 }
 
 // NewCoreDNS creates new instance of CoreDNS component
-func NewCoreDNS(k0sVars *config.CfgVars, clientFactory k8sutil.ClientFactoryInterface, nodeConfig *v1beta1.ClusterConfig) (*CoreDNS, error) {
+func NewCoreDNS(clientFactory k8sutil.ClientFactoryInterface, leaderElector leaderelector.Interface, nodeConfig *v1beta1.ClusterConfig) (*CoreDNS, error) {
 	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.Spec.PrimaryAddressFamily())
 	if err != nil {
 		return nil, err
@@ -312,14 +317,15 @@ func NewCoreDNS(k0sVars *config.CfgVars, clientFactory k8sutil.ClientFactoryInte
 		dnsAddress:    dnsAddress,
 		clusterDomain: nodeConfig.Spec.Network.ClusterDomain,
 		client:        client,
+		clientFactory: clientFactory,
+		leaderElector: leaderElector,
 		log:           logrus.WithField("component", "coredns"),
-		manifestDir:   filepath.Join(k0sVars.ManifestsDir, "coredns"),
 	}, nil
 }
 
-// Init does nothing
+// Init does nothing as there's nothing to initialize
 func (c *CoreDNS) Init(_ context.Context) error {
-	return dir.Init(c.manifestDir, constant.ManifestsDirMode)
+	return nil
 }
 
 // Run runs the CoreDNS reconciler component
@@ -332,11 +338,12 @@ func (c *CoreDNS) Start(ctx context.Context) error {
 		for {
 			select {
 			case <-ticker.C:
-				if c.lastKnownClusterConfig == nil {
+				clusterConfig, _ := c.lastKnownClusterConfig.Peek()
+				if clusterConfig == nil {
 					// We cannot figure out the full config without having the last known cluster config from CR
 					continue
 				}
-				err := c.Reconcile(ctx, c.lastKnownClusterConfig)
+				err := c.Reconcile(ctx, clusterConfig)
 				if err != nil {
 					c.log.Warnf("failed to reconcile coredns based on node count: %v", err)
 				}
@@ -421,6 +428,15 @@ func (c *CoreDNS) Stop() error {
 // Reconcile detects changes in configuration and applies them to the component
 func (c *CoreDNS) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterConfig) error {
 	logrus.Debug("reconcile method called for: CoreDNS")
+
+	// Needed regardless of leadership, so the node-count ticker in Start can
+	// retry once this instance becomes the leader.
+	c.lastKnownClusterConfig.Set(clusterConfig)
+
+	if status, _ := c.leaderElector.CurrentStatus(); status != leaderelection.StatusLeading {
+		return nil
+	}
+
 	cfg, err := c.getConfig(ctx, clusterConfig)
 	if err != nil {
 		return fmt.Errorf("error calculating coredns configs: %w, will retry", err)
@@ -438,15 +454,22 @@ func (c *CoreDNS) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterC
 		Name:     "coredns",
 		Template: coreDNSTemplate,
 		Data:     cfg,
-		Path:     filepath.Join(c.manifestDir, "coredns.yaml"),
 		Patches:  patches,
 	}
-	err = tw.Write()
+	var out bytes.Buffer
+	err = tw.WriteToBuffer(&out)
 	if err != nil {
 		return fmt.Errorf("error writing coredns manifests: %w, will retry", err)
 	}
+	resources, err := applier.ReadUnstructuredStream(&out, CoreDNSStackName)
+	if err != nil {
+		return fmt.Errorf("error reading coredns resources: %w, will retry", err)
+	}
+	if err := applier.ApplyStack(ctx, c.clientFactory, resources, CoreDNSStackName); err != nil {
+		return fmt.Errorf("error applying coredns stack: %w, will retry", err)
+	}
+
 	c.previousConfig = cfg
 	c.previousPatches = patches
-	c.lastKnownClusterConfig = clusterConfig
 	return nil
 }

--- a/pkg/component/controller/coredns.go
+++ b/pkg/component/controller/coredns.go
@@ -9,11 +9,11 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/k0sproject/k0s/internal/sync/value"
 	"github.com/k0sproject/k0s/pkg/applier"
-	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/component/manager"
 	"github.com/k0sproject/k0s/pkg/leaderelection"
 
@@ -277,12 +277,13 @@ type CoreDNS struct {
 	clusterDomain          string
 	client                 metadata.Interface
 	clientFactory          k8sutil.ClientFactoryInterface
-	leaderElector          leaderelector.Interface
+	leaderStatus           leaderelection.StatusFunc
 	log                    *logrus.Entry
 	previousConfig         coreDNSConfig
 	previousPatches        v1beta1.Patches
 	stopFunc               context.CancelFunc
 	lastKnownClusterConfig value.Latest[*v1beta1.ClusterConfig]
+	reconcileMutex         sync.Mutex
 }
 
 type coreDNSConfig struct {
@@ -297,7 +298,7 @@ type coreDNSConfig struct {
 }
 
 // NewCoreDNS creates new instance of CoreDNS component
-func NewCoreDNS(clientFactory k8sutil.ClientFactoryInterface, leaderElector leaderelector.Interface, nodeConfig *v1beta1.ClusterConfig) (*CoreDNS, error) {
+func NewCoreDNS(clientFactory k8sutil.ClientFactoryInterface, leaderStatus leaderelection.StatusFunc, nodeConfig *v1beta1.ClusterConfig) (*CoreDNS, error) {
 	dnsAddress, err := nodeConfig.Spec.Network.DNSAddress(nodeConfig.Spec.PrimaryAddressFamily())
 	if err != nil {
 		return nil, err
@@ -318,7 +319,7 @@ func NewCoreDNS(clientFactory k8sutil.ClientFactoryInterface, leaderElector lead
 		clusterDomain: nodeConfig.Spec.Network.ClusterDomain,
 		client:        client,
 		clientFactory: clientFactory,
-		leaderElector: leaderElector,
+		leaderStatus:  leaderStatus,
 		log:           logrus.WithField("component", "coredns"),
 	}, nil
 }
@@ -340,10 +341,10 @@ func (c *CoreDNS) Start(ctx context.Context) error {
 			case <-ticker.C:
 				clusterConfig, _ := c.lastKnownClusterConfig.Peek()
 				if clusterConfig == nil {
-					// We cannot figure out the full config without having the last known cluster config from CR
+					c.log.Info("no last known cluster config, skipping reconcile")
 					continue
 				}
-				err := c.Reconcile(ctx, clusterConfig)
+				err := c.reconcile(ctx)
 				if err != nil {
 					c.log.Warnf("failed to reconcile coredns based on node count: %v", err)
 				}
@@ -427,13 +428,28 @@ func (c *CoreDNS) Stop() error {
 
 // Reconcile detects changes in configuration and applies them to the component
 func (c *CoreDNS) Reconcile(ctx context.Context, clusterConfig *v1beta1.ClusterConfig) error {
-	logrus.Debug("reconcile method called for: CoreDNS")
-
-	// Needed regardless of leadership, so the node-count ticker in Start can
-	// retry once this instance becomes the leader.
+	// Reconcile is the only source-of-truth for cluster config
 	c.lastKnownClusterConfig.Set(clusterConfig)
+	return c.reconcile(ctx)
+}
 
-	if status, _ := c.leaderElector.CurrentStatus(); status != leaderelection.StatusLeading {
+// reconcile peeks the last known config and reconciles CoreDNS with that
+func (c *CoreDNS) reconcile(ctx context.Context) error {
+	logrus.Debug("reconcile method called for: CoreDNS")
+	// Allow only one concurrent reconcile as it can be triggered either via the ticker or config change
+	c.reconcileMutex.Lock()
+	defer c.reconcileMutex.Unlock()
+
+	clusterConfig, _ := c.lastKnownClusterConfig.Peek()
+	if clusterConfig == nil {
+		c.log.Info("no last known cluster config, skipping reconcile")
+		return nil
+	}
+
+	ctx, cancel := leaderelection.LeaderContext(ctx, c.leaderStatus)
+	defer cancel()
+	if err := ctx.Err(); err != nil {
+		c.log.Debugf("Skipping reconciliation: %v", context.Cause(ctx))
 		return nil
 	}
 

--- a/pkg/component/controller/coredns_test.go
+++ b/pkg/component/controller/coredns_test.go
@@ -8,10 +8,17 @@ import (
 	"testing"
 
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
+	"github.com/k0sproject/k0s/internal/testutil"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
+	"github.com/k0sproject/k0s/pkg/leaderelection"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metadatafake "k8s.io/client-go/metadata/fake"
 )
 
 func TestCoreDNS_RenderWithPatch(t *testing.T) {
@@ -34,6 +41,52 @@ func TestCoreDNS_RenderWithPatch(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, tw.WriteToBuffer(&buf))
 	assert.Contains(t, buf.String(), "patched")
+}
+
+func TestCoreDNS_Reconcile_Leading(t *testing.T) {
+	clients := testutil.NewFakeClientFactory()
+	c := &CoreDNS{
+		clusterDomain: "cluster.local",
+		dnsAddress:    "10.96.0.10",
+		client:        metadatafake.NewSimpleMetadataClient(metadatafake.NewTestScheme()),
+		clientFactory: clients,
+		leaderElector: leaderelector.Off(),
+		log:           logrus.WithField("component", "coredns"),
+	}
+
+	require.NoError(t, c.Reconcile(t.Context(), v1beta1.DefaultClusterConfig()))
+
+	_, err := clients.Client.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(t.Context(), "coredns", metav1.GetOptions{})
+	assert.NoError(t, err, "expected the coredns ConfigMap to be applied")
+}
+
+func TestCoreDNS_Reconcile_NotLeading(t *testing.T) {
+	clients := testutil.NewFakeClientFactory()
+	c := &CoreDNS{
+		clusterDomain: "cluster.local",
+		dnsAddress:    "10.96.0.10",
+		client:        metadatafake.NewSimpleMetadataClient(metadatafake.NewTestScheme()),
+		clientFactory: clients,
+		leaderElector: pendingLeaderElector{},
+		log:           logrus.WithField("component", "coredns"),
+	}
+
+	require.NoError(t, c.Reconcile(t.Context(), v1beta1.DefaultClusterConfig()))
+
+	_, err := clients.Client.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(t.Context(), "coredns", metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err), "a non-leader must not apply the coredns stack, got: %v", err)
+	lastKnownClusterConfig, _ := c.lastKnownClusterConfig.Peek()
+	assert.NotNil(t, lastKnownClusterConfig, "lastKnownClusterConfig must still be tracked so a later leadership change gets picked up")
+}
+
+// pendingLeaderElector is a [leaderelector.Interface] that never leads.
+type pendingLeaderElector struct{}
+
+func (pendingLeaderElector) IsLeader() bool                  { return false }
+func (pendingLeaderElector) AddAcquiredLeaseCallback(func()) {}
+func (pendingLeaderElector) AddLostLeaseCallback(func())     {}
+func (pendingLeaderElector) CurrentStatus() (leaderelection.Status, <-chan struct{}) {
+	return leaderelection.StatusPending, nil
 }
 
 func Test_replicaCount(t *testing.T) {

--- a/pkg/component/controller/coredns_test.go
+++ b/pkg/component/controller/coredns_test.go
@@ -5,12 +5,13 @@ package controller
 
 import (
 	"bytes"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/k0sproject/k0s/internal/pkg/templatewriter"
 	"github.com/k0sproject/k0s/internal/testutil"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
-	"github.com/k0sproject/k0s/pkg/component/controller/leaderelector"
 	"github.com/k0sproject/k0s/pkg/leaderelection"
 
 	"github.com/sirupsen/logrus"
@@ -18,7 +19,9 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	metadatafake "k8s.io/client-go/metadata/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestCoreDNS_RenderWithPatch(t *testing.T) {
@@ -50,7 +53,7 @@ func TestCoreDNS_Reconcile_Leading(t *testing.T) {
 		dnsAddress:    "10.96.0.10",
 		client:        metadatafake.NewSimpleMetadataClient(metadatafake.NewTestScheme()),
 		clientFactory: clients,
-		leaderElector: leaderelector.Off(),
+		leaderStatus:  func() (leaderelection.Status, <-chan struct{}) { return leaderelection.StatusLeading, nil },
 		log:           logrus.WithField("component", "coredns"),
 	}
 
@@ -67,7 +70,7 @@ func TestCoreDNS_Reconcile_NotLeading(t *testing.T) {
 		dnsAddress:    "10.96.0.10",
 		client:        metadatafake.NewSimpleMetadataClient(metadatafake.NewTestScheme()),
 		clientFactory: clients,
-		leaderElector: pendingLeaderElector{},
+		leaderStatus:  func() (leaderelection.Status, <-chan struct{}) { return leaderelection.StatusPending, nil },
 		log:           logrus.WithField("component", "coredns"),
 	}
 
@@ -79,14 +82,59 @@ func TestCoreDNS_Reconcile_NotLeading(t *testing.T) {
 	assert.NotNil(t, lastKnownClusterConfig, "lastKnownClusterConfig must still be tracked so a later leadership change gets picked up")
 }
 
-// pendingLeaderElector is a [leaderelector.Interface] that never leads.
-type pendingLeaderElector struct{}
+// Test that the reconcile handles ordering and config snapshotting properly
+// in case concurrent triggering
+func TestCoreDNS_Reconcile_UsesLatestConfigAfterConcurrentUpdate(t *testing.T) {
+	clients := testutil.NewFakeClientFactory()
+	applyStarted := make(chan struct{})
+	releaseApply := make(chan struct{})
+	var blockOnce sync.Once
+	clients.DynamicClient.PrependReactor("create", "*", func(k8stesting.Action) (bool, runtime.Object, error) {
+		blockOnce.Do(func() {
+			close(applyStarted)
+			<-releaseApply
+		})
+		return false, nil, nil
+	})
 
-func (pendingLeaderElector) IsLeader() bool                  { return false }
-func (pendingLeaderElector) AddAcquiredLeaseCallback(func()) {}
-func (pendingLeaderElector) AddLostLeaseCallback(func())     {}
-func (pendingLeaderElector) CurrentStatus() (leaderelection.Status, <-chan struct{}) {
-	return leaderelection.StatusPending, nil
+	c := &CoreDNS{
+		clusterDomain: "cluster.local",
+		dnsAddress:    "10.96.0.10",
+		client:        metadatafake.NewSimpleMetadataClient(metadatafake.NewTestScheme()),
+		clientFactory: clients,
+		leaderStatus:  func() (leaderelection.Status, <-chan struct{}) { return leaderelection.StatusLeading, nil },
+		log:           logrus.WithField("component", "coredns"),
+	}
+
+	configA := v1beta1.DefaultClusterConfig()
+	configA.Spec.Images.CoreDNS.Image = "coredns-a.example/test"
+	configB := configA.DeepCopy()
+	configB.Spec.Images.CoreDNS.Image = "coredns-b.example/test"
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- c.Reconcile(t.Context(), configA)
+	}()
+
+	<-applyStarted
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- c.Reconcile(t.Context(), configB)
+	}()
+
+	require.Eventually(t, func() bool {
+		latest, _ := c.lastKnownClusterConfig.Peek()
+		return latest == configB
+	}, time.Second, time.Millisecond, "new config was not published")
+
+	close(releaseApply)
+	require.NoError(t, <-firstDone)
+	require.NoError(t, <-secondDone)
+
+	deployment, err := clients.Client.AppsV1().Deployments(metav1.NamespaceSystem).Get(t.Context(), "coredns", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, configB.Spec.Images.CoreDNS.URI(), deployment.Spec.Template.Spec.Containers[0].Image, "latest config should win after concurrent reconciliation")
 }
 
 func Test_replicaCount(t *testing.T) {

--- a/pkg/leaderelection/tasks.go
+++ b/pkg/leaderelection/tasks.go
@@ -11,6 +11,9 @@ import (
 // Indicates that the previously gained lead has been lost.
 var ErrLostLead = errors.New("lost the lead")
 
+// Indicates that the lead wasn't held to begin with.
+var ErrNotLeading = errors.New("not currently leading")
+
 // Returns the current leader election status. Whenever the status becomes
 // outdated, the returned expired channel will be closed.
 type StatusFunc func() (current Status, expired <-chan struct{})
@@ -43,4 +46,33 @@ func RunLeaderTasks(ctx context.Context, statusFunc StatusFunc, tasks func(conte
 			return
 		}
 	}
+}
+
+// Derives a context from ctx for a single leadership snapshot, taken via
+// statusFunc. The returned context is already canceled with ErrNotLeading if
+// the caller isn't currently leading. Otherwise, it gets canceled with
+// ErrLostLead as soon as the lease ends, or whenever ctx itself is done.
+// Unlike RunLeaderTasks, this doesn't loop or wait for the lead to be taken;
+// callers are expected to call it again for every new leadership check. The
+// returned cancel func must be called once the context is no longer needed,
+// to release resources.
+func LeaderContext(ctx context.Context, statusFunc StatusFunc) (context.Context, context.CancelFunc) {
+	status, expired := statusFunc()
+
+	leaderCtx, cancel := context.WithCancelCause(ctx)
+	stop := func() { cancel(nil) }
+	if status != StatusLeading {
+		cancel(ErrNotLeading)
+		return leaderCtx, stop
+	}
+
+	go func() {
+		select {
+		case <-expired:
+			cancel(ErrLostLead)
+		case <-leaderCtx.Done():
+		}
+	}()
+
+	return leaderCtx, stop
 }

--- a/pkg/leaderelection/tasks_test.go
+++ b/pkg/leaderelection/tasks_test.go
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package leaderelection
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLeaderContext_NotLeading(t *testing.T) {
+	statusFunc := func() (Status, <-chan struct{}) { return StatusPending, nil }
+
+	ctx, cancel := LeaderContext(t.Context(), statusFunc)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("expected the context to be already canceled when not leading")
+	}
+	assert.ErrorIs(t, context.Cause(ctx), ErrNotLeading, "unexpected cancellation cause")
+}
+
+func TestLeaderContext_Leading_CancelsOnLeaseLost(t *testing.T) {
+	expired := make(chan struct{})
+	statusFunc := func() (Status, <-chan struct{}) { return StatusLeading, expired }
+
+	ctx, cancel := LeaderContext(t.Context(), statusFunc)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("expected the context to still be active while leading")
+	default:
+	}
+
+	close(expired)
+
+	<-ctx.Done()
+	assert.ErrorIs(t, context.Cause(ctx), ErrLostLead, "unexpected cancellation cause")
+}
+
+func TestLeaderContext_Leading_CancelsOnParentDone(t *testing.T) {
+	statusFunc := func() (Status, <-chan struct{}) { return StatusLeading, make(chan struct{}) }
+
+	parent, parentCancel := context.WithCancel(t.Context())
+	ctx, cancel := LeaderContext(parent, statusFunc)
+	defer cancel()
+
+	parentCancel()
+
+	<-ctx.Done()
+	assert.ErrorIs(t, context.Cause(ctx), context.Canceled, "unexpected cancellation cause")
+}
+
+func TestLeaderContext_Stop_ReleasesTheContext(t *testing.T) {
+	statusFunc := func() (Status, <-chan struct{}) { return StatusLeading, make(chan struct{}) }
+
+	ctx, cancel := LeaderContext(t.Context(), statusFunc)
+	cancel()
+
+	<-ctx.Done()
+	assert.ErrorIs(t, context.Cause(ctx), context.Canceled, "unexpected cancellation cause")
+}


### PR DESCRIPTION
## Description

This is to avoid the async hop via FS which has know timing etc. issues.

Part of #8254

Needs to land AFTER #8220 so we can backport that across all needed branches

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
