### PR TITLE
Add unit tests for DecodeJoinToken, JoinEncode, and GetTokenType

### DIFF
--- a/pkg/token/joindecode_test.go
+++ b/pkg/token/joindecode_test.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package token_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/k0sproject/k0s/pkg/token"
+
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeJoinToken_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := token.JoinEncode(bytes.NewReader([]byte("the-payload")))
+	require.NoError(t, err)
+
+	decoded, err := token.DecodeJoinToken(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("the-payload"), decoded)
+}
+
+func TestDecodeJoinToken_InvalidBase64(t *testing.T) {
+	t.Parallel()
+
+	decoded, err := token.DecodeJoinToken("not-valid-base64!!!")
+	assert.ErrorContains(t, err, "illegal base64 data")
+	assert.Zero(t, decoded)
+}
+
+func TestDecodeJoinToken_InvalidGzip(t *testing.T) {
+	t.Parallel()
+
+	// Valid base64, but not gzip data underneath.
+	decoded, err := token.DecodeJoinToken("bm90LWd6aXA=")
+	assert.ErrorContains(t, err, "unexpected EOF")
+	assert.Zero(t, decoded)
+}
+
+func TestGetTokenType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		contexts map[string]*clientcmdapi.Context
+		want     []string // map iteration order is unspecified, so any of these is acceptable
+	}{
+		{
+			name: "zero contexts",
+			want: []string{""},
+		},
+		{
+			name: "one context",
+			contexts: map[string]*clientcmdapi.Context{
+				"the-context": {AuthInfo: "the-auth-info"},
+			},
+			want: []string{"the-auth-info"},
+		},
+		{
+			name: "two contexts",
+			contexts: map[string]*clientcmdapi.Context{
+				"context-a": {AuthInfo: "auth-a"},
+				"context-b": {AuthInfo: "auth-b"},
+			},
+			want: []string{"auth-a", "auth-b"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &clientcmdapi.Config{Contexts: test.contexts}
+			assert.Contains(t, test.want, token.GetTokenType(cfg))
+		})
+	}
+}


### PR DESCRIPTION
## Description

`pkg/token/joindecode.go` (DecodeJoinToken, GetTokenType) and `pkg/token/joinencode.go` (JoinEncode) had no direct unit tests. They were only exercised indirectly through `pkg/token/joinclient_test.go` (which uses JoinEncode as test setup, not as the thing under test) and `inttest/etcdlearner/etcdlearner_test.go`, which needs a live cluster. Neither exercises DecodeJoinToken's error paths.

Adds direct unit tests for DecodeJoinToken, JoinEncode, and GetTokenType covering the round trip, the invalid base64 and invalid gzip error paths in DecodeJoinToken, and both branches of GetTokenType.

Fixes # (issue)
N/A, no existing issue, found while looking for untested error paths.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

This is a test only change, none of the above categories quite fit; no production code is touched.

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commit messages are signed-off
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
