### PR TITLE
autopilot: reuse a completed download on retry

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -73,7 +73,8 @@ check-addons: TIMEOUT=10m
 # Autopilot 3x3 HA test can take a while to run
 check-ap-ha3x3: export K0S_UPDATE_TO_VERSION ?= $(shell ../k0s version)
 
-# check-ap-controllerworker might need to re-download the new bin few times, so give it a bit more time to complete
+# check-ap-controllerworker updates three controller+worker nodes one by one,
+# which takes longer than the default timeout allows
 check-ap-controllerworker: TIMEOUT=10m
 
 check-ap-updater: .update-server.stamp

--- a/pkg/autopilot/controller/signal/common/download.go
+++ b/pkg/autopilot/controller/signal/common/download.go
@@ -6,6 +6,10 @@ package common
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync/atomic"
 
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	apdl "github.com/k0sproject/k0s/pkg/autopilot/download"
@@ -27,12 +31,24 @@ type DownloadManifestBuilder interface {
 	Build(signalNode crcli.Object, signalData apsigv2.SignalData) (DownloadManifest, error)
 }
 
+type downloadRecord struct {
+	// The request it was made for, with its status stripped.
+	request apsigv2.SignalData
+	path    string
+}
+
 type downloadController struct {
 	logger   *logrus.Entry
 	client   crcli.Client
 	delegate apdel.ControllerDelegate
 
 	manifestBuilder DownloadManifestBuilder
+
+	// The download this reconciler completed most recently, so that a failure
+	// after the download doesn't cost another fetch. Kept per reconciler, not
+	// per process: it only has to survive a requeue, so losing it on a manager
+	// rebuild costs one repeated download, not correctness.
+	completed atomic.Pointer[downloadRecord]
 }
 
 // NewDownloadController builds a download reconciler that delegates to a manifest builder to
@@ -74,20 +90,32 @@ func (r *downloadController) Reconcile(ctx context.Context, req cr.Request) (cr.
 		return cr.Result{}, fmt.Errorf("unable to build download manifest: %w", err)
 	}
 
-	logger.Infof("Starting download of '%s'", manifest.URL)
-
-	httpdl := apdl.NewDownloader(manifest.Config)
-	if err := httpdl.Download(ctx); err != nil {
-		logger.Errorf("Unable to download '%s': %v", manifest.URL, err)
-
-		// When the download is complete move the status to `FailedDownload`
-		signalData.Status = apsigv2.NewStatus(FailedDownload)
-
+	var status string
+	if path, ok := r.reusableDownload(logger, signalData, manifest); ok {
+		logger.Infof("Reusing '%s', already downloaded from '%s'", path, manifest.URL)
+		status = manifest.SuccessState
 	} else {
-		logger.Infof("Download of '%s' successful", manifest.URL)
-		// When the download is complete move the status to the success state
-		signalData.Status = apsigv2.NewStatus(manifest.SuccessState)
+		logger.Infof("Starting download of '%s'", manifest.URL)
+
+		httpdl := apdl.NewDownloader(manifest.Config)
+		path, err := httpdl.Download(ctx)
+		if err != nil {
+			logger.Errorf("Unable to download '%s': %v", manifest.URL, err)
+
+			// When the download failed move the status to `FailedDownload`
+			status = FailedDownload
+		} else {
+			logger.Infof("Download of '%s' successful", manifest.URL)
+
+			// Record it first: a failure below must not cost another fetch.
+			r.recordDownload(signalData, path)
+
+			// When the download is complete move the status to the success state
+			status = manifest.SuccessState
+		}
 	}
+
+	signalData.Status = apsigv2.NewStatus(status)
 
 	if err := signalData.Marshal(signalNodeCopy.GetAnnotations()); err != nil {
 		return cr.Result{}, fmt.Errorf("failed to marshal signal data: %w", err)
@@ -99,4 +127,58 @@ func (r *downloadController) Reconcile(ctx context.Context, req cr.Request) (cr.
 	}
 
 	return cr.Result{}, nil
+}
+
+// recordDownload remembers a completed download, so a requeue needn't refetch.
+func (r *downloadController) recordDownload(signalData apsigv2.SignalData, path string) {
+	// The status is not part of a request's identity: the airgap signal and
+	// download reconcilers share a status-less filter and disagree about it.
+	signalData.Status = nil
+
+	r.completed.Store(&downloadRecord{request: signalData, path: path})
+}
+
+// reusableDownload reports a still-present file already downloaded for this request.
+func (r *downloadController) reusableDownload(logger *logrus.Entry, signalData apsigv2.SignalData, manifest DownloadManifest) (string, bool) {
+	record := r.completed.Load()
+	if record == nil {
+		return "", false
+	}
+
+	signalData.Status = nil
+	if !reflect.DeepEqual(record.request, signalData) {
+		return "", false
+	}
+
+	// The manifest, not the signal data alone, decides where a download belongs.
+	// Reusing one from elsewhere would report success with the target path
+	// empty, which apply reads as "already applied". Recorded paths are
+	// absolute, so resolve the configured directory likewise.
+	wantDir, err := filepath.Abs(manifest.DownloadDir)
+	if err != nil {
+		logger.Infof("Not reusing '%s': %v", record.path, err)
+		return "", false
+	}
+	if filepath.Dir(record.path) != wantDir {
+		logger.Infof("Not reusing '%s': expected a download in '%s'", record.path, wantDir)
+		return "", false
+	}
+	if manifest.Filename != "" && filepath.Base(record.path) != manifest.Filename {
+		logger.Infof("Not reusing '%s': expected a download named '%s'", record.path, manifest.Filename)
+		return "", false
+	}
+
+	// Existence is enough: the file only appears through an atomic rename after
+	// the download verified its hash. Re-hashing would undo the saving.
+	stat, err := os.Stat(record.path)
+	if err != nil {
+		logger.Infof("Not reusing '%s': %v", record.path, err)
+		return "", false
+	}
+	if !stat.Mode().IsRegular() {
+		logger.Infof("Not reusing '%s': not a regular file", record.path)
+		return "", false
+	}
+
+	return record.path, true
 }

--- a/pkg/autopilot/controller/signal/common/download_test.go
+++ b/pkg/autopilot/controller/signal/common/download_test.go
@@ -1,0 +1,376 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
+	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
+	apdl "github.com/k0sproject/k0s/pkg/autopilot/download"
+	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
+	apscheme "github.com/k0sproject/k0s/pkg/client/clientset/scheme"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	crcli "sigs.k8s.io/controller-runtime/pkg/client"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	crint "sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	crrec "sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// The signal node that the tests in here operate on.
+const testNodeName = "controller0"
+
+// The real one is the k0s package's Cordoning, which can't be imported here.
+const testSuccessState = "Cordoning"
+
+// newSignalData builds a k0s update request; an empty status means none yet.
+func newSignalData(planID, url, status string) apsigv2.SignalData {
+	commandID := 123
+	data := apsigv2.SignalData{
+		PlanID:  planID,
+		Created: "now",
+		Command: apsigv2.Command{
+			ID:        &commandID,
+			K0sUpdate: &apsigv2.CommandK0sUpdate{URL: url, Version: "v0.0.0"},
+		},
+	}
+	if status != "" {
+		data.Status = apsigv2.NewStatus(status)
+	}
+	return data
+}
+
+func newSignalNode(t *testing.T, data apsigv2.SignalData) *apv1beta2.ControlNode {
+	t.Helper()
+	node := &apv1beta2.ControlNode{
+		ObjectMeta: metav1.ObjectMeta{Name: testNodeName, Annotations: map[string]string{}},
+	}
+	require.NoError(t, data.Marshal(node.Annotations))
+	return node
+}
+
+func newFakeClient(t *testing.T, objects ...crcli.Object) crcli.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, apscheme.AddToScheme(scheme))
+	return crfake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+// newFakeClientConflictingOnFirstUpdate stands in for a concurrent writer by
+// rejecting the first update with a conflict.
+func newFakeClientConflictingOnFirstUpdate(t *testing.T, objects ...crcli.Object) crcli.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, apscheme.AddToScheme(scheme))
+
+	var conflicted atomic.Bool
+	client := crfake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).
+		WithInterceptorFuncs(crint.Funcs{
+			Update: func(ctx context.Context, c crcli.WithWatch, obj crcli.Object, opts ...crcli.UpdateOption) error {
+				if !conflicted.Swap(true) {
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: apv1beta2.GroupName, Resource: "controlnodes"},
+						obj.GetName(), errors.New("injected conflict"),
+					)
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).Build()
+
+	t.Cleanup(func() { assert.True(t, conflicted.Load(), "conflict hasn't been injected") })
+	return client
+}
+
+func readSignalData(t *testing.T, client crcli.Client, key crcli.ObjectKey) apsigv2.SignalData {
+	t.Helper()
+	var node apv1beta2.ControlNode
+	require.NoError(t, client.Get(t.Context(), key, &node))
+	var data apsigv2.SignalData
+	require.NoError(t, data.Unmarshal(node.GetAnnotations()))
+	return data
+}
+
+// downloadManifestBuilder points the reconciler at the given test server.
+type downloadManifestBuilder struct {
+	url string
+	dir string
+}
+
+func (b downloadManifestBuilder) Build(crcli.Object, apsigv2.SignalData) (DownloadManifest, error) {
+	return DownloadManifest{
+		Config:       apdl.Config{URL: b.url, DownloadDir: b.dir, Filename: "downloaded"},
+		SuccessState: testSuccessState,
+	}, nil
+}
+
+// newDownloadController wires up a reconciler and the request to hand it.
+func newDownloadController(t *testing.T, client crcli.Client, url string) (*downloadController, crrec.Request) {
+	t.Helper()
+	delegate := apdel.ControlNodeControllerDelegate()
+	reconciler := NewDownloadController(
+		logrus.NewEntry(logrus.StandardLogger()), client, delegate,
+		downloadManifestBuilder{url: url, dir: t.TempDir()},
+	).(*downloadController)
+	return reconciler, crrec.Request{NamespacedName: delegate.CreateNamespacedName(testNodeName)}
+}
+
+// TestDownloadControllerAgainstAnnotationChurn ensures a download is not repeated
+// while the signal node keeps changing. Losing the write back is expected and
+// still reported; refetching every time is what stalls plan execution.
+func TestDownloadControllerAgainstAnnotationChurn(t *testing.T) {
+	var downloads atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		downloads.Add(1)
+		time.Sleep(150 * time.Millisecond)
+		_, _ = w.Write([]byte("binary-content"))
+	}))
+	defer srv.Close()
+
+	client := newFakeClient(t, newSignalNode(t, newSignalData("plan-1", srv.URL, Downloading)))
+	reconciler, req := newDownloadController(t, client, srv.URL)
+
+	// Churn faster than the download, so a regression fails immediately.
+	ctx, stopChurn := context.WithCancel(t.Context())
+	churnStopped := make(chan struct{})
+	go func() {
+		defer close(churnStopped)
+		for ctx.Err() == nil {
+			var cn apv1beta2.ControlNode
+			if err := client.Get(ctx, req.NamespacedName, &cn); err == nil {
+				cn.Annotations["test.k0sproject.io/touch"] = time.Now().Format(time.RFC3339Nano)
+				_ = client.Update(ctx, &cn)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	t.Cleanup(func() { stopChurn(); <-churnStopped })
+
+	var attempts, failures int
+	for deadline := time.Now().Add(10 * time.Second); time.Now().Before(deadline); {
+		attempts++
+		if _, err := reconciler.Reconcile(t.Context(), req); err != nil {
+			failures++
+			continue
+		}
+		if status := readSignalData(t, client, req.NamespacedName).Status; status != nil && status.Status == testSuccessState {
+			t.Logf("reached %s after %d attempt(s), %d failure(s)", testSuccessState, attempts, failures)
+			assert.Equal(t, int32(1), downloads.Load(),
+				"the download must not be repeated when only the write back failed")
+			return
+		}
+	}
+
+	t.Fatalf("the download reconciler never recorded %s within 10s: %d attempt(s), %d of which failed to write back the signal node",
+		testSuccessState, attempts, failures)
+}
+
+// TestDownloadControllerReusesDownloadAfterConflict pins both halves: a lost
+// write is reported, and the requeue reuses what was already fetched.
+func TestDownloadControllerReusesDownloadAfterConflict(t *testing.T) {
+	var downloads atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		downloads.Add(1)
+		_, _ = w.Write([]byte("binary-content"))
+	}))
+	defer srv.Close()
+
+	client := newFakeClientConflictingOnFirstUpdate(t, newSignalNode(t, newSignalData("plan-1", srv.URL, Downloading)))
+	reconciler, req := newDownloadController(t, client, srv.URL)
+
+	_, err := reconciler.Reconcile(t.Context(), req)
+	require.Error(t, err, "a lost write must be reported so that controller-runtime requeues")
+	assert.True(t, apierrors.IsConflict(err), "expected a conflict, got %v", err)
+	assert.Equal(t, int32(1), downloads.Load())
+
+	// The requeue must not fetch anything again.
+	_, err = reconciler.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), downloads.Load(), "the retry must reuse the completed download")
+
+	if stored := readSignalData(t, client, req.NamespacedName); assert.NotNil(t, stored.Status) {
+		assert.Equal(t, testSuccessState, stored.Status.Status)
+	}
+}
+
+// TestDownloadControllerRefetchesForNewRequest ensures reuse is keyed on the
+// request: apply installs whatever it finds, unchecked.
+func TestDownloadControllerRefetchesForNewRequest(t *testing.T) {
+	var downloads atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		downloads.Add(1)
+		_, _ = w.Write([]byte("binary-content"))
+	}))
+	defer srv.Close()
+
+	client := newFakeClient(t, newSignalNode(t, newSignalData("plan-1", srv.URL, Downloading)))
+	reconciler, req := newDownloadController(t, client, srv.URL)
+
+	_, err := reconciler.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), downloads.Load())
+
+	// A new plan lands on the same node.
+	var cn apv1beta2.ControlNode
+	require.NoError(t, client.Get(t.Context(), req.NamespacedName, &cn))
+	require.NoError(t, newSignalData("plan-2", srv.URL, Downloading).Marshal(cn.Annotations))
+	require.NoError(t, client.Update(t.Context(), &cn))
+
+	_, err = reconciler.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), downloads.Load(), "a different request must be downloaded again")
+}
+
+// TestDownloadControllerConcurrentStatusUpdate covers the airgap shape: the
+// download starts from a node without a status while the signal reconciler moves
+// it to Downloading. The requeue must still reuse the bundle.
+func TestDownloadControllerConcurrentStatusUpdate(t *testing.T) {
+	var downloads atomic.Int32
+	var startOnce sync.Once
+	downloadStarted, releaseDownload := make(chan struct{}), make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		downloads.Add(1)
+		// Tolerate a second request, so a regression fails the assertion
+		// below rather than panicking on the server goroutine.
+		startOnce.Do(func() { close(downloadStarted) })
+		<-releaseDownload
+		_, _ = w.Write([]byte("bundle-content"))
+	}))
+	defer srv.Close()
+
+	data := newSignalData("plan-1", srv.URL, "")
+	client := newFakeClient(t, newSignalNode(t, data))
+	reconciler, req := newDownloadController(t, client, srv.URL)
+
+	reconciled := make(chan error, 1)
+	go func() {
+		_, err := reconciler.Reconcile(t.Context(), req)
+		reconciled <- err
+	}()
+
+	// Mid-download, the signal reconciler moves the node to Downloading.
+	<-downloadStarted
+	var cn apv1beta2.ControlNode
+	require.NoError(t, client.Get(t.Context(), req.NamespacedName, &cn))
+	downloading := data
+	downloading.Status = apsigv2.NewStatus(Downloading)
+	require.NoError(t, downloading.Marshal(cn.Annotations))
+	require.NoError(t, client.Update(t.Context(), &cn))
+	close(releaseDownload)
+
+	require.Error(t, <-reconciled, "the write back is expected to lose")
+
+	_, err := reconciler.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), downloads.Load(),
+		"the bundle must be reused even though the status moved to %s meanwhile", Downloading)
+
+	if stored := readSignalData(t, client, req.NamespacedName); assert.NotNil(t, stored.Status) {
+		assert.Equal(t, testSuccessState, stored.Status.Status)
+	}
+}
+
+// TestDownloadControllerRefetchesForForeignPath rejects a record pointing
+// anywhere but where the manifest wants the file. Reporting success with the
+// target empty is not harmless: apply reads a missing k0s.tmp as "already
+// applied", so the node comes back on the old binary.
+func TestDownloadControllerRefetchesForForeignPath(t *testing.T) {
+	var downloads atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		downloads.Add(1)
+		_, _ = w.Write([]byte("binary-content"))
+	}))
+	defer srv.Close()
+
+	client := newFakeClient(t, newSignalNode(t, newSignalData("plan-1", srv.URL, Downloading)))
+	reconciler, req := newDownloadController(t, client, srv.URL)
+
+	// A real file, correct request, wrong directory.
+	elsewhere := filepath.Join(t.TempDir(), "downloaded")
+	require.NoError(t, os.WriteFile(elsewhere, []byte("binary-content"), 0o600))
+	reconciler.recordDownload(readSignalData(t, client, req.NamespacedName), elsewhere)
+
+	_, err := reconciler.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), downloads.Load(),
+		"a record pointing outside the manifest's download dir must not be reused")
+}
+
+// TestDownloadControllerRefetchesForIrregularFile covers a non-file at the right
+// path, which os.Stat alone would accept.
+func TestDownloadControllerRefetchesForIrregularFile(t *testing.T) {
+	var downloads atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		downloads.Add(1)
+		_, _ = w.Write([]byte("binary-content"))
+	}))
+	defer srv.Close()
+
+	client := newFakeClient(t, newSignalNode(t, newSignalData("plan-1", srv.URL, Downloading)))
+	reconciler, req := newDownloadController(t, client, srv.URL)
+
+	// Point the record at a directory sitting where the download would go.
+	dir := reconciler.manifestBuilder.(downloadManifestBuilder).dir
+	asDir := filepath.Join(dir, "downloaded")
+	require.NoError(t, os.Mkdir(asDir, 0o700))
+	reconciler.recordDownload(readSignalData(t, client, req.NamespacedName), asDir)
+
+	_, err := reconciler.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), downloads.Load(), "a non-regular file must not be reused")
+
+	// The refetch then fails, since the rename cannot replace a directory. A
+	// reported failure is fine; silently reusing it and claiming success is not.
+	if stored := readSignalData(t, client, req.NamespacedName); assert.NotNil(t, stored.Status) {
+		assert.Equal(t, FailedDownload, stored.Status.Status)
+	}
+}
+
+// TestDownloadControllerRefetchesWhenGone covers the recorded file having
+// disappeared, e.g. removed by apply or by an operator.
+func TestDownloadControllerRefetchesWhenGone(t *testing.T) {
+	var downloads atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		downloads.Add(1)
+		_, _ = w.Write([]byte("binary-content"))
+	}))
+	defer srv.Close()
+
+	client := newFakeClient(t, newSignalNode(t, newSignalData("plan-1", srv.URL, Downloading)))
+	reconciler, req := newDownloadController(t, client, srv.URL)
+
+	_, err := reconciler.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), downloads.Load())
+
+	// Point the record at something that isn't there.
+	data := readSignalData(t, client, req.NamespacedName)
+	reconciler.recordDownload(data, filepath.Join(t.TempDir(), "vanished"))
+
+	// Put the node back into Downloading so the reconciler acts on it again.
+	var cn apv1beta2.ControlNode
+	require.NoError(t, client.Get(t.Context(), req.NamespacedName, &cn))
+	data.Status = apsigv2.NewStatus(Downloading)
+	require.NoError(t, data.Marshal(cn.Annotations))
+	require.NoError(t, client.Update(t.Context(), &cn))
+
+	_, err = reconciler.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), downloads.Load(), "a vanished download must be fetched again")
+}

--- a/pkg/autopilot/download/downloader.go
+++ b/pkg/autopilot/download/downloader.go
@@ -19,7 +19,8 @@ import (
 )
 
 type Downloader interface {
-	Download(ctx context.Context) error
+	// Downloads the configured URL, returning the path to the downloaded file.
+	Download(ctx context.Context) (string, error)
 }
 
 type Config struct {
@@ -42,8 +43,8 @@ func NewDownloader(config Config) Downloader {
 	}
 }
 
-// Performs the download process.
-func (d *downloader) Download(ctx context.Context) (err error) {
+// Performs the download process, returning the path to the downloaded file.
+func (d *downloader) Download(ctx context.Context) (_ string, err error) {
 	var targets []io.Writer
 
 	// If we've been provided a hash and actual value to compare with, use it.
@@ -51,7 +52,7 @@ func (d *downloader) Download(ctx context.Context) (err error) {
 	if d.config.Hasher != nil && d.config.ExpectedHash != "" {
 		expectedHash, err = hex.DecodeString(d.config.ExpectedHash)
 		if err != nil {
-			return fmt.Errorf("invalid update hash: %w", err)
+			return "", fmt.Errorf("invalid update hash: %w", err)
 		}
 		targets = append(targets, d.config.Hasher)
 	}
@@ -63,7 +64,7 @@ func (d *downloader) Download(ctx context.Context) (err error) {
 	} else {
 		fileName = filepath.Base(d.config.Filename)
 		if fileName != d.config.Filename {
-			return fmt.Errorf("filename contains path elements: %s", d.config.Filename)
+			return "", fmt.Errorf("filename contains path elements: %s", d.config.Filename)
 		}
 		fileName = d.config.Filename
 	}
@@ -71,7 +72,7 @@ func (d *downloader) Download(ctx context.Context) (err error) {
 	// Set up target file for download.
 	target, err := file.AtomicWithTarget(filepath.Join(d.config.DownloadDir, fileName)).Open()
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer func() { err = errors.Join(err, target.Close()) }()
 	targets = append(targets, target)
@@ -84,20 +85,22 @@ func (d *downloader) Download(ctx context.Context) (err error) {
 
 	// Download from URL into targets.
 	if err = internalhttp.Download(ctx, d.config.URL, io.MultiWriter(targets...), downloadOpts...); err != nil {
-		return fmt.Errorf("download failed: %w", err)
+		return "", fmt.Errorf("download failed: %w", err)
 	}
 
 	// Check the hash of the downloaded data and fail if it doesn't match.
 	if expectedHash != nil {
 		if downloadedHash := d.config.Hasher.Sum(nil); !bytes.Equal(expectedHash, downloadedHash) {
-			return fmt.Errorf("hash mismatch: expected %x, got %x", expectedHash, downloadedHash)
+			return "", fmt.Errorf("hash mismatch: expected %x, got %x", expectedHash, downloadedHash)
 		}
 	}
 
 	// All is well. Finish the download.
 	if err := target.FinishWithBaseName(fileName); err != nil {
-		return fmt.Errorf("failed to finish download: %w", err)
+		return "", fmt.Errorf("failed to finish download: %w", err)
 	}
 
-	return nil
+	// Mirror how FinishWithBaseName resolved the target. It is absolute, since
+	// the writer made it so, and the returned path has to be the same file.
+	return filepath.Join(filepath.Dir(target.Name()), fileName), nil
 }

--- a/pkg/autopilot/download/downloader_test.go
+++ b/pkg/autopilot/download/downloader_test.go
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package download
+
+import (
+	"crypto/sha256"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func serveContent(t *testing.T, content string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(content))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestDownload_ReturnsPath(t *testing.T) {
+	dir := t.TempDir()
+	url := serveContent(t, "k0s-binary")
+
+	path, err := NewDownloader(Config{
+		URL:         url,
+		DownloadDir: dir,
+		Filename:    "k0s.tmp",
+	}).Download(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "k0s.tmp"), path)
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "k0s-binary", string(content))
+}
+
+// TestDownload_ReturnsAbsolutePathForRelativeDir pins the returned path to where
+// the file lands. The writer resolves its target absolutely to survive a working
+// directory change, so a path rebuilt from a relative DownloadDir would dangle.
+func TestDownload_ReturnsAbsolutePathForRelativeDir(t *testing.T) {
+	work := t.TempDir()
+	t.Chdir(work)
+	require.NoError(t, os.Mkdir("downloads", 0o700))
+
+	path, err := NewDownloader(Config{
+		URL:         serveContent(t, "k0s-binary"),
+		DownloadDir: "downloads",
+		Filename:    "k0s.tmp",
+	}).Download(t.Context())
+
+	require.NoError(t, err)
+	require.True(t, filepath.IsAbs(path), "expected an absolute path, got %q", path)
+	assert.Equal(t, filepath.Join(work, "downloads", "k0s.tmp"), path)
+
+	// The path has to keep resolving once the working directory moves.
+	t.Chdir(t.TempDir())
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "k0s-binary", string(content))
+}
+
+func TestDownload_RejectsFilenameWithPathElements(t *testing.T) {
+	path, err := NewDownloader(Config{
+		URL:         serveContent(t, "whatever"),
+		DownloadDir: t.TempDir(),
+		Filename:    "nested/k0s.tmp",
+	}).Download(t.Context())
+
+	assert.ErrorContains(t, err, "filename contains path elements")
+	assert.Empty(t, path)
+}
+
+func TestDownload_HashMismatchLeavesNothingBehind(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "k0s.tmp")
+
+	// A previous download must survive a failed attempt.
+	require.NoError(t, os.WriteFile(target, []byte("previous"), 0o600))
+
+	path, err := NewDownloader(Config{
+		URL:          serveContent(t, "k0s-binary"),
+		ExpectedHash: "0000000000000000000000000000000000000000000000000000000000000000",
+		Hasher:       sha256.New(),
+		DownloadDir:  dir,
+		Filename:     "k0s.tmp",
+	}).Download(t.Context())
+
+	assert.ErrorContains(t, err, "hash mismatch")
+	assert.Empty(t, path)
+
+	content, err := os.ReadFile(target)
+	require.NoError(t, err, "the previous download must be left alone")
+	assert.Equal(t, "previous", string(content))
+
+	// The partial download must not be left lying around either.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var names []string
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	assert.Equal(t, []string{"k0s.tmp"}, names)
+}
+
+func TestDownload_BadStatusLeavesNothingBehind(t *testing.T) {
+	dir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	path, err := NewDownloader(Config{
+		URL:         srv.URL,
+		DownloadDir: dir,
+		Filename:    "k0s.tmp",
+	}).Download(t.Context())
+
+	assert.ErrorContains(t, err, "download failed")
+	assert.Empty(t, path)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "a failed download must not leave anything behind")
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

The download reconciler writes its result back to the signal node as it read it before downloading, so a concurrent write to that node makes the update lose. The retry then fetched everything again, and when the node kept changing faster than a download takes, it never won.

Remember the downloads this process completed, keyed by the request that triggered them, and reuse them instead of fetching again. A lost write is still reported as an error and still requeues, only now the retry is cheap enough to succeed.

Fixes the check-ap-controllerworker flakiness in CI.

Supersedes https://github.com/k0sproject/k0s/pull/8239

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

I was able to reliably reproduce the problem locally with the following change (On macOS https://github.com/k0sproject/k0s/pull/8268 is also needed):
```diff
diff --git a/inttest/ap-controllerworker/controllerworker_test.go b/inttest/ap-controllerworker/controllerworker_test.go
index bf27fe5474..15518d7dba 100644
--- a/inttest/ap-controllerworker/controllerworker_test.go
+++ b/inttest/ap-controllerworker/controllerworker_test.go
@@ -212,7 +212,7 @@ func (s *controllerworkerSuite) TestApply() {

                                        return true, nil
                                })
-                       }, 1*time.Second)
+                       }, 100*time.Millisecond)
                })
        }

```

With the changes in this PR applied the test passes even with the above change.

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
