### PR TITLE
inttest: reach the load balancer through its published port

### DIFF
--- a/inttest/common/bootloosesuite.go
+++ b/inttest/common/bootloosesuite.go
@@ -892,17 +892,25 @@ func (s *BootlooseSuite) CreateUserAndGetKubeClientConfig(node string, username 
 }
 
 func (s *BootlooseSuite) ClientFactory(node string, k0sKubeconfigArgs ...string) *kubeutil.ClientFactory {
-	var lbAddr string
+	var lbHost string
 	if s.WithLB {
-		lbAddr = s.GetLBAddress()
+		// Reach the load balancer through its published port rather than its
+		// container IP. Clients stay behind the load balancer either way, but
+		// container IPs are not routable from the host on Docker Desktop for
+		// macOS, where the containers live in a VM.
+		machine, err := s.MachineForName(s.LBNode())
+		s.Require().NoError(err)
+		hostPort, err := machine.HostPort(s.KubeAPIExternalPort)
+		s.Require().NoError(err)
+		lbHost = net.JoinHostPort("localhost", strconv.Itoa(hostPort))
 	}
 	return &kubeutil.ClientFactory{
 		LoadRESTConfig: func() (*rest.Config, error) {
 			restConfig, err := s.GetKubeConfig(node, k0sKubeconfigArgs...)
-			if err != nil || lbAddr == "" {
+			if err != nil || lbHost == "" {
 				return restConfig, err
 			}
-			restConfig.Host = net.JoinHostPort(lbAddr, strconv.Itoa(s.KubeAPIExternalPort))
+			restConfig.Host = lbHost
 			return restConfig, nil
 		},
 	}


### PR DESCRIPTION
BootlooseSuite.ClientFactory pointed the REST config at the load balancer's container IP, which is not routable from the host on Docker Desktop for macOS, where the containers live in a VM. The load balancer already publishes the kube API port, since it reuses the same port mappings as the controllers, so go through that instead. Clients stay behind the load balancer either way, which is what routing them there was for.

This allows us to run check-ap-controllerworker on macOS. It does not affect Linux, where container IPs are routable from the host.

<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
