### PR TITLE
Thread the configured status socket path through autopilot

### DIFF
--- a/pkg/autopilot/controller/root/root.go
+++ b/pkg/autopilot/controller/root/root.go
@@ -19,6 +19,7 @@ type RootConfig struct {
 	MetricsBindAddr     string
 	HealthProbeBindAddr string
 	ExcludeFromPlans    []string
+	StatusSocketPath    string
 }
 
 // Root is the 'root' of all controllers

--- a/pkg/autopilot/controller/root_controller.go
+++ b/pkg/autopilot/controller/root_controller.go
@@ -243,7 +243,7 @@ func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *
 	}
 	clusterID := string(ns.UID)
 
-	if err := signal.RegisterControllers(ctx, logger, mgr, delegateMap[apdel.ControllerDelegateController], restartTracker, c.cfg.K0sDataDir, c.enableWorker, clusterID, event); err != nil {
+	if err := signal.RegisterControllers(ctx, logger, mgr, delegateMap[apdel.ControllerDelegateController], restartTracker, c.cfg.K0sDataDir, c.cfg.StatusSocketPath, c.enableWorker, clusterID, event); err != nil {
 		logger.WithError(err).Error("unable to register signal controllers")
 		return err
 	}
@@ -253,7 +253,7 @@ func (c *rootController) startSubControllerRoutine(ctx context.Context, logger *
 		return err
 	}
 
-	if err := updates.RegisterControllers(ctx, logger, mgr, c.autopilotClientFactory, c.clusterInfoCollector, leaderMode, clusterID); err != nil {
+	if err := updates.RegisterControllers(ctx, logger, mgr, c.autopilotClientFactory, c.clusterInfoCollector, leaderMode, clusterID, c.cfg.StatusSocketPath); err != nil {
 		logger.WithError(err).Error("unable to register updates controllers")
 		return err
 	}

--- a/pkg/autopilot/controller/root_worker.go
+++ b/pkg/autopilot/controller/root_worker.go
@@ -115,7 +115,7 @@ func (w *rootWorker) Run(ctx context.Context) error {
 			return fmt.Errorf("unable to register indexers: %w", err)
 		}
 
-		if err := signal.RegisterControllers(ctx, logger, mgr, apdel.NodeControllerDelegate(), &restartTracker, w.cfg.K0sDataDir, true, clusterID, leaderelection.StatusPending); err != nil {
+		if err := signal.RegisterControllers(ctx, logger, mgr, apdel.NodeControllerDelegate(), &restartTracker, w.cfg.K0sDataDir, w.cfg.StatusSocketPath, true, clusterID, leaderelection.StatusPending); err != nil {
 			return fmt.Errorf("unable to register signal controllers: %w", err)
 		}
 

--- a/pkg/autopilot/controller/signal/init.go
+++ b/pkg/autopilot/controller/signal/init.go
@@ -23,8 +23,8 @@ import (
 // controller and worker modes. The restart tracker's lifetime needs to be tied
 // to the process, i.e. it has to be shared by all the managers this function is
 // called with throughout the lifetime of the process.
-func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, restartTracker *k0s.RestartTracker, k0sDataDir string, enableWorker bool, clusterID string, leaseStatus leaderelection.Status) error {
-	if err := k0s.RegisterControllers(ctx, logger, mgr, delegate, restartTracker, enableWorker, clusterID, leaseStatus); err != nil {
+func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, restartTracker *k0s.RestartTracker, k0sDataDir string, statusSocketPath string, enableWorker bool, clusterID string, leaseStatus leaderelection.Status) error {
+	if err := k0s.RegisterControllers(ctx, logger, mgr, delegate, restartTracker, statusSocketPath, enableWorker, clusterID, leaseStatus); err != nil {
 		return fmt.Errorf("unable to register k0s controllers: %w", err)
 	}
 

--- a/pkg/autopilot/controller/signal/k0s/init.go
+++ b/pkg/autopilot/controller/signal/k0s/init.go
@@ -38,7 +38,7 @@ import (
 // controller-runtime manager. The restart tracker's lifetime needs to be tied
 // to the process, i.e. it has to be shared by all the managers this function is
 // called with throughout the lifetime of the process.
-func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, restartTracker *RestartTracker, enableWorker bool, clusterID string, leaseStatus leaderelection.Status) error {
+func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, delegate apdel.ControllerDelegate, restartTracker *RestartTracker, statusSocketPath string, enableWorker bool, clusterID string, leaseStatus leaderelection.Status) error {
 	if restartTracker == nil {
 		return errors.New("restart tracker is required")
 	}
@@ -59,7 +59,7 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 	logger.Infof("Using effective hostname = '%v'", hostname)
 
 	k0sVersionHandler := func() (string, error) {
-		return getK0sVersion(status.DefaultSocketPath)
+		return getK0sVersion(statusSocketPath)
 	}
 
 	if enableWorker {
@@ -150,11 +150,11 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 		return fmt.Errorf("unable to register applying-update controller: %w", err)
 	}
 
-	if err := registerRestart(logger, mgr, restartEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s restart")), delegate, restartTracker.IsRestartPending); err != nil {
+	if err := registerRestart(logger, mgr, restartEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s restart")), delegate, restartTracker.IsRestartPending, statusSocketPath); err != nil {
 		return fmt.Errorf("unable to register restart controller: %w", err)
 	}
 
-	if err := registerRestarted(logger, mgr, restartedEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s restarted")), delegate, restartTracker.IsRestartPending); err != nil {
+	if err := registerRestarted(logger, mgr, restartedEventFilter(hostname, apsigpred.DefaultErrorHandler(logger, "k0s restarted")), delegate, restartTracker.IsRestartPending, statusSocketPath); err != nil {
 		return fmt.Errorf("unable to register restarted controller: %w", err)
 	}
 

--- a/pkg/autopilot/controller/signal/k0s/restart_unix.go
+++ b/pkg/autopilot/controller/signal/k0s/restart_unix.go
@@ -86,13 +86,14 @@ type restart struct {
 	client           crcli.Client
 	delegate         apdel.ControllerDelegate
 	isRestartPending IsRestartPendingFunc
+	statusSocketPath string
 }
 
 // registerRestart registers the 'restart' controller to the controller-runtime manager.
 //
 // This controller is only interested in changes to signal nodes where its signaling
 // status is marked as `Restart`
-func registerRestart(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, isRestartPending IsRestartPendingFunc) error {
+func registerRestart(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, isRestartPending IsRestartPendingFunc, statusSocketPath string) error {
 	name := strings.ToLower(delegate.Name()) + "_k0s_restart"
 	logger.Info("Registering reconciler: ", name)
 
@@ -106,6 +107,7 @@ func registerRestart(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred
 				client:           mgr.GetClient(),
 				delegate:         delegate,
 				isRestartPending: isRestartPending,
+				statusSocketPath: statusSocketPath,
 			},
 		)
 }
@@ -127,7 +129,7 @@ func (r *restart) Reconcile(ctx context.Context, req cr.Request) (cr.Result, err
 
 	// Get the current version of k0s
 	logger.Info("Determining the current version of k0s")
-	k0sVersion, err := getK0sVersion(status.DefaultSocketPath)
+	k0sVersion, err := getK0sVersion(r.statusSocketPath)
 	if err != nil {
 		logger.Info("Unable to determine current verion of k0s; requeuing")
 		return cr.Result{}, fmt.Errorf("unable to get k0s version: %w", err)
@@ -180,7 +182,7 @@ func (r *restart) Reconcile(ctx context.Context, req cr.Request) (cr.Result, err
 
 	logger.Info("Preparing to restart k0s")
 
-	k0sPid, err := getK0sPid(status.DefaultSocketPath)
+	k0sPid, err := getK0sPid(r.statusSocketPath)
 	if err != nil {
 		logger.Info("Unable to determine current k0s pid; requeuing")
 		return cr.Result{RequeueAfter: restartRequeueDuration}, fmt.Errorf("unable to get k0s pid: %w", err)

--- a/pkg/autopilot/controller/signal/k0s/restarted_unix.go
+++ b/pkg/autopilot/controller/signal/k0s/restarted_unix.go
@@ -14,7 +14,6 @@ import (
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	apsigpred "github.com/k0sproject/k0s/pkg/autopilot/controller/signal/common/predicate"
 	apsigv2 "github.com/k0sproject/k0s/pkg/autopilot/signaling/v2"
-	"github.com/k0sproject/k0s/pkg/component/status"
 
 	"github.com/sirupsen/logrus"
 	cr "sigs.k8s.io/controller-runtime"
@@ -29,6 +28,7 @@ type restarted struct {
 	client           crcli.Client
 	delegate         apdel.ControllerDelegate
 	isRestartPending IsRestartPendingFunc
+	statusSocketPath string
 }
 
 // restartedEventFilter creates a controller-runtime predicate that governs which
@@ -52,7 +52,7 @@ func restartedEventFilter(hostname string, handler apsigpred.ErrorHandler) crpre
 //
 // This controller is only interested in changes to signal nodes where its signaling
 // status is marked as `Restart`
-func registerRestarted(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, isRestartPending IsRestartPendingFunc) error {
+func registerRestarted(logger *logrus.Entry, mgr crman.Manager, eventFilter crpred.Predicate, delegate apdel.ControllerDelegate, isRestartPending IsRestartPendingFunc, statusSocketPath string) error {
 	name := strings.ToLower(delegate.Name()) + "_k0s_restarted"
 	logger.Info("Registering reconciler: ", name)
 
@@ -66,6 +66,7 @@ func registerRestarted(logger *logrus.Entry, mgr crman.Manager, eventFilter crpr
 				client:           mgr.GetClient(),
 				delegate:         delegate,
 				isRestartPending: isRestartPending,
+				statusSocketPath: statusSocketPath,
 			},
 		)
 }
@@ -89,7 +90,7 @@ func (r *restarted) Reconcile(ctx context.Context, req cr.Request) (cr.Result, e
 
 	// Get the current version of k0s
 	logger.Info("Determining the current version of k0s")
-	k0sVersion, err := getK0sVersion(status.DefaultSocketPath)
+	k0sVersion, err := getK0sVersion(r.statusSocketPath)
 	if err != nil {
 		logger.Info("Unable to determine current verion of k0s; requeuing")
 		return cr.Result{}, fmt.Errorf("unable to get k0s version: %w", err)

--- a/pkg/autopilot/controller/updates/update_controller.go
+++ b/pkg/autopilot/controller/updates/update_controller.go
@@ -30,23 +30,25 @@ type updateController struct {
 
 	clusterID string
 
-	updaters  map[string]updater
-	parentCtx context.Context
+	updaters         map[string]updater
+	parentCtx        context.Context
+	statusSocketPath string
 }
 
-func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, clientFactory apcli.FactoryInterface, collector *ClusterInfoCollector, leaderMode bool, clusterID string) error {
+func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Manager, clientFactory apcli.FactoryInterface, collector *ClusterInfoCollector, leaderMode bool, clusterID string, statusSocketPath string) error {
 	return cr.NewControllerManagedBy(mgr).
 		Named("updater").
 		For(&apv1beta2.UpdateConfig{}).
 		Complete(
 			&updateController{
-				log:           logger.WithField("reconciler", "updater"),
-				client:        mgr.GetClient(),
-				clientFactory: clientFactory,
-				collector:     collector,
-				clusterID:     clusterID,
-				updaters:      make(map[string]updater),
-				parentCtx:     ctx,
+				log:              logger.WithField("reconciler", "updater"),
+				client:           mgr.GetClient(),
+				clientFactory:    clientFactory,
+				collector:        collector,
+				clusterID:        clusterID,
+				updaters:         make(map[string]updater),
+				parentCtx:        ctx,
+				statusSocketPath: statusSocketPath,
 			},
 		)
 }
@@ -94,7 +96,7 @@ func (u *updateController) Reconcile(ctx context.Context, req cr.Request) (cr.Re
 	}
 	u.log.Debugf("creating new updater for '%s'", req.NamespacedName)
 	// Create new updater
-	updater, err := newUpdater(u.parentCtx, *updaterConfig, u.client, u.clientFactory, u.clusterID, u.collector, token)
+	updater, err := newUpdater(u.parentCtx, *updaterConfig, u.client, u.clientFactory, u.clusterID, u.collector, token, u.statusSocketPath)
 	if err != nil {
 		u.log.Errorf("failed to create updater for '%s': %s", req.NamespacedName, err)
 		return cr.Result{}, err

--- a/pkg/autopilot/controller/updates/updater.go
+++ b/pkg/autopilot/controller/updates/updater.go
@@ -54,7 +54,7 @@ var patchOpts = []crcli.PatchOption{
 	crcli.ForceOwnership,
 }
 
-func newUpdater(parentCtx context.Context, updateConfig apv1beta2.UpdateConfig, k8sClient crcli.Client, apClientFactory apcli.FactoryInterface, clusterID string, collector *ClusterInfoCollector, updateServerToken string) (updater, error) {
+func newUpdater(parentCtx context.Context, updateConfig apv1beta2.UpdateConfig, k8sClient crcli.Client, apClientFactory apcli.FactoryInterface, clusterID string, collector *ClusterInfoCollector, updateServerToken string, statusSocketPath string) (updater, error) {
 	updateClient, err := uc.NewClient(updateConfig.Spec.UpdateServer, updateServerToken)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func newUpdater(parentCtx context.Context, updateConfig apv1beta2.UpdateConfig, 
 
 	switch updateConfig.Spec.UpgradeStrategy.Type {
 	case apv1beta2.UpdateStrategyTypeCron:
-		return newCronUpdater(parentCtx, updateConfig, k8sClient, clusterID, updateClient)
+		return newCronUpdater(parentCtx, updateConfig, k8sClient, clusterID, updateClient, statusSocketPath)
 	case apv1beta2.UpdateStrategyTypePeriodic:
 		return newPeriodicUpdater(parentCtx, updateConfig, k8sClient, apClientFactory, collector, build.Version), nil
 	default:
@@ -70,13 +70,13 @@ func newUpdater(parentCtx context.Context, updateConfig apv1beta2.UpdateConfig, 
 	}
 }
 
-func newCronUpdater(parentCtx context.Context, updateConfig apv1beta2.UpdateConfig, k8sClient crcli.Client, clusterID string, updateClient uc.Client) (updater, error) {
+func newCronUpdater(parentCtx context.Context, updateConfig apv1beta2.UpdateConfig, k8sClient crcli.Client, clusterID string, updateClient uc.Client, statusSocketPath string) (updater, error) {
 	schedule := updateConfig.Spec.UpgradeStrategy.Cron
 	if schedule == "" {
 		schedule = defaultCronSchedule
 	}
 
-	status, err := status.GetStatusInfo(status.DefaultSocketPath)
+	status, err := status.GetStatusInfo(statusSocketPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/controller/autopilot.go
+++ b/pkg/component/controller/autopilot.go
@@ -68,6 +68,7 @@ func (a *Autopilot) Start(ctx context.Context) error {
 		K0sDataDir:          a.K0sVars.DataDir,
 		KubeletExtraArgs:    a.KubeletExtraArgs,
 		KubeAPIPort:         a.KubeAPIPort,
+		StatusSocketPath:    a.K0sVars.StatusSocketPath,
 		Mode:                "controller",
 		ManagerPort:         8899,
 		MetricsBindAddr:     "0",

--- a/pkg/component/worker/autopilot.go
+++ b/pkg/component/worker/autopilot.go
@@ -77,6 +77,7 @@ func (a *Autopilot) Start(ctx context.Context) error {
 		InvocationID:        a.K0sVars.InvocationID,
 		KubeConfig:          a.K0sVars.KubeletAuthConfigPath,
 		K0sDataDir:          a.K0sVars.DataDir,
+		StatusSocketPath:    a.K0sVars.StatusSocketPath,
 		Mode:                "worker",
 		ManagerPort:         8899,
 		MetricsBindAddr:     "0",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

Autopilot hardcoded status.DefaultSocketPath in its signal controllers and the cron updater instead of using the socket path configured via --status-socket or a custom --run-dir. This means a non default status socket or run dir breaks autopilot's version detection and restart logic, since it reads status from the wrong socket. CfgVars.StatusSocketPath already carries the correct configured value and is used correctly everywhere else in k0s (cmd/status, cmd/token, cmd/controller, cmd/worker, cmd/backup, cmd/restore); autopilot was the one place still hardcoding the default.

This threads a StatusSocketPath field through RootConfig from both NewRootController and NewRootWorker's call sites, through signal.RegisterControllers and k0s.RegisterControllers, into the version handler and the restart and restarted reconcilers, and separately through updates.RegisterControllers into the cron updater's initial status read.

Fixes #6750

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

This is a mechanical parameter threading change with no new branches, so no new test was added. Verified with go build and go vet across pkg/autopilot/... and pkg/component/..., and the existing pkg/autopilot/... and pkg/component/... test suites pass unchanged. Confirmed via grep that no status.DefaultSocketPath reference remains anywhere under pkg/autopilot. Did not verify against a running multi node cluster with a custom --status-socket, since that requires infrastructure not available in this environment.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commit messages are signed-off
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
