### PR TITLE
Fix backing up the k0s configuration file

### DIFF
--- a/cmd/backup/backup_unix.go
+++ b/cmd/backup/backup_unix.go
@@ -42,6 +42,10 @@ func NewBackupCmd() *cobra.Command {
 				return err
 			}
 			c := (*command)(opts)
+			// Reading the config from stdin would consume it, leaving nothing to store in the archive.
+			if c.K0sVars.StartupConfigPath == "-" {
+				return errors.New("command 'k0s backup' cannot read the configuration from stdin")
+			}
 			nodeConfig, err := c.K0sVars.NodeConfig()
 			if err != nil {
 				return err
@@ -57,6 +61,7 @@ func NewBackupCmd() *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.AddFlagSet(config.GetPersistentFlagSet())
+	flags.AddFlagSet(config.FileInputFlag())
 	flags.StringVar(&savePath, "save-path", "", "destination directory path for backup assets, use '-' for stdout")
 
 	return cmd

--- a/cmd/backup/backup_unix_test.go
+++ b/cmd/backup/backup_unix_test.go
@@ -1,0 +1,30 @@
+//go:build unix
+
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package backup
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackupCmd_AcceptsConfigFlag(t *testing.T) {
+	flag := NewBackupCmd().Flags().Lookup("config")
+	require.NotNil(t, flag, "k0s backup must accept --config")
+	assert.Equal(t, "c", flag.Shorthand)
+}
+
+func TestBackupCmd_RejectsConfigFromStdin(t *testing.T) {
+	cmd := NewBackupCmd()
+	cmd.SetArgs([]string{"--config=-", "--save-path=-"})
+	cmd.SetIn(strings.NewReader("spec: {}\n"))
+	cmd.SilenceUsage, cmd.SilenceErrors = true, true
+
+	err := cmd.Execute()
+	assert.ErrorContains(t, err, "cannot read the configuration from stdin")
+}

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -38,6 +38,14 @@ k0s backup --save-path=<directory>
 The directory used for the `save-path` value must exist and be writable. The default value is the current working directory.
 The command provides backup archive using following naming convention: `k0s_backup_<ISODatetimeString>.tar.gz`
 
+If the controller was started with a configuration file in a non-default location, pass the same path to the backup command, so that it can find and store the configuration:
+
+```shell
+k0s backup --config=/etc/k0s/my-cluster.yaml --save-path=<directory>
+```
+
+The configuration is always stored in the archive as `k0s.yaml`, whatever the file is called on the node. A cluster that runs without a configuration file at all is backed up without one, and restoring such an archive falls back to the k0s defaults.
+
 Because of the date/time usage, it is guaranteed that none of the previously created archives would be overwritten.
 
 To output the backup archive to standard output, use `-` as the save path.

--- a/pkg/backup/config_unix.go
+++ b/pkg/backup/config_unix.go
@@ -9,20 +9,26 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/k0sproject/k0s/internal/pkg/file"
 	"github.com/sirupsen/logrus"
 )
 
+// configFileName is the name the configuration has inside a backup archive,
+// independent of the file name the cluster was started with.
+const configFileName = "k0s.yaml"
+
 type configurationStep struct {
+	tmpDir             string
 	cfgPath            string
 	restoredConfigPath string
 	out                io.Writer
 }
 
-func newConfigurationStep(cfgPath, restoredConfigPath string, out io.Writer) *configurationStep {
+func newConfigurationStep(tmpDir, cfgPath, restoredConfigPath string, out io.Writer) *configurationStep {
 	return &configurationStep{
+		tmpDir:             tmpDir,
 		cfgPath:            cfgPath,
 		restoredConfigPath: restoredConfigPath,
 		out:                out,
@@ -34,11 +40,22 @@ func (c configurationStep) Name() string {
 }
 
 func (c configurationStep) Backup() (StepResult, error) {
-	return StepResult{filesForBackup: []string{c.cfgPath}}, nil
+	if !file.Exists(c.cfgPath) {
+		logrus.Warnf("configuration file %s does not exist, the backup archive won't contain one", c.cfgPath)
+		return StepResult{}, nil
+	}
+
+	// Stage the configuration under the name that Restore looks for, so that
+	// clusters started with a differently named file can be restored, too.
+	staged := filepath.Join(c.tmpDir, configFileName)
+	if err := file.Copy(c.cfgPath, staged); err != nil {
+		return StepResult{}, fmt.Errorf("failed to stage configuration file %s: %w", c.cfgPath, err)
+	}
+	return StepResult{filesForBackup: []string{staged}}, nil
 }
 
 func (c configurationStep) Restore(restoreFrom, restoreTo string) error {
-	objectPathInArchive := path.Join(restoreFrom, "k0s.yaml")
+	objectPathInArchive := filepath.Join(restoreFrom, configFileName)
 
 	if !file.Exists(objectPathInArchive) {
 		logrus.Debugf("%s does not exist in the backup file", objectPathInArchive)

--- a/pkg/backup/config_unix_test.go
+++ b/pkg/backup/config_unix_test.go
@@ -1,0 +1,109 @@
+//go:build unix
+
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package backup
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/k0sproject/k0s/internal/pkg/archive"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// archiveEntries runs step.Backup and returns the entry names the resulting
+// archive carries, the way RunBackup assembles it.
+func archiveEntries(t *testing.T, step Backuper, dataDir string) []string {
+	t.Helper()
+
+	result, err := step.Backup()
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, createArchive(&buf, result.filesForBackup, dataDir))
+
+	extracted := t.TempDir()
+	require.NoError(t, archive.Extract(&buf, extracted))
+	entries, err := os.ReadDir(extracted)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+func TestConfigurationStepBackup(t *testing.T) {
+	t.Run("stores_the_config_as_k0s_yaml", func(t *testing.T) {
+		cfgPath := filepath.Join(t.TempDir(), "k0s.yaml")
+		require.NoError(t, os.WriteFile(cfgPath, []byte("spec: {}\n"), 0644))
+
+		step := newConfigurationStep(t.TempDir(), cfgPath, "", nil)
+		assert.Equal(t, []string{"k0s.yaml"}, archiveEntries(t, step, t.TempDir()))
+	})
+
+	t.Run("stores_a_custom_config_file_name_as_k0s_yaml", func(t *testing.T) {
+		// Restore only ever looks for k0s.yaml, so the name the cluster was
+		// started with must not leak into the archive.
+		cfgPath := filepath.Join(t.TempDir(), "my-cluster.yaml")
+		require.NoError(t, os.WriteFile(cfgPath, []byte("spec: {}\n"), 0644))
+
+		step := newConfigurationStep(t.TempDir(), cfgPath, "", nil)
+		assert.Equal(t, []string{"k0s.yaml"}, archiveEntries(t, step, t.TempDir()))
+	})
+
+	t.Run("preserves_the_config_contents", func(t *testing.T) {
+		cfgPath := filepath.Join(t.TempDir(), "custom.yaml")
+		content := "spec:\n  storage:\n    type: kine\n"
+		require.NoError(t, os.WriteFile(cfgPath, []byte(content), 0644))
+
+		tmpDir := t.TempDir()
+		step := newConfigurationStep(tmpDir, cfgPath, "", nil)
+		result, err := step.Backup()
+		require.NoError(t, err)
+		require.Len(t, result.filesForBackup, 1)
+
+		staged, err := os.ReadFile(result.filesForBackup[0])
+		require.NoError(t, err)
+		assert.Equal(t, content, string(staged))
+	})
+
+	t.Run("skips_a_missing_config", func(t *testing.T) {
+		// k0s runs happily without /etc/k0s/k0s.yaml, so a backup of such a
+		// cluster must succeed rather than abort.
+		cfgPath := filepath.Join(t.TempDir(), "k0s.yaml") // never created
+
+		step := newConfigurationStep(t.TempDir(), cfgPath, "", nil)
+		result, err := step.Backup()
+		require.NoError(t, err)
+		assert.Empty(t, result.filesForBackup)
+	})
+}
+
+func TestGetConfigForRestore(t *testing.T) {
+	t.Run("reads_k0s_yaml_from_the_archive", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "k0s.yaml"),
+			[]byte("spec:\n  storage:\n    type: kine\n"), 0644))
+
+		cfg, err := Manager{tmpDir: tmpDir}.getConfigForRestore()
+		require.NoError(t, err)
+		assert.Equal(t, "kine", string(cfg.Spec.Storage.Type))
+	})
+
+	t.Run("falls_back_to_defaults_when_absent", func(t *testing.T) {
+		// Archives taken from a cluster that ran without a config file carry
+		// no k0s.yaml; restoring them must still work.
+		cfg, err := Manager{tmpDir: t.TempDir()}.getConfigForRestore()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, "etcd", string(cfg.Spec.Storage.Type))
+	})
+}

--- a/pkg/backup/manager_unix.go
+++ b/pkg/backup/manager_unix.go
@@ -6,6 +6,7 @@
 package backup
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -99,7 +100,7 @@ func (bm *Manager) discoverSteps(configFilePath string, nodeSpec *v1beta1.Cluste
 		}
 		bm.Add(NewFileSystemStep(path))
 	}
-	bm.Add(newConfigurationStep(configFilePath, restoredConfigPath, out))
+	bm.Add(newConfigurationStep(bm.tmpDir, configFilePath, restoredConfigPath, out))
 }
 
 // Add adds backup step
@@ -154,7 +155,7 @@ func (bm *Manager) RunRestore(archivePath string, k0sVars *config.CfgVars, desir
 	if err != nil {
 		return fmt.Errorf("failed to parse backed-up configuration file, check the backup archive: %w", err)
 	}
-	bm.discoverSteps(filepath.Join(bm.tmpDir, "k0s.yaml"), cfg.Spec, k0sVars, "restore", desiredRestoredConfigPath, out)
+	bm.discoverSteps(filepath.Join(bm.tmpDir, configFileName), cfg.Spec, k0sVars, "restore", desiredRestoredConfigPath, out)
 	logrus.Info("Starting restore")
 
 	for _, step := range bm.steps {
@@ -167,10 +168,16 @@ func (bm *Manager) RunRestore(archivePath string, k0sVars *config.CfgVars, desir
 }
 
 func (bm Manager) getConfigForRestore() (*v1beta1.ClusterConfig, error) {
-	configFromBackup := filepath.Join(bm.tmpDir, "k0s.yaml")
+	configFromBackup := filepath.Join(bm.tmpDir, configFileName)
 	logrus.Debugf("Using k0s.yaml from: %s", configFromBackup)
 
 	bytes, err := os.ReadFile(configFromBackup)
+	if errors.Is(err, os.ErrNotExist) {
+		// The cluster ran without a configuration file, so the archive doesn't
+		// carry one. Continue with the defaults, just like k0s does at startup.
+		logrus.Info("Backup archive contains no k0s.yaml, restoring with the default configuration")
+		return v1beta1.DefaultClusterConfig(), nil
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

k0s backup doesn't accept `--config` flag but restore tries to restore it

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
