### PR TITLE
autopilot: refresh discovery before the removed API check

### DIFF
--- a/pkg/autopilot/checks/checks.go
+++ b/pkg/autopilot/checks/checks.go
@@ -25,6 +25,9 @@ func CanUpdate(ctx context.Context, log logrus.FieldLogger, clientFactory kubern
 		return err
 	}
 
+	// Refresh the discovery cache to ensure that we catch freshly created CRDs.
+	discoveryClient.Invalidate()
+
 	_, resources, err := discoveryClient.ServerGroupsAndResources()
 	if err != nil {
 		log.WithError(err).Warn("Error while discovering supported API groups and resources")

--- a/pkg/autopilot/checks/checks_test.go
+++ b/pkg/autopilot/checks/checks_test.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package checks
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/k0sproject/k0s/internal/testutil"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	removedGroup    = "k0s.k0sproject.example.com"
+	removedVersion  = "v1beta1"
+	removedKind     = "RemovedCRD"
+	removedResource = "removedcrds"
+)
+
+// restConfigClientFactory adds a working REST config to the fake client
+// factory, so that [CanUpdate] can build its metadata client.
+type restConfigClientFactory struct {
+	*testutil.FakeClientFactory
+	restConfig *rest.Config
+}
+
+func (f *restConfigClientFactory) GetRESTConfig() (*rest.Config, error) {
+	return f.restConfig, nil
+}
+
+// TestCanUpdate_FreshlyCreatedCRD ensures that the removed API check doesn't
+// miss resources whose CRD was created after the discovery data had been
+// cached. Missing them lets an update proceed that should have been stopped.
+//
+// See https://github.com/k0sproject/k0s/issues/8241
+func TestCanUpdate_FreshlyCreatedCRD(t *testing.T) {
+	// Serve a single instance of the removed resource, and nothing else.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var items []metav1.PartialObjectMetadata
+		if r.URL.Path == "/apis/"+removedGroup+"/"+removedVersion+"/"+removedResource {
+			items = []metav1.PartialObjectMetadata{{
+				ObjectMeta: metav1.ObjectMeta{Name: "removed-resource"},
+			}}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(&metav1.PartialObjectMetadataList{
+			TypeMeta: metav1.TypeMeta{APIVersion: "meta.k8s.io/v1", Kind: "PartialObjectMetadataList"},
+			Items:    items,
+		}))
+	}))
+	t.Cleanup(server.Close)
+
+	fake := testutil.NewFakeClientFactory()
+	clients := &restConfigClientFactory{fake, &rest.Config{Host: server.URL}}
+	log := logrus.New()
+
+	// The cluster doesn't know about the removed API yet, so the update is fine.
+	// This populates the client factory's cached discovery client.
+	require.NoError(t, CanUpdate(t.Context(), log, clients, "v99.99.99"))
+
+	// Now the CRD gets created.
+	fake.DynamicClient.Resources = append(fake.DynamicClient.Resources, &metav1.APIResourceList{
+		GroupVersion: removedGroup + "/" + removedVersion,
+		APIResources: []metav1.APIResource{{
+			Name: removedResource, Kind: removedKind, Namespaced: false,
+			Verbs: metav1.Verbs{"get", "list"},
+		}},
+	})
+
+	err := CanUpdate(t.Context(), log, clients, "v99.99.99")
+	assert.ErrorContains(t, err,
+		removedResource+"."+removedGroup+" "+removedVersion+" has been removed in Kubernetes v99.99.99, but there are 1 such resources in the cluster")
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 k0s authors
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

The client factory's discovery cache is shared across k0s and nothing invalidates it on purpose, so a CRD created after the last refresh stays invisible to the check and the update wrongly proceeds.

Fixes https://github.com/k0sproject/k0s/issues/8241

## Type of change

<!-- check the related options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

`TestCanUpdate_FreshlyCreatedCRD` reproduces the bug deterministically as a unit test: it calls `CanUpdate` once to populate the shared discovery cache, then adds the CRD and calls it again. It fails 20/20 without the fix and passes with it.

```
go test -race -count=1 ./pkg/autopilot/checks/
go test -count=1 ./pkg/autopilot/... ./pkg/applier/... ./pkg/kubernetes/... ./pkg/helm/... ./pkg/component/controller/...
make lint-go GO_LINT_DIRS="./pkg/autopilot/checks/..."
make lint-copyright lint-invisible-unicode
```

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
