### PR TITLE
Unmount leftover mounts under the run dir on reset

### DIFF
--- a/pkg/cleanup/directories.go
+++ b/pkg/cleanup/directories.go
@@ -18,16 +18,24 @@ import (
 	"k8s.io/mount-utils"
 )
 
+// Test seams: constructing the mounter and removing directories touch the host,
+// so tests replace these functions. Because they are package-level overrides,
+// tests that change them must run serially and must not use t.Parallel().
+var (
+	newMounter = func() mount.Interface { return mount.New("") }
+	removeAll  = os.RemoveAll
+)
+
 // Run removes all kubelet mounts and deletes generated dataDir and runDir
 func (d *directories) Run(context.Context) error {
 	// unmount any leftover overlays (such as in alpine)
-	mounter := mount.New("")
+	mounter := newMounter()
 	procMounts, err := mounter.List()
 	if err != nil {
 		return err
 	}
 
-	var dataDirMounted, kubeletRootDirMounted bool
+	var dataDirMounted, kubeletRootDirMounted, runDirMounted bool
 
 	// The kubelet root dir only needs special handling when it lives outside
 	// the data dir. When it's under the data dir (the default location), it
@@ -35,6 +43,10 @@ func (d *directories) Run(context.Context) error {
 	// own mount be unmounted here just like any other mount under the data
 	// dir; otherwise the data dir cleanup would choke on the busy mount.
 	kubeletRootDirSeparate := !isUnderPath(d.kubeletRootDir, d.dataDir)
+
+	// Same reasoning for the run dir, which lives outside the data dir
+	// whenever k0s runs as root (/run/k0s).
+	runDirSeparate := !isUnderPath(d.runDir, d.dataDir)
 
 	// ensure that we don't delete any persistent data volumes that may be
 	// mounted by kubernetes by unmount every mount point under DataDir.
@@ -63,7 +75,11 @@ func (d *directories) Run(context.Context) error {
 			kubeletRootDirMounted = true
 			continue
 		}
-		if isUnderPath(v.Path, d.kubeletRootDir) || isUnderPath(v.Path, d.dataDir) {
+		if v.Path == d.runDir && runDirSeparate {
+			runDirMounted = true
+			continue
+		}
+		if isUnderPath(v.Path, d.kubeletRootDir) || isUnderPath(v.Path, d.dataDir) || isUnderPath(v.Path, d.runDir) {
 			logrus.Debugf("%v is mounted! attempting to unmount...", v.Path)
 			if err = mounter.Unmount(v.Path); err != nil {
 				// if we fail to unmount, try lazy unmount so
@@ -78,7 +94,7 @@ func (d *directories) Run(context.Context) error {
 	}
 
 	logrus.Debugf("removing kubelet root dir (%s)", d.kubeletRootDir)
-	if err := os.RemoveAll(d.kubeletRootDir); err != nil {
+	if err := removeAll(d.kubeletRootDir); err != nil {
 		// if the kubelet root dir is itself a mount point (e.g. mounted on
 		// a separate volume), it can't be removed; emptying its contents is
 		// enough. Bail out only on other errors.
@@ -90,24 +106,36 @@ func (d *directories) Run(context.Context) error {
 		}
 	}
 
+	// The run dir is deleted before the data dir on purpose: the data dir
+	// holds the bundled binaries (runc, containerd, ...) that a retried
+	// reset needs in order to start containerd and clean up any containers
+	// still holding mounts under the run dir. Deleting the data dir first
+	// would make a failure here unrecoverable without a reboot (#8048).
+	logrus.Debugf("deleting k0s generated run-dir (%s)", d.runDir)
+	if err := removeAll(d.runDir); err != nil {
+		// like the other two directories, the run dir may itself be a
+		// mount point; emptying its contents is enough then.
+		if !runDirMounted {
+			return fmt.Errorf("failed to delete %s: %w", d.runDir, err)
+		}
+		if !errorIsUnlinkat(err, d.runDir) {
+			return fmt.Errorf("failed to delete contents of mounted run-dir: %w", err)
+		}
+	}
+
 	if dataDirMounted {
 		logrus.Debugf("removing the contents of mounted data-dir (%s)", d.dataDir)
 	} else {
 		logrus.Debugf("removing k0s generated data-dir (%s)", d.dataDir)
 	}
 
-	if err := os.RemoveAll(d.dataDir); err != nil {
+	if err := removeAll(d.dataDir); err != nil {
 		if !dataDirMounted {
 			return fmt.Errorf("failed to delete k0s generated data-dir: %w", err)
 		}
 		if !errorIsUnlinkat(err, d.dataDir) {
 			return fmt.Errorf("failed to delete contents of mounted data-dir: %w", err)
 		}
-	}
-
-	logrus.Debugf("deleting k0s generated run-dir (%s)", d.runDir)
-	if err := os.RemoveAll(d.runDir); err != nil {
-		return fmt.Errorf("failed to delete %s: %w", d.runDir, err)
 	}
 
 	return nil

--- a/pkg/cleanup/directories_linux_test.go
+++ b/pkg/cleanup/directories_linux_test.go
@@ -8,6 +8,7 @@ package cleanup
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,6 +31,28 @@ func stubSeams(t *testing.T, mounter mount.Interface, removeErrFor string) *[]st
 		removed = append(removed, path)
 		if removeErrFor != "" && path == removeErrFor {
 			return errors.New("injected removal failure")
+		}
+		return nil
+	}
+	return &removed
+}
+
+// stubSeamsErr is stubSeams with a caller-supplied error returned for the
+// removal of one specific path, so a test can inject a synthetic *os.PathError
+// and exercise the mounted-directory tolerance logic (errorIsUnlinkat) without
+// a real mount point.
+func stubSeamsErr(t *testing.T, mounter mount.Interface, errPath string, errVal error) *[]string {
+	t.Helper()
+	var removed []string
+
+	prevMounter, prevRemove := newMounter, removeAll
+	t.Cleanup(func() { newMounter, removeAll = prevMounter, prevRemove })
+
+	newMounter = func() mount.Interface { return mounter }
+	removeAll = func(path string) error {
+		removed = append(removed, path)
+		if path == errPath {
+			return errVal
 		}
 		return nil
 	}
@@ -131,4 +154,46 @@ func TestRunHandlesRunDirNestedInDataDir(t *testing.T) {
 
 	assert.Contains(t, unmountedPaths(fake), taskMount)
 	assert.Equal(t, []string{d.kubeletRootDir, d.runDir, d.dataDir}, *removed)
+}
+
+
+// The run dir can itself be a mount point (e.g. a tmpfs on /run/k0s). os.RemoveAll
+// then empties it and returns an unlinkat error on the mountpoint directory,
+// which the cleanup tolerates rather than failing. This exercises the k0s
+// decision logic with a synthetic *os.PathError; the kernel behavior that
+// actually produces it is covered by a live test (see the PR).
+func TestRunToleratesUnlinkatWhenRunDirIsAMountPoint(t *testing.T) {
+	d := testDirs(t)
+	fake := mount.NewFakeMounter([]mount.MountPoint{{Path: d.runDir}})
+	removed := stubSeamsErr(t, fake, d.runDir, &os.PathError{Op: "unlinkat", Path: d.runDir, Err: errors.New("directory not empty")})
+
+	require.NoError(t, d.Run(context.Background()),
+		"an unlinkat on a run dir that is itself a mount point must be tolerated")
+	assert.Equal(t, []string{d.kubeletRootDir, d.runDir, d.dataDir}, *removed,
+		"tolerating the run dir removal must not stop the data dir cleanup")
+}
+
+// A non-unlinkat error (or an unlinkat on a different path) on a mounted run dir
+// is a real failure, not the empty-a-mount-point case, so it must surface.
+func TestRunFailsOnNonUnlinkatErrorForMountedRunDir(t *testing.T) {
+	d := testDirs(t)
+	fake := mount.NewFakeMounter([]mount.MountPoint{{Path: d.runDir}})
+	removed := stubSeamsErr(t, fake, d.runDir, &os.PathError{Op: "remove", Path: d.runDir, Err: errors.New("permission denied")})
+
+	err := d.Run(context.Background())
+	require.ErrorContains(t, err, "contents of mounted run-dir")
+	assert.NotContains(t, *removed, d.dataDir, "a hard run dir failure must not proceed to the data dir")
+}
+
+// The unlinkat tolerance is gated on the run dir being a mount point. The same
+// error when the run dir is NOT mounted is a genuine failure and must surface.
+func TestRunFailsOnUnlinkatWhenRunDirNotMounted(t *testing.T) {
+	d := testDirs(t)
+	removed := stubSeamsErr(t, mount.NewFakeMounter(nil), d.runDir, &os.PathError{Op: "unlinkat", Path: d.runDir, Err: errors.New("directory not empty")})
+
+	err := d.Run(context.Background())
+	require.ErrorContains(t, err, d.runDir)
+	assert.NotContains(t, err.Error(), "contents of mounted run-dir",
+		"an unmounted run dir failure is the hard-delete error, not the mounted-tolerance path")
+	assert.NotContains(t, *removed, d.dataDir)
 }

--- a/pkg/cleanup/directories_linux_test.go
+++ b/pkg/cleanup/directories_linux_test.go
@@ -1,0 +1,134 @@
+//go:build linux
+
+// SPDX-FileCopyrightText: 2025 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cleanup
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/mount-utils"
+)
+
+// stubSeams replaces the host-touching seams for the duration of a test and
+// returns a recorder of the directory removals in call order.
+func stubSeams(t *testing.T, mounter mount.Interface, removeErrFor string) *[]string {
+	t.Helper()
+	var removed []string
+
+	prevMounter, prevRemove := newMounter, removeAll
+	t.Cleanup(func() { newMounter, removeAll = prevMounter, prevRemove })
+
+	newMounter = func() mount.Interface { return mounter }
+	removeAll = func(path string) error {
+		removed = append(removed, path)
+		if removeErrFor != "" && path == removeErrFor {
+			return errors.New("injected removal failure")
+		}
+		return nil
+	}
+	return &removed
+}
+
+func testDirs(t *testing.T) *directories {
+	t.Helper()
+	base := t.TempDir()
+	return &directories{
+		dataDir:        filepath.Join(base, "data"),
+		kubeletRootDir: filepath.Join(base, "kubelet"),
+		runDir:         filepath.Join(base, "run"),
+	}
+}
+
+func unmountedPaths(fake *mount.FakeMounter) []string {
+	var paths []string
+	for _, action := range fake.GetLog() {
+		if action.Action == mount.FakeActionUnmount {
+			paths = append(paths, action.Target)
+		}
+	}
+	return paths
+}
+
+// Regression test for the first half of https://github.com/k0sproject/k0s/issues/8048:
+// mounts under the run dir (containerd task rootfs overlays) were never
+// unmounted before the run dir was deleted, unlike mounts under the data dir
+// and the kubelet root dir.
+func TestRunUnmountsLeftoverMountsUnderEveryManagedDir(t *testing.T) {
+	d := testDirs(t)
+	taskMount := filepath.Join(d.runDir, "containerd/io.containerd.runtime.v2.task/k8s.io/straggler/rootfs")
+	dataMount := filepath.Join(d.dataDir, "containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1/fs")
+	kubeletMount := filepath.Join(d.kubeletRootDir, "pods/x/volumes/kubernetes.io~projected/kube-api-access")
+	unrelatedMount := filepath.Join(t.TempDir(), "unrelated")
+
+	fake := mount.NewFakeMounter([]mount.MountPoint{
+		{Path: dataMount},
+		{Path: kubeletMount},
+		{Path: taskMount},
+		{Path: unrelatedMount},
+	})
+	stubSeams(t, fake, "")
+
+	require.NoError(t, d.Run(context.Background()))
+
+	unmounted := unmountedPaths(fake)
+	assert.Contains(t, unmounted, taskMount,
+		"a container task mount under the run dir must be unmounted before the run dir is deleted")
+	assert.Contains(t, unmounted, dataMount)
+	assert.Contains(t, unmounted, kubeletMount)
+	assert.NotContains(t, unmounted, unrelatedMount,
+		"mounts outside the managed directories must be left alone")
+}
+
+// Regression test for the second half of https://github.com/k0sproject/k0s/issues/8048:
+// the data dir holds the bundled binaries a retried reset needs, so it must be
+// deleted last.
+func TestRunDeletesDataDirLast(t *testing.T) {
+	d := testDirs(t)
+	removed := stubSeams(t, mount.NewFakeMounter(nil), "")
+
+	require.NoError(t, d.Run(context.Background()))
+
+	assert.Equal(t, []string{d.kubeletRootDir, d.runDir, d.dataDir}, *removed)
+}
+
+// A failure to delete the run dir (e.g. a mount that survived everything else)
+// must leave the data dir untouched so the next reset can still extract the
+// bundled binaries and retry.
+func TestRunPreservesDataDirWhenRunDirDeletionFails(t *testing.T) {
+	d := testDirs(t)
+	removed := stubSeams(t, mount.NewFakeMounter(nil), d.runDir)
+
+	err := d.Run(context.Background())
+
+	require.ErrorContains(t, err, d.runDir)
+	assert.NotContains(t, *removed, d.dataDir,
+		"the data dir must survive a failed run dir deletion")
+}
+
+// The non-root layout nests the run dir inside the data dir (<dataDir>/run).
+// Mounts under it must still be unmounted, and the deletion order must hold
+// with the nested path.
+func TestRunHandlesRunDirNestedInDataDir(t *testing.T) {
+	base := t.TempDir()
+	d := &directories{
+		dataDir:        filepath.Join(base, "data"),
+		kubeletRootDir: filepath.Join(base, "data", "kubelet"),
+		runDir:         filepath.Join(base, "data", "run"),
+	}
+	taskMount := filepath.Join(d.runDir, "containerd/io.containerd.runtime.v2.task/k8s.io/straggler/rootfs")
+
+	fake := mount.NewFakeMounter([]mount.MountPoint{{Path: taskMount}})
+	removed := stubSeams(t, fake, "")
+
+	require.NoError(t, d.Run(context.Background()))
+
+	assert.Contains(t, unmountedPaths(fake), taskMount)
+	assert.Equal(t, []string{d.kubeletRootDir, d.runDir, d.dataDir}, *removed)
+}


### PR DESCRIPTION
## Description

`k0s reset`'s directories step unmounts everything under the data dir and the kubelet root dir before deleting them, but not under the run dir — where containerd's task state lives, including each container's mounted `rootfs` overlay. Any mount that survives the containers cleanup step (anything created outside the CRI plugin, or a leftover shim) makes `os.RemoveAll(runDir)` fail with `ENOTEMPTY`. Because the data dir is deleted before the run dir, that first failure also destroys the bundled binaries (`runc`, `containerd-shim`, …) that a retried reset needs to start containerd — so every subsequent reset fails in ~140 ms and the node needs a manual unmount or a reboot.

Three changes in `pkg/cleanup/directories.go`:

- **Mounts under the run dir are unmounted** in the same reverse-order loop that already covers the data dir and the kubelet root dir, with the existing lazy-unmount fallback — container task `rootfs` overlays live there.
- **A run dir that is itself a mount point is emptied rather than removed**, with the same `unlinkat` tolerance the other two directories already get — completing the mount-awareness parity the issue describes.
- **The run dir is deleted before the data dir**, so a failure at that point leaves the bundled binaries a retried reset needs. A comment records why the order matters.

Regression tests cover all three changes (mounts under every managed dir are unmounted while unrelated mounts are left alone; the data dir is deleted last; a failed run-dir deletion preserves the data dir; the non-root layout where the run dir is nested inside the data dir; and the mounted-run-dir `unlinkat` tolerance, see below). Two small seams (`newMounter`, `removeAll`) make the step testable with the fake mounter from `k8s.io/mount-utils`.

The second change's k0s-side handling is unit-tested: `TestRunToleratesUnlinkatWhenRunDirIsAMountPoint` and its two negative cases inject a synthetic `*os.PathError{Op: "unlinkat"}` through the `removeAll` seam and assert the tolerance is gated on the run dir being a mount point and on the error actually being an `unlinkat` on that directory. What unit tests still cannot reproduce is the *kernel* behavior that produces that error — `os.RemoveAll` partially emptying a real mount point and then failing `unlinkat` on the mountpoint itself — so the end-to-end "run dir as its own mount point" scenario in Manual Testing remains the only confirmation that the real error takes this path.

While verifying this fix, a related but separate gap surfaced: containerd shim state (runc state, IO fifos) lives under the host-shared `/run/containerd`, outside every directory reset cleans, and survives even a successful reset. Filed as #8285; it is out of scope here.

Fixes #8048

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual test
- [x] Auto test added

Manual verification, control vs. patched **on the same host** (Ubuntu 22.04.5, kernel 6.8, x86_64, AWS EC2, single-node `k0s install controller --single`), following the reproduction from #8048.

- **Setup, identical for both runs**: start k0s and wait for the node to be Ready; run a `holder` pod through the API server; create one non-CRI container in the `k8s.io` containerd namespace (`k0s ctr -n k8s.io run -d docker.io/library/busybox:1.36 <id> sleep 100000`); `k0s stop`; then `k0s reset --data-dir /var/lib/k0s --kubelet-root-dir /var/lib/kubelet`, twice.
- **Control (released `v1.36.3+k0s.0`)**: reset attempt 1 exits 1 after ~1.6 s with `failed to delete /run/k0s: unlinkat …/io.containerd.runtime.v2.task/k8s.io/<id>: directory not empty`; `/var/lib/k0s/bin` is already gone. Attempt 2 exits 1 in ~210 ms with `Failed to initialize containerd, skipping container cleanup` and recommends a reboot. One task mount remains.
- **Patched (this branch)**: reset attempt 1 exits 0 and releases the mount; attempt 2 also exits 0 (~94 ms); zero task mounts remain.

Additional scenarios, each on its own fresh single-node instance with the patched binary:

- **Failure-injected retry**: with an immutable file under the kubelet root dir, reset attempt 1 fails but `/var/lib/k0s/bin` is left intact, and attempt 2 then completes cleanly (rc=0, no task mounts) — the retryability the ordering change protects.
- **Run dir as its own mount point**: reset empties it and leaves it mounted rather than failing — the live check for the second change above.
- **Busy task mount**: a process holding the task `rootfs` forces the lazy-unmount fallback, and the reset still succeeds.
- **Decoy mounts**: bind and tmpfs mounts outside the k0s directories survive a reset untouched.
- **Default layout**: with the kubelet root under the data dir, reset completes cleanly.

`go test ./pkg/...` passes on Linux (51 packages, including the new tests), as do `GOOS=linux go build` and `go vet`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commit messages are signed-off
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

